### PR TITLE
feat(lago): add lago wiki CLI subcommands (BRO-603)

### DIFF
--- a/crates/lago/lago-cli/Cargo.toml
+++ b/crates/lago/lago-cli/Cargo.toml
@@ -22,6 +22,7 @@ lago-fs.workspace = true
 lago-ingest.workspace = true
 lago-api.workspace = true
 lago-policy.workspace = true
+lago-knowledge.workspace = true
 lagod = { version = "0.3.0", path = "../lagod" }
 reqwest = { version = "0.12", features = ["json"] }
 urlencoding = "2"

--- a/crates/lago/lago-cli/src/commands/mod.rs
+++ b/crates/lago/lago-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod init;
 pub mod log;
 pub mod serve;
 pub mod session;
+pub mod wiki;

--- a/crates/lago/lago-cli/src/commands/wiki.rs
+++ b/crates/lago/lago-cli/src/commands/wiki.rs
@@ -1,0 +1,309 @@
+//! `lago wiki` subcommands — knowledge substrate operations.
+//!
+//! Operates directly on a directory of `.md` files, building a
+//! `KnowledgeIndex` for search, lint, index generation, and more.
+//! No daemon required — works fully offline.
+
+use std::path::{Path, PathBuf};
+
+use lago_core::ManifestEntry;
+use lago_knowledge::bm25::Bm25Index;
+use lago_knowledge::ingest::{self, IngestConfig};
+use lago_knowledge::{HybridSearchConfig, KnowledgeIndex};
+use lago_store::BlobStore;
+
+/// Build a KnowledgeIndex from all `.md` files in a directory.
+///
+/// Stores content in a temporary BlobStore and constructs the index.
+/// Returns the index and the blob store (kept alive for the index to reference).
+fn build_index_from_dir(
+    wiki_dir: &Path,
+) -> Result<(KnowledgeIndex, BlobStore), Box<dyn std::error::Error>> {
+    let blob_dir = wiki_dir.join(".lago-blobs");
+    std::fs::create_dir_all(&blob_dir)?;
+    let store = BlobStore::open(&blob_dir)?;
+
+    let md_files = collect_md_files(wiki_dir);
+    let mut entries = Vec::new();
+
+    for file in &md_files {
+        let content = std::fs::read(file)?;
+        let hash = store.put(&content)?;
+        let rel_path = file
+            .strip_prefix(wiki_dir)
+            .unwrap_or(file)
+            .to_string_lossy();
+        entries.push(ManifestEntry {
+            path: format!("/{rel_path}"),
+            blob_hash: hash,
+            size_bytes: content.len() as u64,
+            content_type: Some("text/markdown".to_string()),
+            updated_at: file
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        });
+    }
+
+    let index = KnowledgeIndex::build(&entries, &store)?;
+    Ok((index, store))
+}
+
+/// Recursively collect `.md` files, skipping hidden dirs and node_modules.
+fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            if name.starts_with('.') || name == "node_modules" {
+                continue;
+            }
+            if path.is_dir() {
+                files.extend(collect_md_files(&path));
+            } else if path.extension().is_some_and(|e| e == "md") {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+// ── Search ──────────────────────────────────────────────────────────────
+
+pub fn search(
+    wiki_dir: &Path,
+    query: &str,
+    max_results: usize,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (index, _store) = build_index_from_dir(wiki_dir)?;
+    let bm25 = Bm25Index::build(index.notes());
+    let config = HybridSearchConfig {
+        max_results,
+        ..Default::default()
+    };
+
+    let results = index.search_hybrid(query, &bm25, &config);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+    } else if results.is_empty() {
+        println!("No results found for: {query}");
+    } else {
+        for (i, r) in results.iter().enumerate() {
+            println!("{}. **{}** [score: {:.2}]", i + 1, r.name, r.score);
+            println!("   {}", r.path);
+            for excerpt in r.excerpts.iter().take(2) {
+                println!("   > {excerpt}");
+            }
+            if !r.links.is_empty() {
+                println!("   links: {}", r.links.join(", "));
+            }
+            println!();
+        }
+        println!("{} result(s)", results.len());
+    }
+
+    Ok(())
+}
+
+// ── Lint ─────────────────────────────────────────────────────────────────
+
+pub fn lint(wiki_dir: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let (index, _store) = build_index_from_dir(wiki_dir)?;
+    let report = index.lint();
+
+    if json {
+        let json_report = serde_json::json!({
+            "health_score": report.health_score,
+            "orphan_pages": report.orphan_pages,
+            "broken_links": report.broken_links,
+            "contradictions": report.contradictions.iter().map(|c| {
+                serde_json::json!({
+                    "note_a": c.note_a,
+                    "note_b": c.note_b,
+                    "claim_a": c.claim_a,
+                    "claim_b": c.claim_b,
+                    "confidence": c.confidence,
+                })
+            }).collect::<Vec<_>>(),
+            "stale_claims": report.stale_claims,
+            "missing_pages": report.missing_pages,
+            "total_notes": index.len(),
+        });
+        println!("{}", serde_json::to_string_pretty(&json_report)?);
+    } else {
+        println!("## Knowledge Lint Report\n");
+        println!("Health score: **{:.0}%**", report.health_score * 100.0);
+        println!("Total notes: {}\n", index.len());
+
+        if report.orphan_pages.is_empty()
+            && report.broken_links.is_empty()
+            && report.contradictions.is_empty()
+            && report.stale_claims.is_empty()
+            && report.missing_pages.is_empty()
+        {
+            println!("No issues found.");
+            return Ok(());
+        }
+
+        if !report.orphan_pages.is_empty() {
+            println!(
+                "### Orphan Pages ({} notes with no inbound links)",
+                report.orphan_pages.len()
+            );
+            for p in &report.orphan_pages {
+                println!("  - {p}");
+            }
+            println!();
+        }
+
+        if !report.broken_links.is_empty() {
+            println!("### Broken Links ({})", report.broken_links.len());
+            for (source, target) in &report.broken_links {
+                println!("  - {source} → [[{target}]]");
+            }
+            println!();
+        }
+
+        if !report.contradictions.is_empty() {
+            println!("### Contradictions ({})", report.contradictions.len());
+            for c in &report.contradictions {
+                println!(
+                    "  - **{}** vs **{}** (confidence: {:.0}%)",
+                    c.note_a,
+                    c.note_b,
+                    c.confidence * 100.0
+                );
+                println!("    A: {}", c.claim_a);
+                println!("    B: {}", c.claim_b);
+            }
+            println!();
+        }
+
+        if !report.stale_claims.is_empty() {
+            println!("### Stale Claims ({})", report.stale_claims.len());
+            for s in &report.stale_claims {
+                println!("  - {s}");
+            }
+            println!();
+        }
+
+        if !report.missing_pages.is_empty() {
+            println!(
+                "### Missing Pages ({} referenced but not found)",
+                report.missing_pages.len()
+            );
+            for m in &report.missing_pages {
+                println!("  - [[{m}]]");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Index ────────────────────────────────────────────────────────────────
+
+pub fn index(wiki_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let (idx, _store) = build_index_from_dir(wiki_dir)?;
+    let catalog = idx.generate_index();
+    println!("{catalog}");
+    Ok(())
+}
+
+// ── Ingest ───────────────────────────────────────────────────────────────
+
+pub fn ingest_file(path: &Path, verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let config = IngestConfig::default();
+    let cubes = ingest::ingest_file(path, &config)?;
+
+    if cubes.is_empty() {
+        println!("No content extracted from: {}", path.display());
+        return Ok(());
+    }
+
+    println!("Ingested {} MemCubes from: {}", cubes.len(), path.display());
+
+    if verbose {
+        for (i, cube) in cubes.iter().enumerate() {
+            let preview: String = cube.content.chars().take(80).collect();
+            let preview = preview.replace('\n', " ");
+            println!(
+                "  {}. [{}] {} (importance: {:.2}, confidence: {:.2})",
+                i + 1,
+                format!("{:?}", cube.tier).to_lowercase(),
+                preview,
+                cube.importance,
+                cube.confidence,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ── Wake-up ──────────────────────────────────────────────────────────────
+
+pub fn wakeup(wiki_dir: &Path, token_budget: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let (index, _store) = build_index_from_dir(wiki_dir)?;
+
+    // Assemble L0: identity from the index itself
+    let total_notes = index.len();
+    println!("## L0: Knowledge Substrate\n");
+    println!(
+        "Wiki: {} notes indexed from {}\n",
+        total_notes,
+        wiki_dir.display()
+    );
+
+    // Assemble L1: top notes by frontmatter score
+    println!("## L1: Top Entities\n");
+
+    let mut scored_notes: Vec<(&str, &str, i64)> = Vec::new();
+    for note in index.notes().values() {
+        let score = note
+            .frontmatter
+            .get("scoring")
+            .and_then(|s| s.get("raw_score"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let title = note
+            .frontmatter
+            .get("title")
+            .and_then(|v| v.as_str())
+            .or_else(|| note.frontmatter.get("core_claim").and_then(|v| v.as_str()))
+            .unwrap_or(&note.name);
+        scored_notes.push((&note.name, title, score));
+    }
+
+    scored_notes.sort_by(|a, b| b.2.cmp(&a.2));
+
+    let mut tokens_used = 50; // L0 overhead
+    for (name, title, score) in &scored_notes {
+        let line = format!("- {name} | {title} | score: {score}");
+        let est = line.len() / 4;
+        if tokens_used + est > token_budget {
+            break;
+        }
+        println!("{line}");
+        tokens_used += est;
+    }
+
+    // Navigation pointer
+    println!("\n## Navigation\n");
+    println!(
+        "Run `lago wiki index --wiki-dir {}` for full catalog",
+        wiki_dir.display()
+    );
+    println!(
+        "Run `lago wiki search --wiki-dir {} <query>` to find specific topics",
+        wiki_dir.display()
+    );
+
+    Ok(())
+}

--- a/crates/lago/lago-cli/src/main.rs
+++ b/crates/lago/lago-cli/src/main.rs
@@ -115,6 +115,12 @@ enum Commands {
         #[command(subcommand)]
         action: MemoryAction,
     },
+
+    /// Knowledge wiki operations (local, no daemon required)
+    Wiki {
+        #[command(subcommand)]
+        action: WikiAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -226,6 +232,66 @@ enum MemoryAction {
     Delete {
         /// File path in the vault
         path: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum WikiAction {
+    /// Hybrid search (BM25 + graph proximity) across wiki notes
+    Search {
+        /// Search query
+        query: String,
+
+        /// Directory containing .md files
+        #[arg(long, default_value = ".")]
+        wiki_dir: PathBuf,
+
+        /// Maximum results
+        #[arg(long, default_value_t = 10)]
+        max_results: usize,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Lint the knowledge graph for issues
+    Lint {
+        /// Directory containing .md files
+        #[arg(long, default_value = ".")]
+        wiki_dir: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Generate LLM-readable index of all notes
+    Index {
+        /// Directory containing .md files
+        #[arg(long, default_value = ".")]
+        wiki_dir: PathBuf,
+    },
+
+    /// Ingest a document into MemCubes
+    Ingest {
+        /// File to ingest
+        path: PathBuf,
+
+        /// Show detailed output
+        #[arg(long)]
+        verbose: bool,
+    },
+
+    /// Assemble L0+L1 context for session bootstrap
+    WakeUp {
+        /// Directory containing .md files
+        #[arg(long, default_value = ".")]
+        wiki_dir: PathBuf,
+
+        /// Token budget (default 900)
+        #[arg(long, default_value_t = 900)]
+        tokens: usize,
     },
 }
 
@@ -377,6 +443,29 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             )
             .await?;
         }
+
+        Commands::Wiki { action } => match action {
+            WikiAction::Search {
+                query,
+                wiki_dir,
+                max_results,
+                json,
+            } => {
+                commands::wiki::search(&wiki_dir, &query, max_results, json)?;
+            }
+            WikiAction::Lint { wiki_dir, json } => {
+                commands::wiki::lint(&wiki_dir, json)?;
+            }
+            WikiAction::Index { wiki_dir } => {
+                commands::wiki::index(&wiki_dir)?;
+            }
+            WikiAction::Ingest { path, verbose } => {
+                commands::wiki::ingest_file(&path, verbose)?;
+            }
+            WikiAction::WakeUp { wiki_dir, tokens } => {
+                commands::wiki::wakeup(&wiki_dir, tokens)?;
+            }
+        },
 
         Commands::Memory { action } => {
             let base_url = format!("http://127.0.0.1:{api_port}");


### PR DESCRIPTION
## Summary

Wires the lago-knowledge crate capabilities into the existing `lago` CLI as a `wiki` subcommand group. No new binary — extends the existing `lago` CLI.

### Commands

| Command | Description |
|---|---|
| `lago wiki search <query>` | Hybrid search (BM25 + graph proximity) |
| `lago wiki lint` | Health check: orphans, broken links, contradictions, stale claims, missing pages |
| `lago wiki index` | Generate LLM-readable flat catalog |
| `lago wiki ingest <path>` | Ingest document into MemCubes |
| `lago wiki wake-up [--tokens N]` | Assemble L0+L1 session context within token budget |

All commands work offline against local `.md` directories via `--wiki-dir`. No daemon required.

### Tested on real data

- Search: 7 results for "knowledge graph" across 53 entity pages
- Lint: 67% health score, found 47 orphans, 11 broken links, 10 missing pages
- Wake-up: produces context within 500-token budget

## Test plan

- [x] `cargo check -p lago` passes
- [x] `cargo clippy -p lago` — zero warnings
- [x] All commands tested against `research/entities/` (53 real notes)
- [x] Graceful handling of empty directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `lago wiki` command suite for managing offline knowledge bases:
  * `search`: Query Markdown files with result scoring and formatting
  * `lint`: Validate knowledge base integrity and identify issues
  * `index`: Generate comprehensive knowledge base catalog
  * `ingest`: Extract and process file contents
  * `wakeup`: Display high-level knowledge substrate summary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->