### PR TITLE
feat: add life-* facade crates for consolidated crate access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5179,6 +5179,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "life"
+version = "0.3.0"
+dependencies = [
+ "life-aios",
+ "life-anima",
+ "life-arcan",
+ "life-autonomic",
+ "life-haima",
+ "life-lago",
+ "life-nous",
+ "life-praxis",
+ "life-relay",
+ "life-vigil",
+]
+
+[[package]]
+name = "life-aios"
+version = "0.3.0"
+dependencies = [
+ "aios-events",
+ "aios-kernel",
+ "aios-protocol",
+ "aios-runtime",
+]
+
+[[package]]
+name = "life-anima"
+version = "0.3.0"
+dependencies = [
+ "anima-core",
+ "anima-identity",
+ "anima-lago",
+]
+
+[[package]]
+name = "life-arcan"
+version = "0.3.0"
+dependencies = [
+ "arcan-aios-adapters",
+ "arcan-core",
+ "arcan-harness",
+ "arcan-provider",
+ "arcan-store",
+ "arcand",
+]
+
+[[package]]
+name = "life-autonomic"
+version = "0.3.0"
+dependencies = [
+ "autonomic-api",
+ "autonomic-controller",
+ "autonomic-core",
+]
+
+[[package]]
 name = "life-cli"
 version = "0.3.0"
 dependencies = [
@@ -5198,6 +5254,56 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "life-haima"
+version = "0.3.0"
+dependencies = [
+ "haima-api",
+ "haima-core",
+ "haima-wallet",
+ "haima-x402",
+]
+
+[[package]]
+name = "life-lago"
+version = "0.3.0"
+dependencies = [
+ "lago-api",
+ "lago-core",
+ "lago-fs",
+ "lago-journal",
+ "lago-policy",
+ "lago-store",
+]
+
+[[package]]
+name = "life-nous"
+version = "0.3.0"
+dependencies = [
+ "nous-api",
+ "nous-core",
+ "nous-heuristics",
+ "nous-judge",
+]
+
+[[package]]
+name = "life-praxis"
+version = "0.3.0"
+dependencies = [
+ "praxis-core",
+ "praxis-mcp-bridge",
+ "praxis-skills",
+ "praxis-tools",
+]
+
+[[package]]
+name = "life-relay"
+version = "0.3.0"
+dependencies = [
+ "life-relay-api",
+ "life-relay-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,17 @@ members = [
     "crates/cli/life-cli",
     # Spaces A2A
     "crates/spaces-a2a/spaces-a2a",
+    # Facade crates — thin re-export layers
+    "crates/aios/life-aios",
+    "crates/arcan/life-arcan",
+    "crates/lago/life-lago",
+    "crates/praxis/life-praxis",
+    "crates/autonomic/life-autonomic",
+    "crates/haima/life-haima",
+    "crates/nous/life-nous",
+    "crates/anima/life-anima",
+    "crates/relay/life-relay",
+    "crates/life",
 ]
 exclude = ["crates/spaces/life-spaces/spacetimedb"]
 
@@ -155,6 +166,16 @@ praxis-core = { path = "crates/praxis/praxis-core", version = "0.3.0" }
 praxis-mcp-bridge = { path = "crates/praxis/praxis-mcp-bridge", version = "0.3.0" }
 praxis-skills = { path = "crates/praxis/praxis-skills", version = "0.3.0" }
 praxis-tools = { path = "crates/praxis/praxis-tools", version = "0.3.0" }
+# Facade crates
+life-aios = { path = "crates/aios/life-aios", version = "0.3.0" }
+life-arcan = { path = "crates/arcan/life-arcan", version = "0.3.0" }
+life-lago = { path = "crates/lago/life-lago", version = "0.3.0" }
+life-praxis = { path = "crates/praxis/life-praxis", version = "0.3.0" }
+life-autonomic = { path = "crates/autonomic/life-autonomic", version = "0.3.0" }
+life-haima = { path = "crates/haima/life-haima", version = "0.3.0" }
+life-nous = { path = "crates/nous/life-nous", version = "0.3.0" }
+life-anima = { path = "crates/anima/life-anima", version = "0.3.0" }
+life-relay = { path = "crates/relay/life-relay", version = "0.3.0" }
 
 # ── External dependencies ──
 anyhow = "1"

--- a/crates/aios/life-aios/Cargo.toml
+++ b/crates/aios/life-aios/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "life-aios"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Kernel contract facade for the Life Agent OS — re-exports aios-protocol, aios-events, aios-runtime, and aios-kernel"
+
+[dependencies]
+aios-protocol = { path = "../aios-protocol", version = "0.3.0" }
+aios-events = { path = "../aios-events", version = "0.3.0" }
+aios-runtime = { path = "../aios-runtime", version = "0.3.0" }
+aios-kernel = { path = "../aios-kernel", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/aios/life-aios/src/lib.rs
+++ b/crates/aios/life-aios/src/lib.rs
@@ -1,0 +1,4 @@
+pub use aios_events as events;
+pub use aios_kernel as kernel;
+pub use aios_protocol as protocol;
+pub use aios_runtime as runtime;

--- a/crates/anima/life-anima/Cargo.toml
+++ b/crates/anima/life-anima/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "life-anima"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Identity and beliefs facade for the Life Agent OS — re-exports anima-core, anima-identity, and anima-lago"
+
+[dependencies]
+anima-core = { path = "../anima-core", version = "0.3.0" }
+anima-identity = { path = "../anima-identity", version = "0.3.0" }
+anima-lago = { path = "../anima-lago", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/anima/life-anima/src/lib.rs
+++ b/crates/anima/life-anima/src/lib.rs
@@ -1,0 +1,3 @@
+pub use anima_core as core;
+pub use anima_identity as identity;
+pub use anima_lago as lago;

--- a/crates/arcan/life-arcan/Cargo.toml
+++ b/crates/arcan/life-arcan/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "life-arcan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Agent daemon and runtime facade for the Life Agent OS — re-exports arcan-core, arcand, arcan-harness, arcan-store, arcan-provider, and arcan-aios-adapters"
+
+[dependencies]
+arcan-core = { path = "../arcan-core", version = "0.3.0" }
+arcand = { path = "../arcand", version = "0.3.0" }
+arcan-harness = { path = "../arcan-harness", version = "0.3.0" }
+arcan-store = { path = "../arcan-store", version = "0.3.0" }
+arcan-provider = { path = "../arcan-provider", version = "0.3.0" }
+arcan-aios-adapters = { path = "../arcan-aios-adapters", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/arcan/life-arcan/src/lib.rs
+++ b/crates/arcan/life-arcan/src/lib.rs
@@ -1,0 +1,6 @@
+pub use arcan_aios_adapters as aios_adapters;
+pub use arcan_core as core;
+pub use arcan_harness as harness;
+pub use arcan_provider as provider;
+pub use arcan_store as store;
+pub use arcand as daemon;

--- a/crates/autonomic/life-autonomic/Cargo.toml
+++ b/crates/autonomic/life-autonomic/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "life-autonomic"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Homeostasis controller facade for the Life Agent OS — re-exports autonomic-core, autonomic-controller, and autonomic-api"
+
+[dependencies]
+autonomic-core = { path = "../autonomic-core", version = "0.3.0" }
+autonomic-controller = { path = "../autonomic-controller", version = "0.3.0" }
+autonomic-api = { path = "../autonomic-api", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/autonomic/life-autonomic/src/lib.rs
+++ b/crates/autonomic/life-autonomic/src/lib.rs
@@ -1,0 +1,3 @@
+pub use autonomic_api as api;
+pub use autonomic_controller as controller;
+pub use autonomic_core as core;

--- a/crates/haima/life-haima/Cargo.toml
+++ b/crates/haima/life-haima/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "life-haima"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Agentic finance engine facade for the Life Agent OS — re-exports haima-core, haima-wallet, haima-x402, and haima-api"
+
+[dependencies]
+haima-core = { path = "../haima-core", version = "0.3.0" }
+haima-wallet = { path = "../haima-wallet", version = "0.3.0" }
+haima-x402 = { path = "../haima-x402", version = "0.3.0" }
+haima-api = { path = "../haima-api", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/haima/life-haima/src/lib.rs
+++ b/crates/haima/life-haima/src/lib.rs
@@ -1,0 +1,4 @@
+pub use haima_api as api;
+pub use haima_core as core;
+pub use haima_wallet as wallet;
+pub use haima_x402 as x402;

--- a/crates/lago/life-lago/Cargo.toml
+++ b/crates/lago/life-lago/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "life-lago"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Persistence substrate facade for the Life Agent OS — re-exports lago-core, lago-journal, lago-store, lago-fs, lago-api, and lago-policy"
+
+[dependencies]
+lago-core = { path = "../lago-core", version = "0.3.0" }
+lago-journal = { path = "../lago-journal", version = "0.3.0" }
+lago-store = { path = "../lago-store", version = "0.3.0" }
+lago-fs = { path = "../lago-fs", version = "0.3.0" }
+lago-api = { path = "../lago-api", version = "0.3.0" }
+lago-policy = { path = "../lago-policy", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/lago/life-lago/src/lib.rs
+++ b/crates/lago/life-lago/src/lib.rs
@@ -1,0 +1,6 @@
+pub use lago_api as api;
+pub use lago_core as core;
+pub use lago_fs as fs;
+pub use lago_journal as journal;
+pub use lago_policy as policy;
+pub use lago_store as store;

--- a/crates/life/Cargo.toml
+++ b/crates/life/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "life"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Life Agent OS — unified facade re-exporting all subsystem crates (aios, arcan, lago, praxis, autonomic, haima, nous, anima, relay, vigil)"
+
+[dependencies]
+life-aios = { path = "../aios/life-aios", version = "0.3.0" }
+life-arcan = { path = "../arcan/life-arcan", version = "0.3.0" }
+life-lago = { path = "../lago/life-lago", version = "0.3.0" }
+life-praxis = { path = "../praxis/life-praxis", version = "0.3.0" }
+life-autonomic = { path = "../autonomic/life-autonomic", version = "0.3.0" }
+life-haima = { path = "../haima/life-haima", version = "0.3.0" }
+life-nous = { path = "../nous/life-nous", version = "0.3.0" }
+life-anima = { path = "../anima/life-anima", version = "0.3.0" }
+life-relay = { path = "../relay/life-relay", version = "0.3.0" }
+life-vigil = { path = "../vigil/life-vigil", version = "0.3.0" }
+# life-spaces excluded: requires spacetime generate to update bindings
+# life-spaces = { path = "../spaces/life-spaces", version = "0.1.0" }
+
+[lints]
+workspace = true

--- a/crates/life/src/lib.rs
+++ b/crates/life/src/lib.rs
@@ -1,0 +1,11 @@
+pub use life_aios as aios;
+pub use life_anima as anima;
+pub use life_arcan as arcan;
+pub use life_autonomic as autonomic;
+pub use life_haima as haima;
+pub use life_lago as lago;
+pub use life_nous as nous;
+pub use life_praxis as praxis;
+pub use life_relay as relay;
+pub use life_vigil as vigil;
+// life-spaces excluded: requires spacetime generate to update bindings

--- a/crates/nous/life-nous/Cargo.toml
+++ b/crates/nous/life-nous/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "life-nous"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Metacognitive evaluation facade for the Life Agent OS — re-exports nous-core, nous-api, nous-heuristics, and nous-judge"
+
+[dependencies]
+nous-core = { path = "../nous-core", version = "0.3.0" }
+nous-api = { path = "../nous-api", version = "0.3.0" }
+nous-heuristics = { path = "../nous-heuristics", version = "0.3.0" }
+nous-judge = { path = "../nous-judge", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/nous/life-nous/src/lib.rs
+++ b/crates/nous/life-nous/src/lib.rs
@@ -1,0 +1,4 @@
+pub use nous_api as api;
+pub use nous_core as core;
+pub use nous_heuristics as heuristics;
+pub use nous_judge as judge;

--- a/crates/praxis/life-praxis/Cargo.toml
+++ b/crates/praxis/life-praxis/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "life-praxis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Tool execution engine facade for the Life Agent OS — re-exports praxis-core, praxis-tools, praxis-skills, and praxis-mcp-bridge"
+
+[dependencies]
+praxis-core = { path = "../praxis-core", version = "0.3.0" }
+praxis-tools = { path = "../praxis-tools", version = "0.3.0" }
+praxis-skills = { path = "../praxis-skills", version = "0.3.0" }
+praxis-mcp-bridge = { path = "../praxis-mcp-bridge", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/praxis/life-praxis/src/lib.rs
+++ b/crates/praxis/life-praxis/src/lib.rs
@@ -1,0 +1,4 @@
+pub use praxis_core as core;
+pub use praxis_mcp_bridge as mcp_bridge;
+pub use praxis_skills as skills;
+pub use praxis_tools as tools;

--- a/crates/relay/life-relay/Cargo.toml
+++ b/crates/relay/life-relay/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "life-relay"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Remote agent sessions facade for the Life Agent OS — re-exports life-relay-core and life-relay-api"
+
+[dependencies]
+life-relay-core = { path = "../life-relay-core", version = "0.3.0" }
+life-relay-api = { path = "../life-relay-api", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/relay/life-relay/src/lib.rs
+++ b/crates/relay/life-relay/src/lib.rs
@@ -1,0 +1,2 @@
+pub use life_relay_api as api;
+pub use life_relay_core as core;

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -330,3 +330,54 @@ semver_check = false
 [[package]]
 name = "spaces-a2a"
 semver_check = false
+
+# ─── Facade crates ──────────────────────────────────────────────────
+[[package]]
+name = "life-aios"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-arcan"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-lago"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-praxis"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-autonomic"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-haima"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-nous"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-anima"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life-relay"
+# Never published
+semver_check = false
+
+[[package]]
+name = "life"
+# Never published — top-level facade
+semver_check = false


### PR DESCRIPTION
## Summary
- Add 10 thin re-export facade crates (`life-aios`, `life-arcan`, `life-lago`, `life-praxis`, `life-autonomic`, `life-haima`, `life-nous`, `life-anima`, `life-relay`, and top-level `life`) that let users depend on Life subsystems without listing 5+ individual crates
- Each facade contains only a `src/lib.rs` with `pub use` re-exports -- no new logic
- All facades registered in workspace `members`, `[workspace.dependencies]`, and `release-plz.toml`
- `cargo check --workspace` passes cleanly

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt` produces no changes
- [x] Each facade crate compiles independently (`cargo check -p life-aios`, etc.)
- [x] Top-level `life` facade re-exports all subsystem facades including existing `life-vigil`
- [ ] Verify no existing crate behavior is modified (facades are additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified facade modules for major subsystems (AIOS, Arcan, Autonomic, Anima, Haima, Lago, Nous, Praxis, Relay) enabling streamlined access to grouped functionality.

* **Chores**
  * Restructured workspace organization to support new modular facade architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->