### PR TITLE
feat(memory): add memory graph evaluation metrics

### DIFF
--- a/crates/arcan/arcan-lago/src/lib.rs
+++ b/crates/arcan/arcan-lago/src/lib.rs
@@ -35,9 +35,10 @@ pub use ephemeral::{EphemeralJournal, SessionJournalSelector};
 pub use learning::{LearningEntry, LearningMiddleware};
 pub use memory_graph::{
     DEFAULT_GRAPH_DEPTH, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES, MemoryGraphEdge, MemoryGraphError,
-    MemoryGraphNode, MemoryGraphQuery, MemoryGraphRankSignals, MemoryGraphRankingHints,
-    MemoryGraphResponse, memory_graph_from_dir, memory_graph_from_dir_with_ranking,
-    memory_graph_from_index, memory_graph_from_index_with_ranking,
+    MemoryGraphMetrics, MemoryGraphNode, MemoryGraphQuery, MemoryGraphRankSignals,
+    MemoryGraphRankingHints, MemoryGraphResponse, memory_graph_from_dir,
+    memory_graph_from_dir_with_ranking, memory_graph_from_index,
+    memory_graph_from_index_with_ranking,
 };
 pub use memory_projection::MemoryProjection;
 pub use memory_scope::{MemoryEntry, MemoryScopeConfig};

--- a/crates/arcan/arcan-lago/src/memory_graph.rs
+++ b/crates/arcan/arcan-lago/src/memory_graph.rs
@@ -75,6 +75,7 @@ impl MemoryGraphQuery {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct MemoryGraphRankingHints {
     pub semantic_scores: HashMap<String, f32>,
+    pub fallback_path: Option<String>,
 }
 
 impl MemoryGraphRankingHints {
@@ -84,7 +85,18 @@ impl MemoryGraphRankingHints {
                 .into_iter()
                 .map(|(key, score)| (ranking_key(&key), clamp_unit(score)))
                 .collect(),
+            fallback_path: None,
         }
+    }
+
+    pub fn with_fallback_path(mut self, fallback_path: impl Into<String>) -> Self {
+        let fallback_path = fallback_path.into();
+        self.fallback_path = if fallback_path.trim().is_empty() {
+            None
+        } else {
+            Some(fallback_path)
+        };
+        self
     }
 
     fn has_semantic_scores(&self) -> bool {
@@ -161,6 +173,18 @@ pub struct MemoryGraphResponse {
     pub edge_filter: Vec<String>,
     pub query: Option<String>,
     pub ranking_backend: String,
+    pub metrics: MemoryGraphMetrics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryGraphMetrics {
+    pub operation: String,
+    pub returned_node_count: usize,
+    pub returned_edge_count: usize,
+    pub depth_reached: usize,
+    pub ranking_backend: String,
+    pub fallback_path: Option<String>,
+    pub provenance_preserved: bool,
 }
 
 #[derive(Debug, Error)]
@@ -287,6 +311,14 @@ pub fn memory_graph_from_index_with_ranking(
         .collect::<Vec<_>>();
 
     let truncated = candidates_overflowed || edges_overflowed;
+    let ranking_backend = ranking_backend(ranked_mode, ranking_hints.has_semantic_scores());
+    let metrics = graph_metrics(
+        &nodes,
+        &graph_edges.edges,
+        &ranking_backend,
+        ranking_hints.fallback_path.clone(),
+    );
+
     Ok(MemoryGraphResponse {
         found: true,
         start: query.start,
@@ -305,7 +337,38 @@ pub fn memory_graph_from_index_with_ranking(
             query.edge_types
         },
         query: query.query,
-        ranking_backend: ranking_backend(ranked_mode, ranking_hints.has_semantic_scores()),
+        ranking_backend,
+        metrics,
+    })
+}
+
+fn graph_metrics(
+    nodes: &[MemoryGraphNode],
+    edges: &[MemoryGraphEdge],
+    ranking_backend: &str,
+    fallback_path: Option<String>,
+) -> MemoryGraphMetrics {
+    MemoryGraphMetrics {
+        operation: "memory_graph".to_string(),
+        returned_node_count: nodes.len(),
+        returned_edge_count: edges.len(),
+        depth_reached: nodes.iter().map(|node| node.depth).max().unwrap_or(0),
+        ranking_backend: ranking_backend.to_string(),
+        fallback_path,
+        provenance_preserved: graph_provenance_preserved(nodes, edges),
+    }
+}
+
+fn graph_provenance_preserved(nodes: &[MemoryGraphNode], edges: &[MemoryGraphEdge]) -> bool {
+    nodes.iter().all(|node| {
+        !node.node_id.trim().is_empty()
+            && !node.source_ref.trim().is_empty()
+            && node.node_id == node.source_ref
+    }) && edges.iter().all(|edge| {
+        !edge.source.trim().is_empty()
+            && !edge.target.trim().is_empty()
+            && !edge.source_ref.trim().is_empty()
+            && edge.source == edge.source_ref
     })
 }
 
@@ -793,6 +856,13 @@ mod tests {
         assert_eq!(graph.nodes[0].node_type, "decision");
         assert_eq!(graph.nodes[0].source_ref, "/decision.md");
         assert_eq!(graph.nodes[0].outgoing_links, vec!["Evidence"]);
+        assert_eq!(graph.metrics.operation, "memory_graph");
+        assert_eq!(graph.metrics.returned_node_count, 3);
+        assert_eq!(graph.metrics.returned_edge_count, 2);
+        assert_eq!(graph.metrics.depth_reached, 2);
+        assert_eq!(graph.metrics.ranking_backend, "graph_bfs");
+        assert!(graph.metrics.fallback_path.is_none());
+        assert!(graph.metrics.provenance_preserved);
     }
 
     #[test]
@@ -806,6 +876,7 @@ mod tests {
 
         assert_eq!(graph.nodes.len(), 2);
         assert_eq!(graph.edges.len(), 2);
+        assert!(graph.metrics.provenance_preserved);
     }
 
     #[test]
@@ -943,6 +1014,10 @@ mod tests {
             Some("knowledge calibration recall")
         );
         assert_eq!(ranked.ranking_backend, "hybrid_lexical_graph");
+        assert_eq!(ranked.metrics.ranking_backend, "hybrid_lexical_graph");
+        assert_eq!(ranked.metrics.returned_node_count, 2);
+        assert_eq!(ranked.metrics.depth_reached, 1);
+        assert!(ranked.metrics.provenance_preserved);
     }
 
     #[test]
@@ -982,5 +1057,41 @@ mod tests {
         assert_eq!(graph.nodes[1].source_ref, "/semantic-target.md");
         assert!(graph.nodes[1].rank_signals.semantic > 0.9);
         assert_eq!(graph.ranking_backend, "hybrid_vector_graph");
+        assert_eq!(graph.metrics.ranking_backend, "hybrid_vector_graph");
+        assert!(graph.metrics.fallback_path.is_none());
+    }
+
+    #[test]
+    fn graph_metrics_record_semantic_fallback_path() {
+        let (_tmp, index) = build_index(&[
+            ("/root.md", "---\ntitle: Root\n---\nSee [[Evidence]]."),
+            (
+                "/evidence.md",
+                "---\ntitle: Evidence\n---\nEvaluation proof keeps provenance.",
+            ),
+        ]);
+
+        let graph = memory_graph_from_index_with_ranking(
+            &index,
+            MemoryGraphQuery {
+                start: "Root".into(),
+                query: Some("evaluation proof".into()),
+                depth: 1,
+                max_nodes: 12,
+                max_edges: 16,
+                edge_types: Vec::new(),
+            },
+            MemoryGraphRankingHints::default().with_fallback_path("semantic_unavailable"),
+        )
+        .unwrap();
+
+        assert_eq!(graph.ranking_backend, "hybrid_lexical_graph");
+        assert_eq!(
+            graph.metrics.fallback_path.as_deref(),
+            Some("semantic_unavailable")
+        );
+        assert_eq!(graph.metrics.returned_node_count, graph.nodes.len());
+        assert_eq!(graph.metrics.returned_edge_count, graph.edges.len());
+        assert!(graph.metrics.provenance_preserved);
     }
 }

--- a/crates/arcan/arcan/src/memory_tools.rs
+++ b/crates/arcan/arcan/src/memory_tools.rs
@@ -434,14 +434,14 @@ impl MemoryGraphTool {
             .as_ref()
             .zip(self.workspace_journal.as_ref())
         else {
-            return MemoryGraphRankingHints::default();
+            return MemoryGraphRankingHints::default().with_fallback_path("semantic_unavailable");
         };
 
         let query_embedding = match provider.embed(query) {
             Ok(embedding) => embedding,
             Err(e) => {
                 tracing::warn!(error = %e, "memory_graph embedding failed, using lexical graph ranking");
-                return MemoryGraphRankingHints::default();
+                return MemoryGraphRankingHints::default().with_fallback_path("embedding_failed");
             }
         };
 
@@ -454,9 +454,14 @@ impl MemoryGraphTool {
             Ok(events) => events,
             Err(err) => {
                 tracing::warn!(message = %err, "memory_graph vector search failed, using lexical graph ranking");
-                return MemoryGraphRankingHints::default();
+                return MemoryGraphRankingHints::default()
+                    .with_fallback_path("vector_search_failed");
             }
         };
+
+        if events.is_empty() {
+            return MemoryGraphRankingHints::default().with_fallback_path("semantic_empty");
+        }
 
         let mut scores: std::collections::HashMap<String, f32> = std::collections::HashMap::new();
         for event in events {
@@ -471,6 +476,11 @@ impl MemoryGraphTool {
                     .and_modify(|score| *score = score.max(similarity))
                     .or_insert(similarity);
             }
+        }
+
+        if scores.is_empty() {
+            return MemoryGraphRankingHints::default()
+                .with_fallback_path("semantic_metadata_missing");
         }
 
         MemoryGraphRankingHints::new(scores)
@@ -592,12 +602,24 @@ impl Tool for MemoryGraphTool {
             "graph_bfs"
         };
 
-        match memory_graph_from_dir_with_ranking(&self.memory_dir, query, ranking_hints) {
-            Ok(graph) => Ok(ToolResult::json(
-                &call.call_id,
-                &call.tool_name,
-                json!(graph),
-            )),
+        match memory_graph_from_dir_with_ranking(&self.memory_dir, query, ranking_hints.clone()) {
+            Ok(graph) => {
+                tracing::info!(
+                    tool_name = "memory_graph",
+                    returned_node_count = graph.metrics.returned_node_count,
+                    returned_edge_count = graph.metrics.returned_edge_count,
+                    depth_reached = graph.metrics.depth_reached,
+                    ranking_backend = %graph.metrics.ranking_backend,
+                    fallback_path = graph.metrics.fallback_path.as_deref().unwrap_or("none"),
+                    provenance_preserved = graph.metrics.provenance_preserved,
+                    "memory_graph retrieval metrics"
+                );
+                Ok(ToolResult::json(
+                    &call.call_id,
+                    &call.tool_name,
+                    json!(graph),
+                ))
+            }
             Err(MemoryGraphError::StartNodeNotFound(start)) => Ok(ToolResult::json(
                 &call.call_id,
                 &call.tool_name,
@@ -617,6 +639,15 @@ impl Tool for MemoryGraphTool {
                     "edge_filter": edge_filter,
                     "query": bounded_query.query,
                     "ranking_backend": missing_ranking_backend,
+                    "metrics": {
+                        "operation": "memory_graph",
+                        "returned_node_count": 0,
+                        "returned_edge_count": 0,
+                        "depth_reached": 0,
+                        "ranking_backend": missing_ranking_backend,
+                        "fallback_path": ranking_hints.fallback_path,
+                        "provenance_preserved": true
+                    },
                 }),
             )),
             Err(err) => Err(ToolError::ExecutionFailed {
@@ -1422,6 +1453,13 @@ mod tests {
         assert_eq!(result.output["edges"].as_array().unwrap().len(), 1);
         assert_eq!(result.output["nodes"][0]["node_type"], "decision");
         assert_eq!(result.output["nodes"][0]["source_ref"], "/decision.md");
+        assert_eq!(result.output["metrics"]["operation"], "memory_graph");
+        assert_eq!(result.output["metrics"]["returned_node_count"], 2);
+        assert_eq!(result.output["metrics"]["returned_edge_count"], 1);
+        assert_eq!(result.output["metrics"]["depth_reached"], 1);
+        assert_eq!(result.output["metrics"]["ranking_backend"], "graph_bfs");
+        assert!(result.output["metrics"]["fallback_path"].is_null());
+        assert_eq!(result.output["metrics"]["provenance_preserved"], true);
     }
 
     #[test]
@@ -1460,6 +1498,15 @@ mod tests {
         assert_eq!(result.output["ranking_backend"], "hybrid_lexical_graph");
         assert_eq!(result.output["query"], "knowledge calibration recall");
         assert!(result.output["truncated"].as_bool().unwrap());
+        assert_eq!(
+            result.output["metrics"]["fallback_path"],
+            "semantic_unavailable"
+        );
+        assert_eq!(
+            result.output["metrics"]["ranking_backend"],
+            "hybrid_lexical_graph"
+        );
+        assert_eq!(result.output["metrics"]["provenance_preserved"], true);
     }
 
     #[test]
@@ -1528,12 +1575,64 @@ mod tests {
             "/semantic-target.md"
         );
         assert_eq!(result.output["ranking_backend"], "hybrid_vector_graph");
+        assert!(result.output["metrics"]["fallback_path"].is_null());
+        assert_eq!(
+            result.output["metrics"]["ranking_backend"],
+            "hybrid_vector_graph"
+        );
         assert!(
             result.output["nodes"][1]["rank_signals"]["semantic"]
                 .as_f64()
                 .unwrap()
                 > 0.9
         );
+    }
+
+    #[test]
+    fn graph_records_semantic_empty_fallback_metrics() {
+        let dir = TempDir::new().unwrap();
+        create_memory_file(
+            dir.path(),
+            "root",
+            "---\ntitle: Root\n---\nSee [[calibration]].",
+        );
+        create_memory_file(
+            dir.path(),
+            "calibration",
+            "---\ntitle: Calibration\n---\nKnowledge calibration improves recall thresholds.",
+        );
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let journal = rt.block_on(async {
+            Arc::new(
+                LanceJournal::open(dir.path().join("empty-workspace.lance"))
+                    .await
+                    .unwrap(),
+            )
+        });
+
+        let tool = MemoryGraphTool::new_with_semantic(
+            dir.path(),
+            Some(Arc::new(TestEmbeddingProvider {
+                vector: vec![1.0; 1536],
+            })),
+            Some(journal),
+        );
+        let call = make_call(
+            "memory_graph",
+            json!({
+                "start": "root",
+                "query": "knowledge calibration recall",
+                "depth": 1,
+                "max_nodes": 2
+            }),
+        );
+        let result = tool.execute(&call, &make_ctx()).unwrap();
+
+        assert_eq!(result.output["ranking_backend"], "hybrid_lexical_graph");
+        assert_eq!(result.output["metrics"]["fallback_path"], "semantic_empty");
+        assert_eq!(result.output["metrics"]["returned_node_count"], 2);
+        assert_eq!(result.output["metrics"]["provenance_preserved"], true);
     }
 
     #[test]
@@ -1558,6 +1657,13 @@ mod tests {
         assert_eq!(result.output["edge_filter"], json!(["references"]));
         assert!(result.output["query"].is_null());
         assert_eq!(result.output["ranking_backend"], "graph_bfs");
+        assert_eq!(result.output["metrics"]["operation"], "memory_graph");
+        assert_eq!(result.output["metrics"]["returned_node_count"], 0);
+        assert_eq!(result.output["metrics"]["returned_edge_count"], 0);
+        assert_eq!(result.output["metrics"]["depth_reached"], 0);
+        assert_eq!(result.output["metrics"]["ranking_backend"], "graph_bfs");
+        assert!(result.output["metrics"]["fallback_path"].is_null());
+        assert_eq!(result.output["metrics"]["provenance_preserved"], true);
         assert!(!result.is_error);
     }
 

--- a/crates/arcan/arcan/src/shell.rs
+++ b/crates/arcan/arcan/src/shell.rs
@@ -2579,6 +2579,64 @@ mod tests {
     }
 
     #[test]
+    fn shell_execute_tool_smokes_memory_graph() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("decision.md"),
+            "---\ntitle: Decision\ntype: decision\n---\nSee [[Evidence]].",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("evidence.md"),
+            "---\ntitle: Evidence\ntype: evidence\n---\nSee [[Outcome]].",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("outcome.md"),
+            "---\ntitle: Outcome\ntype: outcome\n---\nValidated shell smoke path.",
+        )
+        .unwrap();
+
+        let mut registry = ToolRegistry::default();
+        registry.register(PraxisToolBridge::new(
+            crate::memory_tools::MemoryGraphTool::new(dir.path()),
+        ));
+
+        let call = ToolCall {
+            call_id: "call-memory-graph".into(),
+            tool_name: "memory_graph".into(),
+            input: serde_json::json!({
+                "start": "Decision",
+                "query": "validated shell smoke",
+                "depth": 2,
+                "max_nodes": 3,
+                "max_edges": 2
+            }),
+        };
+        let ctx = ToolContext {
+            run_id: "shell-e2e".into(),
+            session_id: "shell-e2e".into(),
+            iteration: 0,
+        };
+
+        let (content, is_error) = execute_tool(&registry, &call, &ctx);
+        assert!(!is_error, "{content}");
+
+        let output: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(output["found"], true);
+        assert_eq!(output["root"], "/decision.md");
+        assert_eq!(output["nodes"].as_array().unwrap().len(), 3);
+        assert_eq!(output["edges"].as_array().unwrap().len(), 2);
+        assert_eq!(output["metrics"]["operation"], "memory_graph");
+        assert_eq!(output["metrics"]["returned_node_count"], 3);
+        assert_eq!(output["metrics"]["returned_edge_count"], 2);
+        assert_eq!(output["metrics"]["depth_reached"], 2);
+        assert_eq!(output["metrics"]["ranking_backend"], "hybrid_lexical_graph");
+        assert_eq!(output["metrics"]["fallback_path"], "semantic_unavailable");
+        assert_eq!(output["metrics"]["provenance_preserved"], true);
+    }
+
+    #[test]
     fn test_is_memory_signal() {
         // Bullet points
         assert!(is_memory_signal("- This is a key decision we made"));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,10 +169,10 @@ Lago substrate provides:
 - Memory graph retrieval is a derived projection over existing markdown memory
   artifacts, not a second source of truth. `lago-knowledge` owns start-node
   resolution and bounded wikilink traversal; `arcan-lago` shapes traversal into
-  compact `MemoryGraphResponse` nodes/edges with provenance; Arcan shell exposes
-  this through a read-only `memory_graph` tool. V1 supports only `references`
-  edges and hard caps depth/nodes/edges so graph retrieval remains safe for
-  prompt consumption.
+  compact `MemoryGraphResponse` nodes/edges with provenance and retrieval
+  metrics; Arcan shell exposes this through a read-only `memory_graph` tool. V1
+  supports only `references` edges and hard caps depth/nodes/edges so graph
+  retrieval remains safe for prompt consumption.
 
 ## 5) Adapter Architecture
 
@@ -256,7 +256,9 @@ evidence-chain questions:
    labels the path as `graph_bfs`, `hybrid_lexical_graph`, or
    `hybrid_vector_graph`.
 7. `arcan-lago` returns compact nodes and `references` edges with source paths
-   as provenance. Missing starts return a clear empty result at the tool layer.
+   as provenance plus metrics for returned counts, depth reached, backend,
+   fallback path, and provenance preservation. Missing starts return a clear
+   empty result at the tool layer with zero-count metrics.
 
 The authoritative memory model is unchanged: markdown memory artifacts and Lago
 events remain source-of-truth, and Lance only contributes optional ranking

--- a/docs/MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/MEMORY_GRAPH_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Memory Graph Architecture
 
 > **Date**: 2026-04-03
-> **Status**: Phase 3 implemented (`BRO-446`)
+> **Status**: Phase 4 implemented (`BRO-447`)
 > **Linear**: `BRO-444`, `BRO-445`, `BRO-446`, `BRO-447`
 > **Scope**: Lago graph projection + Arcan retrieval tool over the cognitive substrate
 
@@ -290,6 +290,17 @@ pub struct MemoryGraphResponse {
     pub edge_filter: Vec<String>,
     pub query: Option<String>,
     pub ranking_backend: String,
+    pub metrics: MemoryGraphMetrics,
+}
+
+pub struct MemoryGraphMetrics {
+    pub operation: String,
+    pub returned_node_count: usize,
+    pub returned_edge_count: usize,
+    pub depth_reached: usize,
+    pub ranking_backend: String,
+    pub fallback_path: Option<String>,
+    pub provenance_preserved: bool,
 }
 ```
 
@@ -337,6 +348,8 @@ The tool should return:
 - provenance for every node and edge
 - `found`, `truncated`, count, bound, and edge-filter metadata
 - `query`, `ranking_backend`, `score`, and `rank_signals` when ranking is active
+- `metrics` for returned node/edge counts, depth reached, ranking backend,
+  semantic fallback path, and provenance preservation
 
 The tool should not return an unbounded adjacency dump.
 
@@ -462,10 +475,25 @@ Implementation notes:
 
 Ship validation and evaluation:
 
-- shell E2E
-- regression fixtures
-- retrieval metrics
-- provenance checks
+- [x] shell E2E smoke through the real Arcan `ToolRegistry` +
+  `PraxisToolBridge` path
+- [x] regression fixtures for causal chains, cycle handling, bounds, ambiguous
+  start-node resolution, and missing starts
+- [x] retrieval metrics in every successful and missing-start response
+- [x] provenance checks surfaced as `metrics.provenance_preserved`
+
+Implementation notes:
+
+- `MemoryGraphMetrics` is serialized inside `MemoryGraphResponse`, giving
+  agents and evaluators a compact quality signal without scraping logs.
+- Arcan records metrics through `tracing::info!` whenever `memory_graph`
+  returns successfully.
+- `MemoryGraphRankingHints::fallback_path` records why a semantic path degraded
+  to lexical ranking, using values such as `semantic_unavailable`,
+  `embedding_failed`, `vector_search_failed`, `semantic_empty`, and
+  `semantic_metadata_missing`.
+- Missing starts keep the same schema shape and include zero-count metrics with
+  `provenance_preserved = true`.
 
 ## Testing Strategy
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ created: 2026-03-17
 
 # Broomva Life: Implementation Status
 
-**Date**: 2026-03-04**Version**: 0.2.0 (canonical baseline)**Rust**: edition 2024, MSRV 1.85+ (Spaces backend: edition 2021)**Tests**: 1046 passing (+5 ignored) across 30 crates + Spaces (32 crates total)
+**Date**: 2026-03-04**Version**: 0.2.0 (canonical baseline)**Rust**: edition 2024, MSRV 1.85+ (Spaces backend: edition 2021)**Tests**: 1049 passing (+5 ignored) across 30 crates + Spaces (32 crates total)
 
 This document is the canonical implementation-state record for `/Users/broomva/broomva.tech/life`.If another status document conflicts with this one, treat this file as source of truth.
 
@@ -142,13 +142,20 @@ The baseline unification is active and enforced in production paths:
   semantic similarity, importance, recency, and edge weight. Missing embeddings
   or vector-search failures degrade to lexical graph ranking or the original
   graph-only BFS fallback; bounds and provenance remain enforced.
+- 2026-04-10: `memory_graph` validation and evaluation coverage is active.
+  `MemoryGraphResponse` now carries first-class retrieval metrics for returned
+  node/edge counts, depth reached, backend, fallback path, and provenance
+  preservation. Focused regression fixtures cover causal chains, cycle
+  handling, bounds, semantic fallback paths, and missing starts; an Arcan shell
+  smoke test proves the tool works through the real `ToolRegistry` +
+  `PraxisToolBridge` path.
 
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Build | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| Tests | PASS (96) | PASS (478+16 w/ spacetimedb) | PASS (336) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
+| Tests | PASS (96) | PASS (481+16 w/ spacetimedb) | PASS (336) | PASS (219 targeted) | PASS (90) | PASS (26+2 ignored) | N/A (0 tests) |
 | Clippy (-D warnings) | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | Canonical Port Usage | ACTIVE | CONSUMED | CONSUMED | CONSUMED | CONSUMED | CROSS-CUTTING | BRIDGED (arcan-spaces) |
 | Production Runtime Path | CANONICAL | CANONICAL HOST | CANONICAL STORE | ADVISORY | TOOL ENGINE | OBSERVABILITY | NETWORKING |


### PR DESCRIPTION
## Summary

Implements BRO-447 by making `memory_graph` retrieval quality observable and regression-tested.

This adds a serialized `MemoryGraphMetrics` payload to every graph response, including returned node/edge counts, depth reached, ranking backend, semantic fallback path, and a provenance-preservation boolean. The semantic ranking hint path now carries explicit fallback reasons when vector ranking cannot contribute, so evaluators can distinguish graph-only, lexical fallback, and vector-assisted execution.

The Arcan tool now emits structured tracing metrics on successful graph retrieval and preserves schema-stable zero-count metrics for missing starts. Regression coverage was expanded in `arcan-lago` and `arcan`, and a shell smoke test now executes `memory_graph` through the real `ToolRegistry` + `PraxisToolBridge` path.

Closes #459
Linear: BRO-447

## Validation

- `cargo test -p arcan-lago memory_graph -- --nocapture`
- `cargo test -p arcan memory_tools::tests::graph -- --nocapture`
- `cargo test -p arcan shell_execute_tool_smokes_memory_graph -- --nocapture`
- `cargo test -p arcan-lago -p arcan`
- `cargo clippy -p arcan-lago -p arcan --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/conversation-history.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory graph retrieval responses now include detailed operation metrics, providing visibility into returned node/edge counts, maximum search depth reached, ranking backend selection, semantic fallback paths, and provenance preservation status.

* **Documentation**
  * Updated architecture documentation to reflect new retrieval metrics and enhanced observability for memory graph operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->