### PR TITLE
fix(vigil): emit token usage as span event for LangSmith

### DIFF
--- a/crates/arcan/arcan-aios-adapters/src/provider.rs
+++ b/crates/arcan/arcan-aios-adapters/src/provider.rs
@@ -369,9 +369,18 @@ impl ModelProviderPort for ArcanProviderAdapter {
             total_tokens: usage.total() as u32,
         });
 
-        // Record token usage on the chat span.
+        // Record token usage on the chat span (attributes + event for OTel bridge reliability).
         if let Some(ref usage) = usage {
             life_vigil::spans::record_token_usage(&chat_span, usage);
+            // Also emit as span event — events propagate more reliably through
+            // tracing-opentelemetry → LangSmith than record() on Empty fields.
+            let _enter = chat_span.enter();
+            life_vigil::spans::record_usage_event(
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                &provider_name,
+                reason_str,
+            );
         }
 
         // Record GenAI metrics (token usage + operation duration) on shared instruments.

--- a/crates/vigil/life-vigil/src/spans.rs
+++ b/crates/vigil/life-vigil/src/spans.rs
@@ -89,12 +89,31 @@ pub fn tool_span(tool_name: &str, tool_call_id: &str) -> Span {
     )
 }
 
-/// Record token usage on the current span.
+/// Record token usage on the current span via attributes.
 ///
 /// Sets `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`.
 pub fn record_token_usage(span: &Span, usage: &TokenUsage) {
     span.record(semconv::GEN_AI_USAGE_INPUT_TOKENS, usage.prompt_tokens);
     span.record(semconv::GEN_AI_USAGE_OUTPUT_TOKENS, usage.completion_tokens);
+}
+
+/// Emit a `gen_ai.usage` span event with token counts.
+///
+/// This uses the span event mechanism (which reliably propagates through
+/// `tracing-opentelemetry` → LangSmith) rather than `span.record()` on
+/// Empty fields, which may not be exported by some OTel bridges.
+///
+/// Must be called within an entered span context (the chat span).
+pub fn record_usage_event(input_tokens: u32, output_tokens: u32, model: &str, finish_reason: &str) {
+    tracing::event!(
+        name: "gen_ai.usage",
+        tracing::Level::INFO,
+        "gen_ai.usage.input_tokens" = input_tokens,
+        "gen_ai.usage.output_tokens" = output_tokens,
+        "gen_ai.usage.total_tokens" = input_tokens + output_tokens,
+        "gen_ai.response.model" = model,
+        "gen_ai.response.finish_reasons" = finish_reason,
+    );
 }
 
 /// Record the finish reason on the current span.


### PR DESCRIPTION
## Summary
Smoke test revealed `span.record()` on `tracing::field::Empty` fields doesn't propagate through `tracing-opentelemetry` → LangSmith OTEL. Token counts showed as 0 in LangSmith despite being set on the chat span.

**Fix**: Add `record_usage_event()` that emits a `gen_ai.usage` span event (same reliable mechanism used for input/output content capture). Both approaches (attribute + event) are now used for maximum compatibility.

## Smoke test results (Arcan → Vercel AI Gateway → Claude Haiku 4.5 → LangSmith)
- [x] Span hierarchy: `invoke_agent → tick_on_branch → chat (llm)` — correct
- [x] Thread grouping: `session_id` set from `session.id` attribute
- [x] Input capture: prompt text visible in LangSmith
- [x] Output capture: completion text visible in LangSmith
- [x] Model ID: `ls_model_name: "anthropic/claude-haiku-4.5"`
- [x] Token usage: 16,383 prompt + 8 completion tokens in RunFinished events

## Test plan
- [x] `cargo test -p life-vigil` — 55 passed
- [x] `cargo test -p arcan-aios-adapters` — 85 passed
- [x] `cargo clippy` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token usage observability for AI model completions with more detailed event emission, including input and output token counts and response metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->