### PR TITLE
feat(physics): create 2D rigid body physics engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5343,6 +5343,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "life-physics"
+version = "0.3.0"
+dependencies = [
+ "physics-core",
+ "physics-engine",
+]
+
+[[package]]
 name = "life-praxis"
 version = "0.3.0"
 dependencies = [
@@ -6646,6 +6654,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "physics-core"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "physics-engine"
+version = "0.3.0"
+dependencies = [
+ "physics-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,10 @@ members = [
     "crates/opsis/opsis-engine",
     "crates/opsis/opsis-lago",
     "crates/opsis/opsisd",
+    # Physics — 2D rigid body physics engine
+    "crates/physics/physics-core",
+    "crates/physics/physics-engine",
+    "crates/physics/life-physics",
 ]
 exclude = ["crates/spaces/life-spaces/spacetimedb"]
 
@@ -171,6 +175,10 @@ nous-middleware = { path = "crates/nous/nous-middleware", version = "0.3.0" }
 opsis-core = { path = "crates/opsis/opsis-core", version = "0.3.0" }
 opsis-engine = { path = "crates/opsis/opsis-engine", version = "0.3.0" }
 opsis-lago = { path = "crates/opsis/opsis-lago", version = "0.3.0" }
+# Physics
+physics-core = { path = "crates/physics/physics-core", version = "0.3.0" }
+physics-engine = { path = "crates/physics/physics-engine", version = "0.3.0" }
+life-physics = { path = "crates/physics/life-physics", version = "0.3.0" }
 # Relay
 life-relay-api = { path = "crates/relay/life-relay-api", version = "0.3.0" }
 life-relay-core = { path = "crates/relay/life-relay-core", version = "0.3.0" }

--- a/crates/physics/life-physics/Cargo.toml
+++ b/crates/physics/life-physics/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "life-physics"
+description = "Physics engine facade for the Life Agent OS — re-exports physics-core and physics-engine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+physics-core = { path = "../physics-core", version = "0.3.0" }
+physics-engine = { path = "../physics-engine", version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/crates/physics/life-physics/src/lib.rs
+++ b/crates/physics/life-physics/src/lib.rs
@@ -1,0 +1,7 @@
+//! Facade crate for the Life physics engine.
+//!
+//! Re-exports `physics-core` (types) and `physics-engine` (simulation)
+//! under a single convenient namespace.
+
+pub use physics_core as core;
+pub use physics_engine as engine;

--- a/crates/physics/physics-core/Cargo.toml
+++ b/crates/physics/physics-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "physics-core"
+description = "Core types and traits for the 2D rigid body physics engine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"

--- a/crates/physics/physics-core/src/body.rs
+++ b/crates/physics/physics-core/src/body.rs
@@ -1,0 +1,219 @@
+//! Rigid body representation.
+
+use serde::{Deserialize, Serialize};
+
+use crate::material::Material;
+use crate::math::Vec2;
+use crate::shape::Shape;
+
+/// Opaque handle to a body in the physics world.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BodyHandle(pub u32);
+
+impl BodyHandle {
+    /// Returns the raw index (useful for indexing into the body array).
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Whether the body is static, dynamic, or kinematic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BodyKind {
+    /// Immovable body with infinite mass (e.g., ground, walls).
+    Static,
+    /// Fully simulated body affected by forces and collisions.
+    Dynamic,
+    /// User-controlled body that moves at a set velocity but isn't affected by forces.
+    Kinematic,
+}
+
+/// A 2D rigid body with position, velocity, mass, shape, and material.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RigidBody {
+    // ── Transform ──
+    pub position: Vec2,
+    pub angle: f64,
+
+    // ── Velocity ──
+    pub velocity: Vec2,
+    pub angular_velocity: f64,
+
+    // ── Accumulated forces (cleared each step) ──
+    pub force: Vec2,
+    pub torque: f64,
+
+    // ── Mass properties ──
+    pub mass: f64,
+    pub inv_mass: f64,
+    pub inertia: f64,
+    pub inv_inertia: f64,
+
+    // ── Shape & material ──
+    pub shape: Shape,
+    pub material: Material,
+    pub kind: BodyKind,
+}
+
+impl RigidBody {
+    /// Creates a new dynamic body from a shape and material.
+    /// Mass is computed from the shape area and material density.
+    pub fn dynamic(shape: Shape, material: Material) -> Self {
+        let area = shape.area();
+        let mass = area * material.density;
+        let inertia = shape.moment_of_inertia(mass);
+        Self {
+            position: Vec2::ZERO,
+            angle: 0.0,
+            velocity: Vec2::ZERO,
+            angular_velocity: 0.0,
+            force: Vec2::ZERO,
+            torque: 0.0,
+            mass,
+            inv_mass: 1.0 / mass,
+            inertia,
+            inv_inertia: 1.0 / inertia,
+            shape,
+            material,
+            kind: BodyKind::Dynamic,
+        }
+    }
+
+    /// Creates a static (immovable) body.
+    pub fn stationary(shape: Shape, material: Material) -> Self {
+        Self {
+            position: Vec2::ZERO,
+            angle: 0.0,
+            velocity: Vec2::ZERO,
+            angular_velocity: 0.0,
+            force: Vec2::ZERO,
+            torque: 0.0,
+            mass: 0.0,
+            inv_mass: 0.0,
+            inertia: 0.0,
+            inv_inertia: 0.0,
+            shape,
+            material,
+            kind: BodyKind::Static,
+        }
+    }
+
+    /// Creates a kinematic body (user-driven, not affected by forces).
+    pub fn kinematic(shape: Shape, material: Material) -> Self {
+        Self {
+            position: Vec2::ZERO,
+            angle: 0.0,
+            velocity: Vec2::ZERO,
+            angular_velocity: 0.0,
+            force: Vec2::ZERO,
+            torque: 0.0,
+            mass: 0.0,
+            inv_mass: 0.0,
+            inertia: 0.0,
+            inv_inertia: 0.0,
+            shape,
+            material,
+            kind: BodyKind::Kinematic,
+        }
+    }
+
+    /// Builder: set the position.
+    pub fn with_position(mut self, position: Vec2) -> Self {
+        self.position = position;
+        self
+    }
+
+    /// Builder: set the angle (radians).
+    pub fn with_angle(mut self, angle: f64) -> Self {
+        self.angle = angle;
+        self
+    }
+
+    /// Builder: set the initial velocity.
+    pub fn with_velocity(mut self, velocity: Vec2) -> Self {
+        self.velocity = velocity;
+        self
+    }
+
+    /// Apply a force at the center of mass (accumulated until the next step).
+    pub fn apply_force(&mut self, force: Vec2) {
+        self.force += force;
+    }
+
+    /// Apply a force at a world-space point (generates torque).
+    pub fn apply_force_at(&mut self, force: Vec2, point: Vec2) {
+        self.force += force;
+        let r = point - self.position;
+        self.torque += r.cross(force);
+    }
+
+    /// Apply an instantaneous impulse at the center of mass.
+    pub fn apply_impulse(&mut self, impulse: Vec2) {
+        self.velocity += impulse * self.inv_mass;
+    }
+
+    /// Apply an instantaneous impulse at a world-space point.
+    pub fn apply_impulse_at(&mut self, impulse: Vec2, point: Vec2) {
+        self.velocity += impulse * self.inv_mass;
+        let r = point - self.position;
+        self.angular_velocity += r.cross(impulse) * self.inv_inertia;
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_body_has_mass() {
+        let body = RigidBody::dynamic(Shape::circle(1.0), Material::default());
+        assert!(body.mass > 0.0);
+        assert!(body.inv_mass > 0.0);
+        assert!(body.inertia > 0.0);
+        assert_eq!(body.kind, BodyKind::Dynamic);
+    }
+
+    #[test]
+    fn static_body_has_zero_inv_mass() {
+        let body = RigidBody::stationary(Shape::circle(1.0), Material::default());
+        assert_eq!(body.mass, 0.0);
+        assert_eq!(body.inv_mass, 0.0);
+        assert_eq!(body.inv_inertia, 0.0);
+        assert_eq!(body.kind, BodyKind::Static);
+    }
+
+    #[test]
+    fn builder_pattern() {
+        let body = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(5.0, 10.0))
+            .with_velocity(Vec2::new(1.0, 0.0))
+            .with_angle(0.5);
+        assert_eq!(body.position, Vec2::new(5.0, 10.0));
+        assert_eq!(body.velocity, Vec2::new(1.0, 0.0));
+        assert_eq!(body.angle, 0.5);
+    }
+
+    #[test]
+    fn apply_force_accumulates() {
+        let mut body = RigidBody::dynamic(Shape::circle(1.0), Material::default());
+        body.apply_force(Vec2::new(10.0, 0.0));
+        body.apply_force(Vec2::new(0.0, 5.0));
+        assert_eq!(body.force, Vec2::new(10.0, 5.0));
+    }
+
+    #[test]
+    fn apply_impulse_changes_velocity() {
+        let mut body = RigidBody::dynamic(Shape::circle(1.0), Material::default());
+        let inv_mass = body.inv_mass;
+        body.apply_impulse(Vec2::new(10.0, 0.0));
+        assert_eq!(body.velocity, Vec2::new(10.0 * inv_mass, 0.0));
+    }
+
+    #[test]
+    fn body_handle_index() {
+        let h = BodyHandle(42);
+        assert_eq!(h.index(), 42);
+    }
+}

--- a/crates/physics/physics-core/src/contact.rs
+++ b/crates/physics/physics-core/src/contact.rs
@@ -1,0 +1,28 @@
+//! Contact information produced by collision detection.
+
+use crate::math::Vec2;
+
+/// A single contact point in a collision manifold.
+#[derive(Debug, Clone, Copy)]
+pub struct ContactPoint {
+    /// World-space position of the contact.
+    pub position: Vec2,
+    /// Penetration depth (positive means overlapping).
+    pub penetration: f64,
+}
+
+/// A contact manifold between two bodies.
+///
+/// Contains one or more contact points sharing the same contact normal.
+/// The normal always points from `body_a` toward `body_b`.
+#[derive(Debug, Clone)]
+pub struct ContactManifold {
+    /// Index of the first body.
+    pub body_a: usize,
+    /// Index of the second body.
+    pub body_b: usize,
+    /// Contact normal (unit vector from body A toward body B).
+    pub normal: Vec2,
+    /// Contact points.
+    pub contacts: Vec<ContactPoint>,
+}

--- a/crates/physics/physics-core/src/error.rs
+++ b/crates/physics/physics-core/src/error.rs
@@ -1,0 +1,17 @@
+//! Error types for the physics engine.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PhysicsError {
+    #[error("invalid body handle: {0}")]
+    InvalidBodyHandle(u32),
+
+    #[error("invalid shape: {reason}")]
+    InvalidShape { reason: String },
+
+    #[error("invalid parameter: {reason}")]
+    InvalidParameter { reason: String },
+}
+
+pub type PhysicsResult<T> = Result<T, PhysicsError>;

--- a/crates/physics/physics-core/src/lib.rs
+++ b/crates/physics/physics-core/src/lib.rs
@@ -1,0 +1,19 @@
+//! `physics-core` — Core types for the 2D rigid body physics engine.
+//!
+//! This crate contains **zero IO** — only types, traits, and pure logic.
+//! Provides math primitives, shape definitions, rigid body representation,
+//! contact manifolds, and material properties for physics simulation.
+
+pub mod body;
+pub mod contact;
+pub mod error;
+pub mod material;
+pub mod math;
+pub mod shape;
+
+pub use body::{BodyHandle, BodyKind, RigidBody};
+pub use contact::{ContactManifold, ContactPoint};
+pub use error::{PhysicsError, PhysicsResult};
+pub use material::Material;
+pub use math::{Aabb, Vec2};
+pub use shape::Shape;

--- a/crates/physics/physics-core/src/material.rs
+++ b/crates/physics/physics-core/src/material.rs
@@ -1,0 +1,65 @@
+//! Physical material properties for rigid bodies.
+
+use serde::{Deserialize, Serialize};
+
+/// Describes the physical surface properties of a body.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Material {
+    /// Coefficient of restitution (bounciness). 0 = perfectly inelastic, 1 = perfectly elastic.
+    pub restitution: f64,
+    /// Static friction coefficient.
+    pub static_friction: f64,
+    /// Dynamic (kinetic) friction coefficient.
+    pub dynamic_friction: f64,
+    /// Density in kg/m^2 (used to compute mass from shape area).
+    pub density: f64,
+}
+
+impl Default for Material {
+    fn default() -> Self {
+        Self {
+            restitution: 0.3,
+            static_friction: 0.6,
+            dynamic_friction: 0.4,
+            density: 1.0,
+        }
+    }
+}
+
+impl Material {
+    pub fn rubber() -> Self {
+        Self {
+            restitution: 0.8,
+            static_friction: 0.9,
+            dynamic_friction: 0.7,
+            density: 1.5,
+        }
+    }
+
+    pub fn ice() -> Self {
+        Self {
+            restitution: 0.1,
+            static_friction: 0.05,
+            dynamic_friction: 0.02,
+            density: 0.9,
+        }
+    }
+
+    pub fn steel() -> Self {
+        Self {
+            restitution: 0.5,
+            static_friction: 0.74,
+            dynamic_friction: 0.57,
+            density: 7.8,
+        }
+    }
+
+    pub fn bouncy() -> Self {
+        Self {
+            restitution: 0.95,
+            static_friction: 0.3,
+            dynamic_friction: 0.2,
+            density: 1.0,
+        }
+    }
+}

--- a/crates/physics/physics-core/src/math.rs
+++ b/crates/physics/physics-core/src/math.rs
@@ -1,0 +1,381 @@
+//! 2D math primitives: vectors and axis-aligned bounding boxes.
+
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use serde::{Deserialize, Serialize};
+
+// ── Vec2 ──────────────────────────────────────────────────────────────────────
+
+/// A 2D vector with `f64` components.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Vec2 {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Default for Vec2 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl Vec2 {
+    pub const ZERO: Self = Self { x: 0.0, y: 0.0 };
+    pub const ONE: Self = Self { x: 1.0, y: 1.0 };
+    pub const UP: Self = Self { x: 0.0, y: 1.0 };
+    pub const DOWN: Self = Self { x: 0.0, y: -1.0 };
+    pub const LEFT: Self = Self { x: -1.0, y: 0.0 };
+    pub const RIGHT: Self = Self { x: 1.0, y: 0.0 };
+
+    #[inline]
+    pub const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    /// Dot product of two vectors.
+    #[inline]
+    pub fn dot(self, other: Self) -> f64 {
+        self.x * other.x + self.y * other.y
+    }
+
+    /// 2D cross product — returns the z-component of the 3D cross product.
+    /// Positive when `other` is counter-clockwise from `self`.
+    #[inline]
+    pub fn cross(self, other: Self) -> f64 {
+        self.x * other.y - self.y * other.x
+    }
+
+    /// Cross product of a scalar and a vector: `s x v = (-s*v.y, s*v.x)`.
+    /// Useful for computing tangential velocity from angular velocity.
+    #[inline]
+    pub fn cross_scalar(s: f64, v: Self) -> Self {
+        Self::new(-s * v.y, s * v.x)
+    }
+
+    #[inline]
+    pub fn magnitude_squared(self) -> f64 {
+        self.dot(self)
+    }
+
+    #[inline]
+    pub fn magnitude(self) -> f64 {
+        self.magnitude_squared().sqrt()
+    }
+
+    /// Returns the unit vector, or `Vec2::ZERO` if the magnitude is near zero.
+    pub fn normalized(self) -> Self {
+        let mag = self.magnitude();
+        if mag < f64::EPSILON {
+            Self::ZERO
+        } else {
+            self / mag
+        }
+    }
+
+    #[inline]
+    pub fn distance(self, other: Self) -> f64 {
+        (self - other).magnitude()
+    }
+
+    #[inline]
+    pub fn distance_squared(self, other: Self) -> f64 {
+        (self - other).magnitude_squared()
+    }
+
+    /// Returns the vector rotated 90 degrees counter-clockwise.
+    #[inline]
+    pub fn perpendicular(self) -> Self {
+        Self::new(-self.y, self.x)
+    }
+
+    /// Rotates the vector by `angle` radians counter-clockwise.
+    pub fn rotate(self, angle: f64) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self::new(self.x * cos - self.y * sin, self.x * sin + self.y * cos)
+    }
+
+    /// Linear interpolation between `self` and `other` at parameter `t`.
+    #[inline]
+    pub fn lerp(self, other: Self, t: f64) -> Self {
+        self * (1.0 - t) + other * t
+    }
+}
+
+// ── Operator implementations ──────────────────────────────────────────────────
+
+impl Add for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl Sub for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+impl Mul<f64> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: f64) -> Self {
+        Self::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl Mul<Vec2> for f64 {
+    type Output = Vec2;
+    #[inline]
+    fn mul(self, rhs: Vec2) -> Vec2 {
+        Vec2::new(self * rhs.x, self * rhs.y)
+    }
+}
+
+impl Div<f64> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: f64) -> Self {
+        Self::new(self.x / rhs, self.y / rhs)
+    }
+}
+
+impl Neg for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self::new(-self.x, -self.y)
+    }
+}
+
+impl AddAssign for Vec2 {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+    }
+}
+
+impl SubAssign for Vec2 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.x -= rhs.x;
+        self.y -= rhs.y;
+    }
+}
+
+impl MulAssign<f64> for Vec2 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: f64) {
+        self.x *= rhs;
+        self.y *= rhs;
+    }
+}
+
+impl DivAssign<f64> for Vec2 {
+    #[inline]
+    fn div_assign(&mut self, rhs: f64) {
+        self.x /= rhs;
+        self.y /= rhs;
+    }
+}
+
+// ── Aabb ──────────────────────────────────────────────────────────────────────
+
+/// Axis-aligned bounding box defined by min/max corners.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Aabb {
+    pub min: Vec2,
+    pub max: Vec2,
+}
+
+impl Aabb {
+    pub fn new(min: Vec2, max: Vec2) -> Self {
+        Self { min, max }
+    }
+
+    pub fn from_center_half_extents(center: Vec2, half: Vec2) -> Self {
+        Self {
+            min: center - half,
+            max: center + half,
+        }
+    }
+
+    /// Returns `true` if this AABB overlaps `other` (inclusive on boundaries).
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.min.x <= other.max.x
+            && self.max.x >= other.min.x
+            && self.min.y <= other.max.y
+            && self.max.y >= other.min.y
+    }
+
+    pub fn center(&self) -> Vec2 {
+        (self.min + self.max) * 0.5
+    }
+
+    pub fn half_extents(&self) -> Vec2 {
+        (self.max - self.min) * 0.5
+    }
+
+    /// Returns the smallest AABB that contains both `self` and `other`.
+    pub fn merge(&self, other: &Self) -> Self {
+        Self {
+            min: Vec2::new(self.min.x.min(other.min.x), self.min.y.min(other.min.y)),
+            max: Vec2::new(self.max.x.max(other.max.x), self.max.y.max(other.max.y)),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::FRAC_PI_2;
+
+    const EPSILON: f64 = 1e-10;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < EPSILON
+    }
+
+    fn vec2_approx_eq(a: Vec2, b: Vec2) -> bool {
+        approx_eq(a.x, b.x) && approx_eq(a.y, b.y)
+    }
+
+    #[test]
+    fn vec2_add() {
+        let a = Vec2::new(1.0, 2.0);
+        let b = Vec2::new(3.0, 4.0);
+        assert_eq!(a + b, Vec2::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn vec2_sub() {
+        let a = Vec2::new(5.0, 7.0);
+        let b = Vec2::new(2.0, 3.0);
+        assert_eq!(a - b, Vec2::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn vec2_mul_scalar() {
+        let v = Vec2::new(2.0, 3.0);
+        assert_eq!(v * 2.0, Vec2::new(4.0, 6.0));
+        assert_eq!(2.0 * v, Vec2::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn vec2_dot_product() {
+        let a = Vec2::new(1.0, 0.0);
+        let b = Vec2::new(0.0, 1.0);
+        assert!(approx_eq(a.dot(b), 0.0));
+
+        let c = Vec2::new(3.0, 4.0);
+        let d = Vec2::new(2.0, 1.0);
+        assert!(approx_eq(c.dot(d), 10.0));
+    }
+
+    #[test]
+    fn vec2_cross_product() {
+        let a = Vec2::new(1.0, 0.0);
+        let b = Vec2::new(0.0, 1.0);
+        assert!(approx_eq(a.cross(b), 1.0));
+        assert!(approx_eq(b.cross(a), -1.0));
+    }
+
+    #[test]
+    fn vec2_magnitude() {
+        let v = Vec2::new(3.0, 4.0);
+        assert!(approx_eq(v.magnitude(), 5.0));
+        assert!(approx_eq(v.magnitude_squared(), 25.0));
+    }
+
+    #[test]
+    fn vec2_normalized() {
+        let v = Vec2::new(3.0, 4.0);
+        let n = v.normalized();
+        assert!(approx_eq(n.magnitude(), 1.0));
+        assert!(approx_eq(n.x, 0.6));
+        assert!(approx_eq(n.y, 0.8));
+
+        // Zero vector normalization
+        assert_eq!(Vec2::ZERO.normalized(), Vec2::ZERO);
+    }
+
+    #[test]
+    fn vec2_rotate() {
+        let v = Vec2::new(1.0, 0.0);
+        let rotated = v.rotate(FRAC_PI_2);
+        assert!(vec2_approx_eq(rotated, Vec2::new(0.0, 1.0)));
+    }
+
+    #[test]
+    fn vec2_perpendicular() {
+        let v = Vec2::new(1.0, 0.0);
+        assert_eq!(v.perpendicular(), Vec2::new(0.0, 1.0));
+    }
+
+    #[test]
+    fn vec2_distance() {
+        let a = Vec2::new(0.0, 0.0);
+        let b = Vec2::new(3.0, 4.0);
+        assert!(approx_eq(a.distance(b), 5.0));
+    }
+
+    #[test]
+    fn vec2_lerp() {
+        let a = Vec2::new(0.0, 0.0);
+        let b = Vec2::new(10.0, 10.0);
+        assert_eq!(a.lerp(b, 0.5), Vec2::new(5.0, 5.0));
+        assert_eq!(a.lerp(b, 0.0), a);
+        assert_eq!(a.lerp(b, 1.0), b);
+    }
+
+    #[test]
+    fn vec2_cross_scalar() {
+        let v = Vec2::new(1.0, 0.0);
+        let result = Vec2::cross_scalar(1.0, v);
+        assert_eq!(result, Vec2::new(0.0, 1.0));
+    }
+
+    #[test]
+    fn aabb_overlaps() {
+        let a = Aabb::new(Vec2::new(0.0, 0.0), Vec2::new(2.0, 2.0));
+        let b = Aabb::new(Vec2::new(1.0, 1.0), Vec2::new(3.0, 3.0));
+        assert!(a.overlaps(&b));
+        assert!(b.overlaps(&a));
+    }
+
+    #[test]
+    fn aabb_no_overlap() {
+        let a = Aabb::new(Vec2::new(0.0, 0.0), Vec2::new(1.0, 1.0));
+        let b = Aabb::new(Vec2::new(2.0, 2.0), Vec2::new(3.0, 3.0));
+        assert!(!a.overlaps(&b));
+    }
+
+    #[test]
+    fn aabb_touching_edges_overlap() {
+        let a = Aabb::new(Vec2::new(0.0, 0.0), Vec2::new(1.0, 1.0));
+        let b = Aabb::new(Vec2::new(1.0, 0.0), Vec2::new(2.0, 1.0));
+        assert!(a.overlaps(&b));
+    }
+
+    #[test]
+    fn aabb_merge() {
+        let a = Aabb::new(Vec2::new(0.0, 0.0), Vec2::new(1.0, 1.0));
+        let b = Aabb::new(Vec2::new(2.0, 2.0), Vec2::new(3.0, 3.0));
+        let merged = a.merge(&b);
+        assert_eq!(merged.min, Vec2::new(0.0, 0.0));
+        assert_eq!(merged.max, Vec2::new(3.0, 3.0));
+    }
+
+    #[test]
+    fn aabb_center_and_half_extents() {
+        let aabb = Aabb::new(Vec2::new(1.0, 2.0), Vec2::new(5.0, 6.0));
+        assert_eq!(aabb.center(), Vec2::new(3.0, 4.0));
+        assert_eq!(aabb.half_extents(), Vec2::new(2.0, 2.0));
+    }
+}

--- a/crates/physics/physics-core/src/shape.rs
+++ b/crates/physics/physics-core/src/shape.rs
@@ -1,0 +1,220 @@
+//! Shape definitions for rigid bodies.
+
+use serde::{Deserialize, Serialize};
+
+use crate::math::{Aabb, Vec2};
+
+/// A collision shape in local space.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Shape {
+    /// Circle centered at the body origin.
+    Circle { radius: f64 },
+    /// Convex polygon with vertices in local space (counter-clockwise winding).
+    Polygon { vertices: Vec<Vec2> },
+}
+
+impl Shape {
+    /// Creates a circle shape.
+    pub fn circle(radius: f64) -> Self {
+        Self::Circle { radius }
+    }
+
+    /// Creates a rectangle centered at the origin.
+    pub fn rectangle(width: f64, height: f64) -> Self {
+        let hw = width / 2.0;
+        let hh = height / 2.0;
+        Self::Polygon {
+            vertices: vec![
+                Vec2::new(-hw, -hh),
+                Vec2::new(hw, -hh),
+                Vec2::new(hw, hh),
+                Vec2::new(-hw, hh),
+            ],
+        }
+    }
+
+    /// Creates a regular polygon with `n` sides inscribed in a circle of the given `radius`.
+    pub fn regular_polygon(sides: usize, radius: f64) -> Self {
+        assert!(sides >= 3, "polygon must have at least 3 sides");
+        let step = std::f64::consts::TAU / sides as f64;
+        let vertices = (0..sides)
+            .map(|i| {
+                let angle = step * i as f64;
+                Vec2::new(angle.cos() * radius, angle.sin() * radius)
+            })
+            .collect();
+        Self::Polygon { vertices }
+    }
+
+    /// Computes the world-space AABB for this shape given a body transform.
+    pub fn aabb(&self, position: Vec2, angle: f64) -> Aabb {
+        match self {
+            Self::Circle { radius } => {
+                let r = Vec2::new(*radius, *radius);
+                Aabb::from_center_half_extents(position, r)
+            }
+            Self::Polygon { vertices } => {
+                let mut min = Vec2::new(f64::INFINITY, f64::INFINITY);
+                let mut max = Vec2::new(f64::NEG_INFINITY, f64::NEG_INFINITY);
+                for v in vertices {
+                    let world = v.rotate(angle) + position;
+                    min.x = min.x.min(world.x);
+                    min.y = min.y.min(world.y);
+                    max.x = max.x.max(world.x);
+                    max.y = max.y.max(world.y);
+                }
+                Aabb::new(min, max)
+            }
+        }
+    }
+
+    /// Returns the vertices transformed to world space. Empty for circles.
+    pub fn world_vertices(&self, position: Vec2, angle: f64) -> Vec<Vec2> {
+        match self {
+            Self::Circle { .. } => vec![],
+            Self::Polygon { vertices } => vertices
+                .iter()
+                .map(|v| v.rotate(angle) + position)
+                .collect(),
+        }
+    }
+
+    /// Computes the area of the shape.
+    pub fn area(&self) -> f64 {
+        match self {
+            Self::Circle { radius } => std::f64::consts::PI * radius * radius,
+            Self::Polygon { vertices } => polygon_area(vertices),
+        }
+    }
+
+    /// Computes the moment of inertia about the center of mass for a given mass.
+    pub fn moment_of_inertia(&self, mass: f64) -> f64 {
+        match self {
+            Self::Circle { radius } => 0.5 * mass * radius * radius,
+            Self::Polygon { vertices } => polygon_inertia(vertices, mass),
+        }
+    }
+}
+
+/// Signed area of a simple polygon (positive for CCW winding).
+fn polygon_area(vertices: &[Vec2]) -> f64 {
+    let n = vertices.len();
+    let mut area = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        area += vertices[i].cross(vertices[j]);
+    }
+    area.abs() / 2.0
+}
+
+/// Moment of inertia of a convex polygon about its centroid.
+fn polygon_inertia(vertices: &[Vec2], mass: f64) -> f64 {
+    let n = vertices.len();
+    if n < 3 {
+        return 0.0;
+    }
+
+    let mut numerator = 0.0;
+    let mut denominator = 0.0;
+
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let vi = vertices[i];
+        let vj = vertices[j];
+        let cross = vi.cross(vj).abs();
+        numerator += cross * (vi.dot(vi) + vi.dot(vj) + vj.dot(vj));
+        denominator += cross;
+    }
+
+    if denominator.abs() < f64::EPSILON {
+        return 0.0;
+    }
+
+    mass * numerator / (6.0 * denominator)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f64 = 1e-6;
+
+    #[test]
+    fn circle_aabb() {
+        let shape = Shape::circle(2.0);
+        let aabb = shape.aabb(Vec2::new(5.0, 5.0), 0.0);
+        assert_eq!(aabb.min, Vec2::new(3.0, 3.0));
+        assert_eq!(aabb.max, Vec2::new(7.0, 7.0));
+    }
+
+    #[test]
+    fn rectangle_creation() {
+        let shape = Shape::rectangle(4.0, 2.0);
+        if let Shape::Polygon { vertices } = &shape {
+            assert_eq!(vertices.len(), 4);
+            assert_eq!(vertices[0], Vec2::new(-2.0, -1.0));
+            assert_eq!(vertices[1], Vec2::new(2.0, -1.0));
+            assert_eq!(vertices[2], Vec2::new(2.0, 1.0));
+            assert_eq!(vertices[3], Vec2::new(-2.0, 1.0));
+        } else {
+            panic!("expected polygon");
+        }
+    }
+
+    #[test]
+    fn rectangle_aabb_axis_aligned() {
+        let shape = Shape::rectangle(4.0, 2.0);
+        let aabb = shape.aabb(Vec2::new(0.0, 0.0), 0.0);
+        assert!((aabb.min.x - (-2.0)).abs() < EPSILON);
+        assert!((aabb.min.y - (-1.0)).abs() < EPSILON);
+        assert!((aabb.max.x - 2.0).abs() < EPSILON);
+        assert!((aabb.max.y - 1.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn circle_area() {
+        let shape = Shape::circle(1.0);
+        assert!((shape.area() - std::f64::consts::PI).abs() < EPSILON);
+    }
+
+    #[test]
+    fn rectangle_area() {
+        let shape = Shape::rectangle(4.0, 3.0);
+        assert!((shape.area() - 12.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn circle_inertia() {
+        let shape = Shape::circle(2.0);
+        let mass = 5.0;
+        // I = 0.5 * m * r^2 = 0.5 * 5 * 4 = 10
+        assert!((shape.moment_of_inertia(mass) - 10.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn regular_polygon_sides() {
+        let hex = Shape::regular_polygon(6, 1.0);
+        if let Shape::Polygon { vertices } = hex {
+            assert_eq!(vertices.len(), 6);
+        } else {
+            panic!("expected polygon");
+        }
+    }
+
+    #[test]
+    fn world_vertices_circle_empty() {
+        let shape = Shape::circle(1.0);
+        assert!(shape.world_vertices(Vec2::ZERO, 0.0).is_empty());
+    }
+
+    #[test]
+    fn world_vertices_polygon_translated() {
+        let shape = Shape::rectangle(2.0, 2.0);
+        let verts = shape.world_vertices(Vec2::new(5.0, 5.0), 0.0);
+        assert_eq!(verts.len(), 4);
+        assert_eq!(verts[0], Vec2::new(4.0, 4.0));
+        assert_eq!(verts[2], Vec2::new(6.0, 6.0));
+    }
+}

--- a/crates/physics/physics-engine/Cargo.toml
+++ b/crates/physics/physics-engine/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "physics-engine"
+description = "2D rigid body physics simulation engine — broadphase, SAT collision, impulse solver"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+physics-core.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+too_many_arguments = "allow"

--- a/crates/physics/physics-engine/src/broadphase.rs
+++ b/crates/physics/physics-engine/src/broadphase.rs
@@ -1,0 +1,79 @@
+//! Broad-phase collision detection using AABB overlap tests.
+//!
+//! Reduces the number of expensive narrow-phase checks by culling pairs whose
+//! axis-aligned bounding boxes do not overlap.
+
+use physics_core::{BodyKind, RigidBody};
+
+/// A candidate collision pair (indices into the body array).
+#[derive(Debug, Clone, Copy)]
+pub struct BroadPair {
+    pub a: usize,
+    pub b: usize,
+}
+
+/// Returns all pairs of bodies whose AABBs overlap.
+///
+/// Skips pairs where both bodies are static (they can never collide dynamically).
+/// Uses an O(n^2) brute-force sweep — sufficient for small-to-medium body counts.
+/// For large simulations, replace with spatial hashing or sweep-and-prune.
+pub fn detect_pairs(bodies: &[RigidBody]) -> Vec<BroadPair> {
+    let n = bodies.len();
+    let mut pairs = Vec::new();
+
+    // Pre-compute AABBs
+    let aabbs: Vec<_> = bodies
+        .iter()
+        .map(|b| b.shape.aabb(b.position, b.angle))
+        .collect();
+
+    for i in 0..n {
+        for j in (i + 1)..n {
+            // Skip static-static pairs
+            if bodies[i].kind == BodyKind::Static && bodies[j].kind == BodyKind::Static {
+                continue;
+            }
+            if aabbs[i].overlaps(&aabbs[j]) {
+                pairs.push(BroadPair { a: i, b: j });
+            }
+        }
+    }
+
+    pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use physics_core::{Material, RigidBody, Shape, Vec2};
+
+    #[test]
+    fn overlapping_circles_detected() {
+        let a = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(0.0, 0.0));
+        let b = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(1.5, 0.0));
+        let pairs = detect_pairs(&[a, b]);
+        assert_eq!(pairs.len(), 1);
+    }
+
+    #[test]
+    fn distant_circles_not_detected() {
+        let a = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(0.0, 0.0));
+        let b = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(10.0, 0.0));
+        let pairs = detect_pairs(&[a, b]);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn static_static_pairs_skipped() {
+        let a = RigidBody::stationary(Shape::circle(5.0), Material::default())
+            .with_position(Vec2::new(0.0, 0.0));
+        let b = RigidBody::stationary(Shape::circle(5.0), Material::default())
+            .with_position(Vec2::new(1.0, 0.0));
+        let pairs = detect_pairs(&[a, b]);
+        assert!(pairs.is_empty());
+    }
+}

--- a/crates/physics/physics-engine/src/integrator.rs
+++ b/crates/physics/physics-engine/src/integrator.rs
@@ -1,0 +1,118 @@
+//! Semi-implicit Euler integration.
+//!
+//! Integrates velocity from forces, then position from velocity.
+//! This ordering (velocity-first) provides better energy conservation
+//! than explicit Euler at the same computational cost.
+
+use physics_core::{BodyKind, RigidBody, Vec2};
+
+/// Applies accumulated forces to update velocities (for dynamic bodies only).
+pub fn integrate_velocities(bodies: &mut [RigidBody], dt: f64) {
+    for body in bodies.iter_mut() {
+        if body.kind != BodyKind::Dynamic {
+            continue;
+        }
+        body.velocity += (body.force * body.inv_mass) * dt;
+        body.angular_velocity += body.torque * body.inv_inertia * dt;
+    }
+}
+
+/// Updates positions from velocities (for dynamic and kinematic bodies).
+pub fn integrate_positions(bodies: &mut [RigidBody], dt: f64) {
+    for body in bodies.iter_mut() {
+        if body.kind == BodyKind::Static {
+            continue;
+        }
+        body.position += body.velocity * dt;
+        body.angle += body.angular_velocity * dt;
+    }
+}
+
+/// Clears accumulated forces and torques on all bodies.
+pub fn clear_forces(bodies: &mut [RigidBody]) {
+    for body in bodies.iter_mut() {
+        body.force = Vec2::ZERO;
+        body.torque = 0.0;
+    }
+}
+
+/// Applies a uniform gravity force to all dynamic bodies.
+pub fn apply_gravity(bodies: &mut [RigidBody], gravity: Vec2) {
+    for body in bodies.iter_mut() {
+        if body.kind == BodyKind::Dynamic {
+            body.force += gravity * body.mass;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use physics_core::{Material, Shape};
+
+    #[test]
+    fn gravity_accelerates_dynamic_body() {
+        let mut bodies = vec![RigidBody::dynamic(Shape::circle(1.0), Material::default())];
+
+        apply_gravity(&mut bodies, Vec2::new(0.0, -9.81));
+        integrate_velocities(&mut bodies, 1.0);
+
+        assert!(bodies[0].velocity.y < 0.0);
+    }
+
+    #[test]
+    fn static_body_unaffected_by_gravity() {
+        let mut bodies = vec![RigidBody::stationary(
+            Shape::circle(1.0),
+            Material::default(),
+        )];
+
+        apply_gravity(&mut bodies, Vec2::new(0.0, -9.81));
+        integrate_velocities(&mut bodies, 1.0);
+        integrate_positions(&mut bodies, 1.0);
+
+        assert_eq!(bodies[0].velocity, Vec2::ZERO);
+        assert_eq!(bodies[0].position, Vec2::ZERO);
+    }
+
+    #[test]
+    fn position_updates_from_velocity() {
+        let mut bodies = vec![
+            RigidBody::dynamic(Shape::circle(1.0), Material::default())
+                .with_velocity(Vec2::new(10.0, 0.0)),
+        ];
+
+        integrate_positions(&mut bodies, 0.5);
+
+        assert!((bodies[0].position.x - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn clear_forces_resets() {
+        let mut bodies = vec![RigidBody::dynamic(Shape::circle(1.0), Material::default())];
+        bodies[0].force = Vec2::new(100.0, 200.0);
+        bodies[0].torque = 50.0;
+
+        clear_forces(&mut bodies);
+
+        assert_eq!(bodies[0].force, Vec2::ZERO);
+        assert_eq!(bodies[0].torque, 0.0);
+    }
+
+    #[test]
+    fn kinematic_body_moves_but_ignores_forces() {
+        let mut bodies = vec![
+            RigidBody::kinematic(Shape::circle(1.0), Material::default())
+                .with_velocity(Vec2::new(5.0, 0.0)),
+        ];
+        bodies[0].force = Vec2::new(1000.0, 0.0);
+
+        integrate_velocities(&mut bodies, 1.0);
+        integrate_positions(&mut bodies, 1.0);
+
+        // Velocity unchanged by force (kinematic)
+        assert_eq!(bodies[0].velocity, Vec2::new(5.0, 0.0));
+        // Position updated by velocity
+        assert!((bodies[0].position.x - 5.0).abs() < 1e-10);
+    }
+}

--- a/crates/physics/physics-engine/src/lib.rs
+++ b/crates/physics/physics-engine/src/lib.rs
@@ -1,0 +1,16 @@
+//! `physics-engine` — 2D rigid body physics simulation engine.
+//!
+//! Provides a complete physics pipeline:
+//! - **Broad phase**: AABB-based pair culling
+//! - **Narrow phase**: SAT collision detection (circle-circle, circle-polygon, polygon-polygon)
+//! - **Solver**: Impulse-based collision resolution with friction
+//! - **Integrator**: Semi-implicit Euler integration
+//! - **World**: Top-level simulation container
+
+pub mod broadphase;
+pub mod integrator;
+pub mod narrowphase;
+pub mod solver;
+pub mod world;
+
+pub use world::{PhysicsWorld, WorldConfig};

--- a/crates/physics/physics-engine/src/narrowphase.rs
+++ b/crates/physics/physics-engine/src/narrowphase.rs
@@ -1,0 +1,465 @@
+//! Narrow-phase collision detection.
+//!
+//! Implements exact collision tests between shape pairs:
+//! - Circle vs Circle
+//! - Circle vs Convex Polygon
+//! - Convex Polygon vs Convex Polygon (Separating Axis Theorem)
+//!
+//! Contact manifolds contain 1–2 contact points with world-space positions
+//! and penetration depths.
+
+use physics_core::{ContactManifold, ContactPoint, Shape, Vec2};
+
+/// Performs narrow-phase collision detection between two shapes.
+///
+/// Returns a contact manifold if the shapes overlap, with the normal
+/// pointing from body A toward body B.
+pub fn detect(
+    idx_a: usize,
+    shape_a: &Shape,
+    pos_a: Vec2,
+    angle_a: f64,
+    idx_b: usize,
+    shape_b: &Shape,
+    pos_b: Vec2,
+    angle_b: f64,
+) -> Option<ContactManifold> {
+    let result = match (shape_a, shape_b) {
+        (Shape::Circle { radius: ra }, Shape::Circle { radius: rb }) => {
+            circle_vs_circle(pos_a, *ra, pos_b, *rb)
+        }
+        (Shape::Circle { radius }, Shape::Polygon { vertices }) => {
+            let world_verts = world_vertices(vertices, pos_b, angle_b);
+            circle_vs_polygon(pos_a, *radius, &world_verts)
+        }
+        (Shape::Polygon { vertices }, Shape::Circle { radius }) => {
+            let world_verts = world_vertices(vertices, pos_a, angle_a);
+            // Detect with circle as "A" then flip the result
+            circle_vs_polygon(pos_b, *radius, &world_verts).map(|mut r| {
+                r.normal = -r.normal;
+                r
+            })
+        }
+        (Shape::Polygon { vertices: va }, Shape::Polygon { vertices: vb }) => {
+            let wa = world_vertices(va, pos_a, angle_a);
+            let wb = world_vertices(vb, pos_b, angle_b);
+            polygon_vs_polygon(&wa, &wb)
+        }
+    };
+
+    result.map(|r| ContactManifold {
+        body_a: idx_a,
+        body_b: idx_b,
+        normal: r.normal,
+        contacts: r.contacts,
+    })
+}
+
+// ── Internal result type ──────────────────────────────────────────────────────
+
+struct CollisionResult {
+    normal: Vec2,
+    contacts: Vec<ContactPoint>,
+}
+
+// ── Circle vs Circle ──────────────────────────────────────────────────────────
+
+fn circle_vs_circle(
+    pos_a: Vec2,
+    radius_a: f64,
+    pos_b: Vec2,
+    radius_b: f64,
+) -> Option<CollisionResult> {
+    let d = pos_b - pos_a;
+    let dist_sq = d.magnitude_squared();
+    let sum_r = radius_a + radius_b;
+
+    if dist_sq > sum_r * sum_r {
+        return None;
+    }
+
+    let dist = dist_sq.sqrt();
+    let normal = if dist > f64::EPSILON {
+        d / dist
+    } else {
+        Vec2::RIGHT // arbitrary if coincident
+    };
+    let penetration = sum_r - dist;
+    let contact_pos = pos_a + normal * (radius_a - penetration / 2.0);
+
+    Some(CollisionResult {
+        normal,
+        contacts: vec![ContactPoint {
+            position: contact_pos,
+            penetration,
+        }],
+    })
+}
+
+// ── Circle vs Polygon (SAT-based) ────────────────────────────────────────────
+
+fn circle_vs_polygon(
+    circle_pos: Vec2,
+    radius: f64,
+    poly_verts: &[Vec2],
+) -> Option<CollisionResult> {
+    let n = poly_verts.len();
+    if n < 3 {
+        return None;
+    }
+
+    let mut min_pen = f64::INFINITY;
+    let mut best_axis = Vec2::ZERO;
+
+    // Test polygon edge normals
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let edge = poly_verts[j] - poly_verts[i];
+        let axis = Vec2::new(edge.y, -edge.x).normalized();
+        if axis.magnitude_squared() < f64::EPSILON {
+            continue;
+        }
+
+        let (min_p, max_p) = project_vertices(poly_verts, axis);
+        let center_proj = circle_pos.dot(axis);
+        let min_c = center_proj - radius;
+        let max_c = center_proj + radius;
+
+        if min_p >= max_c || min_c >= max_p {
+            return None;
+        }
+
+        let overlap = max_c.min(max_p) - min_c.max(min_p);
+        if overlap < min_pen {
+            min_pen = overlap;
+            best_axis = axis;
+        }
+    }
+
+    // Test axis from closest vertex to circle center
+    let closest = poly_verts
+        .iter()
+        .min_by(|a, b| {
+            a.distance_squared(circle_pos)
+                .partial_cmp(&b.distance_squared(circle_pos))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .unwrap();
+
+    let vertex_axis = (*closest - circle_pos).normalized();
+    if vertex_axis.magnitude_squared() > f64::EPSILON {
+        let (min_p, max_p) = project_vertices(poly_verts, vertex_axis);
+        let center_proj = circle_pos.dot(vertex_axis);
+        let min_c = center_proj - radius;
+        let max_c = center_proj + radius;
+
+        if min_p >= max_c || min_c >= max_p {
+            return None;
+        }
+
+        let overlap = max_c.min(max_p) - min_c.max(min_p);
+        if overlap < min_pen {
+            min_pen = overlap;
+            best_axis = vertex_axis;
+        }
+    }
+
+    // Ensure normal points from circle to polygon
+    let poly_center = centroid(poly_verts);
+    if best_axis.dot(poly_center - circle_pos) < 0.0 {
+        best_axis = -best_axis;
+    }
+
+    let contact_pos = circle_pos + best_axis * (radius - min_pen / 2.0);
+
+    Some(CollisionResult {
+        normal: best_axis,
+        contacts: vec![ContactPoint {
+            position: contact_pos,
+            penetration: min_pen,
+        }],
+    })
+}
+
+// ── Polygon vs Polygon (SAT + Sutherland-Hodgman clipping) ────────────────────
+
+fn polygon_vs_polygon(verts_a: &[Vec2], verts_b: &[Vec2]) -> Option<CollisionResult> {
+    if verts_a.len() < 3 || verts_b.len() < 3 {
+        return None;
+    }
+
+    let mut min_pen = f64::INFINITY;
+    let mut best_axis = Vec2::ZERO;
+
+    // Test A's edge normals
+    if !test_polygon_axes(verts_a, verts_b, &mut min_pen, &mut best_axis) {
+        return None;
+    }
+
+    // Test B's edge normals
+    if !test_polygon_axes(verts_b, verts_a, &mut min_pen, &mut best_axis) {
+        return None;
+    }
+
+    // Ensure normal points from A to B
+    let center_a = centroid(verts_a);
+    let center_b = centroid(verts_b);
+    if best_axis.dot(center_b - center_a) < 0.0 {
+        best_axis = -best_axis;
+    }
+
+    // Generate contact points via edge clipping
+    let contacts = clip_contacts(verts_a, verts_b, best_axis, min_pen);
+    if contacts.is_empty() {
+        return None;
+    }
+
+    Some(CollisionResult {
+        normal: best_axis,
+        contacts,
+    })
+}
+
+/// Tests all edge normals of `source` against the projection of both polygons.
+/// Returns `false` if a separating axis is found.
+fn test_polygon_axes(
+    source: &[Vec2],
+    other: &[Vec2],
+    min_pen: &mut f64,
+    best_axis: &mut Vec2,
+) -> bool {
+    let n = source.len();
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let edge = source[j] - source[i];
+        let axis = Vec2::new(edge.y, -edge.x).normalized();
+        if axis.magnitude_squared() < f64::EPSILON {
+            continue;
+        }
+
+        let (min_a, max_a) = project_vertices(source, axis);
+        let (min_b, max_b) = project_vertices(other, axis);
+
+        if min_a >= max_b || min_b >= max_a {
+            return false;
+        }
+
+        let overlap = max_a.min(max_b) - min_a.max(min_b);
+        if overlap < *min_pen {
+            *min_pen = overlap;
+            *best_axis = axis;
+        }
+    }
+    true
+}
+
+/// Sutherland-Hodgman edge clipping to produce contact points.
+fn clip_contacts(verts_a: &[Vec2], verts_b: &[Vec2], normal: Vec2, _pen: f64) -> Vec<ContactPoint> {
+    // Find the reference edge on A (most aligned with normal)
+    let ref_idx = find_best_edge(verts_a, normal);
+    let ref_v1 = verts_a[ref_idx];
+    let ref_v2 = verts_a[(ref_idx + 1) % verts_a.len()];
+
+    // Find the incident edge on B (most anti-aligned with normal)
+    let inc_idx = find_best_edge(verts_b, -normal);
+    let inc_v1 = verts_b[inc_idx];
+    let inc_v2 = verts_b[(inc_idx + 1) % verts_b.len()];
+
+    let ref_dir = (ref_v2 - ref_v1).normalized();
+
+    // Clip incident edge against reference face side planes
+    let mut clipped = vec![inc_v1, inc_v2];
+    clipped = clip_segment(clipped, -ref_dir, -ref_dir.dot(ref_v1));
+    if clipped.is_empty() {
+        return vec![];
+    }
+    clipped = clip_segment(clipped, ref_dir, ref_dir.dot(ref_v2));
+    if clipped.is_empty() {
+        return vec![];
+    }
+
+    // Keep only points behind the reference face
+    let ref_offset = normal.dot(ref_v1);
+    clipped
+        .into_iter()
+        .filter_map(|p| {
+            let sep = normal.dot(p) - ref_offset;
+            if sep <= 0.0 {
+                Some(ContactPoint {
+                    position: p,
+                    penetration: -sep,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Finds the edge whose outward normal is most aligned with `direction`.
+fn find_best_edge(verts: &[Vec2], direction: Vec2) -> usize {
+    let n = verts.len();
+    let mut best = 0;
+    let mut best_dot = f64::NEG_INFINITY;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        let edge = verts[j] - verts[i];
+        let edge_normal = Vec2::new(edge.y, -edge.x).normalized();
+        let d = edge_normal.dot(direction);
+        if d > best_dot {
+            best_dot = d;
+            best = i;
+        }
+    }
+    best
+}
+
+/// Clips a segment (2 points) against a half-plane defined by `normal . x >= offset`.
+fn clip_segment(points: Vec<Vec2>, plane_normal: Vec2, plane_offset: f64) -> Vec<Vec2> {
+    if points.len() < 2 {
+        return points;
+    }
+
+    let d0 = plane_normal.dot(points[0]) - plane_offset;
+    let d1 = plane_normal.dot(points[1]) - plane_offset;
+
+    let mut out = Vec::with_capacity(2);
+
+    if d0 >= 0.0 {
+        out.push(points[0]);
+    }
+    if d1 >= 0.0 {
+        out.push(points[1]);
+    }
+
+    // If points are on opposite sides, add the intersection
+    if d0 * d1 < 0.0 {
+        let t = d0 / (d0 - d1);
+        out.push(points[0].lerp(points[1], t));
+    }
+
+    out
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn world_vertices(local: &[Vec2], pos: Vec2, angle: f64) -> Vec<Vec2> {
+    local.iter().map(|v| v.rotate(angle) + pos).collect()
+}
+
+fn project_vertices(vertices: &[Vec2], axis: Vec2) -> (f64, f64) {
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    for v in vertices {
+        let proj = v.dot(axis);
+        min = min.min(proj);
+        max = max.max(proj);
+    }
+    (min, max)
+}
+
+fn centroid(vertices: &[Vec2]) -> Vec2 {
+    let n = vertices.len() as f64;
+    let sum = vertices.iter().fold(Vec2::ZERO, |acc, v| acc + *v);
+    sum / n
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use physics_core::Shape;
+
+    #[test]
+    fn circle_circle_collision() {
+        let result = circle_vs_circle(Vec2::new(0.0, 0.0), 1.0, Vec2::new(1.5, 0.0), 1.0);
+        let r = result.expect("should collide");
+        assert!((r.normal.x - 1.0).abs() < 1e-10);
+        assert!(r.normal.y.abs() < 1e-10);
+        assert!((r.contacts[0].penetration - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn circle_circle_no_collision() {
+        let result = circle_vs_circle(Vec2::new(0.0, 0.0), 1.0, Vec2::new(3.0, 0.0), 1.0);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn circle_circle_touching() {
+        let result = circle_vs_circle(Vec2::new(0.0, 0.0), 1.0, Vec2::new(2.0, 0.0), 1.0);
+        // Exactly touching means penetration = 0, which our test treats as no collision
+        // (dist_sq > sum_r * sum_r is false when equal, so it IS detected)
+        assert!(result.is_some());
+        let r = result.unwrap();
+        assert!(r.contacts[0].penetration.abs() < 1e-10);
+    }
+
+    #[test]
+    fn polygon_polygon_collision() {
+        // Two overlapping unit squares
+        let sq_a = Shape::rectangle(2.0, 2.0);
+        let sq_b = Shape::rectangle(2.0, 2.0);
+        let wa = sq_a.world_vertices(Vec2::new(0.0, 0.0), 0.0);
+        let wb = sq_b.world_vertices(Vec2::new(1.5, 0.0), 0.0);
+
+        let result = polygon_vs_polygon(&wa, &wb);
+        let r = result.expect("squares should overlap");
+        assert!(r.contacts[0].penetration > 0.0);
+        // Normal should roughly point in the +x direction (from A to B)
+        assert!(r.normal.x > 0.5);
+    }
+
+    #[test]
+    fn polygon_polygon_no_collision() {
+        let sq_a = Shape::rectangle(2.0, 2.0);
+        let sq_b = Shape::rectangle(2.0, 2.0);
+        let wa = sq_a.world_vertices(Vec2::new(0.0, 0.0), 0.0);
+        let wb = sq_b.world_vertices(Vec2::new(5.0, 0.0), 0.0);
+
+        let result = polygon_vs_polygon(&wa, &wb);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn circle_polygon_collision() {
+        let poly = Shape::rectangle(2.0, 2.0);
+        let world_verts = poly.world_vertices(Vec2::new(0.0, 0.0), 0.0);
+
+        let result = circle_vs_polygon(Vec2::new(1.5, 0.0), 1.0, &world_verts);
+        let r = result.expect("circle should hit rectangle");
+        assert!(r.contacts[0].penetration > 0.0);
+    }
+
+    #[test]
+    fn circle_polygon_no_collision() {
+        let poly = Shape::rectangle(2.0, 2.0);
+        let world_verts = poly.world_vertices(Vec2::new(0.0, 0.0), 0.0);
+
+        let result = circle_vs_polygon(Vec2::new(5.0, 0.0), 1.0, &world_verts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_full_pipeline() {
+        let shape_a = Shape::circle(1.0);
+        let shape_b = Shape::rectangle(2.0, 2.0);
+
+        let manifold = detect(
+            0,
+            &shape_a,
+            Vec2::new(0.0, 0.0),
+            0.0,
+            1,
+            &shape_b,
+            Vec2::new(1.5, 0.0),
+            0.0,
+        );
+
+        let m = manifold.expect("should detect collision");
+        assert_eq!(m.body_a, 0);
+        assert_eq!(m.body_b, 1);
+        assert!(!m.contacts.is_empty());
+    }
+}

--- a/crates/physics/physics-engine/src/solver.rs
+++ b/crates/physics/physics-engine/src/solver.rs
@@ -1,0 +1,239 @@
+//! Impulse-based collision solver with friction and position correction.
+//!
+//! Resolves collisions by applying impulses that modify body velocities
+//! so they separate (or stop penetrating) in the next integration step.
+//! Uses Baumgarte stabilization for positional correction to prevent sinking.
+
+use physics_core::{BodyKind, ContactManifold, RigidBody, Vec2};
+
+/// Solver configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct SolverConfig {
+    /// Number of velocity solver iterations per step.
+    pub velocity_iterations: usize,
+    /// Baumgarte stabilization factor (fraction of penetration corrected per step).
+    pub position_correction_percent: f64,
+    /// Penetration slop — small amount of overlap allowed to prevent jitter.
+    pub position_correction_slop: f64,
+}
+
+impl Default for SolverConfig {
+    fn default() -> Self {
+        Self {
+            velocity_iterations: 8,
+            position_correction_percent: 0.2,
+            position_correction_slop: 0.01,
+        }
+    }
+}
+
+/// Resolves all contacts by iteratively applying impulses.
+pub fn solve(bodies: &mut [RigidBody], manifolds: &[ContactManifold], config: &SolverConfig) {
+    // Iterative impulse solver — multiple passes improve stacking stability
+    for _ in 0..config.velocity_iterations {
+        for manifold in manifolds {
+            solve_manifold_velocities(bodies, manifold);
+        }
+    }
+
+    // Positional correction (Baumgarte stabilization)
+    for manifold in manifolds {
+        correct_positions(bodies, manifold, config);
+    }
+}
+
+/// Applies impulses for a single contact manifold.
+fn solve_manifold_velocities(bodies: &mut [RigidBody], manifold: &ContactManifold) {
+    let a = manifold.body_a;
+    let b = manifold.body_b;
+    let normal = manifold.normal;
+
+    for contact in &manifold.contacts {
+        // Read needed values
+        let inv_mass_a = bodies[a].inv_mass;
+        let inv_mass_b = bodies[b].inv_mass;
+        let inv_inertia_a = bodies[a].inv_inertia;
+        let inv_inertia_b = bodies[b].inv_inertia;
+        let pos_a = bodies[a].position;
+        let pos_b = bodies[b].position;
+        let vel_a = bodies[a].velocity;
+        let vel_b = bodies[b].velocity;
+        let ang_vel_a = bodies[a].angular_velocity;
+        let ang_vel_b = bodies[b].angular_velocity;
+
+        let r_a = contact.position - pos_a;
+        let r_b = contact.position - pos_b;
+
+        // Relative velocity at the contact point
+        let rel_vel = (vel_b + Vec2::cross_scalar(ang_vel_b, r_b))
+            - (vel_a + Vec2::cross_scalar(ang_vel_a, r_a));
+
+        let vel_along_normal = rel_vel.dot(normal);
+
+        // Bodies are already separating
+        if vel_along_normal > 0.0 {
+            continue;
+        }
+
+        // Compute restitution (use minimum)
+        let e = bodies[a]
+            .material
+            .restitution
+            .min(bodies[b].material.restitution);
+
+        // Effective mass for the normal direction
+        let ra_cross_n = r_a.cross(normal);
+        let rb_cross_n = r_b.cross(normal);
+        let inv_mass_sum = inv_mass_a
+            + inv_mass_b
+            + ra_cross_n * ra_cross_n * inv_inertia_a
+            + rb_cross_n * rb_cross_n * inv_inertia_b;
+
+        if inv_mass_sum.abs() < f64::EPSILON {
+            continue;
+        }
+
+        // Normal impulse magnitude
+        let j = -(1.0 + e) * vel_along_normal / inv_mass_sum;
+        let impulse = normal * j;
+
+        // Apply normal impulse
+        bodies[a].velocity -= impulse * inv_mass_a;
+        bodies[b].velocity += impulse * inv_mass_b;
+        bodies[a].angular_velocity -= r_a.cross(impulse) * inv_inertia_a;
+        bodies[b].angular_velocity += r_b.cross(impulse) * inv_inertia_b;
+
+        // ── Friction impulse ──────────────────────────────────────────
+
+        // Recompute relative velocity after normal impulse
+        let vel_a = bodies[a].velocity;
+        let vel_b = bodies[b].velocity;
+        let ang_vel_a = bodies[a].angular_velocity;
+        let ang_vel_b = bodies[b].angular_velocity;
+
+        let rel_vel = (vel_b + Vec2::cross_scalar(ang_vel_b, r_b))
+            - (vel_a + Vec2::cross_scalar(ang_vel_a, r_a));
+
+        // Tangent direction
+        let tangent_vel = rel_vel - normal * rel_vel.dot(normal);
+        let tangent = tangent_vel.normalized();
+        if tangent.magnitude_squared() < f64::EPSILON {
+            continue;
+        }
+
+        // Friction impulse magnitude
+        let jt = -rel_vel.dot(tangent) / inv_mass_sum;
+
+        // Coulomb's friction model
+        let mu_s = (bodies[a].material.static_friction + bodies[b].material.static_friction) * 0.5;
+        let mu_d =
+            (bodies[a].material.dynamic_friction + bodies[b].material.dynamic_friction) * 0.5;
+
+        let friction_impulse = if jt.abs() < j * mu_s {
+            tangent * jt
+        } else {
+            tangent * (-j * mu_d)
+        };
+
+        bodies[a].velocity -= friction_impulse * inv_mass_a;
+        bodies[b].velocity += friction_impulse * inv_mass_b;
+        bodies[a].angular_velocity -= r_a.cross(friction_impulse) * inv_inertia_a;
+        bodies[b].angular_velocity += r_b.cross(friction_impulse) * inv_inertia_b;
+    }
+}
+
+/// Baumgarte positional correction to prevent sinking.
+fn correct_positions(bodies: &mut [RigidBody], manifold: &ContactManifold, config: &SolverConfig) {
+    let a = manifold.body_a;
+    let b = manifold.body_b;
+    let inv_mass_a = bodies[a].inv_mass;
+    let inv_mass_b = bodies[b].inv_mass;
+    let inv_mass_sum = inv_mass_a + inv_mass_b;
+
+    if inv_mass_sum.abs() < f64::EPSILON {
+        return;
+    }
+
+    for contact in &manifold.contacts {
+        let correction_magnitude = (contact.penetration - config.position_correction_slop).max(0.0)
+            * config.position_correction_percent
+            / inv_mass_sum;
+
+        let correction = manifold.normal * correction_magnitude;
+
+        if bodies[a].kind != BodyKind::Static {
+            bodies[a].position -= correction * inv_mass_a;
+        }
+        if bodies[b].kind != BodyKind::Static {
+            bodies[b].position += correction * inv_mass_b;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use physics_core::{ContactPoint, Material};
+
+    #[test]
+    fn separating_bodies_not_resolved() {
+        let mut bodies = vec![
+            RigidBody::dynamic(physics_core::Shape::circle(1.0), Material::default())
+                .with_position(Vec2::new(0.0, 0.0)),
+            RigidBody::dynamic(physics_core::Shape::circle(1.0), Material::default())
+                .with_position(Vec2::new(2.0, 0.0)),
+        ];
+
+        // Bodies already moving apart
+        bodies[0].velocity = Vec2::new(-1.0, 0.0);
+        bodies[1].velocity = Vec2::new(1.0, 0.0);
+
+        let manifold = ContactManifold {
+            body_a: 0,
+            body_b: 1,
+            normal: Vec2::RIGHT,
+            contacts: vec![ContactPoint {
+                position: Vec2::new(1.0, 0.0),
+                penetration: 0.1,
+            }],
+        };
+
+        let vel_a_before = bodies[0].velocity;
+        let vel_b_before = bodies[1].velocity;
+
+        solve(&mut bodies, &[manifold], &SolverConfig::default());
+
+        // Velocities should not change (separating)
+        assert_eq!(bodies[0].velocity, vel_a_before);
+        assert_eq!(bodies[1].velocity, vel_b_before);
+    }
+
+    #[test]
+    fn approaching_bodies_get_impulse() {
+        let mut bodies = vec![
+            RigidBody::dynamic(physics_core::Shape::circle(1.0), Material::default())
+                .with_position(Vec2::new(0.0, 0.0))
+                .with_velocity(Vec2::new(5.0, 0.0)),
+            RigidBody::dynamic(physics_core::Shape::circle(1.0), Material::default())
+                .with_position(Vec2::new(1.5, 0.0))
+                .with_velocity(Vec2::new(-5.0, 0.0)),
+        ];
+
+        let manifold = ContactManifold {
+            body_a: 0,
+            body_b: 1,
+            normal: Vec2::RIGHT,
+            contacts: vec![ContactPoint {
+                position: Vec2::new(0.75, 0.0),
+                penetration: 0.5,
+            }],
+        };
+
+        solve(&mut bodies, &[manifold], &SolverConfig::default());
+
+        // After resolution, body A should be moving left (bounced)
+        assert!(bodies[0].velocity.x < 5.0);
+        // Body B should be moving right (bounced)
+        assert!(bodies[1].velocity.x > -5.0);
+    }
+}

--- a/crates/physics/physics-engine/src/world.rs
+++ b/crates/physics/physics-engine/src/world.rs
@@ -1,0 +1,296 @@
+//! Top-level physics simulation container.
+//!
+//! [`PhysicsWorld`] manages bodies and runs the simulation step:
+//! apply gravity → integrate velocities → detect collisions → solve → integrate positions.
+
+use physics_core::{BodyHandle, ContactManifold, RigidBody, Vec2};
+
+use crate::broadphase;
+use crate::integrator;
+use crate::narrowphase;
+use crate::solver::{self, SolverConfig};
+
+/// Configuration for the physics world.
+#[derive(Debug, Clone, Copy)]
+pub struct WorldConfig {
+    /// Gravity acceleration vector (default: 9.81 m/s^2 downward).
+    pub gravity: Vec2,
+    /// Solver configuration.
+    pub solver: SolverConfig,
+}
+
+impl Default for WorldConfig {
+    fn default() -> Self {
+        Self {
+            gravity: Vec2::new(0.0, -9.81),
+            solver: SolverConfig::default(),
+        }
+    }
+}
+
+/// The physics simulation world.
+///
+/// Holds all rigid bodies and steps the simulation forward in time.
+pub struct PhysicsWorld {
+    bodies: Vec<RigidBody>,
+    config: WorldConfig,
+}
+
+impl PhysicsWorld {
+    /// Creates a new empty physics world with the given configuration.
+    pub fn new(config: WorldConfig) -> Self {
+        Self {
+            bodies: Vec::new(),
+            config,
+        }
+    }
+
+    /// Creates a world with default configuration.
+    pub fn with_default_config() -> Self {
+        Self::new(WorldConfig::default())
+    }
+
+    /// Adds a body to the world and returns its handle.
+    pub fn add_body(&mut self, body: RigidBody) -> BodyHandle {
+        let idx = self.bodies.len() as u32;
+        self.bodies.push(body);
+        BodyHandle(idx)
+    }
+
+    /// Returns a reference to a body by handle.
+    pub fn body(&self, handle: BodyHandle) -> &RigidBody {
+        &self.bodies[handle.index()]
+    }
+
+    /// Returns a mutable reference to a body by handle.
+    pub fn body_mut(&mut self, handle: BodyHandle) -> &mut RigidBody {
+        &mut self.bodies[handle.index()]
+    }
+
+    /// Returns the number of bodies in the world.
+    pub fn body_count(&self) -> usize {
+        self.bodies.len()
+    }
+
+    /// Returns an iterator over all bodies.
+    pub fn bodies(&self) -> &[RigidBody] {
+        &self.bodies
+    }
+
+    /// Returns the world configuration.
+    pub fn config(&self) -> &WorldConfig {
+        &self.config
+    }
+
+    /// Sets the gravity vector.
+    pub fn set_gravity(&mut self, gravity: Vec2) {
+        self.config.gravity = gravity;
+    }
+
+    /// Advances the simulation by `dt` seconds.
+    ///
+    /// Pipeline:
+    /// 1. Apply gravity to dynamic bodies
+    /// 2. Integrate velocities (semi-implicit Euler)
+    /// 3. Broad-phase collision detection (AABB overlap)
+    /// 4. Narrow-phase collision detection (SAT / circle tests)
+    /// 5. Solve contacts (impulse-based with friction)
+    /// 6. Integrate positions
+    /// 7. Clear accumulated forces
+    pub fn step(&mut self, dt: f64) {
+        // 1. Apply gravity
+        integrator::apply_gravity(&mut self.bodies, self.config.gravity);
+
+        // 2. Integrate velocities
+        integrator::integrate_velocities(&mut self.bodies, dt);
+
+        // 3. Broad phase
+        let pairs = broadphase::detect_pairs(&self.bodies);
+
+        // 4. Narrow phase
+        let manifolds: Vec<ContactManifold> = pairs
+            .iter()
+            .filter_map(|pair| {
+                let a = &self.bodies[pair.a];
+                let b = &self.bodies[pair.b];
+                narrowphase::detect(
+                    pair.a, &a.shape, a.position, a.angle, pair.b, &b.shape, b.position, b.angle,
+                )
+            })
+            .collect();
+
+        // 5. Solve contacts
+        solver::solve(&mut self.bodies, &manifolds, &self.config.solver);
+
+        // 6. Integrate positions
+        integrator::integrate_positions(&mut self.bodies, dt);
+
+        // 7. Clear forces
+        integrator::clear_forces(&mut self.bodies);
+    }
+
+    /// Applies a force to a body (accumulated until next step).
+    pub fn apply_force(&mut self, handle: BodyHandle, force: Vec2) {
+        self.bodies[handle.index()].apply_force(force);
+    }
+
+    /// Applies an instantaneous impulse to a body at its center of mass.
+    pub fn apply_impulse(&mut self, handle: BodyHandle, impulse: Vec2) {
+        self.bodies[handle.index()].apply_impulse(impulse);
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use physics_core::{Material, Shape};
+
+    #[test]
+    fn empty_world_steps_without_error() {
+        let mut world = PhysicsWorld::with_default_config();
+        world.step(1.0 / 60.0);
+        assert_eq!(world.body_count(), 0);
+    }
+
+    #[test]
+    fn gravity_moves_body_downward() {
+        let mut world = PhysicsWorld::with_default_config();
+        let ball = RigidBody::dynamic(Shape::circle(0.5), Material::default())
+            .with_position(Vec2::new(0.0, 10.0));
+        let handle = world.add_body(ball);
+
+        // Step 60 frames at 60 FPS (1 second)
+        for _ in 0..60 {
+            world.step(1.0 / 60.0);
+        }
+
+        // Ball should have fallen
+        assert!(world.body(handle).position.y < 10.0);
+        assert!(world.body(handle).velocity.y < 0.0);
+    }
+
+    #[test]
+    fn static_body_stays_put() {
+        let mut world = PhysicsWorld::with_default_config();
+        let floor = RigidBody::stationary(Shape::rectangle(20.0, 1.0), Material::default())
+            .with_position(Vec2::new(0.0, -5.0));
+        let handle = world.add_body(floor);
+
+        for _ in 0..60 {
+            world.step(1.0 / 60.0);
+        }
+
+        assert_eq!(world.body(handle).position, Vec2::new(0.0, -5.0));
+        assert_eq!(world.body(handle).velocity, Vec2::ZERO);
+    }
+
+    #[test]
+    fn ball_bounces_off_floor() {
+        let mut world = PhysicsWorld::new(WorldConfig {
+            gravity: Vec2::new(0.0, -10.0),
+            solver: SolverConfig {
+                velocity_iterations: 10,
+                ..SolverConfig::default()
+            },
+        });
+
+        // Floor at y = 0 (static, 20 wide, 1 tall → top face at y = 0.5)
+        let floor = RigidBody::stationary(
+            Shape::rectangle(20.0, 1.0),
+            Material {
+                restitution: 1.0,
+                ..Material::default()
+            },
+        )
+        .with_position(Vec2::new(0.0, 0.0));
+
+        // Ball above the floor
+        let ball = RigidBody::dynamic(
+            Shape::circle(0.5),
+            Material {
+                restitution: 1.0,
+                ..Material::default()
+            },
+        )
+        .with_position(Vec2::new(0.0, 5.0));
+
+        world.add_body(floor);
+        let ball_handle = world.add_body(ball);
+
+        // Run simulation
+        for _ in 0..300 {
+            world.step(1.0 / 60.0);
+        }
+
+        // Ball should not have fallen through the floor
+        let ball_y = world.body(ball_handle).position.y;
+        assert!(ball_y > -1.0, "ball fell through floor: y = {ball_y}");
+    }
+
+    #[test]
+    fn two_dynamic_bodies_collide() {
+        let mut world = PhysicsWorld::new(WorldConfig {
+            gravity: Vec2::ZERO, // no gravity
+            ..WorldConfig::default()
+        });
+
+        let a = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(-2.0, 0.0))
+            .with_velocity(Vec2::new(5.0, 0.0));
+        let b = RigidBody::dynamic(Shape::circle(1.0), Material::default())
+            .with_position(Vec2::new(2.0, 0.0))
+            .with_velocity(Vec2::new(-5.0, 0.0));
+
+        let ha = world.add_body(a);
+        let hb = world.add_body(b);
+
+        for _ in 0..60 {
+            world.step(1.0 / 60.0);
+        }
+
+        // After collision, bodies should have reversed (or slowed) their velocities
+        // With default restitution 0.3, they won't fully reverse but should change direction
+        let va = world.body(ha).velocity.x;
+        let vb = world.body(hb).velocity.x;
+        // Bodies should have exchanged some momentum
+        assert!(va < 5.0, "body A should have slowed down: vx = {va}");
+        assert!(vb > -5.0, "body B should have slowed down: vx = {vb}");
+    }
+
+    #[test]
+    fn apply_force_accelerates_body() {
+        let mut world = PhysicsWorld::new(WorldConfig {
+            gravity: Vec2::ZERO,
+            ..WorldConfig::default()
+        });
+
+        let body = RigidBody::dynamic(Shape::circle(1.0), Material::default());
+        let handle = world.add_body(body);
+
+        // Apply horizontal force for 1 second (60 steps)
+        for _ in 0..60 {
+            world.apply_force(handle, Vec2::new(100.0, 0.0));
+            world.step(1.0 / 60.0);
+        }
+
+        assert!(world.body(handle).velocity.x > 0.0);
+        assert!(world.body(handle).position.x > 0.0);
+    }
+
+    #[test]
+    fn body_count_tracks_additions() {
+        let mut world = PhysicsWorld::with_default_config();
+        assert_eq!(world.body_count(), 0);
+
+        world.add_body(RigidBody::dynamic(Shape::circle(1.0), Material::default()));
+        assert_eq!(world.body_count(), 1);
+
+        world.add_body(RigidBody::stationary(
+            Shape::rectangle(10.0, 1.0),
+            Material::default(),
+        ));
+        assert_eq!(world.body_count(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- **physics-core**: Zero-IO foundation crate with math primitives (`Vec2`, `Aabb`), shape definitions (circle, convex polygon, rectangle), rigid body representation with builder pattern, contact manifolds, material properties (rubber, ice, steel, bouncy presets), and moment-of-inertia computation
- **physics-engine**: Full 2D simulation pipeline — AABB broadphase pair culling, SAT-based narrowphase (circle-circle, circle-polygon, polygon-polygon with Sutherland-Hodgman edge clipping), impulse-based collision solver with Coulomb friction model and Baumgarte positional correction, semi-implicit Euler integration, and a `PhysicsWorld` container that orchestrates the complete step cycle
- **life-physics**: Thin facade crate re-exporting `physics-core` and `physics-engine`

57 tests passing across both library crates covering vector math, AABB overlap, shape geometry, collision detection, impulse resolution, and full world simulation scenarios (gravity, bouncing, body collisions).

## Test plan

- [x] `cargo test -p physics-core` — 32 tests (math, shapes, bodies)
- [x] `cargo test -p physics-engine` — 25 tests (broadphase, narrowphase, solver, integrator, world)
- [x] `cargo clippy -p physics-core -p physics-engine -p life-physics -- -D warnings` — clean
- [x] `cargo fmt` — formatted

https://claude.ai/code/session_012fu1oYoqJjmfbGJQEfu6PQ