### PR TITLE
chore(rcs): update sync script path after rcs repo refactor

### DIFF
--- a/crates/autonomic/autonomic-core/data/rcs-parameters.toml
+++ b/crates/autonomic/autonomic-core/data/rcs-parameters.toml
@@ -3,7 +3,7 @@
 # =============================================================================
 #
 # THIS FILE IS A MIRROR. The authoritative source lives in the paper repo at:
-#   ~/broomva/research/rcs/latex/parameters.toml
+#   ~/broomva/research/rcs/data/parameters.toml
 # Keep the two in sync via `scripts/sync-rcs-parameters.sh` (or manual copy).
 # The mirror is required because the paper repo is a separate git root and
 # this crate needs compile-time access via `include_str!`.

--- a/scripts/sync-rcs-parameters.sh
+++ b/scripts/sync-rcs-parameters.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 LIFE_ROOT="$(cd "${HERE}/.." && pwd)"
-PAPER_SRC="${HOME}/broomva/research/rcs/latex/parameters.toml"
+PAPER_SRC="${HOME}/broomva/research/rcs/data/parameters.toml"
 MIRROR_DST="${LIFE_ROOT}/crates/autonomic/autonomic-core/data/rcs-parameters.toml"
 
 if [[ ! -f "${PAPER_SRC}" ]]; then
@@ -28,7 +28,7 @@ HEADER="# ======================================================================
 # =============================================================================
 #
 # THIS FILE IS A MIRROR. The authoritative source lives in the paper repo at:
-#   ~/broomva/research/rcs/latex/parameters.toml
+#   ~/broomva/research/rcs/data/parameters.toml
 # Keep the two in sync via \`scripts/sync-rcs-parameters.sh\` (or manual copy).
 # The mirror is required because the paper repo is a separate git root and
 # this crate needs compile-time access via \`include_str!\`.


### PR DESCRIPTION
## Summary

Follow-up to rcs#7 which moved \`parameters.toml\` from \`latex/\` to \`data/\` in the paper repo.

## Changes

- \`scripts/sync-rcs-parameters.sh\`: \`PAPER_SRC\` now reads \`~/broomva/research/rcs/data/parameters.toml\`; the HEADER comment embedded in the generated mirror updated to match.
- \`crates/autonomic/autonomic-core/data/rcs-parameters.toml\`: re-synced via the updated script. **Only the header comment changed** (\`latex/\` -> \`data/\` in the source-path reference). The TOML body is byte-identical.

## Verification

\`\`\`
cargo test -p autonomic-core --lib
...
test rcs_budget::tests::margin_matches_paper_derived_values ... ok
...
test result: ok. 62 passed; 0 failed; 0 ignored
\`\`\`

The canonical-lambda cross-check (<1e-3 tolerance against paper's \`[derived.lambda]\`) still passes — so no numeric drift was introduced by the re-sync.

## Why this PR

Before this PR, running \`bash scripts/sync-rcs-parameters.sh\` on a fresh checkout would fail with \"paper source missing at /Users/.../rcs/latex/parameters.toml\". The mirror file itself was still valid (synced correctly at the last F2 landing), so Rust builds and tests kept working — but any future edit on the paper side couldn't propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)