### PR TITLE
feat(vigil): record LLM OTel metrics

### DIFF
--- a/crates/arcan/arcan-aios-adapters/src/provider.rs
+++ b/crates/arcan/arcan-aios-adapters/src/provider.rs
@@ -420,8 +420,16 @@ impl ModelProviderPort for ArcanProviderAdapter {
                 life_vigil::spans::record_reliability(&chat_span, 0, false, "closed");
                 self.genai_metrics.record_operation_duration(
                     &provider_system,
+                    &model_name,
                     "chat",
+                    "error",
                     call_duration,
+                );
+                self.genai_metrics.record_llm_request(
+                    &provider_system,
+                    &model_name,
+                    "chat",
+                    "error",
                 );
                 let record = llm_call_record(error_envelope, None, Some(error.clone()));
                 write_llm_call_record(self.jsonl_writer.as_ref(), &record);
@@ -441,8 +449,16 @@ impl ModelProviderPort for ArcanProviderAdapter {
                 life_vigil::spans::record_reliability(&chat_span, 0, false, "closed");
                 self.genai_metrics.record_operation_duration(
                     &provider_system,
+                    &model_name,
                     "chat",
+                    "error",
                     call_duration,
+                );
+                self.genai_metrics.record_llm_request(
+                    &provider_system,
+                    &model_name,
+                    "chat",
+                    "error",
                 );
                 let record = llm_call_record(error_envelope, None, Some(error.clone()));
                 write_llm_call_record(self.jsonl_writer.as_ref(), &record);
@@ -554,14 +570,34 @@ impl ModelProviderPort for ArcanProviderAdapter {
         life_vigil::spans::record_reliability(&chat_span, 0, false, "closed");
 
         // Record GenAI metrics (token usage + operation duration) on shared instruments.
+        self.genai_metrics.record_operation_duration(
+            &provider_system,
+            &model_name,
+            "chat",
+            "success",
+            call_duration,
+        );
         self.genai_metrics
-            .record_operation_duration(&provider_system, "chat", call_duration);
+            .record_llm_request(&provider_system, &model_name, "chat", "success");
         if let Some(ref usage) = usage {
             self.genai_metrics.record_token_usage(
                 &provider_system,
+                &model_name,
                 "chat",
                 usage.prompt_tokens as u64,
                 usage.completion_tokens as u64,
+            );
+        }
+        if let Some(cost_usd) = response_economics
+            .as_ref()
+            .and_then(|economics| economics.total_cost_usd)
+        {
+            self.genai_metrics.record_estimated_cost_usd(
+                &provider_system,
+                &model_name,
+                "chat",
+                "direct_provider_handle",
+                cost_usd,
             );
         }
 

--- a/crates/vigil/life-vigil/src/metrics.rs
+++ b/crates/vigil/life-vigil/src/metrics.rs
@@ -19,6 +19,12 @@ pub struct GenAiMetrics {
     /// `gen_ai.client.operation.duration` — histogram of LLM call duration in seconds.
     pub operation_duration: Histogram<f64>,
 
+    /// `vigil.estimated_cost_usd` — cumulative estimated LLM cost in USD.
+    pub estimated_cost_usd: Counter<f64>,
+
+    /// `vigil.requests` — counter of LLM requests by provider/model/status.
+    pub requests: Counter<u64>,
+
     /// `life.tool.executions` — counter of tool executions by name and status.
     pub tool_executions: Counter<u64>,
 
@@ -60,6 +66,17 @@ impl GenAiMetrics {
             .with_boundaries(vec![0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0])
             .build();
 
+        let estimated_cost_usd = meter
+            .f64_counter("vigil.estimated_cost_usd")
+            .with_description("Cumulative estimated LLM cost")
+            .with_unit("USD")
+            .build();
+
+        let requests = meter
+            .u64_counter("vigil.requests")
+            .with_description("Number of LLM provider requests")
+            .build();
+
         let tool_executions = meter
             .u64_counter("life.tool.executions")
             .with_description("Number of tool executions")
@@ -96,6 +113,8 @@ impl GenAiMetrics {
         Self {
             token_usage,
             operation_duration,
+            estimated_cost_usd,
+            requests,
             tool_executions,
             budget_tokens_remaining,
             budget_cost_remaining,
@@ -108,12 +127,14 @@ impl GenAiMetrics {
     /// Record token usage for a GenAI operation.
     pub fn record_token_usage(
         &self,
+        system: &str,
         model: &str,
         operation: &str,
         input_tokens: u64,
         output_tokens: u64,
     ) {
         let base_attrs = [
+            KeyValue::new(semconv::GEN_AI_SYSTEM, system.to_string()),
             KeyValue::new(semconv::GEN_AI_REQUEST_MODEL, model.to_string()),
             KeyValue::new(semconv::GEN_AI_OPERATION_NAME, operation.to_string()),
         ];
@@ -130,12 +151,58 @@ impl GenAiMetrics {
     }
 
     /// Record the duration of a GenAI operation.
-    pub fn record_operation_duration(&self, model: &str, operation: &str, duration: Duration) {
+    pub fn record_operation_duration(
+        &self,
+        system: &str,
+        model: &str,
+        operation: &str,
+        status: &str,
+        duration: Duration,
+    ) {
         self.operation_duration.record(
             duration.as_secs_f64(),
             &[
+                KeyValue::new(semconv::GEN_AI_SYSTEM, system.to_string()),
                 KeyValue::new(semconv::GEN_AI_REQUEST_MODEL, model.to_string()),
                 KeyValue::new(semconv::GEN_AI_OPERATION_NAME, operation.to_string()),
+                KeyValue::new(semconv::VIGIL_STATUS, status.to_string()),
+            ],
+        );
+    }
+
+    /// Record an LLM request outcome.
+    pub fn record_llm_request(&self, system: &str, model: &str, operation: &str, status: &str) {
+        self.requests.add(
+            1,
+            &[
+                KeyValue::new(semconv::GEN_AI_SYSTEM, system.to_string()),
+                KeyValue::new(semconv::GEN_AI_REQUEST_MODEL, model.to_string()),
+                KeyValue::new(semconv::GEN_AI_OPERATION_NAME, operation.to_string()),
+                KeyValue::new(semconv::VIGIL_STATUS, status.to_string()),
+            ],
+        );
+    }
+
+    /// Record estimated LLM cost in USD.
+    pub fn record_estimated_cost_usd(
+        &self,
+        system: &str,
+        model: &str,
+        operation: &str,
+        route: &str,
+        cost_usd: f64,
+    ) {
+        if cost_usd <= 0.0 {
+            return;
+        }
+
+        self.estimated_cost_usd.add(
+            cost_usd,
+            &[
+                KeyValue::new(semconv::GEN_AI_SYSTEM, system.to_string()),
+                KeyValue::new(semconv::GEN_AI_REQUEST_MODEL, model.to_string()),
+                KeyValue::new(semconv::GEN_AI_OPERATION_NAME, operation.to_string()),
+                KeyValue::new(semconv::VIGIL_ROUTE, route.to_string()),
             ],
         );
     }
@@ -189,8 +256,16 @@ mod tests {
         let metrics = GenAiMetrics::new("test-service");
 
         // All instruments should be usable without panicking
-        metrics.record_token_usage("test-model", "chat", 100, 50);
-        metrics.record_operation_duration("test-model", "chat", Duration::from_millis(1500));
+        metrics.record_token_usage("anthropic", "test-model", "chat", 100, 50);
+        metrics.record_operation_duration(
+            "anthropic",
+            "test-model",
+            "chat",
+            "success",
+            Duration::from_millis(1500),
+        );
+        metrics.record_llm_request("anthropic", "test-model", "chat", "success");
+        metrics.record_estimated_cost_usd("anthropic", "test-model", "chat", "direct", 0.01);
         metrics.record_tool_execution("read_file", "ok");
         metrics.record_budget(10000, 4.50);
         metrics.record_mode_transition("explore", "execute");
@@ -200,6 +275,6 @@ mod tests {
     fn create_metrics_from_meter() {
         let meter = global::meter("test");
         let metrics = GenAiMetrics::from_meter(&meter);
-        metrics.record_token_usage("claude", "chat", 200, 100);
+        metrics.record_token_usage("anthropic", "claude", "chat", 200, 100);
     }
 }

--- a/crates/vigil/life-vigil/src/metrics.rs
+++ b/crates/vigil/life-vigil/src/metrics.rs
@@ -192,7 +192,7 @@ impl GenAiMetrics {
         route: &str,
         cost_usd: f64,
     ) {
-        if cost_usd <= 0.0 {
+        if !cost_usd.is_finite() || cost_usd <= 0.0 {
             return;
         }
 

--- a/crates/vigil/life-vigil/src/semconv.rs
+++ b/crates/vigil/life-vigil/src/semconv.rs
@@ -178,6 +178,12 @@ pub const VIGIL_LLM_PII_DETECTED: &str = "vigil.llm.pii_detected";
 /// Whether provider-bound content was redacted.
 pub const VIGIL_LLM_REDACTION_APPLIED: &str = "vigil.llm.redaction_applied";
 
+/// Low-cardinality operation status used for Vigil metrics (success, error).
+pub const VIGIL_STATUS: &str = "vigil.status";
+
+/// Low-cardinality route or policy label used for cost attribution metrics.
+pub const VIGIL_ROUTE: &str = "vigil.route";
+
 // ─── Reliability Attributes ─────────────────────────────────────────────────
 
 /// Number of retries before the request succeeded (0 = first attempt).
@@ -272,6 +278,8 @@ mod tests {
         assert!(VIGIL_LLM_PROVIDER_REQUESTED.starts_with("vigil.llm."));
         assert!(VIGIL_LLM_ESTIMATED_COST_USD.starts_with("vigil.llm."));
         assert!(VIGIL_LLM_POLICY_DECISION.starts_with("vigil.llm."));
+        assert!(VIGIL_STATUS.starts_with("vigil."));
+        assert!(VIGIL_ROUTE.starts_with("vigil."));
     }
 
     #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -376,12 +376,12 @@ Current suite validates:
 - **semconv**: GenAI semantic conventions (`gen_ai.*`), Life attributes (`life.*`), Autonomic attributes (`autonomic.*`), Lago attributes (`lago.*`).
 - **envelope/jsonl/pricing**: typed LLM call envelope, best-effort JSONL dual-write, and local model-pricing snapshot for response-side cost estimation.
 - **spans**: Contract-derived span builders (`agent_span`, `phase_span`, `chat_span`, `tool_span`), knowledge-operation spans (`knowledge.context_build`, `knowledge.search`, `knowledge.lint`), typed LLM envelope attributes, and trace context helpers (`current_trace_context`, `write_trace_context`, `extract_trace_context`).
-- **metrics**: `GenAiMetrics` — OTel instruments for token usage, operation duration, tool executions, budget gauges, mode transitions.
+- **metrics**: `GenAiMetrics` — OTel instruments for token usage, operation duration, LLM request outcomes, estimated cost, tool executions, budget gauges, and mode transitions.
 
 ### Integration Points
 
 - Depends on `aios-protocol` (canonical contract — `EventEnvelope`, `LoopPhase`, `TokenUsage`).
-- Consumed by Arcan provider adapters for chat-span enrichment, local JSONL LLM call artifacts, and serialized cost-envelope persistence through `ModelCompletion`.
+- Consumed by Arcan provider adapters for chat-span enrichment, aggregate GenAI/Vigil metrics, local JSONL LLM call artifacts, and serialized cost-envelope persistence through `ModelCompletion`.
 - Graceful degradation: structured logging via `tracing-subscriber` when no OTLP endpoint is configured.
 
 ### Known Gaps

--- a/docs/control/OBSERVABILITY.md
+++ b/docs/control/OBSERVABILITY.md
@@ -158,10 +158,14 @@ invoke_agent (session)
 |--------|------|-------------|
 | `gen_ai.client.token.usage` | Histogram | Token counts per request (input/output) |
 | `gen_ai.client.operation.duration` | Histogram | LLM call duration (seconds) |
+| `vigil.requests` | Counter | LLM requests by provider, model, operation, and status |
+| `vigil.estimated_cost_usd` | Counter | Cumulative estimated LLM cost by provider, model, operation, and route |
 | `life.tool.executions` | Counter | Tool executions by name and status |
 | `life.budget.tokens_remaining` | Gauge | Remaining token budget |
 | `life.budget.cost_remaining_usd` | Gauge | Remaining cost budget (USD) |
 | `life.mode.transitions` | Counter | Operating mode transitions |
+
+LLM metrics intentionally use only low-cardinality dimensions: `gen_ai.system`, `gen_ai.request.model`, `gen_ai.operation.name`, `vigil.status`, and `vigil.route`. Per-call identifiers remain in spans, JSONL artifacts, and Lago events.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

Closes #554.

This wires the LLM metrics path onto the cost-envelope spine that landed in #689. The provider adapter now records aggregate OTel metrics for successful and failed provider calls without adding high-cardinality request/session identifiers to metric attributes.

## Changes

- Extend `GenAiMetrics` with `vigil.requests` and `vigil.estimated_cost_usd` instruments.
- Add low-cardinality metric dimensions through Vigil semconv constants: `vigil.status` and `vigil.route`.
- Record `gen_ai.client.operation.duration` with provider system, model, operation, and success/error status.
- Record `gen_ai.client.token.usage` with provider system and requested model, not provider-as-model.
- Record `vigil.requests` on success and provider-error paths.
- Record `vigil.estimated_cost_usd` from response economics on successful calls.
- Document the aggregate metric surface and cardinality boundary.

## Validation

- `cargo test -p life-vigil -p arcan-aios-adapters`
- `cargo clippy -p life-vigil -p arcan-aios-adapters --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Notes

Per-call identifiers remain in spans, JSONL records, and Lago events. Metrics only use low-cardinality aggregate dimensions: provider system, model, operation, status, and route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now record LLM request counts segmented by provider, model, operation, and status.
  * Operation durations and token-usage metrics are model-aware and include success/error outcomes.
  * Added estimated cost tracking for LLM operations (provider, model, operation, route).

* **Documentation**
  * Updated observability docs to describe new request/count, cost, and low-cardinality attribute constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->