### PR TITLE
feat(autonomic): add knowledge regression rollback

### DIFF
--- a/crates/arcan/arcan-aios-adapters/src/embedded_autonomic.rs
+++ b/crates/arcan/arcan-aios-adapters/src/embedded_autonomic.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use autonomic_controller::{
-    BudgetExhaustionRule, ContextPressureRule, ErrorStreakRule, SpendVelocityRule, SurvivalRule,
-    TokenExhaustionRule,
+    BudgetExhaustionRule, ContextPressureRule, ErrorStreakRule, KnowledgeHealthRule,
+    KnowledgeRegressionRule, SpendVelocityRule, SurvivalRule, TokenExhaustionRule,
 };
 use autonomic_core::gating::{AutonomicGatingProfile, HomeostaticState};
 use autonomic_core::rules::RuleSet;
@@ -35,7 +35,7 @@ pub struct EmbeddedAutonomicController {
 }
 
 impl EmbeddedAutonomicController {
-    /// Create a new embedded controller with the default 6-rule set.
+    /// Create a new embedded controller with the default rule set.
     pub fn new(economic_handle: EconomicGateHandle) -> Self {
         Self {
             projections: Arc::new(RwLock::new(HashMap::new())),
@@ -104,7 +104,7 @@ impl EmbeddedAutonomicController {
     }
 }
 
-/// Build the default 6-rule set (same as the standalone Autonomic daemon).
+/// Build the default rule set (same core gates as the standalone Autonomic daemon).
 fn default_rules() -> RuleSet {
     let mut rules = RuleSet::new();
     rules.add(Box::new(SurvivalRule));
@@ -113,6 +113,8 @@ fn default_rules() -> RuleSet {
     rules.add(Box::new(ContextPressureRule::default()));
     rules.add(Box::new(TokenExhaustionRule::default()));
     rules.add(Box::new(ErrorStreakRule::default()));
+    rules.add(Box::new(KnowledgeHealthRule::default()));
+    rules.add(Box::new(KnowledgeRegressionRule::default()));
     rules
 }
 

--- a/crates/arcan/arcan-aios-adapters/src/embedded_autonomic.rs
+++ b/crates/arcan/arcan-aios-adapters/src/embedded_autonomic.rs
@@ -13,6 +13,7 @@ use autonomic_controller::{
     BudgetExhaustionRule, ContextPressureRule, ErrorStreakRule, KnowledgeHealthRule,
     KnowledgeRegressionRule, SpendVelocityRule, SurvivalRule, TokenExhaustionRule,
 };
+use autonomic_core::AutonomicEvent;
 use autonomic_core::gating::{AutonomicGatingProfile, HomeostaticState};
 use autonomic_core::rules::RuleSet;
 use lago_core::event::EventPayload;
@@ -62,12 +63,16 @@ impl EmbeddedAutonomicController {
     /// Returns `None` if no projection exists yet (no events seen for this session).
     /// The caller should fall through to the inner gate in that case.
     pub async fn evaluate_gating(&self, session_id: &str) -> Option<AutonomicGatingProfile> {
-        let projections = self.projections.read().await;
-        let state = projections.get(session_id)?;
-        let profile = autonomic_controller::evaluate(state, &self.rules);
+        let state = {
+            let projections = self.projections.read().await;
+            projections.get(session_id).cloned()?
+        };
+        let profile = autonomic_controller::evaluate(&state, &self.rules);
 
         // Update the economic handle for the provider layer.
         self.update_economic_handle(&profile).await;
+        self.acknowledge_advisory_events(session_id, &profile.advisory_events)
+            .await;
 
         Some(profile)
     }
@@ -101,6 +106,24 @@ impl EmbeddedAutonomicController {
 
         let mut handle = self.economic_handle.write().await;
         *handle = Some(gates);
+    }
+
+    async fn acknowledge_advisory_events(&self, session_id: &str, events: &[AutonomicEvent]) {
+        if events.is_empty() {
+            return;
+        }
+
+        let mut projections = self.projections.write().await;
+        let Some(state) = projections.get_mut(session_id) else {
+            return;
+        };
+
+        for event in events {
+            let payload = event.clone().into_event_kind();
+            let seq = state.last_event_seq;
+            let ts_ms = lago_core::event::EventEnvelope::now_micros() / 1_000;
+            *state = autonomic_controller::fold(state.clone(), &payload, seq, ts_ms);
+        }
     }
 }
 
@@ -317,6 +340,46 @@ mod tests {
         // After: handle is populated
         let gates = handle.read().await;
         assert!(gates.is_some());
+    }
+
+    #[tokio::test]
+    async fn knowledge_rollback_advisory_is_acknowledged_once() {
+        let handle: EconomicGateHandle = Arc::new(tokio::sync::RwLock::new(None));
+        let controller = EmbeddedAutonomicController::new(handle);
+
+        {
+            let mut state = HomeostaticState::for_agent("s1");
+            state.cognitive.knowledge_health = 0.62;
+            state.cognitive.knowledge_note_count = 100;
+            state.cognitive.knowledge_promotion.active_version = Some("v2".into());
+            state.cognitive.knowledge_promotion.rollback_target = Some("v1".into());
+            state.cognitive.knowledge_promotion.health_threshold = Some(0.70);
+            state.cognitive.knowledge_promotion.regression_evaluations = 4;
+            state.cognitive.knowledge_promotion.last_regression_score = Some(0.62);
+
+            let mut projections = controller.projections.write().await;
+            projections.insert("s1".into(), state);
+        }
+
+        let first = controller.evaluate_gating("s1").await.unwrap();
+        assert_eq!(first.advisory_events.len(), 1);
+        match &first.advisory_events[0] {
+            AutonomicEvent::RollbackRequested {
+                artifact,
+                rollback_to,
+                ..
+            } => {
+                assert_eq!(artifact, "knowledge_thresholds");
+                assert_eq!(rollback_to, "v1");
+            }
+            other => panic!("expected rollback advisory, got {other:?}"),
+        }
+
+        let state = controller.get_projection("s1").await.unwrap();
+        assert!(state.cognitive.knowledge_promotion.rollback_requested);
+
+        let second = controller.evaluate_gating("s1").await.unwrap();
+        assert!(second.advisory_events.is_empty());
     }
 
     #[tokio::test]

--- a/crates/autonomic/autonomic-api/src/router.rs
+++ b/crates/autonomic/autonomic-api/src/router.rs
@@ -80,13 +80,18 @@ async fn get_gating(
     let homeostatic_state = get_or_bootstrap(&state, &session_id).await;
 
     let profile = evaluate(&homeostatic_state, &state.rules);
-    publish_advisory_events(&state, &session_id, profile.advisory_events.clone()).await;
+    let published_watermark =
+        publish_advisory_events(&state, &session_id, profile.advisory_events.clone()).await;
+    let (last_event_seq, last_event_ms) = published_watermark.unwrap_or((
+        homeostatic_state.last_event_seq,
+        homeostatic_state.last_event_ms,
+    ));
 
     Ok(Json(GatingResponse {
         session_id,
         profile,
-        last_event_seq: homeostatic_state.last_event_seq,
-        last_event_ms: homeostatic_state.last_event_ms,
+        last_event_seq,
+        last_event_ms,
     }))
 }
 
@@ -175,15 +180,20 @@ async fn get_or_bootstrap(state: &AppState, session_id: &str) -> HomeostaticStat
     HomeostaticState::for_agent(session_id)
 }
 
-async fn publish_advisory_events(state: &AppState, session_id: &str, events: Vec<AutonomicEvent>) {
+async fn publish_advisory_events(
+    state: &AppState,
+    session_id: &str,
+    events: Vec<AutonomicEvent>,
+) -> Option<(u64, u64)> {
     if events.is_empty() {
-        return;
+        return None;
     }
 
     let Some(journal) = &state.journal else {
-        return;
+        return None;
     };
 
+    let mut watermark = None;
     for event in events {
         let payload = event.clone().into_event_kind();
         match autonomic_lago::publish_event(journal.clone(), session_id, "main", event).await {
@@ -194,6 +204,7 @@ async fn publish_advisory_events(state: &AppState, session_id: &str, events: Vec
                     .entry(session_id.to_owned())
                     .or_insert_with(|| HomeostaticState::for_agent(session_id));
                 *projected = autonomic_controller::fold(projected.clone(), &payload, seq, ts_ms);
+                watermark = Some((seq, ts_ms));
             }
             Err(error) => {
                 tracing::warn!(
@@ -204,16 +215,27 @@ async fn publish_advisory_events(state: &AppState, session_id: &str, events: Vec
             }
         }
     }
+
+    watermark
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use autonomic_core::rules::RuleSet;
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
+    use autonomic_core::rules::{GatingDecision, HomeostaticRule, RuleSet};
     use axum::body::Body;
     use axum::http::Request;
     use http_body_util::BodyExt;
     use lago_auth::jwt::BroomvaClaims;
+    use lago_core::error::{LagoError, LagoResult};
+    use lago_core::event::EventEnvelope;
+    use lago_core::id::{BranchId, EventId, SeqNo, SessionId};
+    use lago_core::journal::{EventQuery, EventStream, Journal};
+    use lago_core::session::Session;
     use tower::ServiceExt;
 
     const TEST_SECRET: &str = "autonomic-test-secret-32bytes!!";
@@ -248,6 +270,146 @@ mod tests {
     async fn body_json(resp: axum::http::Response<Body>) -> serde_json::Value {
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         serde_json::from_slice(&body).unwrap()
+    }
+
+    #[derive(Clone)]
+    enum AppendBehavior {
+        Success(SeqNo),
+        Failure(&'static str),
+    }
+
+    struct MockJournal {
+        behavior: AppendBehavior,
+        appended: Arc<Mutex<Vec<EventEnvelope>>>,
+    }
+
+    impl MockJournal {
+        fn success(seq: SeqNo) -> Arc<Self> {
+            Arc::new(Self {
+                behavior: AppendBehavior::Success(seq),
+                appended: Arc::new(Mutex::new(Vec::new())),
+            })
+        }
+
+        fn failure(message: &'static str) -> Arc<Self> {
+            Arc::new(Self {
+                behavior: AppendBehavior::Failure(message),
+                appended: Arc::new(Mutex::new(Vec::new())),
+            })
+        }
+    }
+
+    impl Journal for MockJournal {
+        fn append(
+            &self,
+            event: EventEnvelope,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            let behavior = self.behavior.clone();
+            let appended = self.appended.clone();
+            Box::pin(async move {
+                match behavior {
+                    AppendBehavior::Success(seq) => {
+                        appended.lock().unwrap().push(event);
+                        Ok(seq)
+                    }
+                    AppendBehavior::Failure(message) => Err(LagoError::Journal(message.into())),
+                }
+            })
+        }
+
+        fn append_batch(
+            &self,
+            events: Vec<EventEnvelope>,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            let behavior = self.behavior.clone();
+            let appended = self.appended.clone();
+            Box::pin(async move {
+                match behavior {
+                    AppendBehavior::Success(seq) => {
+                        appended.lock().unwrap().extend(events);
+                        Ok(seq)
+                    }
+                    AppendBehavior::Failure(message) => Err(LagoError::Journal(message.into())),
+                }
+            })
+        }
+
+        fn read(
+            &self,
+            _query: EventQuery,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<EventEnvelope>>> + Send + '_>>
+        {
+            let appended = self.appended.clone();
+            Box::pin(async move { Ok(appended.lock().unwrap().clone()) })
+        }
+
+        fn get_event(
+            &self,
+            _event_id: &EventId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<EventEnvelope>>> + Send + '_>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn head_seq(
+            &self,
+            _session_id: &SessionId,
+            _branch_id: &BranchId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            Box::pin(async { Ok(0) })
+        }
+
+        fn stream(
+            &self,
+            _session_id: SessionId,
+            _branch_id: BranchId,
+            _after_seq: SeqNo,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<EventStream>> + Send + '_>>
+        {
+            Box::pin(async { Err(LagoError::Journal("stream unsupported in mock".into())) })
+        }
+
+        fn put_session(
+            &self,
+            _session: Session,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<()>> + Send + '_>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn get_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<Session>>> + Send + '_>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn list_sessions(
+            &self,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<Session>>> + Send + '_>>
+        {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+    }
+
+    struct AdvisoryRule;
+
+    impl HomeostaticRule for AdvisoryRule {
+        fn rule_id(&self) -> &str {
+            "advisory"
+        }
+
+        fn evaluate(&self, _state: &HomeostaticState) -> Option<GatingDecision> {
+            Some(GatingDecision {
+                advisory_events: vec![AutonomicEvent::RollbackRequested {
+                    artifact: "knowledge_thresholds".into(),
+                    rollback_to: "v1".into(),
+                    reason: "regression".into(),
+                }],
+                rationale: "emit advisory".into(),
+                ..GatingDecision::noop(self.rule_id())
+            })
+        }
     }
 
     // --- Health endpoint (always unprotected) ---
@@ -344,6 +506,134 @@ mod tests {
 
         let json = body_json(resp).await;
         assert_eq!(json["session_id"], "test-session");
+    }
+
+    #[tokio::test]
+    async fn gating_returns_fresh_watermark_after_advisory_publish() {
+        let journal = MockJournal::success(42);
+        let mut rules = RuleSet::new();
+        rules.add(Box::new(AdvisoryRule));
+        let projections = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        {
+            let mut state = HomeostaticState::for_agent("sess-rollback");
+            state.cognitive.knowledge_promotion.active_version = Some("v2".into());
+            state.cognitive.knowledge_promotion.rollback_target = Some("v1".into());
+            projections
+                .write()
+                .await
+                .insert("sess-rollback".into(), state);
+        }
+        let state = AppState::with_journal(projections.clone(), rules, journal.clone());
+        let app = build_router_with_auth(state, AuthConfig::disabled());
+
+        let req = Request::builder()
+            .uri("/gating/sess-rollback")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let json = body_json(resp).await;
+        assert_eq!(json["last_event_seq"], 42);
+        assert!(json["last_event_ms"].as_u64().unwrap() > 0);
+        assert_eq!(journal.appended.lock().unwrap().len(), 1);
+
+        let projected = projections.read().await;
+        assert!(
+            projected
+                .get("sess-rollback")
+                .unwrap()
+                .cognitive
+                .knowledge_promotion
+                .rollback_requested
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_advisory_events_updates_projection_on_success() {
+        let journal = MockJournal::success(7);
+        let projections = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        {
+            let mut state = HomeostaticState::for_agent("sess-1");
+            state.cognitive.knowledge_promotion.active_version = Some("v2".into());
+            state.cognitive.knowledge_promotion.rollback_target = Some("v1".into());
+            projections.write().await.insert("sess-1".into(), state);
+        }
+        let state = AppState::with_journal(projections.clone(), RuleSet::new(), journal.clone());
+
+        let watermark = publish_advisory_events(
+            &state,
+            "sess-1",
+            vec![AutonomicEvent::RollbackRequested {
+                artifact: "knowledge_thresholds".into(),
+                rollback_to: "v1".into(),
+                reason: "regression".into(),
+            }],
+        )
+        .await
+        .expect("publish should return watermark");
+
+        assert_eq!(watermark.0, 7);
+        assert!(watermark.1 > 0);
+        assert_eq!(journal.appended.lock().unwrap().len(), 1);
+        let projected = projections.read().await;
+        let promotion = &projected
+            .get("sess-1")
+            .unwrap()
+            .cognitive
+            .knowledge_promotion;
+        assert!(promotion.rollback_requested);
+        assert_eq!(promotion.rollback_target.as_deref(), Some("v1"));
+    }
+
+    #[tokio::test]
+    async fn publish_advisory_events_leaves_projection_unchanged_on_failure() {
+        let journal = MockJournal::failure("disk unavailable");
+        let projections = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        {
+            let mut state = HomeostaticState::for_agent("sess-1");
+            state.last_event_seq = 5;
+            state.cognitive.knowledge_promotion.active_version = Some("v2".into());
+            state.cognitive.knowledge_promotion.rollback_target = Some("v1".into());
+            projections.write().await.insert("sess-1".into(), state);
+        }
+        let state = AppState::with_journal(projections.clone(), RuleSet::new(), journal.clone());
+
+        let watermark = publish_advisory_events(
+            &state,
+            "sess-1",
+            vec![AutonomicEvent::RollbackRequested {
+                artifact: "knowledge_thresholds".into(),
+                rollback_to: "v1".into(),
+                reason: "regression".into(),
+            }],
+        )
+        .await;
+
+        assert!(watermark.is_none());
+        assert!(journal.appended.lock().unwrap().is_empty());
+        let projected = projections.read().await;
+        let session = projected.get("sess-1").unwrap();
+        assert_eq!(session.last_event_seq, 5);
+        assert!(!session.cognitive.knowledge_promotion.rollback_requested);
+    }
+
+    #[tokio::test]
+    async fn publish_advisory_events_noops_without_journal() {
+        let state = test_state();
+        let watermark = publish_advisory_events(
+            &state,
+            "sess-1",
+            vec![AutonomicEvent::RollbackRequested {
+                artifact: "knowledge_thresholds".into(),
+                rollback_to: "v1".into(),
+                reason: "regression".into(),
+            }],
+        )
+        .await;
+
+        assert!(watermark.is_none());
+        assert!(state.projections.read().await.is_empty());
     }
 
     // --- Projection endpoint: auth enabled ---

--- a/crates/autonomic/autonomic-api/src/router.rs
+++ b/crates/autonomic/autonomic-api/src/router.rs
@@ -15,6 +15,7 @@ use serde_json::json;
 use tracing::instrument;
 
 use autonomic_controller::{compute_trust_score, evaluate};
+use autonomic_core::AutonomicEvent;
 use autonomic_core::gating::{AutonomicGatingProfile, HomeostaticState};
 use autonomic_core::trust::TrustScore;
 
@@ -79,6 +80,7 @@ async fn get_gating(
     let homeostatic_state = get_or_bootstrap(&state, &session_id).await;
 
     let profile = evaluate(&homeostatic_state, &state.rules);
+    publish_advisory_events(&state, &session_id, profile.advisory_events.clone()).await;
 
     Ok(Json(GatingResponse {
         session_id,
@@ -171,6 +173,37 @@ async fn get_or_bootstrap(state: &AppState, session_id: &str) -> HomeostaticStat
     }
 
     HomeostaticState::for_agent(session_id)
+}
+
+async fn publish_advisory_events(state: &AppState, session_id: &str, events: Vec<AutonomicEvent>) {
+    if events.is_empty() {
+        return;
+    }
+
+    let Some(journal) = &state.journal else {
+        return;
+    };
+
+    for event in events {
+        let payload = event.clone().into_event_kind();
+        match autonomic_lago::publish_event(journal.clone(), session_id, "main", event).await {
+            Ok(seq) => {
+                let ts_ms = lago_core::event::EventEnvelope::now_micros() / 1_000;
+                let mut projections = state.projections.write().await;
+                let projected = projections
+                    .entry(session_id.to_owned())
+                    .or_insert_with(|| HomeostaticState::for_agent(session_id));
+                *projected = autonomic_controller::fold(projected.clone(), &payload, seq, ts_ms);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %error,
+                    "failed to publish Autonomic advisory event"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/autonomic/autonomic-controller/src/engine.rs
+++ b/crates/autonomic/autonomic-controller/src/engine.rs
@@ -50,9 +50,11 @@ fn merge_decisions(decisions: &[GatingDecision]) -> AutonomicGatingProfile {
     let mut restrict_expensive = false;
     let mut restrict_side_effects = false;
     let mut min_tool_calls: Option<u32> = None;
+    let mut advisory_events = Vec::new();
 
     for d in decisions {
         rationale.push(d.rationale.clone());
+        advisory_events.extend(d.advisory_events.clone());
 
         if let Some(mode) = d.economic_mode
             && economic_mode_severity(mode) > economic_mode_severity(most_restrictive_mode)
@@ -122,6 +124,7 @@ fn merge_decisions(decisions: &[GatingDecision]) -> AutonomicGatingProfile {
     }
 
     profile.rationale = rationale;
+    profile.advisory_events = advisory_events;
     profile
 }
 
@@ -243,6 +246,27 @@ mod tests {
             profile.operational.require_approval_for_risk,
             RiskLevel::Low
         );
+    }
+
+    #[test]
+    fn advisory_events_propagate_to_profile() {
+        let mut rules = RuleSet::new();
+        rules.add(Box::new(MockRule {
+            id: "rollback".into(),
+            decision: Some(GatingDecision {
+                advisory_events: vec![autonomic_core::AutonomicEvent::RollbackRequested {
+                    artifact: "knowledge_thresholds".into(),
+                    rollback_to: "v1".into(),
+                    reason: "regression".into(),
+                }],
+                rationale: "rollback requested".into(),
+                ..GatingDecision::noop("rollback")
+            }),
+        }));
+
+        let state = HomeostaticState::for_agent("test");
+        let profile = evaluate(&state, &rules);
+        assert_eq!(profile.advisory_events.len(), 1);
     }
 
     #[test]

--- a/crates/autonomic/autonomic-controller/src/engine.rs
+++ b/crates/autonomic/autonomic-controller/src/engine.rs
@@ -267,6 +267,18 @@ mod tests {
         let state = HomeostaticState::for_agent("test");
         let profile = evaluate(&state, &rules);
         assert_eq!(profile.advisory_events.len(), 1);
+        match &profile.advisory_events[0] {
+            autonomic_core::AutonomicEvent::RollbackRequested {
+                artifact,
+                rollback_to,
+                reason,
+            } => {
+                assert_eq!(artifact, "knowledge_thresholds");
+                assert_eq!(rollback_to, "v1");
+                assert_eq!(reason, "regression");
+            }
+            other => panic!("expected rollback advisory event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/autonomic/autonomic-controller/src/knowledge_rules.rs
+++ b/crates/autonomic/autonomic-controller/src/knowledge_rules.rs
@@ -381,6 +381,19 @@ mod tests {
     }
 
     #[test]
+    fn regression_rule_restricts_without_advisory_when_rollback_target_missing() {
+        let rule = KnowledgeRegressionRule::default();
+        let mut state = state_with_promotion(4);
+        state.cognitive.knowledge_promotion.rollback_target = None;
+
+        let decision = rule.evaluate(&state).expect("rule should fire");
+
+        assert!(decision.rationale.contains("no rollback target"));
+        assert_eq!(decision.restrict_side_effects, Some(true));
+        assert!(decision.advisory_events.is_empty());
+    }
+
+    #[test]
     fn regression_rule_is_idempotent_after_rollback_requested() {
         let rule = KnowledgeRegressionRule::default();
         let mut state = state_with_promotion(4);

--- a/crates/autonomic/autonomic-controller/src/knowledge_rules.rs
+++ b/crates/autonomic/autonomic-controller/src/knowledge_rules.rs
@@ -3,6 +3,7 @@
 //! Monitors knowledge graph health and memory pressure, producing
 //! advisory signals when the agent's knowledge is degraded.
 
+use autonomic_core::AutonomicEvent;
 use autonomic_core::gating::HomeostaticState;
 use autonomic_core::rules::{GatingDecision, HomeostaticRule};
 
@@ -91,6 +92,87 @@ impl HomeostaticRule for KnowledgeHealthRule {
                 None
             },
             rationale,
+            ..GatingDecision::noop(self.rule_id())
+        })
+    }
+}
+
+/// Rule that requests rollback after sustained post-promotion knowledge regression.
+///
+/// Promotion remains advisory-first: this rule does not mutate configuration.
+/// Instead it emits an `autonomic.RollbackRequested` advisory event that EGRI
+/// can consume and use to restore the previous artifact version.
+pub struct KnowledgeRegressionRule {
+    /// Number of consecutive below-threshold evaluations required before rollback.
+    pub min_regression_evaluations: u32,
+}
+
+impl KnowledgeRegressionRule {
+    pub fn new(min_regression_evaluations: u32) -> Self {
+        Self {
+            min_regression_evaluations,
+        }
+    }
+}
+
+impl Default for KnowledgeRegressionRule {
+    fn default() -> Self {
+        // Spec B requires rollback only after >3 consecutive regressions.
+        Self::new(4)
+    }
+}
+
+impl HomeostaticRule for KnowledgeRegressionRule {
+    fn rule_id(&self) -> &str {
+        "knowledge_regression"
+    }
+
+    fn evaluate(&self, state: &HomeostaticState) -> Option<GatingDecision> {
+        let promotion = &state.cognitive.knowledge_promotion;
+        let version = promotion.active_version.as_ref()?;
+
+        if promotion.rollback_requested
+            || promotion.regression_evaluations < self.min_regression_evaluations
+        {
+            return None;
+        }
+
+        let rollback_to = match &promotion.rollback_target {
+            Some(target) => target.clone(),
+            None => {
+                return Some(GatingDecision {
+                    rule_id: self.rule_id().into(),
+                    rationale: format!(
+                        "post-promotion regression detected for knowledge thresholds {version}, \
+                         but no rollback target is available"
+                    ),
+                    restrict_side_effects: Some(true),
+                    ..GatingDecision::noop(self.rule_id())
+                });
+            }
+        };
+        let threshold = promotion.health_threshold.unwrap_or(0.70);
+        let score = promotion
+            .last_regression_score
+            .unwrap_or(state.cognitive.knowledge_health);
+        let reason = format!(
+            "post-promotion regression detected: knowledge thresholds {version} had {} \
+             consecutive evaluations below {:.0}% health threshold (latest {:.0}%), \
+             requesting rollback to {rollback_to}",
+            promotion.regression_evaluations,
+            threshold * 100.0,
+            score * 100.0
+        );
+
+        Some(GatingDecision {
+            rule_id: self.rule_id().into(),
+            restrict_side_effects: Some(true),
+            rationale: reason.clone(),
+            advisory_events: vec![AutonomicEvent::RollbackRequested {
+                artifact: "knowledge_thresholds".into(),
+                rollback_to,
+                reason,
+            }],
             ..GatingDecision::noop(self.rule_id())
         })
     }
@@ -244,5 +326,65 @@ mod tests {
         // Just above threshold
         let state = state_with_knowledge(0.95, 100, 51, 0, 1_000, 2_000);
         assert!(rule.evaluate(&state).is_some());
+    }
+
+    fn state_with_promotion(regressions: u32) -> HomeostaticState {
+        let mut state = HomeostaticState::for_agent("test");
+        state.cognitive.knowledge_health = 0.62;
+        state.cognitive.knowledge_note_count = 100;
+        state.cognitive.knowledge_promotion.active_version = Some("v2".into());
+        state.cognitive.knowledge_promotion.rollback_target = Some("v1".into());
+        state.cognitive.knowledge_promotion.health_threshold = Some(0.70);
+        state.cognitive.knowledge_promotion.regression_evaluations = regressions;
+        state.cognitive.knowledge_promotion.last_regression_score = Some(0.62);
+        state
+    }
+
+    #[test]
+    fn regression_rule_does_not_fire_before_promotion() {
+        let rule = KnowledgeRegressionRule::default();
+        let state = HomeostaticState::for_agent("test");
+        assert!(rule.evaluate(&state).is_none());
+    }
+
+    #[test]
+    fn regression_rule_waits_for_sustained_regression() {
+        let rule = KnowledgeRegressionRule::default();
+        let state = state_with_promotion(3);
+        assert!(rule.evaluate(&state).is_none());
+    }
+
+    #[test]
+    fn regression_rule_emits_rollback_request() {
+        let rule = KnowledgeRegressionRule::default();
+        let state = state_with_promotion(4);
+        let decision = rule.evaluate(&state).expect("rule should fire");
+
+        assert!(
+            decision
+                .rationale
+                .contains("post-promotion regression detected")
+        );
+        assert_eq!(decision.restrict_side_effects, Some(true));
+        assert_eq!(decision.advisory_events.len(), 1);
+        match &decision.advisory_events[0] {
+            AutonomicEvent::RollbackRequested {
+                artifact,
+                rollback_to,
+                ..
+            } => {
+                assert_eq!(artifact, "knowledge_thresholds");
+                assert_eq!(rollback_to, "v1");
+            }
+            _ => panic!("expected rollback request"),
+        }
+    }
+
+    #[test]
+    fn regression_rule_is_idempotent_after_rollback_requested() {
+        let rule = KnowledgeRegressionRule::default();
+        let mut state = state_with_promotion(4);
+        state.cognitive.knowledge_promotion.rollback_requested = true;
+        assert!(rule.evaluate(&state).is_none());
     }
 }

--- a/crates/autonomic/autonomic-controller/src/lib.rs
+++ b/crates/autonomic/autonomic-controller/src/lib.rs
@@ -22,7 +22,7 @@ pub use cognitive_rules::{ContextPressureRule, TokenExhaustionRule};
 pub use economic_rules::{BudgetExhaustionRule, SpendVelocityRule, SurvivalRule};
 pub use engine::evaluate;
 pub use eval_rules::EvalQualityRule;
-pub use knowledge_rules::KnowledgeHealthRule;
+pub use knowledge_rules::{KnowledgeHealthRule, KnowledgeRegressionRule};
 pub use operational_rules::ErrorStreakRule;
 pub use projection::fold;
 pub use strategy_rules::StrategyRule;

--- a/crates/autonomic/autonomic-controller/src/projection.rs
+++ b/crates/autonomic/autonomic-controller/src/projection.rs
@@ -88,9 +88,7 @@ pub fn fold(
             note_count,
             ..
         } => {
-            state.cognitive.knowledge_health = *health_score;
-            state.cognitive.knowledge_note_count = *note_count;
-            state.cognitive.knowledge_last_indexed_ms = ts_ms;
+            apply_knowledge_health_score(&mut state, *health_score, Some(*note_count), ts_ms);
         }
 
         // ── Text streaming (token tracking) ──
@@ -130,6 +128,8 @@ pub fn fold(
                 apply_strategy_event(&mut state, event_type, ts_ms);
             } else if event_type.starts_with(EVAL_EVENT_PREFIX) {
                 apply_eval_event(&mut state, event_type, data, ts_ms);
+            } else if event_type == EGRI_KNOWLEDGE_PROMOTED_EVENT_TYPE {
+                apply_knowledge_promotion_event(&mut state, data, ts_ms);
             } else if event_type.starts_with(KNOWLEDGE_EVENT_PREFIX) {
                 apply_knowledge_event(&mut state, event_type, data, ts_ms);
             }
@@ -189,6 +189,9 @@ const EVAL_EVENT_PREFIX: &str = "eval.";
 /// Prefix for knowledge events from lago-knowledge.
 const KNOWLEDGE_EVENT_PREFIX: &str = "knowledge.";
 
+/// EGRI promotion event emitted by the Lago Knowledge promotion pipeline.
+const EGRI_KNOWLEDGE_PROMOTED_EVENT_TYPE: &str = "egri.knowledge.promoted";
+
 /// Apply an Autonomic-specific event to state.
 fn apply_autonomic_event(state: &mut HomeostaticState, event: &AutonomicEvent) {
     match event {
@@ -226,6 +229,17 @@ fn apply_autonomic_event(state: &mut HomeostaticState, event: &AutonomicEvent) {
         }
         AutonomicEvent::GatingDecision { .. } => {
             // Informational — no state mutation needed
+        }
+        AutonomicEvent::RollbackRequested {
+            artifact,
+            rollback_to,
+            ..
+        } => {
+            if artifact == "knowledge_thresholds" {
+                state.cognitive.knowledge_promotion.rollback_requested = true;
+                state.cognitive.knowledge_promotion.rollback_target = Some(rollback_to.clone());
+                state.cognitive.knowledge_promotion.rollback_requested_ms = state.last_event_ms;
+            }
         }
     }
 }
@@ -417,7 +431,7 @@ fn apply_knowledge_event(
     state: &mut HomeostaticState,
     event_type: &str,
     data: &serde_json::Value,
-    _ts_ms: u64,
+    ts_ms: u64,
 ) {
     match event_type {
         "knowledge.indexed" => {
@@ -425,14 +439,87 @@ fn apply_knowledge_event(
                 state.cognitive.knowledge_note_count = count as u32;
             }
             if let Some(health) = data.get("health_score").and_then(|v| v.as_f64()) {
-                state.cognitive.knowledge_health = health as f32;
+                apply_knowledge_health_score(state, health as f32, None, ts_ms);
+            } else {
+                state.cognitive.knowledge_last_indexed_ms = ts_ms;
             }
-            state.cognitive.knowledge_last_indexed_ms = state.last_event_ms;
         }
         "knowledge.searched" => {
             state.cognitive.knowledge_search_count += 1;
         }
         _ => {}
+    }
+}
+
+/// Fold an EGRI knowledge-threshold promotion into cognitive regulation state.
+fn apply_knowledge_promotion_event(
+    state: &mut HomeostaticState,
+    data: &serde_json::Value,
+    ts_ms: u64,
+) {
+    let Some(version) = data.get("version").and_then(serde_json::Value::as_str) else {
+        return;
+    };
+
+    let promotion = &mut state.cognitive.knowledge_promotion;
+    promotion.active_version = Some(version.to_owned());
+    promotion.rollback_target = data
+        .get("rollback_target")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    promotion.trial_id = data
+        .get("trial_id")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    promotion.baseline_score = data
+        .get("baseline_score")
+        .and_then(serde_json::Value::as_f64);
+    promotion.promoted_score = data
+        .get("promoted_score")
+        .and_then(serde_json::Value::as_f64);
+    promotion.health_threshold = data
+        .get("artifact")
+        .and_then(|artifact| artifact.get("health_threshold"))
+        .and_then(serde_json::Value::as_f64)
+        .map(|threshold| threshold as f32);
+    promotion.promoted_at_ms = ts_ms;
+    promotion.regression_evaluations = 0;
+    promotion.last_regression_score = None;
+    promotion.last_regression_ms = 0;
+    promotion.rollback_requested = false;
+    promotion.rollback_requested_ms = 0;
+}
+
+/// Update knowledge health and the post-promotion consecutive regression counter.
+fn apply_knowledge_health_score(
+    state: &mut HomeostaticState,
+    health_score: f32,
+    note_count: Option<u32>,
+    ts_ms: u64,
+) {
+    state.cognitive.knowledge_health = health_score;
+    if let Some(note_count) = note_count {
+        state.cognitive.knowledge_note_count = note_count;
+    }
+    state.cognitive.knowledge_last_indexed_ms = ts_ms;
+
+    let promotion = &mut state.cognitive.knowledge_promotion;
+    let Some(threshold) = promotion.health_threshold else {
+        return;
+    };
+
+    if promotion.active_version.is_none() || promotion.rollback_requested {
+        return;
+    }
+
+    if health_score < threshold {
+        promotion.regression_evaluations = promotion.regression_evaluations.saturating_add(1);
+        promotion.last_regression_score = Some(health_score);
+        promotion.last_regression_ms = ts_ms;
+    } else {
+        promotion.regression_evaluations = 0;
+        promotion.last_regression_score = None;
+        promotion.last_regression_ms = 0;
     }
 }
 
@@ -1297,6 +1384,122 @@ mod tests {
         assert_eq!(new_state.cognitive.knowledge_note_count, 64);
         assert!((new_state.cognitive.knowledge_health - 0.82).abs() < f32::EPSILON);
         assert_eq!(new_state.cognitive.knowledge_last_indexed_ms, 6200);
+    }
+
+    fn knowledge_promotion_event(version: &str, rollback_target: Option<&str>) -> EventKind {
+        knowledge_event(
+            "egri.knowledge.promoted",
+            serde_json::json!({
+                "trial_id": "trial-042",
+                "version": version,
+                "rollback_target": rollback_target,
+                "baseline_score": 0.72,
+                "promoted_score": 0.85,
+                "parameters_changed": ["health_threshold"],
+                "artifact": {
+                    "health_threshold": 0.70
+                }
+            }),
+        )
+    }
+
+    #[test]
+    fn fold_egri_knowledge_promotion_tracks_active_version() {
+        let state = default_state();
+        let kind = knowledge_promotion_event("v2", Some("v1"));
+        let new_state = fold(state, &kind, 1, 6300);
+        let promotion = &new_state.cognitive.knowledge_promotion;
+
+        assert_eq!(promotion.active_version.as_deref(), Some("v2"));
+        assert_eq!(promotion.rollback_target.as_deref(), Some("v1"));
+        assert_eq!(promotion.trial_id.as_deref(), Some("trial-042"));
+        assert!((promotion.health_threshold.unwrap() - 0.70).abs() < f32::EPSILON);
+        assert_eq!(promotion.promoted_at_ms, 6300);
+    }
+
+    #[test]
+    fn fold_post_promotion_health_regression_counts_consecutively() {
+        let mut state = default_state();
+        state = fold(state, &knowledge_promotion_event("v2", Some("v1")), 1, 6300);
+
+        for i in 0..3 {
+            state = fold(
+                state,
+                &EventKind::KnowledgeEvaluated {
+                    health_score: 0.62,
+                    note_count: 100,
+                    contradictions: 4,
+                    missing_pages: 2,
+                    orphans: 1,
+                },
+                i + 2,
+                6400 + i * 100,
+            );
+        }
+
+        assert_eq!(
+            state.cognitive.knowledge_promotion.regression_evaluations,
+            3
+        );
+        assert_eq!(
+            state.cognitive.knowledge_promotion.last_regression_score,
+            Some(0.62)
+        );
+
+        state = fold(
+            state,
+            &EventKind::KnowledgeEvaluated {
+                health_score: 0.72,
+                note_count: 100,
+                contradictions: 0,
+                missing_pages: 0,
+                orphans: 0,
+            },
+            5,
+            7000,
+        );
+
+        assert_eq!(
+            state.cognitive.knowledge_promotion.regression_evaluations,
+            0
+        );
+        assert!(
+            state
+                .cognitive
+                .knowledge_promotion
+                .last_regression_score
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn fold_autonomic_rollback_requested_marks_promotion_handled() {
+        let mut state = default_state();
+        state = fold(state, &knowledge_promotion_event("v2", Some("v1")), 1, 6300);
+
+        let event = AutonomicEvent::RollbackRequested {
+            artifact: "knowledge_thresholds".into(),
+            rollback_to: "v1".into(),
+            reason: "post-promotion regression detected".into(),
+        };
+        let new_state = fold(state, &event.into_event_kind(), 2, 7100);
+
+        assert!(new_state.cognitive.knowledge_promotion.rollback_requested);
+        assert_eq!(
+            new_state
+                .cognitive
+                .knowledge_promotion
+                .rollback_target
+                .as_deref(),
+            Some("v1")
+        );
+        assert_eq!(
+            new_state
+                .cognitive
+                .knowledge_promotion
+                .rollback_requested_ms,
+            7100
+        );
     }
 
     #[test]

--- a/crates/autonomic/autonomic-core/src/events.rs
+++ b/crates/autonomic/autonomic-core/src/events.rs
@@ -35,6 +35,12 @@ pub enum AutonomicEvent {
         rationale: Vec<String>,
         economic_mode: EconomicMode,
     },
+    /// A controller detected sustained regression and requests artifact rollback.
+    RollbackRequested {
+        artifact: String,
+        rollback_to: String,
+        reason: String,
+    },
     /// Credits were deposited (revenue, grant, transfer).
     CreditDeposited {
         amount_micro_credits: i64,
@@ -77,6 +83,18 @@ impl AutonomicEvent {
                     "session_id": session_id,
                     "rationale": rationale,
                     "economic_mode": economic_mode,
+                }),
+            ),
+            Self::RollbackRequested {
+                artifact,
+                rollback_to,
+                reason,
+            } => (
+                "autonomic.RollbackRequested",
+                json!({
+                    "artifact": artifact,
+                    "rollback_to": rollback_to,
+                    "reason": reason,
                 }),
             ),
             Self::CreditDeposited {
@@ -137,6 +155,16 @@ impl AutonomicEvent {
                     session_id,
                     rationale,
                     economic_mode,
+                })
+            }
+            "autonomic.RollbackRequested" => {
+                let artifact = data.get("artifact")?.as_str()?.to_owned();
+                let rollback_to = data.get("rollback_to")?.as_str()?.to_owned();
+                let reason = data.get("reason")?.as_str()?.to_owned();
+                Some(Self::RollbackRequested {
+                    artifact,
+                    rollback_to,
+                    reason,
                 })
             }
             "autonomic.CreditDeposited" => {
@@ -237,6 +265,32 @@ mod tests {
                     amount_micro_credits: 5_000_000,
                     ..
                 }
+            ));
+        } else {
+            panic!("expected Custom");
+        }
+    }
+
+    #[test]
+    fn rollback_requested_roundtrip() {
+        let event = AutonomicEvent::RollbackRequested {
+            artifact: "knowledge_thresholds".into(),
+            rollback_to: "v1".into(),
+            reason: "post-promotion regression detected".into(),
+        };
+        let kind = event.into_event_kind();
+        if let EventKind::Custom { event_type, data } = kind {
+            assert_eq!(event_type, "autonomic.RollbackRequested");
+            assert_eq!(data["artifact"], "knowledge_thresholds");
+            assert_eq!(data["rollback_to"], "v1");
+
+            let parsed = AutonomicEvent::from_custom(&event_type, &data).unwrap();
+            assert!(matches!(
+                parsed,
+                AutonomicEvent::RollbackRequested {
+                    rollback_to,
+                    ..
+                } if rollback_to == "v1"
             ));
         } else {
             panic!("expected Custom");

--- a/crates/autonomic/autonomic-core/src/gating.rs
+++ b/crates/autonomic/autonomic-core/src/gating.rs
@@ -8,6 +8,7 @@ use aios_protocol::mode::{GatingProfile, OperatingMode};
 use serde::{Deserialize, Serialize};
 
 use crate::economic::{EconomicMode, EconomicState, ModelTier};
+use crate::events::AutonomicEvent;
 use crate::hysteresis::HysteresisGate;
 
 /// Economic gates — extensions to the canonical `GatingProfile`.
@@ -49,6 +50,9 @@ pub struct AutonomicGatingProfile {
     pub economic: EconomicGates,
     /// Human-readable rationale for why this profile was chosen.
     pub rationale: Vec<String>,
+    /// Advisory events that should be persisted if a controller has a journal.
+    #[serde(default)]
+    pub advisory_events: Vec<AutonomicEvent>,
 }
 
 /// Operational health state — derived from `AgentStateVector` events.
@@ -112,6 +116,9 @@ pub struct CognitiveState {
     pub knowledge_search_count: u32,
     /// Timestamp of last knowledge index build (ms since epoch).
     pub knowledge_last_indexed_ms: u64,
+    /// Active EGRI knowledge promotion and post-promotion regression counters.
+    #[serde(default)]
+    pub knowledge_promotion: KnowledgePromotionState,
 }
 
 impl Default for CognitiveState {
@@ -134,8 +141,42 @@ impl Default for CognitiveState {
             knowledge_note_count: 0,
             knowledge_search_count: 0,
             knowledge_last_indexed_ms: 0,
+            knowledge_promotion: KnowledgePromotionState::default(),
         }
     }
+}
+
+/// Active EGRI knowledge-threshold promotion state.
+///
+/// Populated from `egri.knowledge.promoted` and used by Autonomic to detect
+/// sustained post-promotion knowledge-health regressions before requesting
+/// rollback.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct KnowledgePromotionState {
+    /// Active promoted artifact version, e.g. `v2`.
+    pub active_version: Option<String>,
+    /// Previous artifact version that can be restored.
+    pub rollback_target: Option<String>,
+    /// Trial that produced the active promotion.
+    pub trial_id: Option<String>,
+    /// Baseline score before promotion.
+    pub baseline_score: Option<f64>,
+    /// Score that justified promotion.
+    pub promoted_score: Option<f64>,
+    /// Promoted health threshold for post-promotion monitoring.
+    pub health_threshold: Option<f32>,
+    /// Timestamp when the promotion event was folded.
+    pub promoted_at_ms: u64,
+    /// Consecutive knowledge-health evaluations below the promoted threshold.
+    pub regression_evaluations: u32,
+    /// Most recent regressed health score.
+    pub last_regression_score: Option<f32>,
+    /// Timestamp of the most recent regression.
+    pub last_regression_ms: u64,
+    /// Whether Autonomic has already requested rollback for this promotion.
+    pub rollback_requested: bool,
+    /// Timestamp of the rollback request event, if one has been folded.
+    pub rollback_requested_ms: u64,
 }
 
 /// Strategy event tracking state.
@@ -283,6 +324,7 @@ mod tests {
                 allow_replication: false,
             },
             rationale: vec!["balance low".into(), "reducing spend".into()],
+            advisory_events: Vec::new(),
         };
         let json = serde_json::to_string(&profile).unwrap();
         let back: AutonomicGatingProfile = serde_json::from_str(&json).unwrap();
@@ -366,6 +408,45 @@ mod tests {
         let state = HomeostaticState::for_agent("test");
         assert_eq!(state.eval.inline_eval_count, 0);
         assert!((state.eval.aggregate_quality_score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn knowledge_promotion_state_defaults_to_inactive() {
+        let state = HomeostaticState::for_agent("test");
+        assert!(state.cognitive.knowledge_promotion.active_version.is_none());
+        assert_eq!(
+            state.cognitive.knowledge_promotion.regression_evaluations,
+            0
+        );
+        assert!(!state.cognitive.knowledge_promotion.rollback_requested);
+    }
+
+    #[test]
+    fn cognitive_state_serde_defaults_missing_knowledge_promotion() {
+        let json = r#"{
+            "total_tokens_used": 0,
+            "tokens_remaining": 120000,
+            "context_pressure": 0.0,
+            "turns_completed": 0,
+            "tool_density": 0.0,
+            "turns_since_compact": 0,
+            "dilation_gate": {
+                "threshold_enter": 0.6,
+                "threshold_exit": 0.45,
+                "min_hold_ms": 0,
+                "active": false,
+                "last_transition_ms": 0
+            },
+            "observation_count": 0,
+            "memory_commit_count": 0,
+            "compaction_count": 0,
+            "knowledge_health": 1.0,
+            "knowledge_note_count": 0,
+            "knowledge_search_count": 0,
+            "knowledge_last_indexed_ms": 0
+        }"#;
+        let cog: CognitiveState = serde_json::from_str(json).unwrap();
+        assert!(cog.knowledge_promotion.active_version.is_none());
     }
 
     #[test]

--- a/crates/autonomic/autonomic-core/src/lib.rs
+++ b/crates/autonomic/autonomic-core/src/lib.rs
@@ -21,7 +21,7 @@ pub use error::{AutonomicError, AutonomicResult};
 pub use events::AutonomicEvent;
 pub use gating::{
     AutonomicGatingProfile, BeliefState, CognitiveState, EconomicGates, EvalState,
-    HomeostaticState, OperationalState, StrategyState,
+    HomeostaticState, KnowledgePromotionState, OperationalState, StrategyState,
 };
 pub use hysteresis::HysteresisGate;
 pub use identity::EconomicIdentity;

--- a/crates/autonomic/autonomic-core/src/rules.rs
+++ b/crates/autonomic/autonomic-core/src/rules.rs
@@ -30,6 +30,7 @@ pub struct GatingDecision {
     /// Human-readable rationale.
     pub rationale: String,
     /// Advisory events that a controller may persist after evaluation.
+    #[serde(default)]
     pub advisory_events: Vec<AutonomicEvent>,
 }
 
@@ -161,5 +162,22 @@ mod tests {
         assert_eq!(decision.rule_id, "test");
         assert!(decision.economic_mode.is_none());
         assert!(decision.max_tokens_next_turn.is_none());
+    }
+
+    #[test]
+    fn gating_decision_deserializes_missing_advisory_events_as_empty() {
+        let json = serde_json::json!({
+            "rule_id": "legacy",
+            "economic_mode": null,
+            "max_tokens_next_turn": null,
+            "preferred_model": null,
+            "restrict_expensive_tools": null,
+            "restrict_side_effects": null,
+            "max_tool_calls_per_tick": null,
+            "rationale": "legacy payload"
+        });
+
+        let decision: GatingDecision = serde_json::from_value(json).unwrap();
+        assert!(decision.advisory_events.is_empty());
     }
 }

--- a/crates/autonomic/autonomic-core/src/rules.rs
+++ b/crates/autonomic/autonomic-core/src/rules.rs
@@ -7,6 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::economic::{EconomicMode, ModelTier};
+use crate::events::AutonomicEvent;
 use crate::gating::HomeostaticState;
 
 /// A decision produced by a homeostatic rule.
@@ -28,6 +29,8 @@ pub struct GatingDecision {
     pub max_tool_calls_per_tick: Option<u32>,
     /// Human-readable rationale.
     pub rationale: String,
+    /// Advisory events that a controller may persist after evaluation.
+    pub advisory_events: Vec<AutonomicEvent>,
 }
 
 impl GatingDecision {
@@ -42,6 +45,7 @@ impl GatingDecision {
             restrict_side_effects: None,
             max_tool_calls_per_tick: None,
             rationale: String::new(),
+            advisory_events: Vec::new(),
         }
     }
 }

--- a/crates/autonomic/autonomicd/src/main.rs
+++ b/crates/autonomic/autonomicd/src/main.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use autonomic_api::{AppState, AuthConfig, build_router_with_auth};
 use autonomic_controller::{
     BudgetExhaustionRule, ContextPressureRule, ErrorStreakRule, KnowledgeHealthRule,
-    SpendVelocityRule, StrategyRule, SurvivalRule, TokenExhaustionRule,
+    KnowledgeRegressionRule, SpendVelocityRule, StrategyRule, SurvivalRule, TokenExhaustionRule,
 };
 use autonomic_core::rules::RuleSet;
 use clap::Parser;
@@ -57,6 +57,7 @@ fn build_rule_set(config: &AutonomicConfig) -> RuleSet {
 
     // Knowledge & memory regulation
     rules.add(Box::new(KnowledgeHealthRule::default()));
+    rules.add(Box::new(KnowledgeRegressionRule::default()));
 
     rules
 }

--- a/crates/lago/docs/development-guide.md
+++ b/crates/lago/docs/development-guide.md
@@ -215,6 +215,9 @@ EGRI-approved knowledge threshold artifacts are promoted into the optional
 The writer validates the artifact, preserves unrelated TOML sections, increments
 the promotion `version`, records `rollback_target`, and emits an
 `egri.knowledge.promoted` event payload for audit/replay.
+Autonomic consumes that promotion event, monitors consecutive post-promotion
+knowledge-health regressions, and writes an `autonomic.RollbackRequested`
+advisory event when EGRI should restore the prior threshold artifact.
 See `/Users/broomva/broomva/core/life/docs/STATUS.md` for canonical crate and
 test accounting tied to this capability.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,6 +150,13 @@ Lago substrate provides:
   allowing future Arcan/Nous runtime collectors to attach reasoning, health,
   token, speed, and safety signals without mutating the evaluator or crossing
   the contract-first layering boundary.
+- Autonomic closes the feedback side of that seam without taking ownership of
+  config mutation: its projection folds `egri.knowledge.promoted` into active
+  promotion state, `KnowledgeRegressionRule` detects sustained health
+  regression after promotion, and `autonomic-api` persists a structured
+  `autonomic.RollbackRequested` advisory event to Lago when a journal is
+  configured. EGRI remains responsible for consuming that signal and restoring
+  the prior artifact.
 
 ## 5) Adapter Architecture
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -102,15 +102,18 @@ The baseline unification is active and enforced in production paths:
   `autonomic.RollbackRequested` acknowledgements. `KnowledgeRegressionRule`
   requests rollback after more than three consecutive regressions by attaching
   a structured advisory event to the gating profile; `autonomic-api` persists
-  that advisory event to Lago when a journal is configured and updates the
-  in-memory projection to prevent duplicate rollback requests.
+  that advisory event to Lago when a journal is configured, returns the fresh
+  published watermark in the gating response, and updates the in-memory
+  projection to prevent duplicate rollback requests. Embedded Arcan gating
+  acknowledges the same advisory events locally so rollback requests remain
+  once-only even without the standalone Autonomic API.
 
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Build | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| Tests | PASS (96) | PASS (465+16 w/ spacetimedb) | PASS (332) | PASS (212 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
+| Tests | PASS (96) | PASS (466+16 w/ spacetimedb) | PASS (332) | PASS (218 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
 | Clippy (-D warnings) | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | Canonical Port Usage | ACTIVE | CONSUMED | CONSUMED | CONSUMED | CONSUMED | CROSS-CUTTING | BRIDGED (arcan-spaces) |
 | Production Runtime Path | CANONICAL | CANONICAL HOST | CANONICAL STORE | ADVISORY | TOOL ENGINE | OBSERVABILITY | NETWORKING |
@@ -273,7 +276,7 @@ Current suite validates:
 ### Homeostasis Controller
 
 - Three-pillar regulation: operational, cognitive, economic homeostasis.
-- 5 crates: `autonomic-core` (24 tests), `autonomic-controller` (31 tests), `autonomic-lago` (8 tests), `autonomic-api` (4 tests), `autonomicd` (2 tests).
+- 5 crates: `autonomic-core` (51 tests), `autonomic-controller` (139 tests), `autonomic-lago` (8 tests), `autonomic-api` (18 tests), `autonomicd` (2 tests).
 - Pure rule engine with deterministic projection fold over events.
 - Economic modes: Sovereign, Conserving, Hustle, Hibernate — with hysteresis-gated transitions.
 - Dual-mode advisory architecture:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -95,13 +95,22 @@ The baseline unification is active and enforced in production paths:
   `egri.knowledge.promoted` Lago event payload for audit and future Autonomic
   regression monitoring. Local `cargo test -p lago-knowledge` passes with 139
   tests.
+- 2026-04-10: EGRI calibration rollback monitoring is active in Autonomic.
+  The projection reducer now folds `egri.knowledge.promoted` into typed
+  promotion state, counts consecutive post-promotion knowledge-health
+  regressions against the promoted `health_threshold`, and folds
+  `autonomic.RollbackRequested` acknowledgements. `KnowledgeRegressionRule`
+  requests rollback after more than three consecutive regressions by attaching
+  a structured advisory event to the gating profile; `autonomic-api` persists
+  that advisory event to Lago when a journal is configured and updates the
+  in-memory projection to prevent duplicate rollback requests.
 
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Build | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| Tests | PASS (96) | PASS (465+16 w/ spacetimedb) | PASS (332) | PASS (69) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
+| Tests | PASS (96) | PASS (465+16 w/ spacetimedb) | PASS (332) | PASS (212 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
 | Clippy (-D warnings) | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | Canonical Port Usage | ACTIVE | CONSUMED | CONSUMED | CONSUMED | CONSUMED | CROSS-CUTTING | BRIDGED (arcan-spaces) |
 | Production Runtime Path | CANONICAL | CANONICAL HOST | CANONICAL STORE | ADVISORY | TOOL ENGINE | OBSERVABILITY | NETWORKING |
@@ -223,6 +232,10 @@ Validation gates currently pass:
   composite scoring, evaluator-ready trial execution, and governed promotion to
   the `lago.toml` `[knowledge]` section with versioned rollback metadata plus
   `egri.knowledge.promoted` audit events.
+- Autonomic: EGRI rollback monitoring folds promoted knowledge threshold
+  versions and regression counters, emits durable `autonomic.RollbackRequested`
+  advisories after sustained post-promotion health regression, and marks the
+  active promotion as handled once the rollback request is folded.
 - `lago-auth`: JWT validation (HS256 shared secret), axum auth middleware, user→session mapping (`vault:{user_id}`).
 - `lago-api`: Auth-protected `/v1/memory/*` routes (manifest, file CRUD, search, traverse, note resolution).
 - `lagod`: `LAGO_JWT_SECRET` env var or `[auth]` TOML section. Session map rebuilt on startup. Backward-compatible when no secret set.


### PR DESCRIPTION
## Summary
- fold `egri.knowledge.promoted` into Autonomic promotion state with rollback metadata and promoted health threshold
- count consecutive post-promotion knowledge-health regressions and add `KnowledgeRegressionRule`
- attach structured `autonomic.RollbackRequested` advisory events to gating profiles and persist them through `autonomic-api` when a Lago journal is configured
- wire the regression rule into standalone and embedded Autonomic rule sets
- update architecture/status docs for the EGRI promotion feedback loop

## Validation
- `cargo fmt --all --check`
- `cargo test -p autonomic-core -p autonomic-controller -p autonomic-api -p autonomicd -p arcan-aios-adapters`
- `cargo test -p autonomic-lago`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`

Linear: BRO-623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge regression monitoring detects sustained post-promotion health decline and emits structured rollback advisory events.
  * Advisory publishing updates session state so rollbacks are recorded and not repeatedly suggested.

* **Bug Fixes**
  * Advisory events are now acknowledged so duplicate rollback advisories are avoided.

* **Documentation**
  * Architecture and status docs updated to describe promotion/regression/rollback flow.

* **Tests**
  * Added tests validating advisory emission, publication, acknowledgement, and projection updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->