### PR TITLE
feat: cognitive stack — Nous knowledge evaluators + Anima knowledge awareness (BRO-605)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "lago-core",
  "lago-fs",
  "lago-journal",
+ "lago-knowledge",
  "lago-policy",
  "lago-store",
  "praxis-core",
@@ -4440,6 +4441,7 @@ dependencies = [
  "lago-fs",
  "lago-ingest",
  "lago-journal",
+ "lago-knowledge",
  "lago-policy",
  "lago-store",
  "lagod",
@@ -5886,9 +5888,14 @@ dependencies = [
 name = "nous-heuristics"
 version = "0.3.0"
 dependencies = [
+ "lago-core",
+ "lago-knowledge",
+ "lago-store",
  "nous-core",
  "serde",
  "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/anima/anima-core/src/belief.rs
+++ b/crates/anima/anima-core/src/belief.rs
@@ -21,6 +21,22 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AnimaError, AnimaResult};
 use crate::policy::PolicyManifest;
 
+/// A detected knowledge gap — a topic the agent needs but does not yet have.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct KnowledgeGap {
+    /// The topic slug (e.g., "rust-async-patterns", "x402-protocol").
+    pub topic: String,
+
+    /// When this gap was first identified.
+    pub identified_at: DateTime<Utc>,
+
+    /// Priority of filling this gap (0.0 = low, 1.0 = critical).
+    pub priority: f64,
+
+    /// What triggered the gap detection (e.g., "tool_call:knowledge:read", "task_failure").
+    pub source: String,
+}
+
 /// The agent's mutable model of its own capabilities, constraints,
 /// trust relationships, and economic situation.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -39,6 +55,15 @@ pub struct AgentBelief {
 
     /// The agent's understanding of its economic situation.
     pub economic_belief: EconomicBelief,
+
+    /// Knowledge relevance scores — which topics matter to this agent's mission.
+    /// Projected from `knowledge.accessed` events. Keys are topic slugs.
+    #[serde(default)]
+    pub knowledge_relevance: HashMap<String, f64>,
+
+    /// Known knowledge gaps — topics the agent needs but doesn't have.
+    #[serde(default)]
+    pub knowledge_gaps: Vec<KnowledgeGap>,
 
     /// Timestamp of the last belief update.
     pub last_updated: DateTime<Utc>,
@@ -204,6 +229,8 @@ impl Default for AgentBelief {
             trust_scores: HashMap::new(),
             reputation: ReputationVector::default(),
             economic_belief: EconomicBelief::default(),
+            knowledge_relevance: HashMap::new(),
+            knowledge_gaps: Vec::new(),
             last_updated: Utc::now(),
             last_event_seq: 0,
         }
@@ -277,6 +304,55 @@ impl AgentBelief {
         for score in self.trust_scores.values_mut() {
             score.decay(now);
         }
+    }
+
+    /// Record that a knowledge topic was accessed, boosting its relevance.
+    ///
+    /// The relevance score is clamped to `[0.0, 1.0]`. Repeated access
+    /// accumulates relevance, modelling the agent's growing expertise.
+    pub fn record_knowledge_access(&mut self, topic: &str, boost: f64) {
+        let entry = self
+            .knowledge_relevance
+            .entry(topic.to_string())
+            .or_insert(0.0);
+        *entry = (*entry + boost).min(1.0);
+        self.last_updated = Utc::now();
+    }
+
+    /// Record a knowledge gap — something the agent needs but lacks.
+    ///
+    /// Duplicate topics are silently ignored (idempotent).
+    pub fn record_knowledge_gap(&mut self, topic: String, priority: f64, source: String) {
+        if !self.knowledge_gaps.iter().any(|g| g.topic == topic) {
+            self.knowledge_gaps.push(KnowledgeGap {
+                topic,
+                identified_at: Utc::now(),
+                priority,
+                source,
+            });
+            self.last_updated = Utc::now();
+        }
+    }
+
+    /// Remove a gap when the knowledge is acquired.
+    pub fn resolve_knowledge_gap(&mut self, topic: &str) {
+        let before = self.knowledge_gaps.len();
+        self.knowledge_gaps.retain(|g| g.topic != topic);
+        if self.knowledge_gaps.len() != before {
+            self.last_updated = Utc::now();
+        }
+    }
+
+    /// Get top-k most relevant knowledge topics, sorted by descending relevance.
+    pub fn top_knowledge_topics(&self, k: usize) -> Vec<(&str, f64)> {
+        let mut sorted: Vec<_> = self
+            .knowledge_relevance
+            .iter()
+            .map(|(t, s)| (t.as_str(), *s))
+            .collect();
+        sorted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.truncate(k);
+        sorted
     }
 
     /// Validate that the entire belief state is consistent with the soul's policy.
@@ -417,5 +493,111 @@ mod tests {
 
         belief.grant_capability(grant, &policy).unwrap();
         assert!(!belief.has_capability("chat:send"));
+    }
+
+    // ── Knowledge awareness tests ──────────────────────────────────────
+
+    #[test]
+    fn serde_roundtrip_with_knowledge_fields() {
+        let mut belief = AgentBelief::default();
+        belief.record_knowledge_access("rust-async", 0.7);
+        belief.record_knowledge_gap("x402-protocol".into(), 0.9, "task_failure".into());
+
+        let json = serde_json::to_string(&belief).unwrap();
+        let deserialized: AgentBelief = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.knowledge_relevance["rust-async"], 0.7);
+        assert_eq!(deserialized.knowledge_gaps.len(), 1);
+        assert_eq!(deserialized.knowledge_gaps[0].topic, "x402-protocol");
+        assert!((deserialized.knowledge_gaps[0].priority - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn backwards_compat_deserialize_without_knowledge_fields() {
+        // Simulate old JSON that lacks the new fields entirely.
+        let old_json = serde_json::json!({
+            "capabilities": [],
+            "constraints": [],
+            "trust_scores": {},
+            "reputation": { "overall": 0.5, "tasks_completed": 0, "tasks_failed": 0, "violations": 0 },
+            "economic_belief": {
+                "balance_micro_credits": 0,
+                "burn_rate_per_hour": 0.0,
+                "hours_until_exhaustion": null,
+                "economic_mode": "sovereign",
+                "session_spend_micro_credits": 0
+            },
+            "last_updated": "2026-01-01T00:00:00Z",
+            "last_event_seq": 42
+        });
+
+        let belief: AgentBelief = serde_json::from_value(old_json).unwrap();
+        assert!(belief.knowledge_relevance.is_empty());
+        assert!(belief.knowledge_gaps.is_empty());
+        assert_eq!(belief.last_event_seq, 42);
+    }
+
+    #[test]
+    fn knowledge_access_boosts_and_clamps() {
+        let mut belief = AgentBelief::default();
+
+        belief.record_knowledge_access("topic-a", 0.3);
+        assert!((belief.knowledge_relevance["topic-a"] - 0.3).abs() < f64::EPSILON);
+
+        belief.record_knowledge_access("topic-a", 0.5);
+        assert!((belief.knowledge_relevance["topic-a"] - 0.8).abs() < f64::EPSILON);
+
+        // Should clamp at 1.0
+        belief.record_knowledge_access("topic-a", 0.5);
+        assert!((belief.knowledge_relevance["topic-a"] - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn knowledge_gap_no_duplicate() {
+        let mut belief = AgentBelief::default();
+
+        belief.record_knowledge_gap("topic-x".into(), 0.8, "source-1".into());
+        belief.record_knowledge_gap("topic-x".into(), 0.9, "source-2".into());
+
+        assert_eq!(belief.knowledge_gaps.len(), 1);
+        // First insertion wins
+        assert_eq!(belief.knowledge_gaps[0].source, "source-1");
+    }
+
+    #[test]
+    fn resolve_knowledge_gap_removes() {
+        let mut belief = AgentBelief::default();
+
+        belief.record_knowledge_gap("gap-a".into(), 0.5, "src".into());
+        belief.record_knowledge_gap("gap-b".into(), 0.7, "src".into());
+        assert_eq!(belief.knowledge_gaps.len(), 2);
+
+        belief.resolve_knowledge_gap("gap-a");
+        assert_eq!(belief.knowledge_gaps.len(), 1);
+        assert_eq!(belief.knowledge_gaps[0].topic, "gap-b");
+
+        // Resolving a non-existent gap is a no-op
+        belief.resolve_knowledge_gap("gap-nonexistent");
+        assert_eq!(belief.knowledge_gaps.len(), 1);
+    }
+
+    #[test]
+    fn top_knowledge_topics_sorts_correctly() {
+        let mut belief = AgentBelief::default();
+
+        belief.record_knowledge_access("low", 0.1);
+        belief.record_knowledge_access("high", 0.9);
+        belief.record_knowledge_access("mid", 0.5);
+
+        let top2 = belief.top_knowledge_topics(2);
+        assert_eq!(top2.len(), 2);
+        assert_eq!(top2[0].0, "high");
+        assert!((top2[0].1 - 0.9).abs() < f64::EPSILON);
+        assert_eq!(top2[1].0, "mid");
+        assert!((top2[1].1 - 0.5).abs() < f64::EPSILON);
+
+        // k larger than entries returns all
+        let all = belief.top_knowledge_topics(100);
+        assert_eq!(all.len(), 3);
     }
 }

--- a/crates/nous/nous-heuristics/Cargo.toml
+++ b/crates/nous/nous-heuristics/Cargo.toml
@@ -9,13 +9,18 @@ repository.workspace = true
 description = "Inline heuristic evaluators for Nous — fast (< 2ms), no I/O"
 
 [dependencies]
+lago-knowledge.workspace = true
 nous-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
+lago-core.workspace = true
+lago-store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/nous/nous-heuristics/src/knowledge.rs
+++ b/crates/nous/nous-heuristics/src/knowledge.rs
@@ -1,0 +1,412 @@
+//! Knowledge quality evaluators.
+//!
+//! Evaluate the freshness, coherence, and coverage of the agent's
+//! knowledge substrate (backed by `lago-knowledge::KnowledgeIndex`).
+//! These run at the `OnRunFinished` hook.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use lago_knowledge::KnowledgeIndex;
+use nous_core::{EvalContext, EvalLayer, EvalScore, EvalTiming, NousEvaluator, NousResult};
+
+// ---------------------------------------------------------------------------
+// KnowledgeFreshnessEvaluator
+// ---------------------------------------------------------------------------
+
+/// Evaluates whether the knowledge index is fresh enough for reliable use.
+///
+/// Score interpretation:
+/// - 1.0: index is fresh (built within `stale_threshold`)
+/// - 0.5: index exists but is stale
+/// - 0.0: index is empty
+pub struct KnowledgeFreshnessEvaluator {
+    index: Arc<RwLock<KnowledgeIndex>>,
+    stale_threshold: Duration,
+}
+
+impl KnowledgeFreshnessEvaluator {
+    /// Create with a custom stale threshold.
+    pub fn new(index: Arc<RwLock<KnowledgeIndex>>, stale_threshold: Duration) -> Self {
+        Self {
+            index,
+            stale_threshold,
+        }
+    }
+
+    /// Create with the default 1-hour stale threshold.
+    pub fn with_defaults(index: Arc<RwLock<KnowledgeIndex>>) -> Self {
+        Self::new(index, Duration::from_secs(3600))
+    }
+}
+
+impl NousEvaluator for KnowledgeFreshnessEvaluator {
+    fn name(&self) -> &str {
+        "knowledge_freshness"
+    }
+
+    fn layer(&self) -> EvalLayer {
+        EvalLayer::Reasoning
+    }
+
+    fn timing(&self) -> EvalTiming {
+        EvalTiming::Inline
+    }
+
+    fn evaluate(&self, ctx: &EvalContext) -> NousResult<Vec<EvalScore>> {
+        let guard = match self.index.read() {
+            Ok(g) => g,
+            Err(_) => {
+                tracing::warn!("knowledge_freshness: failed to acquire read lock");
+                return Ok(vec![]);
+            }
+        };
+
+        if guard.is_empty() {
+            let score = EvalScore::new(
+                self.name(),
+                0.0,
+                self.layer(),
+                self.timing(),
+                &ctx.session_id,
+            )?
+            .with_explanation("Knowledge index is empty (0 notes)".to_string());
+            return Ok(vec![score]);
+        }
+
+        let note_count = guard.len();
+        let is_stale = guard.is_stale(self.stale_threshold);
+        let value = if is_stale { 0.5 } else { 1.0 };
+
+        let freshness_label = if is_stale { "stale" } else { "fresh" };
+        let explanation = format!(
+            "Knowledge index has {note_count} notes, {freshness_label} (threshold: {}s)",
+            self.stale_threshold.as_secs()
+        );
+
+        let score = EvalScore::new(
+            self.name(),
+            value,
+            self.layer(),
+            self.timing(),
+            &ctx.session_id,
+        )?
+        .with_explanation(explanation);
+
+        Ok(vec![score])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KnowledgeCoherenceEvaluator
+// ---------------------------------------------------------------------------
+
+/// Evaluates the structural coherence of the knowledge index via lint.
+///
+/// Score = `report.health_score` (0.0 = many issues, 1.0 = perfect).
+/// Explanation includes contradiction and broken-link counts.
+pub struct KnowledgeCoherenceEvaluator {
+    index: Arc<RwLock<KnowledgeIndex>>,
+}
+
+impl KnowledgeCoherenceEvaluator {
+    pub fn new(index: Arc<RwLock<KnowledgeIndex>>) -> Self {
+        Self { index }
+    }
+}
+
+impl NousEvaluator for KnowledgeCoherenceEvaluator {
+    fn name(&self) -> &str {
+        "knowledge_coherence"
+    }
+
+    fn layer(&self) -> EvalLayer {
+        EvalLayer::Reasoning
+    }
+
+    fn timing(&self) -> EvalTiming {
+        EvalTiming::Inline
+    }
+
+    fn evaluate(&self, ctx: &EvalContext) -> NousResult<Vec<EvalScore>> {
+        let guard = match self.index.read() {
+            Ok(g) => g,
+            Err(_) => {
+                tracing::warn!("knowledge_coherence: failed to acquire read lock");
+                return Ok(vec![]);
+            }
+        };
+
+        let report = guard.lint();
+        let value = report.health_score as f64;
+
+        let explanation = format!(
+            "Lint: {} contradictions, {} broken links, {} orphans, {} stale claims (health {:.2})",
+            report.contradictions.len(),
+            report.broken_links.len(),
+            report.orphan_pages.len(),
+            report.stale_claims.len(),
+            report.health_score
+        );
+
+        let score = EvalScore::new(
+            self.name(),
+            value,
+            self.layer(),
+            self.timing(),
+            &ctx.session_id,
+        )?
+        .with_explanation(explanation);
+
+        Ok(vec![score])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KnowledgeCoverageEvaluator
+// ---------------------------------------------------------------------------
+
+/// Evaluates knowledge coverage: how many referenced concepts have pages.
+///
+/// Score = 1.0 - (missing_pages / (total_notes + missing_pages)).
+/// Explanation lists the top 3 missing pages.
+pub struct KnowledgeCoverageEvaluator {
+    index: Arc<RwLock<KnowledgeIndex>>,
+}
+
+impl KnowledgeCoverageEvaluator {
+    pub fn new(index: Arc<RwLock<KnowledgeIndex>>) -> Self {
+        Self { index }
+    }
+}
+
+impl NousEvaluator for KnowledgeCoverageEvaluator {
+    fn name(&self) -> &str {
+        "knowledge_coverage"
+    }
+
+    fn layer(&self) -> EvalLayer {
+        EvalLayer::Reasoning
+    }
+
+    fn timing(&self) -> EvalTiming {
+        EvalTiming::Inline
+    }
+
+    fn evaluate(&self, ctx: &EvalContext) -> NousResult<Vec<EvalScore>> {
+        let guard = match self.index.read() {
+            Ok(g) => g,
+            Err(_) => {
+                tracing::warn!("knowledge_coverage: failed to acquire read lock");
+                return Ok(vec![]);
+            }
+        };
+
+        let report = guard.lint();
+        let total_notes = guard.len();
+        let missing_count = report.missing_pages.len();
+
+        let denominator = total_notes + missing_count;
+        let value = if denominator == 0 {
+            1.0 // No notes and no missing pages — vacuously covered
+        } else {
+            1.0 - (missing_count as f64 / denominator as f64)
+        };
+
+        let top_missing: Vec<&str> = report
+            .missing_pages
+            .iter()
+            .take(3)
+            .map(String::as_str)
+            .collect();
+
+        let explanation = if top_missing.is_empty() {
+            format!("All {total_notes} referenced concepts have pages")
+        } else {
+            format!(
+                "{missing_count} missing pages out of {denominator} total concepts; top missing: {}",
+                top_missing.join(", ")
+            )
+        };
+
+        let score = EvalScore::new(
+            self.name(),
+            value,
+            self.layer(),
+            self.timing(),
+            &ctx.session_id,
+        )?
+        .with_explanation(explanation);
+
+        Ok(vec![score])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lago_core::ManifestEntry;
+    use lago_store::BlobStore;
+    use tempfile::TempDir;
+
+    /// Helper: build a `KnowledgeIndex` from in-memory files.
+    fn build_index(files: &[(&str, &str)]) -> (TempDir, Arc<RwLock<KnowledgeIndex>>) {
+        let tmp = TempDir::new().unwrap();
+        let store = BlobStore::open(tmp.path()).unwrap();
+        let mut entries = Vec::new();
+
+        for (path, content) in files {
+            let hash = store.put(content.as_bytes()).unwrap();
+            entries.push(ManifestEntry {
+                path: path.to_string(),
+                blob_hash: hash,
+                size_bytes: content.len() as u64,
+                content_type: Some("text/markdown".to_string()),
+                updated_at: 0,
+            });
+        }
+
+        let index = KnowledgeIndex::build(&entries, &store).unwrap();
+        (tmp, Arc::new(RwLock::new(index)))
+    }
+
+    /// Helper: build an empty index.
+    fn build_empty_index() -> (TempDir, Arc<RwLock<KnowledgeIndex>>) {
+        build_index(&[])
+    }
+
+    // --- KnowledgeFreshnessEvaluator tests ---
+
+    #[test]
+    fn freshness_fresh_index_scores_high() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[B]]."),
+            ("/b.md", "# B\n\nSee [[A]]."),
+        ]);
+        let eval = KnowledgeFreshnessEvaluator::with_defaults(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value - 1.0).abs() < f64::EPSILON);
+        assert!(scores[0].explanation.as_ref().unwrap().contains("fresh"));
+    }
+
+    #[test]
+    fn freshness_empty_index_scores_zero() {
+        let (_tmp, index) = build_empty_index();
+        let eval = KnowledgeFreshnessEvaluator::with_defaults(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value).abs() < f64::EPSILON);
+        assert!(scores[0].explanation.as_ref().unwrap().contains("empty"));
+    }
+
+    #[test]
+    fn freshness_stale_index_scores_half() {
+        let (_tmp, index) = build_index(&[("/a.md", "# A")]);
+        // Zero-duration threshold makes any non-empty index immediately stale
+        let eval = KnowledgeFreshnessEvaluator::new(index, Duration::ZERO);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value - 0.5).abs() < f64::EPSILON);
+        assert!(scores[0].explanation.as_ref().unwrap().contains("stale"));
+    }
+
+    // --- KnowledgeCoherenceEvaluator tests ---
+
+    #[test]
+    fn coherence_healthy_vault_scores_high() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[B]]."),
+            ("/b.md", "# B\n\nSee [[A]]."),
+        ]);
+        let eval = KnowledgeCoherenceEvaluator::new(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value - 1.0).abs() < f64::EPSILON);
+        assert!(
+            scores[0]
+                .explanation
+                .as_ref()
+                .unwrap()
+                .contains("0 contradictions")
+        );
+    }
+
+    #[test]
+    fn coherence_broken_vault_scores_low() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[NonExistent]]."),
+            ("/b.md", "# B\n\nIsolated."),
+        ]);
+        let eval = KnowledgeCoherenceEvaluator::new(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!(scores[0].value < 1.0);
+    }
+
+    // --- KnowledgeCoverageEvaluator tests ---
+
+    #[test]
+    fn coverage_full_coverage_scores_high() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[B]]."),
+            ("/b.md", "# B\n\nSee [[A]]."),
+        ]);
+        let eval = KnowledgeCoverageEvaluator::new(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value - 1.0).abs() < f64::EPSILON);
+        assert!(
+            scores[0]
+                .explanation
+                .as_ref()
+                .unwrap()
+                .contains("All 2 referenced concepts have pages")
+        );
+    }
+
+    #[test]
+    fn coverage_missing_pages_scores_low() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[X]] and [[Y]] and [[Z]]."),
+            ("/b.md", "# B\n\nSee [[A]]."),
+        ]);
+        let eval = KnowledgeCoverageEvaluator::new(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        // 2 notes + 3 missing = 5 total; score = 1.0 - 3/5 = 0.4
+        assert!((scores[0].value - 0.4).abs() < f64::EPSILON);
+        assert!(
+            scores[0]
+                .explanation
+                .as_ref()
+                .unwrap()
+                .contains("missing pages")
+        );
+    }
+
+    #[test]
+    fn coverage_empty_index_scores_one() {
+        let (_tmp, index) = build_empty_index();
+        let eval = KnowledgeCoverageEvaluator::new(index);
+        let ctx = EvalContext::new("test");
+
+        let scores = eval.evaluate(&ctx).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0].value - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/nous/nous-heuristics/src/lib.rs
+++ b/crates/nous/nous-heuristics/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod argument_validity;
 pub mod budget_adherence;
+pub mod knowledge;
 pub mod safety_compliance;
 pub mod step_efficiency;
 pub mod token_efficiency;
@@ -12,6 +13,9 @@ pub mod tool_correctness;
 
 pub use argument_validity::ArgumentValidity;
 pub use budget_adherence::BudgetAdherence;
+pub use knowledge::{
+    KnowledgeCoherenceEvaluator, KnowledgeCoverageEvaluator, KnowledgeFreshnessEvaluator,
+};
 pub use safety_compliance::SafetyCompliance;
 pub use step_efficiency::StepEfficiency;
 pub use token_efficiency::TokenEfficiency;


### PR DESCRIPTION
## Summary

Completes the cognitive stack integration: Nous evaluates knowledge quality, Anima tracks knowledge relevance.

### Nous Knowledge Evaluators (nous-heuristics)

Three new evaluators that take `Arc<RwLock<KnowledgeIndex>>` at construction:

| Evaluator | Measures | Score |
|---|---|---|
| `knowledge_freshness` | Is the index stale? | 1.0 (fresh) / 0.5 (stale) / 0.0 (empty) |
| `knowledge_coherence` | Contradictions, broken links, orphans | `lint().health_score` (0.0-1.0) |
| `knowledge_coverage` | Missing pages relative to total | `1.0 - missing / (total + missing)` |

All run on `OnRunFinished` hook, `EvalLayer::Reasoning`, `EvalTiming::Inline`.

### Anima Knowledge Awareness (anima-core)

Extended `AgentBelief` with:
- `knowledge_relevance: HashMap<String, f64>` — topic → relevance score, boosted on access
- `knowledge_gaps: Vec<KnowledgeGap>` — tracked knowledge deficits with priority
- Methods: `record_knowledge_access()`, `record_knowledge_gap()`, `resolve_knowledge_gap()`, `top_knowledge_topics()`

All new fields use `#[serde(default)]` for backwards-compatible deserialization.

### Cognitive Stack

```
Anima (Identity) — who am I, what do I value, what do I know about
Nous (Evaluation) — is my knowledge fresh, coherent, complete
Knowledge (lago-knowledge) — BM25 search, lint, index, assemble
Consciousness (SessionConsciousness) — agent loop + context compiler
```

## Test plan
- [x] 38 tests in nous-heuristics (7 new), all passing
- [x] 57 tests in anima-core (6 new), all passing
- [x] 146 tests in arcan-lago, all passing (no regressions)
- [x] Cross-crate `cargo check` clean
- [x] Backwards-compatible serde (all new fields defaulted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added knowledge relevance tracking for agents to monitor topic importance
  * Introduced knowledge gap identification and management to surface missing information
  * Added three knowledge health evaluators: freshness (detecting stale content), coherence (checking consistency), and coverage (measuring completeness)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->