### PR TITLE
fix(vigil): record input/output on root agent_span for LangSmith

### DIFF
--- a/crates/arcan/arcand/src/canonical.rs
+++ b/crates/arcan/arcand/src/canonical.rs
@@ -1764,6 +1764,13 @@ async fn run_session(
     const MAX_AGENT_ITERATIONS: u32 = 10;
 
     let agent_span = life_vigil::spans::agent_span(session_id.as_str(), "arcan");
+
+    // Record the user objective as root-level input for LangSmith trace list view.
+    {
+        let _enter = agent_span.enter();
+        life_vigil::spans::record_prompt_content(&request.objective);
+    }
+
     let mut tick_result = state
         .runtime
         .tick_on_branch(
@@ -1823,6 +1830,31 @@ async fn run_session(
     }
 
     let tick = tick_result.map_err(internal_error)?;
+
+    // Record response as root-level output for LangSmith trace list view.
+    // Extract assistant text from session events (same logic as extract_run_context).
+    {
+        if let Ok(events) = state.runtime.read_events(&session_id, 0, 1000).await {
+            let mut output_text = String::new();
+            for record in &events {
+                match &record.kind {
+                    aios_protocol::event::EventKind::TextDelta { delta, .. } => {
+                        output_text.push_str(delta);
+                    }
+                    aios_protocol::event::EventKind::Message { content, role, .. }
+                        if role == "assistant" =>
+                    {
+                        output_text = content.clone();
+                    }
+                    _ => {}
+                }
+            }
+            if !output_text.is_empty() {
+                let _enter = agent_span.enter();
+                life_vigil::spans::record_completion_content(&output_text);
+            }
+        }
+    }
 
     // Evaluate Autonomic context regulation after each run.
     {


### PR DESCRIPTION
## Problem
LangSmith trace list view shows Input/Output columns from the ROOT span only. Our `invoke_agent` root span had no content events, so all columns appeared empty despite child `chat` spans having the data.

## Fix
Emit `gen_ai.content.prompt` (objective) and `gen_ai.content.completion` (response) span events on the root `agent_span` in `canonical.rs`:
- **Before tick**: record user objective as prompt
- **After tick**: extract assistant text from events and record as completion

## Verified
- `cargo clippy -p arcand -p arcan -- -D warnings` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session event tracking and agent response recording for improved observability and monitoring of agent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->