### PR TITLE
feat(opsis): GDELT + NASA EONET feeds (BRO-509)

### DIFF
--- a/crates/arcan/arcan-core/src/prompt.rs
+++ b/crates/arcan/arcan-core/src/prompt.rs
@@ -800,7 +800,7 @@ mod tests {
     fn test_load_control_policy() {
         let tmp = TempDir::new().unwrap();
         let workspace = tmp.path();
-        let control_dir = workspace.join(".control");
+        let control_dir = workspace.join(".life/control");
         fs::create_dir_all(&control_dir).unwrap();
         fs::write(
             control_dir.join("policy.yaml"),
@@ -917,7 +917,7 @@ mod tests {
         let docs = workspace.join("docs");
         fs::create_dir_all(&docs).unwrap();
         fs::write(docs.join("STATUS.md"), "All green.").unwrap();
-        let control = workspace.join(".control");
+        let control = workspace.join(".life/control");
         fs::create_dir_all(&control).unwrap();
         fs::write(control.join("policy.yaml"), "version: 1").unwrap();
 

--- a/crates/opsis/feeds.toml
+++ b/crates/opsis/feeds.toml
@@ -67,3 +67,68 @@ summary = "$.iss_position"
 lat = "$.iss_position.latitude"
 lon = "$.iss_position.longitude"
 tags = ["iss", "space", "orbit"]
+
+# ── NASA EONET (Earth Observatory Natural Events) ──────────────────
+# Real-time natural events: wildfires, storms, volcanoes, icebergs.
+# Free, no auth, returns GeoJSON-like with coordinates + magnitude.
+
+[[feeds]]
+name = "nasa-eonet"
+connector = "poll"
+url = "https://eonet.gsfc.nasa.gov/api/v3/events?limit=50&status=open"
+interval_secs = 600
+schema = "nasa.eonet.v3"
+domain = "Emergency"
+
+[feeds.normalize]
+events_path = "$.events[*]"
+summary = "$.title"
+severity = "$.geometry[0].magnitudeValue"
+severity_range = [0, 10000]
+lat = "$.geometry[0].coordinates[1]"
+lon = "$.geometry[0].coordinates[0]"
+tags = ["nasa", "eonet", "natural-events"]
+
+# ── GDELT feeds (BRO-509) ──────────────────────────────────────────
+# GDELT DOC API v2 returns global news articles matching query terms.
+# Articles lack coordinates — events flow through Gaia for domain-level
+# anomaly detection but don't pin to globe. Rate limit: 1 req / 5s.
+
+[[feeds]]
+name = "gdelt-conflict"
+connector = "poll"
+url = "https://api.gdeltproject.org/api/v2/doc/doc?query=conflict%20OR%20war%20OR%20military%20OR%20attack&mode=ArtList&maxrecords=25&format=json&TIMESPAN=15min"
+interval_secs = 900
+schema = "gdelt.doc.v2"
+domain = "Conflict"
+
+[feeds.normalize]
+events_path = "$.articles[*]"
+summary = "$.title"
+tags = ["gdelt", "conflict", "news"]
+
+[[feeds]]
+name = "gdelt-politics"
+connector = "poll"
+url = "https://api.gdeltproject.org/api/v2/doc/doc?query=election%20OR%20sanctions%20OR%20diplomacy%20OR%20treaty&mode=ArtList&maxrecords=25&format=json&TIMESPAN=15min"
+interval_secs = 900
+schema = "gdelt.doc.v2"
+domain = "Politics"
+
+[feeds.normalize]
+events_path = "$.articles[*]"
+summary = "$.title"
+tags = ["gdelt", "politics", "news"]
+
+[[feeds]]
+name = "gdelt-trade"
+connector = "poll"
+url = "https://api.gdeltproject.org/api/v2/doc/doc?query=trade%20OR%20tariff%20OR%20export%20OR%20import%20OR%20economic%20crisis&mode=ArtList&maxrecords=25&format=json&TIMESPAN=15min"
+interval_secs = 900
+schema = "gdelt.doc.v2"
+domain = "Trade"
+
+[feeds.normalize]
+events_path = "$.articles[*]"
+summary = "$.title"
+tags = ["gdelt", "trade", "economics"]

--- a/crates/opsis/opsis-core/src/feed.rs
+++ b/crates/opsis/opsis-core/src/feed.rs
@@ -277,34 +277,30 @@ token_env = "EXAMPLE_API_TOKEN"
     fn feed_config_with_normalizer() {
         let toml_str = r#"
 [[feeds]]
-name = "gdelt-events"
+name = "gdelt-conflict"
 connector = "poll"
-url = "http://data.gdeltproject.org/gdeltv2/lastupdate.json"
+url = "https://api.gdeltproject.org/api/v2/doc/doc?query=conflict&mode=ArtList&maxrecords=25&format=json&TIMESPAN=15min"
 interval_secs = 900
-schema = "gdelt.events.v2"
+schema = "gdelt.doc.v2"
 domain = "Conflict"
 
 [feeds.normalize]
-events_path = "$.data[*]"
-summary = "$.headline"
-severity = "$.goldstein_scale"
-severity_range = [-10, 10]
-lat = "$.lat"
-lon = "$.lon"
-tags = ["gdelt", "news"]
+events_path = "$.articles[*]"
+summary = "$.title"
+tags = ["gdelt", "conflict", "news"]
 "#;
         let config: FeedsConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.feeds.len(), 1);
         let feed = &config.feeds[0];
-        assert_eq!(feed.name, "gdelt-events");
+        assert_eq!(feed.name, "gdelt-conflict");
         assert_eq!(feed.domain.as_deref(), Some("Conflict"));
 
         let norm = feed.normalize.as_ref().unwrap();
-        assert_eq!(norm.events_path.as_deref(), Some("$.data[*]"));
-        assert_eq!(norm.summary, "$.headline");
-        assert_eq!(norm.severity.as_deref(), Some("$.goldstein_scale"));
-        assert_eq!(norm.severity_range, [-10.0, 10.0]);
-        assert_eq!(norm.tags, vec!["gdelt", "news"]);
+        assert_eq!(norm.events_path.as_deref(), Some("$.articles[*]"));
+        assert_eq!(norm.summary, "$.title");
+        assert!(norm.severity.is_none()); // GDELT artlist has no tone data
+        assert!(norm.lat.is_none()); // No coordinates in artlist mode
+        assert_eq!(norm.tags, vec!["gdelt", "conflict", "news"]);
     }
 
     #[test]

--- a/crates/opsis/opsis-core/src/schema.rs
+++ b/crates/opsis/opsis-core/src/schema.rs
@@ -71,6 +71,22 @@ pub fn builtin_schemas() -> Vec<SchemaDefinition> {
             event_kind_hint: OpsisEventKindHint::AgentObservation,
             domain_hint: None,
         },
+        SchemaDefinition {
+            key: SchemaKey::new("gdelt.doc.v2"),
+            version: 2,
+            description: "GDELT DOC API v2 article list — global news events".into(),
+            producer: SchemaProducer::Feed,
+            event_kind_hint: OpsisEventKindHint::WorldObservation,
+            domain_hint: None, // Domain set per-feed (Conflict, Politics, Trade)
+        },
+        SchemaDefinition {
+            key: SchemaKey::new("nasa.eonet.v3"),
+            version: 3,
+            description: "NASA EONET v3 — natural events (wildfires, storms, volcanoes)".into(),
+            producer: SchemaProducer::Feed,
+            event_kind_hint: OpsisEventKindHint::WorldObservation,
+            domain_hint: Some(StateDomain::Emergency),
+        },
     ]
 }
 
@@ -107,7 +123,17 @@ mod tests {
     }
 
     #[test]
-    fn four_builtin_schemas() {
-        assert_eq!(builtin_schemas().len(), 4);
+    fn six_builtin_schemas() {
+        assert_eq!(builtin_schemas().len(), 6);
+    }
+
+    #[test]
+    fn gdelt_schema_exists() {
+        let schemas = builtin_schemas();
+        assert!(
+            schemas
+                .iter()
+                .any(|s| s.key == SchemaKey::new("gdelt.doc.v2"))
+        );
     }
 }

--- a/crates/opsis/opsis-engine/src/feeds/generic_poll.rs
+++ b/crates/opsis/opsis-engine/src/feeds/generic_poll.rs
@@ -305,6 +305,169 @@ mod tests {
         assert!(events[0].severity.is_none());
     }
 
+    /// Simulates a real GDELT DOC API v2 artlist response to validate the normalizer config.
+    #[test]
+    fn normalize_gdelt_artlist_response() {
+        let normalizer = NormalizerConfig {
+            events_path: Some("$.articles[*]".into()),
+            summary: "$.title".into(),
+            severity: None,
+            severity_range: [0.0, 1.0],
+            lat: None,
+            lon: None,
+            tags: vec!["gdelt".into(), "conflict".into(), "news".into()],
+        };
+        let config = FeedConfig {
+            name: "gdelt-conflict".into(),
+            connector: ConnectorConfig::Poll {
+                url: "https://api.gdeltproject.org/api/v2/doc/doc?query=conflict&mode=ArtList&maxrecords=25&format=json".into(),
+                interval_secs: 900,
+            },
+            schema: "gdelt.doc.v2".into(),
+            domain: Some("Conflict".into()),
+            auth: None,
+            normalize: Some(normalizer.clone()),
+        };
+
+        let feed = GenericPollFeed::new(config, normalizer);
+
+        // Simulate GDELT artlist response.
+        let gdelt_response = json!({
+            "articles": [
+                {
+                    "url": "https://example.com/article1",
+                    "url_mobile": "",
+                    "title": "Tensions rise in Eastern Europe amid military buildup",
+                    "seendate": "20260406T120000Z",
+                    "socialimage": "https://example.com/img1.jpg",
+                    "domain": "example.com",
+                    "language": "English",
+                    "sourcecountry": "United States"
+                },
+                {
+                    "url": "https://example.com/article2",
+                    "url_mobile": "",
+                    "title": "Peace talks resume after ceasefire agreement",
+                    "seendate": "20260406T110000Z",
+                    "socialimage": "",
+                    "domain": "example.com",
+                    "language": "English",
+                    "sourcecountry": "United Kingdom"
+                }
+            ]
+        });
+
+        // Extract articles array.
+        let items = crate::jsonpath::extract_array(&gdelt_response, "$.articles[*]");
+        assert_eq!(items.len(), 2);
+
+        // Build raw events (simulating poll_raw).
+        let raw = RawFeedEvent {
+            id: EventId::default(),
+            timestamp: chrono::Utc::now(),
+            source: feed.source(),
+            feed_schema: feed.schema(),
+            location: None, // GDELT artlist has no coordinates
+            payload: items[0].clone(),
+        };
+
+        let events = feed.normalize(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+
+        let event = &events[0];
+        match &event.kind {
+            OpsisEventKind::WorldObservation { summary } => {
+                assert_eq!(
+                    summary,
+                    "Tensions rise in Eastern Europe amid military buildup"
+                );
+            }
+            _ => panic!("expected WorldObservation"),
+        }
+        assert!(event.location.is_none()); // No geo for artlist
+        assert!(event.severity.is_none()); // No tone data in artlist
+        assert_eq!(event.domain, Some(StateDomain::Conflict));
+        assert_eq!(event.tags, vec!["gdelt", "conflict", "news"]);
+        assert_eq!(event.schema_key.to_string(), "gdelt.doc.v2");
+    }
+
+    /// Simulates NASA EONET v3 response — events with coordinates and magnitude.
+    #[test]
+    fn normalize_eonet_response() {
+        let normalizer = NormalizerConfig {
+            events_path: Some("$.events[*]".into()),
+            summary: "$.title".into(),
+            severity: Some("$.geometry[0].magnitudeValue".into()),
+            severity_range: [0.0, 10000.0],
+            lat: Some("$.geometry[0].coordinates[1]".into()),
+            lon: Some("$.geometry[0].coordinates[0]".into()),
+            tags: vec!["nasa".into(), "eonet".into(), "natural-events".into()],
+        };
+        let config = FeedConfig {
+            name: "nasa-eonet".into(),
+            connector: ConnectorConfig::Poll {
+                url: "https://eonet.gsfc.nasa.gov/api/v3/events?limit=50&status=open".into(),
+                interval_secs: 600,
+            },
+            schema: "nasa.eonet.v3".into(),
+            domain: Some("Emergency".into()),
+            auth: None,
+            normalize: Some(normalizer.clone()),
+        };
+
+        let feed = GenericPollFeed::new(config, normalizer);
+
+        // Simulate EONET event (wildfire with coordinates).
+        let eonet_event = json!({
+            "id": "EONET_19351",
+            "title": "EASTER PASTURE Wildfire, Hendry, Florida",
+            "description": "15 Miles E from IMMOKALEE, FL",
+            "categories": [{"id": "wildfires", "title": "Wildfires"}],
+            "geometry": [{
+                "magnitudeValue": 562.0,
+                "magnitudeUnit": "acres",
+                "date": "2026-04-05T22:32:00Z",
+                "type": "Point",
+                "coordinates": [-81.0269444, 26.4713889]
+            }]
+        });
+
+        // Verify jsonpath extraction of nested coordinates.
+        let lat = crate::jsonpath::extract_f64(&eonet_event, "$.geometry[0].coordinates[1]");
+        let lon = crate::jsonpath::extract_f64(&eonet_event, "$.geometry[0].coordinates[0]");
+        assert!((lat.unwrap() - 26.4713889).abs() < 0.001);
+        assert!((lon.unwrap() - (-81.0269444)).abs() < 0.001);
+
+        // Verify magnitude extraction.
+        let mag = crate::jsonpath::extract_f64(&eonet_event, "$.geometry[0].magnitudeValue");
+        assert!((mag.unwrap() - 562.0).abs() < 0.001);
+
+        // Build raw event and normalize.
+        let raw = RawFeedEvent {
+            id: EventId::default(),
+            timestamp: chrono::Utc::now(),
+            source: feed.source(),
+            feed_schema: feed.schema(),
+            location: Some(GeoPoint::new(26.4713889, -81.0269444)),
+            payload: eonet_event,
+        };
+
+        let events = feed.normalize(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+
+        let event = &events[0];
+        match &event.kind {
+            OpsisEventKind::WorldObservation { summary } => {
+                assert_eq!(summary, "EASTER PASTURE Wildfire, Hendry, Florida");
+            }
+            _ => panic!("expected WorldObservation"),
+        }
+        // 562 / 10000 = 0.0562
+        assert!((event.severity.unwrap() - 0.0562).abs() < 0.001);
+        assert_eq!(event.domain, Some(StateDomain::Emergency));
+        assert_eq!(event.tags, vec!["nasa", "eonet", "natural-events"]);
+    }
+
     #[test]
     fn normalize_missing_summary_defaults() {
         let feed = GenericPollFeed::new(make_config(make_normalizer()), make_normalizer());

--- a/crates/opsis/opsis-engine/src/schema_registry.rs
+++ b/crates/opsis/opsis-engine/src/schema_registry.rs
@@ -81,13 +81,13 @@ mod tests {
         };
         reg.register(custom);
         assert!(reg.lookup(&SchemaKey::new("custom.feed.v1")).is_some());
-        assert_eq!(reg.all().len(), 5);
+        assert_eq!(reg.all().len(), 7);
     }
 
     #[test]
     fn all_returns_all_schemas() {
         let reg = SchemaRegistry::new();
-        assert_eq!(reg.all().len(), 4);
+        assert_eq!(reg.all().len(), 6);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add 3 GDELT DOC API v2 feeds (Conflict, Politics, Trade domains) — declarative TOML config using GenericPollFeed, no Rust code needed
- Add NASA EONET v3 feed — real-time natural events (wildfires, storms, volcanoes) with geo-coordinates and magnitude
- Register `gdelt.doc.v2` and `nasa.eonet.v3` builtin schemas
- Fix arcan-core prompt tests for `.control` → `.life/control` rename (pre-existing CI blocker)

## Details

**GDELT feeds** use the DOC API artlist mode which returns article metadata (title, date, source country) without coordinates. Events flow through Gaia for domain-level anomaly detection. Three separate feeds cover Conflict, Politics, and Trade domains with different query terms. Rate limit: 1 req/5s, polling every 15 minutes.

**NASA EONET** returns structured natural event data with GeoJSON-like geometry (Point coordinates + magnitude). Events pin to the CesiumJS globe. Categories include wildfires, severe storms, volcanoes, and icebergs.

## Test plan
- [x] GDELT artlist response normalization test validates title extraction, domain assignment, schema key
- [x] EONET response normalization test validates nested jsonpath for `$.geometry[0].coordinates[1]`, magnitude normalization, geo-point extraction
- [x] feeds.toml parses correctly with all 8 feeds (2 custom + 6 generic)
- [x] All 245 tests pass (146 arcan-core + 43 opsis-core + 56 opsis-engine)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new data feeds: NASA EONET for environmental and natural disaster events, GDELT Conflict for geopolitical events, GDELT Politics for political news, and GDELT Trade for trade-related events. Each includes event summaries, severity levels where applicable, and geographic coordinates.

* **Tests**
  * Expanded test coverage for feed normalization and schema configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->