### PR TITLE
feat(memory): add hybrid memory graph ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "reqwest-eventsource",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/arcan/arcan-lago/Cargo.toml
+++ b/crates/arcan/arcan-lago/Cargo.toml
@@ -29,6 +29,7 @@ lago-policy.workspace = true
 praxis-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 thiserror.workspace = true

--- a/crates/arcan/arcan-lago/src/lib.rs
+++ b/crates/arcan/arcan-lago/src/lib.rs
@@ -35,8 +35,9 @@ pub use ephemeral::{EphemeralJournal, SessionJournalSelector};
 pub use learning::{LearningEntry, LearningMiddleware};
 pub use memory_graph::{
     DEFAULT_GRAPH_DEPTH, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES, MemoryGraphEdge, MemoryGraphError,
-    MemoryGraphNode, MemoryGraphQuery, MemoryGraphResponse, memory_graph_from_dir,
-    memory_graph_from_index,
+    MemoryGraphNode, MemoryGraphQuery, MemoryGraphRankSignals, MemoryGraphRankingHints,
+    MemoryGraphResponse, memory_graph_from_dir, memory_graph_from_dir_with_ranking,
+    memory_graph_from_index, memory_graph_from_index_with_ranking,
 };
 pub use memory_projection::MemoryProjection;
 pub use memory_scope::{MemoryEntry, MemoryScopeConfig};

--- a/crates/arcan/arcan-lago/src/memory_graph.rs
+++ b/crates/arcan/arcan-lago/src/memory_graph.rs
@@ -4,9 +4,11 @@
 //! shapes Lago traversal primitives into compact, provenance-preserving payloads
 //! that Arcan can expose as an agent tool.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use lago_knowledge::{KnowledgeError, KnowledgeIndex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -24,6 +26,7 @@ pub const MAX_GRAPH_EDGES: usize = 100;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryGraphQuery {
     pub start: String,
+    pub query: Option<String>,
     pub depth: usize,
     pub max_nodes: usize,
     pub max_edges: usize,
@@ -34,6 +37,7 @@ impl MemoryGraphQuery {
     pub fn new(start: impl Into<String>) -> Self {
         Self {
             start: start.into(),
+            query: None,
             depth: DEFAULT_GRAPH_DEPTH,
             max_nodes: DEFAULT_MAX_NODES,
             max_edges: DEFAULT_MAX_EDGES,
@@ -42,6 +46,10 @@ impl MemoryGraphQuery {
     }
 
     pub fn bounded(mut self) -> Self {
+        self.query = self
+            .query
+            .map(|query| query.trim().to_string())
+            .filter(|query| !query.is_empty());
         self.depth = self.depth.min(MAX_GRAPH_DEPTH);
         self.max_nodes = self.max_nodes.clamp(1, MAX_GRAPH_NODES);
         self.max_edges = self.max_edges.min(MAX_GRAPH_EDGES);
@@ -59,6 +67,52 @@ impl MemoryGraphQuery {
     }
 }
 
+/// Optional rank hints from semantic retrieval backends.
+///
+/// `arcan-lago` deliberately accepts score hints instead of depending on a
+/// concrete vector store. This keeps Lance and embedding providers owned by
+/// Arcan while preserving a deterministic graph-only fallback.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MemoryGraphRankingHints {
+    pub semantic_scores: HashMap<String, f32>,
+}
+
+impl MemoryGraphRankingHints {
+    pub fn new(semantic_scores: HashMap<String, f32>) -> Self {
+        Self {
+            semantic_scores: semantic_scores
+                .into_iter()
+                .map(|(key, score)| (ranking_key(&key), clamp_unit(score)))
+                .collect(),
+        }
+    }
+
+    fn has_semantic_scores(&self) -> bool {
+        !self.semantic_scores.is_empty()
+    }
+
+    fn semantic_score_for_note(&self, note: &lago_knowledge::Note) -> f32 {
+        if self.semantic_scores.is_empty() {
+            return 0.0;
+        }
+
+        let mut keys = vec![note.path.clone(), note.name.clone()];
+        if let Some(title) = frontmatter_string(note, &["title", "core_claim", "description"]) {
+            keys.push(title);
+        }
+
+        keys.iter()
+            .filter_map(|key| {
+                self.semantic_scores
+                    .get(&ranking_key(key))
+                    .copied()
+                    .or_else(|| self.semantic_scores.get(key.as_str()).copied())
+            })
+            .map(clamp_unit)
+            .fold(0.0, f32::max)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MemoryGraphNode {
     pub node_id: String,
@@ -68,6 +122,18 @@ pub struct MemoryGraphNode {
     pub source_ref: String,
     pub depth: usize,
     pub outgoing_links: Vec<String>,
+    pub score: f32,
+    pub rank_signals: MemoryGraphRankSignals,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryGraphRankSignals {
+    pub depth: f32,
+    pub query: f32,
+    pub semantic: f32,
+    pub importance: f32,
+    pub recency: f32,
+    pub edge_weight: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -93,6 +159,8 @@ pub struct MemoryGraphResponse {
     pub max_nodes: usize,
     pub max_edges: usize,
     pub edge_filter: Vec<String>,
+    pub query: Option<String>,
+    pub ranking_backend: String,
 }
 
 #[derive(Debug, Error)]
@@ -108,14 +176,32 @@ pub fn memory_graph_from_dir(
     memory_dir: &Path,
     query: MemoryGraphQuery,
 ) -> Result<MemoryGraphResponse, MemoryGraphError> {
+    memory_graph_from_dir_with_ranking(memory_dir, query, MemoryGraphRankingHints::default())
+}
+
+/// Build a graph response from markdown files with optional rank hints.
+pub fn memory_graph_from_dir_with_ranking(
+    memory_dir: &Path,
+    query: MemoryGraphQuery,
+    ranking_hints: MemoryGraphRankingHints,
+) -> Result<MemoryGraphResponse, MemoryGraphError> {
     let (index, _store) = build_index_from_dir(memory_dir)?;
-    memory_graph_from_index(&index, query)
+    memory_graph_from_index_with_ranking(&index, query, ranking_hints)
 }
 
 /// Build a graph response from an already-built knowledge index.
 pub fn memory_graph_from_index(
     index: &KnowledgeIndex,
     query: MemoryGraphQuery,
+) -> Result<MemoryGraphResponse, MemoryGraphError> {
+    memory_graph_from_index_with_ranking(index, query, MemoryGraphRankingHints::default())
+}
+
+/// Build a graph response with optional query-conditioned and semantic ranking.
+pub fn memory_graph_from_index_with_ranking(
+    index: &KnowledgeIndex,
+    query: MemoryGraphQuery,
+    ranking_hints: MemoryGraphRankingHints,
 ) -> Result<MemoryGraphResponse, MemoryGraphError> {
     let query = query.bounded();
     let Some(start_note) = index.resolve_note_ref(&query.start) else {
@@ -128,12 +214,34 @@ pub fn memory_graph_from_index(
         0
     };
 
-    let mut traversal = index.traverse(
-        &start_note.path,
-        effective_depth,
-        query.max_nodes.saturating_add(1),
-    );
-    let nodes_overflowed = traversal.len() > query.max_nodes;
+    let ranked_mode = query.query.is_some() || ranking_hints.has_semantic_scores();
+    let traversal_limit = if ranked_mode {
+        query
+            .max_nodes
+            .saturating_mul(4)
+            .max(query.max_nodes.saturating_add(1))
+            .min(MAX_GRAPH_NODES.saturating_add(1))
+    } else {
+        query.max_nodes.saturating_add(1)
+    };
+
+    let mut traversal = index.traverse(&start_note.path, effective_depth, traversal_limit);
+    let candidates_overflowed = traversal.len() > query.max_nodes;
+
+    if ranked_mode {
+        traversal = rank_traversal(
+            index,
+            &start_note.path,
+            traversal,
+            effective_depth,
+            &query,
+            &ranking_hints,
+        )
+        .into_iter()
+        .map(|ranked| ranked.node)
+        .collect();
+    }
+
     traversal.truncate(query.max_nodes);
 
     let returned_paths: HashSet<&str> = traversal.iter().map(|node| node.path.as_str()).collect();
@@ -145,11 +253,24 @@ pub fn memory_graph_from_index(
     };
     let edges_overflowed = graph_edges.overflowed;
     let mut outgoing_links_by_source = graph_edges.outgoing_links_by_source;
+    let edge_weights = graph_edge_weights(index, &traversal, &returned_paths);
+    let search_terms = query_terms(query.query.as_deref());
 
     let nodes = traversal
         .iter()
         .filter_map(|node| {
-            index.get_note(&node.path).map(|note| MemoryGraphNode {
+            let note = index.get_note(&node.path)?;
+            let rank_signals = rank_signals(
+                note,
+                node.depth,
+                effective_depth,
+                &search_terms,
+                &ranking_hints,
+                edge_weights.get(note.path.as_str()).copied().unwrap_or(0.0),
+            );
+            let score = composite_score(&rank_signals, ranked_mode);
+
+            Some(MemoryGraphNode {
                 node_id: note.path.clone(),
                 node_type: note_type(note),
                 title: note_title(note),
@@ -159,11 +280,13 @@ pub fn memory_graph_from_index(
                 outgoing_links: outgoing_links_by_source
                     .remove(&note.path)
                     .unwrap_or_default(),
+                score,
+                rank_signals,
             })
         })
         .collect::<Vec<_>>();
 
-    let truncated = nodes_overflowed || edges_overflowed;
+    let truncated = candidates_overflowed || edges_overflowed;
     Ok(MemoryGraphResponse {
         found: true,
         start: query.start,
@@ -181,7 +304,73 @@ pub fn memory_graph_from_index(
         } else {
             query.edge_types
         },
+        query: query.query,
+        ranking_backend: ranking_backend(ranked_mode, ranking_hints.has_semantic_scores()),
     })
+}
+
+#[derive(Debug)]
+struct RankedTraversal {
+    node: lago_knowledge::TraversalResult,
+    score: f32,
+    original_index: usize,
+}
+
+fn rank_traversal(
+    index: &KnowledgeIndex,
+    root_path: &str,
+    traversal: Vec<lago_knowledge::TraversalResult>,
+    effective_depth: usize,
+    query: &MemoryGraphQuery,
+    ranking_hints: &MemoryGraphRankingHints,
+) -> Vec<RankedTraversal> {
+    let search_terms = query_terms(query.query.as_deref());
+    let candidate_paths: HashSet<&str> = traversal.iter().map(|node| node.path.as_str()).collect();
+    let edge_weights = graph_edge_weights(index, &traversal, &candidate_paths);
+
+    let mut ranked = traversal
+        .into_iter()
+        .enumerate()
+        .map(|(original_index, node)| {
+            let score = index
+                .get_note(&node.path)
+                .map(|note| {
+                    let signals = rank_signals(
+                        note,
+                        node.depth,
+                        effective_depth,
+                        &search_terms,
+                        ranking_hints,
+                        edge_weights.get(note.path.as_str()).copied().unwrap_or(0.0),
+                    );
+                    composite_score(&signals, true)
+                })
+                .unwrap_or(0.0);
+
+            RankedTraversal {
+                node,
+                score,
+                original_index,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    ranked.sort_by(|a, b| {
+        let a_is_root = a.node.path == root_path;
+        let b_is_root = b.node.path == root_path;
+        match (a_is_root, b_is_root) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => b
+                .score
+                .partial_cmp(&a.score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.node.depth.cmp(&b.node.depth))
+                .then_with(|| a.original_index.cmp(&b.original_index)),
+        }
+    });
+
+    ranked
 }
 
 #[derive(Debug, Default)]
@@ -242,6 +431,241 @@ fn graph_edges(
         edges,
         outgoing_links_by_source,
         overflowed,
+    }
+}
+
+fn graph_edge_weights(
+    index: &KnowledgeIndex,
+    traversal: &[lago_knowledge::TraversalResult],
+    candidate_paths: &HashSet<&str>,
+) -> HashMap<String, f32> {
+    let mut weights: HashMap<String, usize> = HashMap::new();
+
+    for source in traversal {
+        let Some(note) = index.get_note(&source.path) else {
+            continue;
+        };
+
+        for link in &note.links {
+            let Some(target) = index.resolve_note_ref(link) else {
+                continue;
+            };
+            if !candidate_paths.contains(target.path.as_str()) {
+                continue;
+            }
+
+            *weights.entry(note.path.clone()).or_default() += 1;
+            *weights.entry(target.path.clone()).or_default() += 1;
+        }
+    }
+
+    weights
+        .into_iter()
+        .map(|(path, weight)| (path, (weight as f32 / 4.0).min(1.0)))
+        .collect()
+}
+
+fn rank_signals(
+    note: &lago_knowledge::Note,
+    depth: usize,
+    max_depth: usize,
+    search_terms: &[String],
+    ranking_hints: &MemoryGraphRankingHints,
+    edge_weight: f32,
+) -> MemoryGraphRankSignals {
+    MemoryGraphRankSignals {
+        depth: depth_score(depth, max_depth),
+        query: lexical_query_score(note, search_terms),
+        semantic: ranking_hints.semantic_score_for_note(note),
+        importance: frontmatter_unit(note, &["importance", "knowledge_relevance", "priority"])
+            .unwrap_or(0.0),
+        recency: frontmatter_recency(note),
+        edge_weight: clamp_unit(edge_weight),
+    }
+}
+
+fn composite_score(signals: &MemoryGraphRankSignals, ranked_mode: bool) -> f32 {
+    let score = if ranked_mode {
+        (signals.depth * 0.20)
+            + (signals.query * 0.35)
+            + (signals.semantic * 0.25)
+            + (signals.importance * 0.10)
+            + (signals.recency * 0.05)
+            + (signals.edge_weight * 0.05)
+    } else {
+        (signals.depth * 0.60)
+            + (signals.importance * 0.15)
+            + (signals.recency * 0.10)
+            + (signals.edge_weight * 0.15)
+    };
+
+    clamp_unit(score)
+}
+
+fn depth_score(depth: usize, max_depth: usize) -> f32 {
+    let denominator = max_depth.saturating_add(1).max(1) as f32;
+    let remaining = max_depth.saturating_add(1).saturating_sub(depth) as f32;
+    clamp_unit(remaining / denominator)
+}
+
+fn lexical_query_score(note: &lago_knowledge::Note, search_terms: &[String]) -> f32 {
+    if search_terms.is_empty() {
+        return 0.0;
+    }
+
+    let title = note_title(note).to_lowercase();
+    let summary = note_summary(note).to_lowercase();
+    let name = note.name.to_lowercase();
+    let body = note.body.to_lowercase();
+    let tags = frontmatter_tags(note);
+
+    let mut score = 0.0f32;
+    for term in search_terms {
+        let mut term_score = 0.0f32;
+        if title.contains(term) || name.contains(term) {
+            term_score += 0.45;
+        }
+        if summary.contains(term) {
+            term_score += 0.25;
+        }
+        if body.contains(term) {
+            term_score += 0.20;
+        }
+        if tags.iter().any(|tag| tag == term) {
+            term_score += 0.10;
+        }
+        score += term_score.min(1.0);
+    }
+
+    clamp_unit(score / search_terms.len() as f32)
+}
+
+fn frontmatter_tags(note: &lago_knowledge::Note) -> Vec<String> {
+    note.frontmatter
+        .get("tags")
+        .and_then(|value| value.as_sequence())
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|tag| tag.as_str())
+                .map(|tag| tag.trim().to_lowercase())
+                .filter(|tag| !tag.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn frontmatter_unit(note: &lago_knowledge::Note, keys: &[&str]) -> Option<f32> {
+    keys.iter().find_map(|key| {
+        note.frontmatter
+            .get(*key)
+            .and_then(yaml_number)
+            .map(|value| if value > 1.0 { value / 100.0 } else { value })
+            .map(clamp_unit)
+    })
+}
+
+fn frontmatter_recency(note: &lago_knowledge::Note) -> f32 {
+    if let Some(score) = frontmatter_unit(note, &["recency"]) {
+        return score;
+    }
+
+    [
+        "updated_at",
+        "updated",
+        "created_at",
+        "created",
+        "timestamp",
+    ]
+    .iter()
+    .find_map(|key| note.frontmatter.get(*key).and_then(temporal_score))
+    .unwrap_or(0.0)
+}
+
+fn temporal_score(value: &serde_yaml::Value) -> Option<f32> {
+    let observed_at = if let Some(number) = yaml_number(value) {
+        timestamp_to_datetime(number)?
+    } else {
+        let value = value.as_str()?.trim();
+        DateTime::parse_from_rfc3339(value)
+            .map(|dt| dt.with_timezone(&Utc))
+            .ok()
+            .or_else(|| {
+                NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                    .ok()
+                    .and_then(|date| date.and_hms_opt(0, 0, 0))
+                    .map(|dt| Utc.from_utc_datetime(&dt))
+            })?
+    };
+
+    let now = Utc::now();
+    let age_days = now.signed_duration_since(observed_at).num_days().max(0) as f32;
+    Some(clamp_unit(1.0 / (1.0 + age_days / 30.0)))
+}
+
+fn timestamp_to_datetime(timestamp: f32) -> Option<DateTime<Utc>> {
+    let timestamp = timestamp as f64;
+    let seconds = if timestamp > 1_000_000_000_000_000.0 {
+        timestamp / 1_000_000.0
+    } else if timestamp > 1_000_000_000_000.0 {
+        timestamp / 1_000.0
+    } else {
+        timestamp
+    };
+
+    let whole_seconds = seconds.trunc() as i64;
+    let nanos = ((seconds.fract() * 1_000_000_000.0).round() as u32).min(999_999_999);
+    Utc.timestamp_opt(whole_seconds, nanos).single()
+}
+
+fn yaml_number(value: &serde_yaml::Value) -> Option<f32> {
+    value
+        .as_f64()
+        .map(|value| value as f32)
+        .or_else(|| value.as_i64().map(|value| value as f32))
+        .or_else(|| value.as_u64().map(|value| value as f32))
+        .or_else(|| value.as_str()?.trim().parse::<f32>().ok())
+}
+
+fn query_terms(query: Option<&str>) -> Vec<String> {
+    query
+        .unwrap_or_default()
+        .to_lowercase()
+        .split_whitespace()
+        .map(|term| {
+            term.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_' && ch != '-')
+                .to_string()
+        })
+        .filter(|term| !term.is_empty())
+        .collect()
+}
+
+fn ranking_backend(ranked_mode: bool, has_semantic_scores: bool) -> String {
+    match (ranked_mode, has_semantic_scores) {
+        (true, true) => "hybrid_vector_graph".to_string(),
+        (true, false) => "hybrid_lexical_graph".to_string(),
+        (false, _) => "graph_bfs".to_string(),
+    }
+}
+
+fn ranking_key(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches("[[")
+        .trim_end_matches("]]")
+        .split('#')
+        .next()
+        .unwrap_or(value)
+        .trim()
+        .trim_start_matches('/')
+        .trim_end_matches(".md")
+        .to_lowercase()
+}
+
+fn clamp_unit(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(0.0, 1.0)
+    } else {
+        0.0
     }
 }
 
@@ -353,6 +777,7 @@ mod tests {
             &index,
             MemoryGraphQuery {
                 start: "Decision".into(),
+                query: None,
                 depth: 2,
                 max_nodes: 12,
                 max_edges: 16,
@@ -396,6 +821,7 @@ mod tests {
             &index,
             MemoryGraphQuery {
                 start: "/a.md".into(),
+                query: None,
                 depth: 1,
                 max_nodes: 2,
                 max_edges: 1,
@@ -419,6 +845,7 @@ mod tests {
             &index,
             MemoryGraphQuery {
                 start: "A".into(),
+                query: None,
                 depth: 1,
                 max_nodes: 2,
                 max_edges: 1,
@@ -447,6 +874,7 @@ mod tests {
             &index,
             MemoryGraphQuery {
                 start: "A".into(),
+                query: None,
                 depth: 2,
                 max_nodes: 12,
                 max_edges: 16,
@@ -458,5 +886,101 @@ mod tests {
         assert_eq!(graph.nodes.len(), 1);
         assert!(graph.edges.is_empty());
         assert_eq!(graph.edge_filter, vec!["supports"]);
+    }
+
+    #[test]
+    fn query_conditioned_ranking_promotes_relevant_nodes_within_bounds() {
+        let (_tmp, index) = build_index(&[
+            (
+                "/root.md",
+                "---\ntitle: Root\n---\nSee [[Noise]] and [[Calibration]].",
+            ),
+            (
+                "/noise.md",
+                "---\ntitle: Noise\n---\nDeployment notes unrelated to evaluation.",
+            ),
+            (
+                "/calibration.md",
+                "---\ntitle: Calibration\nimportance: 0.8\n---\nRecall threshold tuning improves knowledge calibration.",
+            ),
+        ]);
+
+        let plain = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "Root".into(),
+                query: None,
+                depth: 1,
+                max_nodes: 2,
+                max_edges: 16,
+                edge_types: Vec::new(),
+            },
+        )
+        .unwrap();
+        assert_eq!(plain.nodes[1].source_ref, "/noise.md");
+        assert_eq!(plain.ranking_backend, "graph_bfs");
+
+        let ranked = memory_graph_from_index(
+            &index,
+            MemoryGraphQuery {
+                start: "Root".into(),
+                query: Some("knowledge calibration recall".into()),
+                depth: 1,
+                max_nodes: 2,
+                max_edges: 16,
+                edge_types: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(ranked.nodes.len(), 2);
+        assert_eq!(ranked.nodes[0].source_ref, "/root.md");
+        assert_eq!(ranked.nodes[1].source_ref, "/calibration.md");
+        assert!(ranked.nodes[1].rank_signals.query > plain.nodes[1].rank_signals.query);
+        assert!(ranked.truncated);
+        assert_eq!(
+            ranked.query.as_deref(),
+            Some("knowledge calibration recall")
+        );
+        assert_eq!(ranked.ranking_backend, "hybrid_lexical_graph");
+    }
+
+    #[test]
+    fn semantic_hints_can_promote_vector_matched_nodes() {
+        let (_tmp, index) = build_index(&[
+            (
+                "/root.md",
+                "---\ntitle: Root\n---\nSee [[Noise]] and [[semantic-target]].",
+            ),
+            (
+                "/noise.md",
+                "---\ntitle: Noise\n---\nPlain first BFS result.",
+            ),
+            (
+                "/semantic-target.md",
+                "---\ntitle: Semantic Target\n---\nVector-only match.",
+            ),
+        ]);
+
+        let mut scores = HashMap::new();
+        scores.insert("Semantic Target".to_string(), 0.98);
+
+        let graph = memory_graph_from_index_with_ranking(
+            &index,
+            MemoryGraphQuery {
+                start: "Root".into(),
+                query: Some("opaque query".into()),
+                depth: 1,
+                max_nodes: 2,
+                max_edges: 16,
+                edge_types: Vec::new(),
+            },
+            MemoryGraphRankingHints::new(scores),
+        )
+        .unwrap();
+
+        assert_eq!(graph.nodes[1].source_ref, "/semantic-target.md");
+        assert!(graph.nodes[1].rank_signals.semantic > 0.9);
+        assert_eq!(graph.ranking_backend, "hybrid_vector_graph");
     }
 }

--- a/crates/arcan/arcan/src/memory_tools.rs
+++ b/crates/arcan/arcan/src/memory_tools.rs
@@ -14,7 +14,7 @@ use aios_protocol::tool::{
 };
 use arcan_lago::{
     DEFAULT_GRAPH_DEPTH, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES, MemoryGraphError, MemoryGraphQuery,
-    memory_graph_from_dir,
+    MemoryGraphRankingHints, memory_graph_from_dir_with_ranking,
 };
 use lago_core::event::{EventEnvelope, EventPayload};
 use lago_lance::{EMBEDDING_META_KEY, LanceJournal};
@@ -106,20 +106,31 @@ fn run_async<T, F>(future: F) -> Result<T, ToolError>
 where
     F: std::future::Future<Output = Result<T, lago_core::LagoError>>,
 {
+    run_async_for_tool("memory_similar", "Semantic search failed", future)
+}
+
+fn run_async_for_tool<T, F>(
+    tool_name: &str,
+    failure_prefix: &str,
+    future: F,
+) -> Result<T, ToolError>
+where
+    F: std::future::Future<Output = Result<T, lago_core::LagoError>>,
+{
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => handle
             .block_on(future)
             .map_err(|e| ToolError::ExecutionFailed {
-                tool_name: "memory_similar".into(),
-                message: format!("Semantic search failed: {e}"),
+                tool_name: tool_name.into(),
+                message: format!("{failure_prefix}: {e}"),
             }),
         Err(_) => match tokio::runtime::Runtime::new() {
             Ok(rt) => rt.block_on(future).map_err(|e| ToolError::ExecutionFailed {
-                tool_name: "memory_similar".into(),
-                message: format!("Semantic search failed: {e}"),
+                tool_name: tool_name.into(),
+                message: format!("{failure_prefix}: {e}"),
             }),
             Err(e) => Err(ToolError::ExecutionFailed {
-                tool_name: "memory_similar".into(),
+                tool_name: tool_name.into(),
                 message: format!("Failed to create async runtime: {e}"),
             }),
         },
@@ -138,6 +149,15 @@ fn event_embedding(event: &EventEnvelope) -> Option<Vec<f32>> {
         .metadata
         .get(EMBEDDING_META_KEY)
         .and_then(|json| serde_json::from_str(json).ok())
+}
+
+fn semantic_event_keys(event: &EventEnvelope) -> Vec<String> {
+    ["title", "path", "source_ref", "memory_file"]
+        .iter()
+        .filter_map(|key| event.metadata.get(*key))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
@@ -374,13 +394,86 @@ impl Tool for MemorySimilarTool {
 /// Bounded graph traversal over wikilinked memory files.
 pub struct MemoryGraphTool {
     memory_dir: PathBuf,
+    embedding_provider: Option<Arc<dyn crate::embedding::EmbeddingProvider>>,
+    workspace_journal: Option<Arc<LanceJournal>>,
 }
 
 impl MemoryGraphTool {
+    #[cfg(test)]
     pub fn new(memory_dir: &Path) -> Self {
         Self {
             memory_dir: memory_dir.to_path_buf(),
+            embedding_provider: None,
+            workspace_journal: None,
         }
+    }
+
+    pub fn new_with_semantic(
+        memory_dir: &Path,
+        embedding_provider: Option<Arc<dyn crate::embedding::EmbeddingProvider>>,
+        workspace_journal: Option<Arc<LanceJournal>>,
+    ) -> Self {
+        Self {
+            memory_dir: memory_dir.to_path_buf(),
+            embedding_provider,
+            workspace_journal,
+        }
+    }
+
+    fn semantic_ranking_hints(
+        &self,
+        query: Option<&str>,
+        max_nodes: usize,
+    ) -> MemoryGraphRankingHints {
+        let Some(query) = query.map(str::trim).filter(|query| !query.is_empty()) else {
+            return MemoryGraphRankingHints::default();
+        };
+
+        let Some((provider, journal)) = self
+            .embedding_provider
+            .as_ref()
+            .zip(self.workspace_journal.as_ref())
+        else {
+            return MemoryGraphRankingHints::default();
+        };
+
+        let query_embedding = match provider.embed(query) {
+            Ok(embedding) => embedding,
+            Err(e) => {
+                tracing::warn!(error = %e, "memory_graph embedding failed, using lexical graph ranking");
+                return MemoryGraphRankingHints::default();
+            }
+        };
+
+        let limit = max_nodes.saturating_mul(4).clamp(DEFAULT_MAX_NODES, 50);
+        let events = match run_async_for_tool(
+            "memory_graph",
+            "Semantic graph ranking failed",
+            journal.vector_search(&query_embedding, limit),
+        ) {
+            Ok(events) => events,
+            Err(err) => {
+                tracing::warn!(message = %err, "memory_graph vector search failed, using lexical graph ranking");
+                return MemoryGraphRankingHints::default();
+            }
+        };
+
+        let mut scores: std::collections::HashMap<String, f32> = std::collections::HashMap::new();
+        for event in events {
+            let similarity = event_embedding(&event)
+                .as_deref()
+                .and_then(|embedding| cosine_similarity(&query_embedding, embedding))
+                .unwrap_or(0.0);
+
+            for key in semantic_event_keys(&event) {
+                scores
+                    .entry(key)
+                    .and_modify(|score| *score = score.max(similarity))
+                    .or_insert(similarity);
+            }
+        }
+
+        MemoryGraphRankingHints::new(scores)
     }
 }
 
@@ -395,6 +488,10 @@ impl Tool for MemoryGraphTool {
                     "start": {
                         "type": "string",
                         "description": "Start memory by title, filename, path, or wikilink target"
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional natural-language query used to rank graph candidates by lexical and semantic relevance"
                     },
                     "depth": {
                         "type": "integer",
@@ -443,6 +540,13 @@ impl Tool for MemoryGraphTool {
         let depth = bounded_usize_arg(&call.input, "depth", DEFAULT_GRAPH_DEPTH);
         let max_nodes = bounded_usize_arg(&call.input, "max_nodes", DEFAULT_MAX_NODES);
         let max_edges = bounded_usize_arg(&call.input, "max_edges", DEFAULT_MAX_EDGES);
+        let rank_query = call
+            .input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned);
         let edge_types = call
             .input
             .get("edge_types")
@@ -458,12 +562,15 @@ impl Tool for MemoryGraphTool {
 
         let query = MemoryGraphQuery {
             start: start.to_string(),
+            query: rank_query,
             depth,
             max_nodes,
             max_edges,
             edge_types,
         };
         let bounded_query = query.clone().bounded();
+        let ranking_hints =
+            self.semantic_ranking_hints(bounded_query.query.as_deref(), bounded_query.max_nodes);
         let effective_depth = if bounded_query.edge_types.is_empty()
             || bounded_query
                 .edge_types
@@ -479,8 +586,13 @@ impl Tool for MemoryGraphTool {
         } else {
             bounded_query.edge_types.clone()
         };
+        let missing_ranking_backend = if bounded_query.query.is_some() {
+            "hybrid_lexical_graph"
+        } else {
+            "graph_bfs"
+        };
 
-        match memory_graph_from_dir(&self.memory_dir, query) {
+        match memory_graph_from_dir_with_ranking(&self.memory_dir, query, ranking_hints) {
             Ok(graph) => Ok(ToolResult::json(
                 &call.call_id,
                 &call.tool_name,
@@ -503,6 +615,8 @@ impl Tool for MemoryGraphTool {
                     "max_nodes": bounded_query.max_nodes,
                     "max_edges": bounded_query.max_edges,
                     "edge_filter": edge_filter,
+                    "query": bounded_query.query,
+                    "ranking_backend": missing_ranking_backend,
                 }),
             )),
             Err(err) => Err(ToolError::ExecutionFailed {
@@ -1311,6 +1425,118 @@ mod tests {
     }
 
     #[test]
+    fn graph_query_promotes_relevant_memory_over_plain_bfs() {
+        let dir = TempDir::new().unwrap();
+        create_memory_file(
+            dir.path(),
+            "root",
+            "---\ntitle: Root\n---\nSee [[noise]] and [[calibration]].",
+        );
+        create_memory_file(
+            dir.path(),
+            "noise",
+            "---\ntitle: Noise\n---\nDeployment notes unrelated to evaluation.",
+        );
+        create_memory_file(
+            dir.path(),
+            "calibration",
+            "---\ntitle: Calibration\n---\nKnowledge calibration improves recall thresholds.",
+        );
+
+        let tool = MemoryGraphTool::new(dir.path());
+        let call = make_call(
+            "memory_graph",
+            json!({
+                "start": "root",
+                "query": "knowledge calibration recall",
+                "depth": 1,
+                "max_nodes": 2
+            }),
+        );
+        let result = tool.execute(&call, &make_ctx()).unwrap();
+
+        assert_eq!(result.output["nodes"].as_array().unwrap().len(), 2);
+        assert_eq!(result.output["nodes"][1]["source_ref"], "/calibration.md");
+        assert_eq!(result.output["ranking_backend"], "hybrid_lexical_graph");
+        assert_eq!(result.output["query"], "knowledge calibration recall");
+        assert!(result.output["truncated"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn graph_uses_vector_hints_when_semantic_backend_is_available() {
+        let dir = TempDir::new().unwrap();
+        create_memory_file(
+            dir.path(),
+            "root",
+            "---\ntitle: Root\n---\nSee [[noise]] and [[semantic-target]].",
+        );
+        create_memory_file(
+            dir.path(),
+            "noise",
+            "---\ntitle: Noise\n---\nPlain first BFS result.",
+        );
+        create_memory_file(
+            dir.path(),
+            "semantic-target",
+            "---\ntitle: Semantic Target\n---\nVector-only relevant memory.",
+        );
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let journal = rt.block_on(async {
+            let journal = Arc::new(
+                LanceJournal::open(dir.path().join("workspace.lance"))
+                    .await
+                    .unwrap(),
+            );
+            journal
+                .append_with_embedding(
+                    make_memory_event("Vector-only relevant memory", "Semantic Target"),
+                    vec![1.0; 1536],
+                )
+                .await
+                .unwrap();
+            journal
+                .append_with_embedding(
+                    make_memory_event("Unrelated graph neighbor", "Noise"),
+                    vec![0.0; 1536],
+                )
+                .await
+                .unwrap();
+            journal
+        });
+
+        let tool = MemoryGraphTool::new_with_semantic(
+            dir.path(),
+            Some(Arc::new(TestEmbeddingProvider {
+                vector: vec![1.0; 1536],
+            })),
+            Some(journal),
+        );
+        let call = make_call(
+            "memory_graph",
+            json!({
+                "start": "root",
+                "query": "opaque semantic request",
+                "depth": 1,
+                "max_nodes": 2
+            }),
+        );
+        let result = tool.execute(&call, &make_ctx()).unwrap();
+
+        assert_eq!(
+            result.output["nodes"][1]["source_ref"],
+            "/semantic-target.md"
+        );
+        assert_eq!(result.output["ranking_backend"], "hybrid_vector_graph");
+        assert!(
+            result.output["nodes"][1]["rank_signals"]["semantic"]
+                .as_f64()
+                .unwrap()
+                > 0.9
+        );
+    }
+
+    #[test]
     fn graph_missing_start_returns_clear_empty_result() {
         let dir = TempDir::new().unwrap();
         create_memory_file(dir.path(), "a", "# A");
@@ -1330,6 +1556,8 @@ mod tests {
         assert_eq!(result.output["max_nodes"], DEFAULT_MAX_NODES);
         assert_eq!(result.output["max_edges"], DEFAULT_MAX_EDGES);
         assert_eq!(result.output["edge_filter"], json!(["references"]));
+        assert!(result.output["query"].is_null());
+        assert_eq!(result.output["ranking_backend"], "graph_bfs");
         assert!(!result.is_error);
     }
 

--- a/crates/arcan/arcan/src/shell.rs
+++ b/crates/arcan/arcan/src/shell.rs
@@ -1109,7 +1109,11 @@ pub fn run_shell(
             crate::memory_tools::MemoryForgetTool::new(&memory_dir),
         ));
         registry.register(PraxisToolBridge::new(
-            crate::memory_tools::MemoryGraphTool::new(&memory_dir),
+            crate::memory_tools::MemoryGraphTool::new_with_semantic(
+                &memory_dir,
+                embedding_provider.clone(),
+                workspace_lance.clone(),
+            ),
         ));
 
         // --- Phase 2: Governed memory tools (BRO-360, BRO-361, BRO-385) ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,19 +239,28 @@ The agent-driven memory path now includes graph-shaped retrieval for causal and
 evidence-chain questions:
 
 1. Arcan shell registers `memory_graph` as a read-only, idempotent memory tool.
-2. The tool parses `start`, optional `depth`, `max_nodes`, `max_edges`, and
-   `edge_types` arguments, then delegates to `arcan-lago`.
+2. The tool parses `start`, optional `query`, `depth`, `max_nodes`,
+   `max_edges`, and `edge_types` arguments, then delegates to `arcan-lago`.
 3. `arcan-lago` builds a transient `KnowledgeIndex` from `.arcan/memory` via the
    existing blob-backed `build_index_from_dir()` helper.
 4. `lago-knowledge` resolves the start node by exact path, relative path, path
    stem, or wikilink target and traverses outgoing wikilinks with BFS, visited
    set, and node bounds.
-5. `arcan-lago` returns compact nodes and `references` edges with source paths
+5. If `query` is present, Arcan optionally embeds the query and asks the shared
+   workspace Lance journal for vector neighbors, then passes normalized semantic
+   score hints into `arcan-lago`. If embeddings or Lance are unavailable, this
+   step is skipped.
+6. `arcan-lago` ranks bounded graph candidates by depth, lexical query
+   relevance, optional semantic score, frontmatter importance/recency, and edge
+   weight. It keeps the root first, reapplies `max_nodes`/`max_edges`, and
+   labels the path as `graph_bfs`, `hybrid_lexical_graph`, or
+   `hybrid_vector_graph`.
+7. `arcan-lago` returns compact nodes and `references` edges with source paths
    as provenance. Missing starts return a clear empty result at the tool layer.
 
-This path is intentionally topology-only in v1. Hybrid graph + semantic ranking
-belongs to the next memory graph phase, where Lance similarity can narrow or
-rank nodes without changing the authoritative memory model.
+The authoritative memory model is unchanged: markdown memory artifacts and Lago
+events remain source-of-truth, and Lance only contributes optional ranking
+hints.
 
 ### LLM Cost Envelope Spine
 

--- a/docs/MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/MEMORY_GRAPH_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Memory Graph Architecture
 
 > **Date**: 2026-04-03
-> **Status**: Phase 2 implemented (`BRO-445`)
+> **Status**: Phase 3 implemented (`BRO-446`)
 > **Linear**: `BRO-444`, `BRO-445`, `BRO-446`, `BRO-447`
 > **Scope**: Lago graph projection + Arcan retrieval tool over the cognitive substrate
 
@@ -242,11 +242,23 @@ pub struct MemoryGraphNode {
     pub source_ref: String,
     pub depth: usize,
     pub outgoing_links: Vec<String>,
+    pub score: f32,
+    pub rank_signals: MemoryGraphRankSignals,
+}
+
+pub struct MemoryGraphRankSignals {
+    pub depth: f32,
+    pub query: f32,
+    pub semantic: f32,
+    pub importance: f32,
+    pub recency: f32,
+    pub edge_weight: f32,
 }
 ```
 
 `outgoing_links` is derived from the actual returned, capped edge set. It is not
-the raw note link list.
+the raw note link list. `score` and `rank_signals` are advisory ranking metadata
+for prompt shaping and evaluation; provenance remains `source_ref`.
 
 ### Edge Contract
 
@@ -276,6 +288,8 @@ pub struct MemoryGraphResponse {
     pub max_nodes: usize,
     pub max_edges: usize,
     pub edge_filter: Vec<String>,
+    pub query: Option<String>,
+    pub ranking_backend: String,
 }
 ```
 
@@ -305,6 +319,7 @@ This keeps the tool ergonomic while staying deterministic by default.
 ```json
 {
   "start": "auth-middleware-regression",
+  "query": "why did auth middleware regress?",
   "depth": 2,
   "max_nodes": 12,
   "max_edges": 16,
@@ -321,6 +336,7 @@ The tool should return:
 - capped `references` edges
 - provenance for every node and edge
 - `found`, `truncated`, count, bound, and edge-filter metadata
+- `query`, `ranking_backend`, `score`, and `rank_signals` when ranking is active
 
 The tool should not return an unbounded adjacency dump.
 
@@ -343,25 +359,35 @@ Defaults:
 
 ### V2
 
-Add hybrid ranking:
+Hybrid ranking now preserves BFS as the no-query fallback and switches to
+ranked candidate selection when `query` or semantic score hints are present.
+The adapter overfetches bounded graph candidates, scores them, keeps the root
+first, then truncates back to `max_nodes`.
 
-- depth penalty
-- node importance
-- recency
-- semantic similarity
-- edge weight
+Current signals:
+
+- depth proximity
+- lexical query relevance over title, summary, body, and tags
+- optional semantic similarity from Arcan-provided Lance score hints
+- frontmatter importance
+- frontmatter recency
+- graph edge weight inside the candidate set
 
 Conceptually:
 
 ```text
-score = semantic_similarity
+score = depth
+      + query_relevance
+      + semantic_similarity
       + importance
-      + recency_bonus
+      + recency
       + edge_weight
-      - depth_penalty
 ```
 
-The exact coefficients can evolve after evaluation.
+The exact coefficients can evolve after evaluation, but they live in
+`arcan-lago` so prompt-facing behavior stays deterministic and testable.
+Arcan owns the Lance call and passes normalized score hints into the adapter;
+`arcan-lago` does not depend on Lance or embedding providers.
 
 ## Scope Model
 
@@ -413,9 +439,24 @@ Implementation notes:
 
 Ship hybrid ranking:
 
-- Lance-assisted node ranking
-- optional query-conditioned expansion
-- graph-only fallback
+- [x] Lance-assisted node ranking via optional score hints
+- [x] optional query-conditioned expansion
+- [x] graph-only fallback
+
+Implementation notes:
+
+- `MemoryGraphQuery::query` activates ranked candidate selection without making
+  embeddings mandatory.
+- `MemoryGraphRankingHints` accepts optional semantic scores keyed by memory
+  title/path/name. Arcan populates those hints from `workspace.lance` when an
+  embedding provider is configured.
+- `ranking_backend` is one of `graph_bfs`, `hybrid_lexical_graph`, or
+  `hybrid_vector_graph`.
+- Query-conditioned retrieval overfetches bounded candidates, promotes relevant
+  non-root nodes above plain BFS neighbors, then re-applies `max_nodes` and
+  `max_edges`.
+- Missing embeddings, missing Lance datasets, or vector-search errors degrade
+  to lexical graph ranking or BFS rather than failing the tool.
 
 ### Phase 4 — `BRO-447`
 
@@ -446,6 +487,7 @@ Ship validation and evaluation:
 - edge filtering
 - deterministic result ordering
 - scope-preserving output
+- lexical and semantic ranking promotion while preserving bounds
 
 ### Tool Tests
 
@@ -455,6 +497,8 @@ Ship validation and evaluation:
 - bounded result size
 - readable summary formatting
 - fallback behavior when graph unavailable
+- query-conditioned ranking
+- Lance-backed semantic hints when available
 
 ### E2E
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ created: 2026-03-17
 
 # Broomva Life: Implementation Status
 
-**Date**: 2026-03-04**Version**: 0.2.0 (canonical baseline)**Rust**: edition 2024, MSRV 1.85+ (Spaces backend: edition 2021)**Tests**: 1042 passing (+5 ignored) across 30 crates + Spaces (32 crates total)
+**Date**: 2026-03-04**Version**: 0.2.0 (canonical baseline)**Rust**: edition 2024, MSRV 1.85+ (Spaces backend: edition 2021)**Tests**: 1046 passing (+5 ignored) across 30 crates + Spaces (32 crates total)
 
 This document is the canonical implementation-state record for `/Users/broomva/broomva.tech/life`.If another status document conflicts with this one, treat this file as source of truth.
 
@@ -135,13 +135,20 @@ The baseline unification is active and enforced in production paths:
   protection, and returns compact nodes plus `references` edges with
   provenance. The graph remains a derived retrieval layer; no new authoritative
   graph store or mandatory Lago route was introduced.
+- 2026-04-10: `memory_graph` hybrid ranking is active. The tool now accepts an
+  optional `query`, Arcan can derive semantic ranking hints from the shared
+  workspace Lance journal when embeddings are configured, and `arcan-lago`
+  scores bounded graph candidates by depth, lexical relevance, optional
+  semantic similarity, importance, recency, and edge weight. Missing embeddings
+  or vector-search failures degrade to lexical graph ranking or the original
+  graph-only BFS fallback; bounds and provenance remain enforced.
 
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Build | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| Tests | PASS (96) | PASS (474+16 w/ spacetimedb) | PASS (336) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
+| Tests | PASS (96) | PASS (478+16 w/ spacetimedb) | PASS (336) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
 | Clippy (-D warnings) | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | Canonical Port Usage | ACTIVE | CONSUMED | CONSUMED | CONSUMED | CONSUMED | CROSS-CUTTING | BRIDGED (arcan-spaces) |
 | Production Runtime Path | CANONICAL | CANONICAL HOST | CANONICAL STORE | ADVISORY | TOOL ENGINE | OBSERVABILITY | NETWORKING |


### PR DESCRIPTION
## Summary

Implements BRO-446 by upgrading `memory_graph` from pure bounded topology traversal to query-conditioned hybrid graph retrieval. The authoritative memory model stays unchanged: markdown memory artifacts and Lago events remain the source of truth, while Lance contributes optional score hints only when Arcan has an embedding provider and workspace journal available.

The fix adds `MemoryGraphQuery::query`, node `score`/`rank_signals`, and a `ranking_backend` marker so callers can distinguish `graph_bfs`, `hybrid_lexical_graph`, and `hybrid_vector_graph`. `arcan-lago` now overfetches bounded graph candidates only when ranking is active, keeps the root node first, scores candidates by depth, lexical relevance, optional semantic similarity, frontmatter importance/recency, and edge weight, then reapplies node and edge caps.

Arcan wires the existing embedding provider and shared workspace Lance journal into `MemoryGraphTool::new_with_semantic`. If embedding or vector search is unavailable, the tool degrades to lexical graph ranking or the original BFS path instead of failing retrieval.

Docs were updated in `docs/MEMORY_GRAPH_ARCHITECTURE.md`, `docs/ARCHITECTURE.md`, and `docs/STATUS.md`. The conversation bridge was also run and refreshed `docs/conversations/Conversations.md` in ignored JSONL-only mode.

Closes #458
Linear: BRO-446

## Validation

- `cargo test -p arcan-lago -p arcan`
- `cargo clippy -p arcan-lago -p arcan --all-targets -- -D warnings`
- `cargo test -p arcan-lago -p arcan graph -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional query parameter to memory graph searches for improved result relevance.
  * Integrated semantic ranking using vector embeddings when available, with graceful fallback to lexical ranking.
  * Results now include relevance scores and indicate which ranking backend was used.

* **Documentation**
  * Updated architecture and memory graph specifications to reflect hybrid ranking capability and Phase 3 status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->