### PR TITLE
feat(nous): persist eval scores to Lago journal

### DIFF
--- a/crates/nous/nous-heuristics/src/lib.rs
+++ b/crates/nous/nous-heuristics/src/lib.rs
@@ -21,8 +21,9 @@ pub use step_efficiency::StepEfficiency;
 pub use token_efficiency::TokenEfficiency;
 pub use tool_correctness::ToolCorrectness;
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
+use lago_knowledge::KnowledgeIndex;
 use nous_core::{EvalHook, EvaluatorRegistry, NousResult};
 
 /// Build a registry with the default set of inline heuristic evaluators.
@@ -49,9 +50,41 @@ pub fn default_registry() -> NousResult<EvaluatorRegistry> {
     Ok(registry)
 }
 
+/// Build a registry with the default heuristic evaluators plus knowledge evaluators.
+///
+/// Requires a [`KnowledgeIndex`] — call this when `wiki_dir` is configured
+/// and a knowledge index is available. The knowledge evaluators run at
+/// `OnRunFinished` and measure freshness, coherence, and coverage of
+/// the agent's knowledge substrate.
+///
+/// This is the recommended registry for production Arcan instances
+/// that have Lago knowledge integration enabled.
+pub fn registry_with_knowledge(
+    index: Arc<RwLock<KnowledgeIndex>>,
+) -> NousResult<EvaluatorRegistry> {
+    let mut registry = default_registry()?;
+
+    registry.register(
+        EvalHook::OnRunFinished,
+        Arc::new(KnowledgeFreshnessEvaluator::with_defaults(index.clone())),
+    )?;
+    registry.register(
+        EvalHook::OnRunFinished,
+        Arc::new(KnowledgeCoherenceEvaluator::new(index.clone())),
+    )?;
+    registry.register(
+        EvalHook::OnRunFinished,
+        Arc::new(KnowledgeCoverageEvaluator::new(index)),
+    )?;
+
+    Ok(registry)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lago_core::ManifestEntry;
+    use lago_store::BlobStore;
 
     #[test]
     fn default_registry_has_six_evaluators() {
@@ -71,5 +104,57 @@ mod tests {
                 .evaluators_for(EvalHook::BeforeModelCall)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn registry_with_knowledge_has_nine_evaluators() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = BlobStore::open(tmp.path()).unwrap();
+
+        // Build a minimal knowledge index with two linked pages.
+        let content_a = "# A\n\nSee [[B]].";
+        let content_b = "# B\n\nSee [[A]].";
+        let hash_a = store.put(content_a.as_bytes()).unwrap();
+        let hash_b = store.put(content_b.as_bytes()).unwrap();
+
+        let entries = vec![
+            ManifestEntry {
+                path: "/a.md".to_string(),
+                blob_hash: hash_a,
+                size_bytes: content_a.len() as u64,
+                content_type: Some("text/markdown".to_string()),
+                updated_at: 0,
+            },
+            ManifestEntry {
+                path: "/b.md".to_string(),
+                blob_hash: hash_b,
+                size_bytes: content_b.len() as u64,
+                content_type: Some("text/markdown".to_string()),
+                updated_at: 0,
+            },
+        ];
+
+        let index = KnowledgeIndex::build(&entries, &store).unwrap();
+        let index = Arc::new(RwLock::new(index));
+
+        let registry = registry_with_knowledge(index).unwrap();
+        // 6 default + 3 knowledge = 9 total
+        assert_eq!(registry.len(), 9);
+    }
+
+    #[test]
+    fn registry_with_knowledge_adds_to_on_run_finished() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = BlobStore::open(tmp.path()).unwrap();
+        let index = KnowledgeIndex::build(&[], &store).unwrap();
+        let index = Arc::new(RwLock::new(index));
+
+        let registry = registry_with_knowledge(index).unwrap();
+        // default has 2 OnRunFinished + 3 knowledge = 5
+        assert_eq!(registry.evaluators_for(EvalHook::OnRunFinished).len(), 5);
+        // Other hooks unchanged
+        assert_eq!(registry.evaluators_for(EvalHook::AfterModelCall).len(), 2);
+        assert_eq!(registry.evaluators_for(EvalHook::PreToolCall).len(), 1);
+        assert_eq!(registry.evaluators_for(EvalHook::PostToolCall).len(), 1);
     }
 }

--- a/crates/nous/nous-lago/src/lib.rs
+++ b/crates/nous/nous-lago/src/lib.rs
@@ -3,9 +3,12 @@
 //! Follows the same pattern as `autonomic-lago`:
 //! - Publisher: writes `eval.*` events to the Lago journal
 //! - Subscriber: reads `eval.*` events for replay and projection
+//! - ScoreSink: bridges middleware on_score callback to Lago persistence
 
 pub mod publisher;
+pub mod score_sink;
 pub mod subscriber;
 
 pub use publisher::{LivePublisher, NousPublisher};
+pub use score_sink::{ScoreSink, persist_scores};
 pub use subscriber::{EvalProjection, EvalState, NousSubscriber};

--- a/crates/nous/nous-lago/src/score_sink.rs
+++ b/crates/nous/nous-lago/src/score_sink.rs
@@ -1,0 +1,289 @@
+//! Persists Nous evaluation scores as canonical Lago events.
+//!
+//! Each `EvalScore` becomes an `EventKind::Custom` with `"eval."` prefix,
+//! making it visible to Autonomic's projection fold and the entire
+//! control stack.
+//!
+//! The [`ScoreSink`] wraps a [`LivePublisher`] and provides a
+//! `ScoreCallback`-compatible closure via [`ScoreSink::callback()`],
+//! bridging the `NousMiddleware` on_score hook to Lago persistence.
+
+use std::sync::Arc;
+
+use lago_core::journal::Journal;
+use nous_core::score::EvalScore;
+use tokio::runtime::Handle;
+use tracing::warn;
+
+use crate::LivePublisher;
+
+/// Bridge between the `NousMiddleware` score callback and Lago journal persistence.
+///
+/// Wraps a [`LivePublisher`] and provides a synchronous `Fn(&EvalScore)` callback
+/// that can be passed to `NousMiddleware::with_on_score()`. Each score is published
+/// to the Lago journal as an `eval.InlineCompleted` event, making it visible to
+/// Autonomic's projection fold.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// let sink = ScoreSink::new(journal, "session-1", "agent-1");
+/// let middleware = NousMiddleware::with_on_score(registry, sink.callback());
+/// ```
+pub struct ScoreSink {
+    publisher: Arc<LivePublisher>,
+}
+
+impl ScoreSink {
+    /// Create a new score sink backed by a Lago journal.
+    pub fn new(
+        journal: Arc<dyn Journal>,
+        session_id: impl Into<String>,
+        agent_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            publisher: Arc::new(LivePublisher::new(journal, session_id, agent_id)),
+        }
+    }
+
+    /// Create a callback compatible with `NousMiddleware::with_on_score()`.
+    ///
+    /// The returned closure captures an `Arc<LivePublisher>` and a Tokio
+    /// `Handle`. Each invocation spawns a non-blocking task to persist
+    /// the score, so the synchronous evaluator hot path is not blocked.
+    ///
+    /// If no Tokio runtime is available when this method is called,
+    /// the callback will log a warning and drop scores silently.
+    pub fn callback(self) -> Arc<dyn Fn(&EvalScore) + Send + Sync> {
+        let publisher = self.publisher;
+        let handle = Handle::try_current().ok();
+
+        Arc::new(move |score: &EvalScore| {
+            let Some(ref handle) = handle else {
+                warn!("score_sink: no tokio runtime, dropping score");
+                return;
+            };
+
+            let publisher = publisher.clone();
+            let score = score.clone();
+
+            handle.spawn(async move {
+                if let Err(e) = publisher.publish_score(&score).await {
+                    warn!(
+                        evaluator = %score.evaluator,
+                        error = %e,
+                        "score_sink: failed to persist eval score to Lago (non-fatal)"
+                    );
+                }
+            });
+        })
+    }
+}
+
+/// Persist a batch of `EvalScore`s to the Lago journal.
+///
+/// Convenience function for one-shot batch persistence (e.g., from
+/// `NousMiddleware::scores()` after a run completes). Each score is
+/// published individually to preserve per-score metadata and timestamps.
+///
+/// Returns the number of scores successfully persisted.
+pub async fn persist_scores(
+    journal: &Arc<dyn Journal>,
+    session_id: &str,
+    agent_id: &str,
+    scores: &[EvalScore],
+) -> usize {
+    if scores.is_empty() {
+        return 0;
+    }
+
+    let publisher = LivePublisher::new(journal.clone(), session_id, agent_id);
+    let mut persisted = 0;
+
+    for score in scores {
+        match publisher.publish_score(score).await {
+            Ok(seq) => {
+                tracing::debug!(
+                    evaluator = %score.evaluator,
+                    value = score.value,
+                    seq,
+                    "persisted eval score to Lago"
+                );
+                persisted += 1;
+            }
+            Err(e) => {
+                warn!(
+                    evaluator = %score.evaluator,
+                    error = %e,
+                    "failed to persist eval score to Lago"
+                );
+            }
+        }
+    }
+
+    persisted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aios_protocol::event::EventKind;
+    use lago_core::id::{BranchId, SessionId};
+    use lago_core::journal::EventQuery;
+    use lago_journal::RedbJournal;
+    use nous_core::{EvalLayer, EvalTiming};
+
+    fn open_journal(dir: &std::path::Path) -> Arc<dyn Journal> {
+        let db_path = dir.join("test.redb");
+        Arc::new(RedbJournal::open(db_path).unwrap()) as Arc<dyn Journal>
+    }
+
+    #[test]
+    fn score_sink_creates_without_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = open_journal(dir.path());
+        let _sink = ScoreSink::new(journal, "sess-1", "agent-1");
+    }
+
+    #[tokio::test]
+    async fn persist_scores_empty_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = open_journal(dir.path());
+
+        let count = persist_scores(&journal, "sess-1", "agent-1", &[]).await;
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn persist_scores_writes_correct_event_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = open_journal(dir.path());
+
+        let scores = vec![
+            EvalScore::new(
+                "token_efficiency",
+                0.85,
+                EvalLayer::Execution,
+                EvalTiming::Inline,
+                "sess-1",
+            )
+            .unwrap(),
+            EvalScore::new(
+                "tool_correctness",
+                0.5,
+                EvalLayer::Action,
+                EvalTiming::Inline,
+                "sess-1",
+            )
+            .unwrap(),
+        ];
+
+        let count = persist_scores(&journal, "sess-1", "agent-1", &scores).await;
+        assert_eq!(count, 2);
+
+        // Read back events and verify structure.
+        let query = EventQuery::new()
+            .session(SessionId::from_string("sess-1"))
+            .branch(BranchId::from_string("main"));
+        let events = journal.read(query).await.unwrap();
+        assert_eq!(events.len(), 2);
+
+        // First event: token_efficiency
+        if let EventKind::Custom { event_type, data } = &events[0].payload {
+            assert_eq!(event_type, "eval.InlineCompleted");
+            assert_eq!(data["evaluator"], "token_efficiency");
+            assert_eq!(data["score"], 0.85);
+        } else {
+            panic!("expected Custom event kind with eval. prefix");
+        }
+
+        // Second event: tool_correctness
+        if let EventKind::Custom { event_type, data } = &events[1].payload {
+            assert_eq!(event_type, "eval.InlineCompleted");
+            assert_eq!(data["evaluator"], "tool_correctness");
+            assert_eq!(data["score"], 0.5);
+        } else {
+            panic!("expected Custom event kind with eval. prefix");
+        }
+
+        // Verify metadata
+        for event in &events {
+            assert_eq!(event.metadata.get("agent_id").unwrap(), "agent-1");
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_scores_preserves_async_timing() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = open_journal(dir.path());
+
+        // An async-timed score should still become eval.InlineCompleted
+        // because NousPublisher::score_to_event_kind uses from_inline_score
+        // which maps based on the NousEvent variant, not the timing field.
+        let scores = vec![
+            EvalScore::new(
+                "plan_quality",
+                0.7,
+                EvalLayer::Reasoning,
+                EvalTiming::Async,
+                "sess-2",
+            )
+            .unwrap(),
+        ];
+
+        let count = persist_scores(&journal, "sess-2", "agent-1", &scores).await;
+        assert_eq!(count, 1);
+
+        let query = EventQuery::new()
+            .session(SessionId::from_string("sess-2"))
+            .branch(BranchId::from_string("main"));
+        let events = journal.read(query).await.unwrap();
+        assert_eq!(events.len(), 1);
+
+        if let EventKind::Custom { event_type, data } = &events[0].payload {
+            assert!(event_type.starts_with("eval."));
+            assert_eq!(data["evaluator"], "plan_quality");
+            assert_eq!(data["score"], 0.7);
+        } else {
+            panic!("expected Custom event kind");
+        }
+    }
+
+    #[tokio::test]
+    async fn score_sink_callback_persists_via_tokio() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = open_journal(dir.path());
+
+        let sink = ScoreSink::new(journal.clone(), "sess-cb", "agent-cb");
+        let callback = sink.callback();
+
+        let score = EvalScore::new(
+            "safety_compliance",
+            1.0,
+            EvalLayer::Safety,
+            EvalTiming::Inline,
+            "sess-cb",
+        )
+        .unwrap();
+
+        // Invoke the callback (fire-and-forget)
+        callback(&score);
+
+        // Give the spawned task time to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let query = EventQuery::new()
+            .session(SessionId::from_string("sess-cb"))
+            .branch(BranchId::from_string("main"));
+        let events = journal.read(query).await.unwrap();
+        assert_eq!(events.len(), 1);
+
+        if let EventKind::Custom { event_type, data } = &events[0].payload {
+            assert_eq!(event_type, "eval.InlineCompleted");
+            assert_eq!(data["evaluator"], "safety_compliance");
+            assert_eq!(data["score"], 1.0);
+        } else {
+            panic!("expected Custom event kind");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **score_sink module** (`nous-lago`): Adds `ScoreSink` — a bridge that wraps `LivePublisher` and produces a `ScoreCallback`-compatible closure for `NousMiddleware::with_on_score()`. Each score is fire-and-forget published to Lago as `eval.InlineCompleted` events via a Tokio spawn, keeping the evaluator hot path non-blocking.
- **persist_scores helper** (`nous-lago`): Convenience async function for batch-persisting accumulated scores after a run completes (e.g., from `NousMiddleware::scores()`).
- **registry_with_knowledge** (`nous-heuristics`): New public helper that extends `default_registry()` with 3 knowledge evaluators (freshness, coherence, coverage) when a `KnowledgeIndex` is available. Production Arcan instances with wiki_dir configured should use this instead of `default_registry()`.

## Why this matters

Nous eval scores were being logged via tracing and accumulated in memory, but the `NousMiddleware` path had no direct Lago persistence bridge. The `NousToolObserver` in Arcan already persists scores, but middleware users (tests, standalone consumers) had no equivalent. Once scores are Lago events, Autonomic's projection fold automatically sees them via `apply_eval_event()` — no changes needed in Autonomic.

## Test plan

- [x] `cargo clippy -p nous-lago -p nous-heuristics -- -D warnings` — zero warnings
- [x] `cargo test -p nous-lago` — 24 tests pass (5 new in score_sink)
- [x] `cargo test -p nous-heuristics` — 42 tests pass (2 new for registry_with_knowledge)
- [x] Score sink callback test verifies end-to-end: callback -> tokio spawn -> LivePublisher -> redb journal -> read back correct event_type and data
- [x] Batch persist test verifies multiple scores write with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge evaluation capabilities to assess freshness, coherence, and coverage of knowledge bases.
  * Added score persistence functionality to store and track evaluation results in the system journal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->