### PR TITLE
feat(memory): add bounded memory graph retrieval

### DIFF
--- a/crates/arcan/arcan-lago/src/lib.rs
+++ b/crates/arcan/arcan-lago/src/lib.rs
@@ -5,6 +5,7 @@ pub mod knowledge_context;
 pub mod knowledge_events;
 pub mod knowledge_tools;
 pub mod learning;
+pub mod memory_graph;
 pub mod memory_projection;
 pub mod memory_scope;
 pub mod memory_tools;
@@ -32,6 +33,11 @@ pub use knowledge_tools::{WikiLintTool, WikiSearchTool};
 pub use arcan_core::runtime::{ApprovalGateHook, ApprovalResolver};
 pub use ephemeral::{EphemeralJournal, SessionJournalSelector};
 pub use learning::{LearningEntry, LearningMiddleware};
+pub use memory_graph::{
+    DEFAULT_GRAPH_DEPTH, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES, MemoryGraphEdge, MemoryGraphError,
+    MemoryGraphNode, MemoryGraphQuery, MemoryGraphResponse, memory_graph_from_dir,
+    memory_graph_from_index,
+};
 pub use memory_projection::MemoryProjection;
 pub use memory_scope::{MemoryEntry, MemoryScopeConfig};
 pub use memory_tools::{MemoryCommitTool, MemoryProposeTool, MemoryQueryTool};

--- a/crates/arcan/arcan-lago/src/memory_graph.rs
+++ b/crates/arcan/arcan-lago/src/memory_graph.rs
@@ -4,7 +4,7 @@
 //! shapes Lago traversal primitives into compact, provenance-preserving payloads
 //! that Arcan can expose as an agent tool.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use lago_knowledge::{KnowledgeError, KnowledgeIndex};
@@ -128,8 +128,23 @@ pub fn memory_graph_from_index(
         0
     };
 
-    let traversal = index.traverse(&start_note.path, effective_depth, query.max_nodes);
+    let mut traversal = index.traverse(
+        &start_note.path,
+        effective_depth,
+        query.max_nodes.saturating_add(1),
+    );
+    let nodes_overflowed = traversal.len() > query.max_nodes;
+    traversal.truncate(query.max_nodes);
+
     let returned_paths: HashSet<&str> = traversal.iter().map(|node| node.path.as_str()).collect();
+
+    let graph_edges = if query.includes_references() {
+        graph_edges(index, &traversal, &returned_paths, query.max_edges)
+    } else {
+        GraphEdges::default()
+    };
+    let edges_overflowed = graph_edges.overflowed;
+    let mut outgoing_links_by_source = graph_edges.outgoing_links_by_source;
 
     let nodes = traversal
         .iter()
@@ -141,26 +156,22 @@ pub fn memory_graph_from_index(
                 summary: note_summary(note),
                 source_ref: note.path.clone(),
                 depth: node.depth,
-                outgoing_links: note.links.clone(),
+                outgoing_links: outgoing_links_by_source
+                    .remove(&note.path)
+                    .unwrap_or_default(),
             })
         })
         .collect::<Vec<_>>();
 
-    let edges = if query.includes_references() {
-        graph_edges(index, &traversal, &returned_paths, query.max_edges)
-    } else {
-        Vec::new()
-    };
-
-    let truncated = nodes.len() == query.max_nodes || edges.len() == query.max_edges;
+    let truncated = nodes_overflowed || edges_overflowed;
     Ok(MemoryGraphResponse {
         found: true,
         start: query.start,
         root: Some(start_note.path.clone()),
         total_nodes: nodes.len(),
-        total_edges: edges.len(),
+        total_edges: graph_edges.edges.len(),
         nodes,
-        edges,
+        edges: graph_edges.edges,
         truncated,
         depth: effective_depth,
         max_nodes: query.max_nodes,
@@ -173,14 +184,23 @@ pub fn memory_graph_from_index(
     })
 }
 
+#[derive(Debug, Default)]
+struct GraphEdges {
+    edges: Vec<MemoryGraphEdge>,
+    outgoing_links_by_source: HashMap<String, Vec<String>>,
+    overflowed: bool,
+}
+
 fn graph_edges(
     index: &KnowledgeIndex,
     traversal: &[lago_knowledge::TraversalResult],
     returned_paths: &HashSet<&str>,
     max_edges: usize,
-) -> Vec<MemoryGraphEdge> {
+) -> GraphEdges {
     let mut edges = Vec::new();
+    let mut outgoing_links_by_source: HashMap<String, Vec<String>> = HashMap::new();
     let mut seen = HashSet::new();
+    let mut overflowed = false;
 
     for source in traversal {
         let Some(note) = index.get_note(&source.path) else {
@@ -188,9 +208,6 @@ fn graph_edges(
         };
 
         for link in &note.links {
-            if edges.len() >= max_edges {
-                return edges;
-            }
             let Some(target) = index.resolve_note_ref(link) else {
                 continue;
             };
@@ -202,6 +219,11 @@ fn graph_edges(
                 continue;
             }
 
+            if edges.len() >= max_edges {
+                overflowed = true;
+                continue;
+            }
+
             edges.push(MemoryGraphEdge {
                 source: note.path.clone(),
                 target: target.path.clone(),
@@ -209,10 +231,18 @@ fn graph_edges(
                 label: link.clone(),
                 source_ref: note.path.clone(),
             });
+            outgoing_links_by_source
+                .entry(note.path.clone())
+                .or_default()
+                .push(link.clone());
         }
     }
 
-    edges
+    GraphEdges {
+        edges,
+        outgoing_links_by_source,
+        overflowed,
+    }
 }
 
 fn note_title(note: &lago_knowledge::Note) -> String {
@@ -337,6 +367,7 @@ mod tests {
         assert_eq!(graph.edges.len(), 2);
         assert_eq!(graph.nodes[0].node_type, "decision");
         assert_eq!(graph.nodes[0].source_ref, "/decision.md");
+        assert_eq!(graph.nodes[0].outgoing_links, vec!["Evidence"]);
     }
 
     #[test]
@@ -376,6 +407,29 @@ mod tests {
         assert_eq!(graph.nodes.len(), 2);
         assert_eq!(graph.edges.len(), 1);
         assert!(graph.truncated);
+        assert_eq!(graph.nodes[0].outgoing_links, vec!["B"]);
+    }
+
+    #[test]
+    fn graph_does_not_report_truncated_when_result_exactly_matches_limits() {
+        let (_tmp, index) =
+            build_index(&[("/a.md", "# A\n\nSee [[B]]."), ("/b.md", "# B\n\nEnd.")]);
+
+        let graph = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "A".into(),
+                depth: 1,
+                max_nodes: 2,
+                max_edges: 1,
+                edge_types: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 1);
+        assert!(!graph.truncated);
     }
 
     #[test]

--- a/crates/arcan/arcan-lago/src/memory_graph.rs
+++ b/crates/arcan/arcan-lago/src/memory_graph.rs
@@ -1,0 +1,408 @@
+//! Bounded memory graph retrieval over `lago-knowledge`.
+//!
+//! The graph is a derived view over markdown memory artifacts. This adapter
+//! shapes Lago traversal primitives into compact, provenance-preserving payloads
+//! that Arcan can expose as an agent tool.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use lago_knowledge::{KnowledgeError, KnowledgeIndex};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::build_index_from_dir;
+
+pub const DEFAULT_GRAPH_DEPTH: usize = 2;
+pub const DEFAULT_MAX_NODES: usize = 12;
+pub const DEFAULT_MAX_EDGES: usize = 16;
+pub const MAX_GRAPH_DEPTH: usize = 4;
+pub const MAX_GRAPH_NODES: usize = 50;
+pub const MAX_GRAPH_EDGES: usize = 100;
+
+/// Query parameters for bounded memory graph retrieval.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryGraphQuery {
+    pub start: String,
+    pub depth: usize,
+    pub max_nodes: usize,
+    pub max_edges: usize,
+    pub edge_types: Vec<String>,
+}
+
+impl MemoryGraphQuery {
+    pub fn new(start: impl Into<String>) -> Self {
+        Self {
+            start: start.into(),
+            depth: DEFAULT_GRAPH_DEPTH,
+            max_nodes: DEFAULT_MAX_NODES,
+            max_edges: DEFAULT_MAX_EDGES,
+            edge_types: Vec::new(),
+        }
+    }
+
+    pub fn bounded(mut self) -> Self {
+        self.depth = self.depth.min(MAX_GRAPH_DEPTH);
+        self.max_nodes = self.max_nodes.clamp(1, MAX_GRAPH_NODES);
+        self.max_edges = self.max_edges.min(MAX_GRAPH_EDGES);
+        self.edge_types = self
+            .edge_types
+            .into_iter()
+            .map(|edge| edge.trim().to_lowercase())
+            .filter(|edge| !edge.is_empty())
+            .collect();
+        self
+    }
+
+    fn includes_references(&self) -> bool {
+        self.edge_types.is_empty() || self.edge_types.iter().any(|edge| edge == "references")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryGraphNode {
+    pub node_id: String,
+    pub node_type: String,
+    pub title: String,
+    pub summary: String,
+    pub source_ref: String,
+    pub depth: usize,
+    pub outgoing_links: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryGraphEdge {
+    pub source: String,
+    pub target: String,
+    pub edge_type: String,
+    pub label: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryGraphResponse {
+    pub found: bool,
+    pub start: String,
+    pub root: Option<String>,
+    pub nodes: Vec<MemoryGraphNode>,
+    pub edges: Vec<MemoryGraphEdge>,
+    pub total_nodes: usize,
+    pub total_edges: usize,
+    pub truncated: bool,
+    pub depth: usize,
+    pub max_nodes: usize,
+    pub max_edges: usize,
+    pub edge_filter: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum MemoryGraphError {
+    #[error("failed to build knowledge index: {0}")]
+    Index(#[from] KnowledgeError),
+    #[error("memory graph start node not found: {0}")]
+    StartNodeNotFound(String),
+}
+
+/// Build a graph response from markdown files in `memory_dir`.
+pub fn memory_graph_from_dir(
+    memory_dir: &Path,
+    query: MemoryGraphQuery,
+) -> Result<MemoryGraphResponse, MemoryGraphError> {
+    let (index, _store) = build_index_from_dir(memory_dir)?;
+    memory_graph_from_index(&index, query)
+}
+
+/// Build a graph response from an already-built knowledge index.
+pub fn memory_graph_from_index(
+    index: &KnowledgeIndex,
+    query: MemoryGraphQuery,
+) -> Result<MemoryGraphResponse, MemoryGraphError> {
+    let query = query.bounded();
+    let Some(start_note) = index.resolve_note_ref(&query.start) else {
+        return Err(MemoryGraphError::StartNodeNotFound(query.start));
+    };
+
+    let effective_depth = if query.includes_references() {
+        query.depth
+    } else {
+        0
+    };
+
+    let traversal = index.traverse(&start_note.path, effective_depth, query.max_nodes);
+    let returned_paths: HashSet<&str> = traversal.iter().map(|node| node.path.as_str()).collect();
+
+    let nodes = traversal
+        .iter()
+        .filter_map(|node| {
+            index.get_note(&node.path).map(|note| MemoryGraphNode {
+                node_id: note.path.clone(),
+                node_type: note_type(note),
+                title: note_title(note),
+                summary: note_summary(note),
+                source_ref: note.path.clone(),
+                depth: node.depth,
+                outgoing_links: note.links.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let edges = if query.includes_references() {
+        graph_edges(index, &traversal, &returned_paths, query.max_edges)
+    } else {
+        Vec::new()
+    };
+
+    let truncated = nodes.len() == query.max_nodes || edges.len() == query.max_edges;
+    Ok(MemoryGraphResponse {
+        found: true,
+        start: query.start,
+        root: Some(start_note.path.clone()),
+        total_nodes: nodes.len(),
+        total_edges: edges.len(),
+        nodes,
+        edges,
+        truncated,
+        depth: effective_depth,
+        max_nodes: query.max_nodes,
+        max_edges: query.max_edges,
+        edge_filter: if query.edge_types.is_empty() {
+            vec!["references".to_string()]
+        } else {
+            query.edge_types
+        },
+    })
+}
+
+fn graph_edges(
+    index: &KnowledgeIndex,
+    traversal: &[lago_knowledge::TraversalResult],
+    returned_paths: &HashSet<&str>,
+    max_edges: usize,
+) -> Vec<MemoryGraphEdge> {
+    let mut edges = Vec::new();
+    let mut seen = HashSet::new();
+
+    for source in traversal {
+        let Some(note) = index.get_note(&source.path) else {
+            continue;
+        };
+
+        for link in &note.links {
+            if edges.len() >= max_edges {
+                return edges;
+            }
+            let Some(target) = index.resolve_note_ref(link) else {
+                continue;
+            };
+            if !returned_paths.contains(target.path.as_str()) {
+                continue;
+            }
+            let key = (note.path.clone(), target.path.clone(), link.clone());
+            if !seen.insert(key) {
+                continue;
+            }
+
+            edges.push(MemoryGraphEdge {
+                source: note.path.clone(),
+                target: target.path.clone(),
+                edge_type: "references".to_string(),
+                label: link.clone(),
+                source_ref: note.path.clone(),
+            });
+        }
+    }
+
+    edges
+}
+
+fn note_title(note: &lago_knowledge::Note) -> String {
+    frontmatter_string(note, &["title", "core_claim", "description"])
+        .unwrap_or_else(|| note.name.clone())
+}
+
+fn note_type(note: &lago_knowledge::Note) -> String {
+    frontmatter_string(note, &["node_type", "type", "tier"])
+        .map(|value| value.trim().to_lowercase())
+        .filter(|value| {
+            matches!(
+                value.as_str(),
+                "memory"
+                    | "decision"
+                    | "evidence"
+                    | "outcome"
+                    | "pattern"
+                    | "artifact"
+                    | "session_summary"
+            )
+        })
+        .unwrap_or_else(|| "memory".to_string())
+}
+
+fn note_summary(note: &lago_knowledge::Note) -> String {
+    frontmatter_string(note, &["summary", "core_claim", "description"])
+        .unwrap_or_else(|| body_preview(&note.body))
+}
+
+fn frontmatter_string(note: &lago_knowledge::Note, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        note.frontmatter
+            .get(*key)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn body_preview(body: &str) -> String {
+    let summary = body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .take(4)
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    truncate_chars(&summary, 280)
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    let mut truncated = value.chars().take(max_chars).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lago_core::ManifestEntry;
+    use lago_store::BlobStore;
+    use tempfile::TempDir;
+
+    fn build_index(files: &[(&str, &str)]) -> (TempDir, KnowledgeIndex) {
+        let tmp = TempDir::new().unwrap();
+        let store = BlobStore::open(tmp.path()).unwrap();
+        let entries = files
+            .iter()
+            .map(|(path, content)| {
+                let hash = store.put(content.as_bytes()).unwrap();
+                ManifestEntry {
+                    path: (*path).to_string(),
+                    blob_hash: hash,
+                    size_bytes: content.len() as u64,
+                    content_type: Some("text/markdown".to_string()),
+                    updated_at: 0,
+                }
+            })
+            .collect::<Vec<_>>();
+        (tmp, KnowledgeIndex::build(&entries, &store).unwrap())
+    }
+
+    #[test]
+    fn graph_returns_chain_with_edges_and_provenance() {
+        let (_tmp, index) = build_index(&[
+            (
+                "/decision.md",
+                "---\ntitle: Sandbox decision\ntype: decision\nsummary: Choose bounded sandbox routing.\n---\nSee [[Evidence]].",
+            ),
+            (
+                "/evidence.md",
+                "---\ntitle: Evidence\ntype: evidence\n---\nSee [[Outcome]].",
+            ),
+            (
+                "/outcome.md",
+                "---\ntitle: Outcome\ntype: outcome\n---\nPolicy stayed replay-safe.",
+            ),
+        ]);
+
+        let graph = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "Decision".into(),
+                depth: 2,
+                max_nodes: 12,
+                max_edges: 16,
+                edge_types: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert!(graph.found);
+        assert_eq!(graph.root.as_deref(), Some("/decision.md"));
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.edges.len(), 2);
+        assert_eq!(graph.nodes[0].node_type, "decision");
+        assert_eq!(graph.nodes[0].source_ref, "/decision.md");
+    }
+
+    #[test]
+    fn graph_handles_cycles_without_repeating_nodes() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "---\ntitle: A\n---\nSee [[B]]."),
+            ("/b.md", "---\ntitle: B\n---\nSee [[A]]."),
+        ]);
+
+        let graph = memory_graph_from_index(&index, MemoryGraphQuery::new("A")).unwrap();
+
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 2);
+    }
+
+    #[test]
+    fn graph_respects_node_and_edge_bounds() {
+        let (_tmp, index) = build_index(&[
+            ("/a.md", "# A\n\nSee [[B]] and [[C]] and [[D]]."),
+            ("/b.md", "# B"),
+            ("/c.md", "# C"),
+            ("/d.md", "# D"),
+        ]);
+
+        let graph = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "/a.md".into(),
+                depth: 1,
+                max_nodes: 2,
+                max_edges: 1,
+                edge_types: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 1);
+        assert!(graph.truncated);
+    }
+
+    #[test]
+    fn graph_reports_missing_start_node() {
+        let (_tmp, index) = build_index(&[("/a.md", "# A")]);
+        let err = memory_graph_from_index(&index, MemoryGraphQuery::new("missing")).unwrap_err();
+        assert!(matches!(err, MemoryGraphError::StartNodeNotFound(_)));
+    }
+
+    #[test]
+    fn graph_edge_filter_excluding_references_returns_root_only() {
+        let (_tmp, index) = build_index(&[("/a.md", "# A\n\nSee [[B]]."), ("/b.md", "# B")]);
+
+        let graph = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "A".into(),
+                depth: 2,
+                max_nodes: 12,
+                max_edges: 16,
+                edge_types: vec!["supports".into()],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(graph.nodes.len(), 1);
+        assert!(graph.edges.is_empty());
+        assert_eq!(graph.edge_filter, vec!["supports"]);
+    }
+}

--- a/crates/arcan/arcan/src/memory_tools.rs
+++ b/crates/arcan/arcan/src/memory_tools.rs
@@ -7,9 +7,14 @@
 //! - `memory_offload` — save content to episodic memory
 //! - `memory_forget` — mark a memory as low importance
 //! - `memory_similar` — semantic retrieval over Lance embeddings
+//! - `memory_graph` — bounded graph traversal over wikilinked memory files
 
 use aios_protocol::tool::{
     Tool, ToolAnnotations, ToolCall, ToolContext, ToolDefinition, ToolError, ToolResult,
+};
+use arcan_lago::{
+    DEFAULT_GRAPH_DEPTH, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES, MemoryGraphError, MemoryGraphQuery,
+    memory_graph_from_dir,
 };
 use lago_core::event::{EventEnvelope, EventPayload};
 use lago_lance::{EMBEDDING_META_KEY, LanceJournal};
@@ -362,6 +367,136 @@ impl Tool for MemorySimilarTool {
             }),
         ))
     }
+}
+
+// ── MemoryGraphTool ────────────────────────────────────────────────
+
+/// Bounded graph traversal over wikilinked memory files.
+pub struct MemoryGraphTool {
+    memory_dir: PathBuf,
+}
+
+impl MemoryGraphTool {
+    pub fn new(memory_dir: &Path) -> Self {
+        Self {
+            memory_dir: memory_dir.to_path_buf(),
+        }
+    }
+}
+
+impl Tool for MemoryGraphTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "memory_graph".into(),
+            description: "Traverse related memories from a start note using bounded wikilink graph retrieval. Returns compact nodes, references edges, and provenance paths.".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "string",
+                        "description": "Start memory by title, filename, path, or wikilink target"
+                    },
+                    "depth": {
+                        "type": "integer",
+                        "description": "Maximum traversal depth (default: 2, capped at 4)"
+                    },
+                    "max_nodes": {
+                        "type": "integer",
+                        "description": "Maximum nodes to return (default: 12, capped at 50)"
+                    },
+                    "max_edges": {
+                        "type": "integer",
+                        "description": "Maximum edges to return (default: 16, capped at 100)"
+                    },
+                    "edge_types": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional edge filter. V1 supports references."
+                    }
+                },
+                "required": ["start"]
+            }),
+            title: Some("Memory Graph".into()),
+            output_schema: None,
+            annotations: Some(ToolAnnotations {
+                read_only: true,
+                idempotent: true,
+                ..Default::default()
+            }),
+            category: Some("memory".into()),
+            tags: vec!["memory".into(), "graph".into(), "retrieval".into()],
+            timeout_secs: Some(15),
+        }
+    }
+
+    fn execute(&self, call: &ToolCall, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let start = call
+            .input
+            .get("start")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "Missing or invalid 'start' argument".into(),
+            })?;
+
+        let depth = bounded_usize_arg(&call.input, "depth", DEFAULT_GRAPH_DEPTH);
+        let max_nodes = bounded_usize_arg(&call.input, "max_nodes", DEFAULT_MAX_NODES);
+        let max_edges = bounded_usize_arg(&call.input, "max_edges", DEFAULT_MAX_EDGES);
+        let edge_types = call
+            .input
+            .get("edge_types")
+            .and_then(serde_json::Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let query = MemoryGraphQuery {
+            start: start.to_string(),
+            depth,
+            max_nodes,
+            max_edges,
+            edge_types,
+        };
+
+        match memory_graph_from_dir(&self.memory_dir, query) {
+            Ok(graph) => Ok(ToolResult::json(
+                &call.call_id,
+                &call.tool_name,
+                json!(graph),
+            )),
+            Err(MemoryGraphError::StartNodeNotFound(start)) => Ok(ToolResult::json(
+                &call.call_id,
+                &call.tool_name,
+                json!({
+                    "found": false,
+                    "start": start,
+                    "message": "Memory graph start node not found",
+                    "nodes": [],
+                    "edges": [],
+                    "total_nodes": 0,
+                    "total_edges": 0,
+                }),
+            )),
+            Err(err) => Err(ToolError::ExecutionFailed {
+                tool_name: "memory_graph".into(),
+                message: format!("Memory graph retrieval failed: {err}"),
+            }),
+        }
+    }
+}
+
+fn bounded_usize_arg(input: &serde_json::Value, key: &str, default: usize) -> usize {
+    input
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(default)
 }
 
 /// Extract a short excerpt around the first keyword match.
@@ -1122,6 +1257,62 @@ mod tests {
         assert_eq!(result.output["matches"][0]["file"], "auth-notes");
     }
 
+    // ── MemoryGraphTool tests ──
+
+    #[test]
+    fn graph_traverses_wikilinked_memories() {
+        let dir = TempDir::new().unwrap();
+        create_memory_file(
+            dir.path(),
+            "decision",
+            "---\ntitle: Sandbox Decision\ntype: decision\nsummary: Route commands through sandbox policy.\n---\nSee [[Evidence]].",
+        );
+        create_memory_file(
+            dir.path(),
+            "evidence",
+            "---\ntitle: Evidence\ntype: evidence\n---\nThe prior run leaked host state.",
+        );
+
+        let tool = MemoryGraphTool::new(dir.path());
+        let call = make_call(
+            "memory_graph",
+            json!({"start": "decision", "depth": 1, "max_nodes": 12}),
+        );
+        let result = tool.execute(&call, &make_ctx()).unwrap();
+
+        assert!(result.output["found"].as_bool().unwrap());
+        assert_eq!(result.output["root"], "/decision.md");
+        assert_eq!(result.output["nodes"].as_array().unwrap().len(), 2);
+        assert_eq!(result.output["edges"].as_array().unwrap().len(), 1);
+        assert_eq!(result.output["nodes"][0]["node_type"], "decision");
+        assert_eq!(result.output["nodes"][0]["source_ref"], "/decision.md");
+    }
+
+    #[test]
+    fn graph_missing_start_returns_clear_empty_result() {
+        let dir = TempDir::new().unwrap();
+        create_memory_file(dir.path(), "a", "# A");
+
+        let tool = MemoryGraphTool::new(dir.path());
+        let call = make_call("memory_graph", json!({"start": "missing"}));
+        let result = tool.execute(&call, &make_ctx()).unwrap();
+
+        assert!(!result.output["found"].as_bool().unwrap());
+        assert_eq!(result.output["total_nodes"], 0);
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn graph_tool_definition_is_read_only() {
+        let dir = TempDir::new().unwrap();
+        let tool = MemoryGraphTool::new(dir.path());
+        let def = tool.definition();
+
+        assert_eq!(def.name, "memory_graph");
+        assert_eq!(def.category.as_deref(), Some("memory"));
+        assert!(def.annotations.unwrap().read_only);
+    }
+
     // ── MemoryBrowseTool tests ──
 
     #[test]
@@ -1390,6 +1581,7 @@ mod tests {
             Box::new(MemoryRecentTool::new(&path)),
             Box::new(MemoryOffloadTool::new(&path)),
             Box::new(MemoryForgetTool::new(&path)),
+            Box::new(MemoryGraphTool::new(&path)),
         ];
 
         let expected_names = [
@@ -1399,6 +1591,7 @@ mod tests {
             "memory_recent",
             "memory_offload",
             "memory_forget",
+            "memory_graph",
         ];
 
         for (tool, expected_name) in tools.iter().zip(expected_names.iter()) {

--- a/crates/arcan/arcan/src/memory_tools.rs
+++ b/crates/arcan/arcan/src/memory_tools.rs
@@ -463,6 +463,22 @@ impl Tool for MemoryGraphTool {
             max_edges,
             edge_types,
         };
+        let bounded_query = query.clone().bounded();
+        let effective_depth = if bounded_query.edge_types.is_empty()
+            || bounded_query
+                .edge_types
+                .iter()
+                .any(|edge_type| edge_type == "references")
+        {
+            bounded_query.depth
+        } else {
+            0
+        };
+        let edge_filter = if bounded_query.edge_types.is_empty() {
+            vec!["references".to_string()]
+        } else {
+            bounded_query.edge_types.clone()
+        };
 
         match memory_graph_from_dir(&self.memory_dir, query) {
             Ok(graph) => Ok(ToolResult::json(
@@ -477,10 +493,16 @@ impl Tool for MemoryGraphTool {
                     "found": false,
                     "start": start,
                     "message": "Memory graph start node not found",
+                    "root": null,
                     "nodes": [],
                     "edges": [],
                     "total_nodes": 0,
                     "total_edges": 0,
+                    "truncated": false,
+                    "depth": effective_depth,
+                    "max_nodes": bounded_query.max_nodes,
+                    "max_edges": bounded_query.max_edges,
+                    "edge_filter": edge_filter,
                 }),
             )),
             Err(err) => Err(ToolError::ExecutionFailed {
@@ -1299,6 +1321,15 @@ mod tests {
 
         assert!(!result.output["found"].as_bool().unwrap());
         assert_eq!(result.output["total_nodes"], 0);
+        assert_eq!(result.output["total_edges"], 0);
+        assert!(result.output["root"].is_null());
+        assert_eq!(result.output["nodes"].as_array().unwrap().len(), 0);
+        assert_eq!(result.output["edges"].as_array().unwrap().len(), 0);
+        assert!(!result.output["truncated"].as_bool().unwrap());
+        assert_eq!(result.output["depth"], DEFAULT_GRAPH_DEPTH);
+        assert_eq!(result.output["max_nodes"], DEFAULT_MAX_NODES);
+        assert_eq!(result.output["max_edges"], DEFAULT_MAX_EDGES);
+        assert_eq!(result.output["edge_filter"], json!(["references"]));
         assert!(!result.is_error);
     }
 

--- a/crates/arcan/arcan/src/shell.rs
+++ b/crates/arcan/arcan/src/shell.rs
@@ -1108,6 +1108,9 @@ pub fn run_shell(
         registry.register(PraxisToolBridge::new(
             crate::memory_tools::MemoryForgetTool::new(&memory_dir),
         ));
+        registry.register(PraxisToolBridge::new(
+            crate::memory_tools::MemoryGraphTool::new(&memory_dir),
+        ));
 
         // --- Phase 2: Governed memory tools (BRO-360, BRO-361, BRO-385) ---
         let memory_journal: Arc<dyn Journal> =

--- a/crates/lago/lago-knowledge/src/traversal.rs
+++ b/crates/lago/lago-knowledge/src/traversal.rs
@@ -20,6 +20,42 @@ pub struct TraversalResult {
 }
 
 impl KnowledgeIndex {
+    /// Resolve a user-facing graph reference to a note.
+    ///
+    /// Accepts exact manifest paths (`/notes/foo.md`), relative paths
+    /// (`notes/foo.md`), path stems (`notes/foo`), plain wikilink targets
+    /// (`Foo`), and bracketed wikilinks (`[[Foo#heading]]`).
+    pub fn resolve_note_ref(&self, target: &str) -> Option<&crate::index::Note> {
+        let clean = target
+            .trim()
+            .trim_start_matches("[[")
+            .trim_end_matches("]]")
+            .split('#')
+            .next()
+            .unwrap_or(target)
+            .trim();
+
+        if clean.is_empty() {
+            return None;
+        }
+
+        if let Some(note) = self.get_note(clean) {
+            return Some(note);
+        }
+
+        if !clean.starts_with('/') {
+            let absolute = format!("/{clean}");
+            if let Some(note) = self.get_note(&absolute) {
+                return Some(note);
+            }
+        }
+
+        let without_md = clean.trim_end_matches(".md");
+        self.resolve_wikilink(without_md.trim_start_matches('/'))
+            .or_else(|| self.resolve_wikilink(without_md))
+            .or_else(|| self.resolve_wikilink(clean))
+    }
+
     /// Find all notes that link TO a given slug (reverse edges / backlinks).
     ///
     /// Iterates all notes and returns those whose outgoing wikilinks
@@ -112,7 +148,7 @@ impl KnowledgeIndex {
         let mut queue = VecDeque::new();
 
         // Resolve the start note
-        let start_note = match self.resolve_wikilink(start) {
+        let start_note = match self.resolve_note_ref(start) {
             Some(note) => note,
             None => return results,
         };
@@ -256,6 +292,27 @@ mod tests {
         let (_tmp, index) = build_index(&[("/a.md", "# A")]);
         let results = index.traverse("nonexistent", 1, 10);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn resolves_exact_path_and_bracketed_wikilink_refs() {
+        let (_tmp, index) = build_index(&[
+            ("/notes/a.md", "# A\n\nSee [[B#details]]."),
+            ("/notes/b.md", "# B"),
+        ]);
+
+        assert_eq!(
+            index
+                .resolve_note_ref("/notes/a.md")
+                .map(|note| note.path.as_str()),
+            Some("/notes/a.md")
+        );
+        assert_eq!(
+            index
+                .resolve_note_ref("[[B#details]]")
+                .map(|note| note.path.as_str()),
+            Some("/notes/b.md")
+        );
     }
 
     // --- backlinks tests ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,6 +166,13 @@ Lago substrate provides:
   `autonomic.RollbackRequested` advisory event to Lago when a journal is
   configured. EGRI remains responsible for consuming that signal and restoring
   the prior artifact.
+- Memory graph retrieval is a derived projection over existing markdown memory
+  artifacts, not a second source of truth. `lago-knowledge` owns start-node
+  resolution and bounded wikilink traversal; `arcan-lago` shapes traversal into
+  compact `MemoryGraphResponse` nodes/edges with provenance; Arcan shell exposes
+  this through a read-only `memory_graph` tool. V1 supports only `references`
+  edges and hard caps depth/nodes/edges so graph retrieval remains safe for
+  prompt consumption.
 
 ## 5) Adapter Architecture
 
@@ -225,6 +232,26 @@ The reasoning/knowledge path now follows the same canonical event route as the r
 8. The async observer handoff runs under `run_observer.notify`, and both derived `Knowledge*` events plus `nous-lago` eval publications preserve the active trace context, so post-run judge scores and EGRI outcome events stay attached to the originating trace.
 
 This keeps knowledge observability aligned with the contract-first architecture: tools stay pure, the kernel event spine remains authoritative, and downstream regulation/evaluation consume the same typed substrate.
+
+### Memory Graph Retrieval
+
+The agent-driven memory path now includes graph-shaped retrieval for causal and
+evidence-chain questions:
+
+1. Arcan shell registers `memory_graph` as a read-only, idempotent memory tool.
+2. The tool parses `start`, optional `depth`, `max_nodes`, `max_edges`, and
+   `edge_types` arguments, then delegates to `arcan-lago`.
+3. `arcan-lago` builds a transient `KnowledgeIndex` from `.arcan/memory` via the
+   existing blob-backed `build_index_from_dir()` helper.
+4. `lago-knowledge` resolves the start node by exact path, relative path, path
+   stem, or wikilink target and traverses outgoing wikilinks with BFS, visited
+   set, and node bounds.
+5. `arcan-lago` returns compact nodes and `references` edges with source paths
+   as provenance. Missing starts return a clear empty result at the tool layer.
+
+This path is intentionally topology-only in v1. Hybrid graph + semantic ranking
+belongs to the next memory graph phase, where Lance similarity can narrow or
+rank nodes without changing the authoritative memory model.
 
 ### LLM Cost Envelope Spine
 

--- a/docs/MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/MEMORY_GRAPH_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Memory Graph Architecture
 
 > **Date**: 2026-04-03
-> **Status**: Design specification
+> **Status**: Phase 2 implemented (`BRO-445`)
 > **Linear**: `BRO-444`, `BRO-445`, `BRO-446`, `BRO-447`
 > **Scope**: Lago graph projection + Arcan retrieval tool over the cognitive substrate
 
@@ -396,10 +396,22 @@ Ship the contract:
 
 Ship v1:
 
-- bounded graph retrieval over `lago-knowledge`
-- `memory_graph` tool in Arcan
-- deterministic tests
-- no mandatory new Lago route
+- [x] bounded graph retrieval over `lago-knowledge`
+- [x] `memory_graph` tool in Arcan shell
+- [x] deterministic tests for chain, cycle, bounds, missing start, and edge filtering
+- [x] no mandatory new Lago route
+
+Implementation notes:
+
+- `lago-knowledge::KnowledgeIndex::resolve_note_ref()` accepts exact manifest
+  paths, relative paths, path stems, plain wikilink targets, and bracketed
+  wikilinks.
+- `arcan-lago::memory_graph` owns bounded response shaping with
+  `MemoryGraphQuery`, `MemoryGraphResponse`, compact nodes, `references` edges,
+  provenance paths, and hard caps.
+- `arcan::memory_tools::MemoryGraphTool` maps missing start nodes to a clear
+  non-error empty JSON result so agents can recover by trying `memory_search`,
+  `memory_browse`, or `memory_similar`.
 
 ### Phase 3 — `BRO-446`
 

--- a/docs/MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/MEMORY_GRAPH_ARCHITECTURE.md
@@ -227,71 +227,61 @@ The first stable schema should be narrow.
 
 ### Edge Types
 
-- `references`
-- `derived_from`
-- `supports`
-- `contradicts`
-- `led_to`
-- `caused_by`
+- `references` is the only shipped v1 edge type.
+- `derived_from`, `supports`, `contradicts`, `led_to`, and `caused_by` are planned
+  semantic edge types for a future typed-memory phase.
 
 ### Node Contract
 
 ```rust
-pub enum MemoryGraphNodeType {
-    Memory,
-    Decision,
-    Evidence,
-    Outcome,
-    Pattern,
-    Artifact,
-    SessionSummary,
-}
-
 pub struct MemoryGraphNode {
     pub node_id: String,
-    pub node_type: MemoryGraphNodeType,
+    pub node_type: String,
     pub title: String,
     pub summary: String,
     pub source_ref: String,
-    pub importance: Option<f32>,
-    pub created_at: Option<i64>,
-    pub updated_at: Option<i64>,
+    pub depth: usize,
+    pub outgoing_links: Vec<String>,
 }
 ```
+
+`outgoing_links` is derived from the actual returned, capped edge set. It is not
+the raw note link list.
 
 ### Edge Contract
 
 ```rust
-pub enum MemoryGraphEdgeType {
-    References,
-    DerivedFrom,
-    Supports,
-    Contradicts,
-    LedTo,
-    CausedBy,
-}
-
 pub struct MemoryGraphEdge {
-    pub from: String,
-    pub to: String,
-    pub edge_type: MemoryGraphEdgeType,
-    pub weight: Option<f32>,
-    pub provenance: String,
+    pub source: String,
+    pub target: String,
+    pub edge_type: String,
+    pub label: String,
+    pub source_ref: String,
 }
 ```
 
 ### Retrieval Result Contract
 
 ```rust
-pub struct MemoryGraphResult {
-    pub root: MemoryGraphNode,
+pub struct MemoryGraphResponse {
+    pub found: bool,
+    pub start: String,
+    pub root: Option<String>,
     pub nodes: Vec<MemoryGraphNode>,
     pub edges: Vec<MemoryGraphEdge>,
-    pub summary: String,
+    pub total_nodes: usize,
+    pub total_edges: usize,
+    pub truncated: bool,
+    pub depth: usize,
+    pub max_nodes: usize,
+    pub max_edges: usize,
+    pub edge_filter: Vec<String>,
 }
 ```
 
-The LLM-facing tool output should include compact prose plus the structured payload.
+The LLM-facing v1 tool output is structured JSON only. `truncated` is set from
+explicit node/edge overflow detection, not from result size equaling the
+configured limits.
 
 ## Start-Node Resolution
 
@@ -299,12 +289,12 @@ The tool must not require opaque internal IDs only.
 
 Resolution order:
 
-1. direct graph node id
-2. exact note path
-3. exact note name
-4. wikilink resolution
-5. semantic narrowing if a query is present
-6. fail with candidate suggestions
+1. exact manifest path, for example `/notes/foo.md`
+2. relative path, for example `notes/foo.md`
+3. path stem, for example `notes/foo`
+4. plain wikilink target, for example `Foo`
+5. bracketed wikilink target, for example `[[Foo#heading]]`
+6. non-error empty JSON from the Arcan tool boundary when no start node resolves
 
 This keeps the tool ergonomic while staying deterministic by default.
 
@@ -316,9 +306,9 @@ This keeps the tool ergonomic while staying deterministic by default.
 {
   "start": "auth-middleware-regression",
   "depth": 2,
-  "limit": 12,
-  "edge_types": ["caused_by", "supports", "led_to"],
-  "query": "what led to the auth regression?"
+  "max_nodes": 12,
+  "max_edges": 16,
+  "edge_types": ["references"]
 }
 ```
 
@@ -326,13 +316,18 @@ This keeps the tool ergonomic while staying deterministic by default.
 
 The tool should return:
 
-- one root node
+- `root` as the resolved note path
 - a bounded set of related nodes
-- labeled edges
-- a compact natural-language summary
+- capped `references` edges
 - provenance for every node and edge
+- `found`, `truncated`, count, bound, and edge-filter metadata
 
 The tool should not return an unbounded adjacency dump.
+
+When the start node is missing, `arcan::memory_tools::MemoryGraphTool` returns
+the same top-level response shape with `found = false`, `root = null`, empty
+`nodes`/`edges`, zero counts, and the bounded request metadata. This lets
+clients recover without special-casing transport errors.
 
 ## Traversal Strategy
 
@@ -408,10 +403,11 @@ Implementation notes:
   wikilinks.
 - `arcan-lago::memory_graph` owns bounded response shaping with
   `MemoryGraphQuery`, `MemoryGraphResponse`, compact nodes, `references` edges,
-  provenance paths, and hard caps.
+  provenance paths, capped `outgoing_links`, explicit truncation flags, and hard
+  caps.
 - `arcan::memory_tools::MemoryGraphTool` maps missing start nodes to a clear
-  non-error empty JSON result so agents can recover by trying `memory_search`,
-  `memory_browse`, or `memory_similar`.
+  schema-stable, non-error empty JSON result so agents can recover by trying
+  `memory_search`, `memory_browse`, or `memory_similar`.
 
 ### Phase 3 — `BRO-446`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -93,7 +93,7 @@ The baseline unification is active and enforced in production paths:
   uses a path-scoped writer lock plus atomic rename, tolerates unversioned
   hand-authored knowledge baselines, and produces an
   `egri.knowledge.promoted` Lago event payload for audit and future Autonomic
-  regression monitoring. Local `cargo test -p lago-knowledge` passes with 139
+  regression monitoring. Local `cargo test -p lago-knowledge` passes with 143
   tests.
 - 2026-04-10: EGRI calibration rollback monitoring is active in Autonomic.
   The projection reducer now folds `egri.knowledge.promoted` into typed

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -129,13 +129,19 @@ The baseline unification is active and enforced in production paths:
   `vigil.llm_call` custom event, so Lago replay can correlate provider
   economics with the same canonical session event spine used for reasoning
   observability and Autonomic regulation.
+- 2026-04-10: `memory_graph` v1 is active in Arcan shell. The tool builds a
+  derived Lago knowledge index over `.arcan/memory`, resolves starts by exact
+  path/name/wikilink target, performs bounded wikilink traversal with cycle
+  protection, and returns compact nodes plus `references` edges with
+  provenance. The graph remains a derived retrieval layer; no new authoritative
+  graph store or mandatory Lago route was introduced.
 
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Build | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| Tests | PASS (96) | PASS (466+16 w/ spacetimedb) | PASS (335) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
+| Tests | PASS (96) | PASS (474+16 w/ spacetimedb) | PASS (336) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
 | Clippy (-D warnings) | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | Canonical Port Usage | ACTIVE | CONSUMED | CONSUMED | CONSUMED | CONSUMED | CROSS-CUTTING | BRIDGED (arcan-spaces) |
 | Production Runtime Path | CANONICAL | CANONICAL HOST | CANONICAL STORE | ADVISORY | TOOL ENGINE | OBSERVABILITY | NETWORKING |
@@ -247,7 +253,7 @@ Validation gates currently pass:
 
 ### Context Engine (2026-03-19)
 
-- 12 crates total (was 10): added `lago-knowledge` (142 tests) and `lago-auth` (5 tests).
+- 12 crates total (was 10): added `lago-knowledge` (143 tests) and `lago-auth` (5 tests).
 - `lago-knowledge`: YAML frontmatter parsing, `[[wikilink]]` extraction, in-memory knowledge index, scored search (+2 name, +1 body, +1 tag), BFS graph traversal.
 - `lago-knowledge`: also now includes EGRI calibration substrate —
   typed benchmark schema/runner, a seed benchmark corpus, parameterized BM25
@@ -258,6 +264,11 @@ Validation gates currently pass:
   execution, full campaign orchestration, and governed promotion to the
   `lago.toml` `[knowledge]` section with versioned rollback metadata plus
   `egri.knowledge.promoted` audit events.
+- `lago-knowledge` traversal resolution now accepts exact paths, relative
+  paths, path stems, and wikilink syntax for graph starts. `arcan-lago` shapes
+  those traversal primitives into `MemoryGraphResponse`, and Arcan shell
+  exposes the read-only `memory_graph` tool beside the existing agent-driven
+  memory retrieval tools.
 - Autonomic: EGRI rollback monitoring folds promoted knowledge threshold
   versions and regression counters, emits durable `autonomic.RollbackRequested`
   advisories after sustained post-promotion health regression, and marks the


### PR DESCRIPTION
## Summary

Implements BRO-445 / closes #457 by adding `memory_graph` v1 as a bounded, derived graph retrieval path over existing Lago knowledge primitives.

- Add `KnowledgeIndex::resolve_note_ref()` for exact path, relative path, path stem, plain wikilink, and bracketed wikilink starts.
- Add `arcan-lago::memory_graph` bridge response shaping with compact nodes, `references` edges, provenance paths, hard depth/node/edge caps, and deterministic tests.
- Add Arcan shell `memory_graph` tool registration and schema, with clear non-error empty JSON for missing starts.
- Update canonical architecture/status docs and the memory graph design spec.

## Validation

- `cargo test -p lago-knowledge traversal -- --nocapture`
- `cargo test -p arcan-lago memory_graph -- --nocapture`
- `cargo test -p arcan memory_tools -- --nocapture`
- `cargo clippy -p lago-knowledge -p arcan-lago -p arcan --all-targets -- -D warnings`
- `cargo test -p lago-knowledge -p arcan-lago -p arcan`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only memory_graph tool to the Arcan shell for bounded traversal of wikilinked memory with configurable start, depth, node/edge limits, and edge-type filtering.
  * Improved start-node resolution to accept exact paths, relative paths, path stems, and wikilink/wikilink-with-heading formats.
  * Tool returns a clear empty JSON result when the start node is missing.

* **Documentation**
  * Added architecture and status docs describing memory graph retrieval v1 and usage.

* **Tests**
  * Added deterministic tests covering chains, cycles, bounds, missing-start, and edge filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->