### PR TITLE
feat(vigil): local pricing model + reliability tracking (BRO-516/519)

### DIFF
--- a/crates/vigil/life-vigil/src/lib.rs
+++ b/crates/vigil/life-vigil/src/lib.rs
@@ -25,12 +25,14 @@
 pub mod config;
 pub mod envelope;
 pub mod metrics;
+pub mod pricing;
 pub mod semconv;
 pub mod spans;
 
 pub use config::{LogFormat, OtlpProtocol, VigConfig};
 pub use envelope::{CircuitState, CostSource, LlmRequestEnvelope, LlmResponseEconomics};
 pub use metrics::GenAiMetrics;
+pub use pricing::{ModelPricing, PRICING_SNAPSHOT, estimate_cost, lookup_pricing};
 
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;

--- a/crates/vigil/life-vigil/src/pricing.rs
+++ b/crates/vigil/life-vigil/src/pricing.rs
@@ -1,0 +1,237 @@
+//! Local pricing model for GenAI cost estimation.
+//!
+//! Provides a static pricing snapshot for common LLM models, enabling
+//! cost estimation without calling provider pricing APIs. Prices are
+//! per-million-tokens in USD.
+//!
+//! # Cost Source
+//!
+//! All estimates from this module use [`CostSource::EstimatedLocalSnapshot`]
+//! provenance — fast but may be stale. Update the snapshot when providers
+//! change pricing.
+
+use crate::envelope::{CostSource, LlmResponseEconomics};
+use std::time::Duration;
+
+/// Per-model pricing in USD per million tokens.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelPricing {
+    /// Model identifier (matched against `gen_ai.request.model`).
+    pub model: &'static str,
+    /// Input (prompt) cost per million tokens.
+    pub input_per_million: f64,
+    /// Output (completion) cost per million tokens.
+    pub output_per_million: f64,
+}
+
+/// Static pricing snapshot — update when providers change rates.
+///
+/// Sources: Anthropic pricing page, OpenAI pricing page (as of 2026-04).
+/// Prices are in USD per million tokens.
+pub const PRICING_SNAPSHOT: &[ModelPricing] = &[
+    // ─── Anthropic ─────────────────────────────────────────────────
+    ModelPricing {
+        model: "claude-opus-4-20250514",
+        input_per_million: 15.0,
+        output_per_million: 75.0,
+    },
+    ModelPricing {
+        model: "claude-sonnet-4-20250514",
+        input_per_million: 3.0,
+        output_per_million: 15.0,
+    },
+    ModelPricing {
+        model: "claude-sonnet-4-5-20250929",
+        input_per_million: 3.0,
+        output_per_million: 15.0,
+    },
+    ModelPricing {
+        model: "claude-haiku-4-5-20251001",
+        input_per_million: 0.80,
+        output_per_million: 4.0,
+    },
+    // ─── OpenAI ────────────────────────────────────────────────────
+    ModelPricing {
+        model: "gpt-4o",
+        input_per_million: 2.50,
+        output_per_million: 10.0,
+    },
+    ModelPricing {
+        model: "gpt-4o-mini",
+        input_per_million: 0.15,
+        output_per_million: 0.60,
+    },
+    ModelPricing {
+        model: "o3",
+        input_per_million: 10.0,
+        output_per_million: 40.0,
+    },
+    ModelPricing {
+        model: "o3-mini",
+        input_per_million: 1.10,
+        output_per_million: 4.40,
+    },
+    ModelPricing {
+        model: "o4-mini",
+        input_per_million: 1.10,
+        output_per_million: 4.40,
+    },
+    // ─── OpenRouter / proxy models (common patterns) ───────────────
+    ModelPricing {
+        model: "anthropic/claude-haiku-4.5",
+        input_per_million: 0.80,
+        output_per_million: 4.0,
+    },
+    ModelPricing {
+        model: "anthropic/claude-sonnet-4",
+        input_per_million: 3.0,
+        output_per_million: 15.0,
+    },
+    ModelPricing {
+        model: "anthropic/claude-opus-4",
+        input_per_million: 15.0,
+        output_per_million: 75.0,
+    },
+];
+
+/// Look up pricing for a model by name.
+///
+/// Tries exact match first, then substring match (e.g. "claude-sonnet-4"
+/// matches "anthropic/claude-sonnet-4" or a dated variant).
+pub fn lookup_pricing(model: &str) -> Option<&'static ModelPricing> {
+    // Exact match first.
+    if let Some(p) = PRICING_SNAPSHOT.iter().find(|p| p.model == model) {
+        return Some(p);
+    }
+    // Substring match: model name contains a known pricing key.
+    PRICING_SNAPSHOT
+        .iter()
+        .find(|p| model.contains(p.model) || p.model.contains(model))
+}
+
+/// Estimate USD cost for a given token count.
+///
+/// Returns `(input_cost, output_cost, total_cost)` or `None` if the
+/// model is not in the pricing snapshot.
+pub fn estimate_cost(
+    model: &str,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> Option<(f64, f64, f64)> {
+    let pricing = lookup_pricing(model)?;
+    let input_cost = (input_tokens as f64 / 1_000_000.0) * pricing.input_per_million;
+    let output_cost = (output_tokens as f64 / 1_000_000.0) * pricing.output_per_million;
+    Some((input_cost, output_cost, input_cost + output_cost))
+}
+
+/// Build an `LlmResponseEconomics` from token counts and a model name.
+///
+/// Uses the local pricing snapshot for cost estimation. If the model is not
+/// found, costs are set to `None` but token counts are still recorded.
+pub fn build_response_economics(
+    model: &str,
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_tokens: u32,
+    cache_creation_tokens: u32,
+    duration: Duration,
+) -> LlmResponseEconomics {
+    let costs = estimate_cost(model, input_tokens, output_tokens);
+
+    LlmResponseEconomics {
+        cost_source: CostSource::EstimatedLocalSnapshot,
+        input_tokens,
+        output_tokens,
+        total_tokens: input_tokens + output_tokens,
+        input_cost_usd: costs.map(|(i, _, _)| i),
+        output_cost_usd: costs.map(|(_, o, _)| o),
+        total_cost_usd: costs.map(|(_, _, t)| t),
+        cache_read_tokens,
+        cache_creation_tokens,
+        duration,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_exact_match() {
+        let p = lookup_pricing("claude-sonnet-4-20250514").unwrap();
+        assert!((p.input_per_million - 3.0).abs() < 0.001);
+        assert!((p.output_per_million - 15.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn lookup_substring_match() {
+        // Proxy-style model names should match
+        let p = lookup_pricing("anthropic/claude-haiku-4.5").unwrap();
+        assert!((p.input_per_million - 0.80).abs() < 0.001);
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(lookup_pricing("unknown-model-xyz").is_none());
+    }
+
+    #[test]
+    fn estimate_cost_claude_sonnet() {
+        let (input, output, total) = estimate_cost("claude-sonnet-4-20250514", 1000, 500).unwrap();
+        // 1000 input tokens at $3/M = $0.003
+        assert!((input - 0.003).abs() < 0.0001);
+        // 500 output tokens at $15/M = $0.0075
+        assert!((output - 0.0075).abs() < 0.0001);
+        assert!((total - 0.0105).abs() < 0.0001);
+    }
+
+    #[test]
+    fn estimate_cost_gpt4o() {
+        let (input, output, total) = estimate_cost("gpt-4o", 10_000, 2_000).unwrap();
+        // 10k input at $2.50/M = $0.025
+        assert!((input - 0.025).abs() < 0.001);
+        // 2k output at $10/M = $0.02
+        assert!((output - 0.02).abs() < 0.001);
+        assert!((total - 0.045).abs() < 0.001);
+    }
+
+    #[test]
+    fn estimate_cost_unknown_model() {
+        assert!(estimate_cost("llama-local", 100, 50).is_none());
+    }
+
+    #[test]
+    fn build_response_economics_known_model() {
+        let econ = build_response_economics(
+            "claude-sonnet-4-20250514",
+            1000,
+            500,
+            0,
+            0,
+            Duration::from_millis(800),
+        );
+        assert_eq!(econ.cost_source, CostSource::EstimatedLocalSnapshot);
+        assert_eq!(econ.input_tokens, 1000);
+        assert_eq!(econ.output_tokens, 500);
+        assert_eq!(econ.total_tokens, 1500);
+        assert!(econ.total_cost_usd.is_some());
+        assert!((econ.total_cost_usd.unwrap() - 0.0105).abs() < 0.0001);
+    }
+
+    #[test]
+    fn build_response_economics_unknown_model() {
+        let econ =
+            build_response_economics("local-llama", 100, 50, 0, 0, Duration::from_millis(200));
+        assert_eq!(econ.cost_source, CostSource::EstimatedLocalSnapshot);
+        assert_eq!(econ.input_tokens, 100);
+        assert!(econ.total_cost_usd.is_none());
+    }
+
+    #[test]
+    fn zero_tokens_zero_cost() {
+        let (input, output, total) = estimate_cost("gpt-4o", 0, 0).unwrap();
+        assert!(input.abs() < f64::EPSILON);
+        assert!(output.abs() < f64::EPSILON);
+        assert!(total.abs() < f64::EPSILON);
+    }
+}

--- a/crates/vigil/life-vigil/src/semconv.rs
+++ b/crates/vigil/life-vigil/src/semconv.rs
@@ -122,6 +122,17 @@ pub const LIFE_TOOL_STATUS: &str = "life.tool.status";
 /// Tool execution output (when content capture is enabled).
 pub const LIFE_TOOL_OUTPUT: &str = "life.tool.output";
 
+// ─── Reliability Attributes ─────────────────────────────────────────────────
+
+/// Number of retries before the request succeeded (0 = first attempt).
+pub const LIFE_RETRY_COUNT: &str = "life.reliability.retry_count";
+
+/// Whether a fallback provider was used for this call.
+pub const LIFE_FALLBACK_TRIGGERED: &str = "life.reliability.fallback_triggered";
+
+/// Circuit breaker state at time of call (closed, open, half_open).
+pub const LIFE_CIRCUIT_STATE: &str = "life.reliability.circuit_state";
+
 // ─── Autonomic Attributes ────────────────────────────────────────────────────
 
 /// Autonomic economic mode (sovereign, conserving, hustle, hibernate).

--- a/crates/vigil/life-vigil/src/spans.rs
+++ b/crates/vigil/life-vigil/src/spans.rs
@@ -69,6 +69,10 @@ pub fn chat_span(
         { semconv::GEN_AI_USAGE_OUTPUT_TOKENS } = tracing::field::Empty,
         { semconv::GEN_AI_RESPONSE_FINISH_REASONS } = tracing::field::Empty,
         { semconv::GEN_AI_RESPONSE_ID } = tracing::field::Empty,
+        // Reliability (filled via record_reliability after provider call):
+        { semconv::LIFE_RETRY_COUNT } = tracing::field::Empty,
+        { semconv::LIFE_FALLBACK_TRIGGERED } = tracing::field::Empty,
+        { semconv::LIFE_CIRCUIT_STATE } = tracing::field::Empty,
         // LangSmith thread grouping: session.id on the GenAI span itself.
         "session.id" = session_id,
     )
@@ -132,6 +136,21 @@ pub fn record_completion_content(content: &str) {
         tracing::Level::INFO,
         "gen_ai.completion" = content,
     );
+}
+
+/// Record reliability attributes on a chat span.
+///
+/// Emits retry count, fallback status, and circuit breaker state.
+/// Call after a provider call completes (successful or not).
+pub fn record_reliability(
+    span: &Span,
+    retry_count: u32,
+    fallback_triggered: bool,
+    circuit_state: &str,
+) {
+    span.record(semconv::LIFE_RETRY_COUNT, retry_count);
+    span.record(semconv::LIFE_FALLBACK_TRIGGERED, fallback_triggered);
+    span.record(semconv::LIFE_CIRCUIT_STATE, circuit_state);
 }
 
 /// Emit a `gen_ai.evaluation.result` span event with eval attributes.
@@ -335,6 +354,13 @@ mod tests {
         let span = chat_span("test-model", "test", None, None, "sess-completion");
         let _guard = span.enter();
         record_completion_content("I'm doing well, thanks!");
+    }
+
+    #[test]
+    fn record_reliability_does_not_panic() {
+        ensure_subscriber();
+        let span = chat_span("test-model", "test", None, None, "sess-reliability");
+        record_reliability(&span, 2, true, "half_open");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **BRO-516**: Local pricing model with per-model token costs for Anthropic, OpenAI, and OpenRouter proxy names. `estimate_cost()` and `build_response_economics()` produce USD estimates with `CostSource::EstimatedLocalSnapshot` provenance.
- **BRO-519**: Reliability span attributes (`life.reliability.retry_count`, `fallback_triggered`, `circuit_state`) declared on `chat_span` and recordable via `record_reliability()`.

## Changes
- `life-vigil/src/pricing.rs`: New module — `PRICING_SNAPSHOT`, `lookup_pricing()`, `estimate_cost()`, `build_response_economics()`
- `life-vigil/src/semconv.rs`: +3 reliability constants
- `life-vigil/src/spans.rs`: +reliability fields on chat_span, +`record_reliability()` function
- `life-vigil/src/lib.rs`: register pricing module + re-exports

## Test plan
- [x] `cargo test -p life-vigil` — 49 passed (+10: 9 pricing, 1 reliability)
- [x] `cargo clippy -p life-vigil -p arcan-aios-adapters -p arcan -- -D warnings` — 0 warnings
- [x] `cargo check -p arcan` — binary compiles clean

## Remaining
- BRO-518 (JSONL dual-write) is the last ticket in the series

🤖 Generated with [Claude Code](https://claude.com/claude-code)