### PR TITLE
docs(rcs_budget): update stale path refs post-rcs-layout-refactor

### DIFF
--- a/crates/autonomic/autonomic-core/data/rcs-parameters.toml
+++ b/crates/autonomic/autonomic-core/data/rcs-parameters.toml
@@ -10,9 +10,10 @@
 #
 #
 # Single source of truth for the recursive stability budget parameters used by
-# the paper (latex/rcs-definitions*.tex) and the proof tests (tests/*.py).
-# The future Life integration harness (core/life/crates/.../rcs_budget.rs)
-# will also deserialize this file via serde.
+# the paper (papers/p0-foundations/main*.tex via latex/parameters.tex),
+# the Python proof tests (tests/*.py), and the Rust Life harness
+# (core/life/crates/autonomic/autonomic-core/src/rcs_budget.rs via its
+# mirror at core/life/.../data/rcs-parameters.toml).
 #
 # The stability budget at each level is:
 #
@@ -24,7 +25,7 @@
 #
 # A level is individually stable iff lambda_i > 0. The composite multi-level
 # system is exponentially stable when lambda_i > 0 at every level (Theorem 1,
-# rcs-definitions.tex).
+# papers/p0-foundations/main.tex).
 #
 # Editing rules:
 #   - Bump the schema_version below when adding/removing fields.

--- a/crates/autonomic/autonomic-core/src/rcs_budget.rs
+++ b/crates/autonomic/autonomic-core/src/rcs_budget.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is the Rust-native F2 instrumentation for the Recursive
 //! Controlled Systems (RCS) paper. It mirrors the formal definition in
-//! `research/rcs/latex/rcs-definitions.tex` (Theorem 1): a level is
+//! `research/rcs/papers/p0-foundations/main.tex` (Theorem 1): a level is
 //! individually stable iff its stability margin
 //!
 //! ```text
@@ -30,11 +30,12 @@ use serde::Deserialize;
 
 use crate::gating::HomeostaticState;
 
-/// Canonical parameters.toml mirrored from `research/rcs/latex/parameters.toml`.
+/// Canonical parameters.toml mirrored from `research/rcs/data/parameters.toml`.
 ///
 /// Embedded at compile time — editing the mirror is the single source of
-/// truth for Rust. The paper repo's `parameters.toml` is the single source of
-/// truth for the paper; a sync script keeps them aligned.
+/// truth for Rust. The paper repo's `data/parameters.toml` is the single
+/// source of truth for the paper; `scripts/sync-rcs-parameters.sh` keeps
+/// the two aligned.
 const CANONICAL_PARAMETERS_TOML: &str = include_str!("../data/rcs-parameters.toml");
 
 /// Cached parsed canonical parameters.
@@ -83,7 +84,7 @@ struct CanonicalLevel {
 /// Stability budget at a single level of the RCS hierarchy.
 ///
 /// Fields correspond one-to-one with the symbols in the paper's Theorem 1.
-/// See `research/rcs/latex/rcs-definitions.tex` for the full derivation.
+/// See `research/rcs/papers/p0-foundations/main.tex` for the full derivation.
 ///
 /// Construct either directly (fields are public) or via
 /// [`StabilityBudget::from_canonical`] to pull the paper's values.


### PR DESCRIPTION
## Summary

Three module-level comments in \`crates/autonomic/autonomic-core/src/rcs_budget.rs\` pointed at the old \`research/rcs/latex/...\` paths. After rcs#7 moved the paper sources to \`research/rcs/papers/p0-foundations/\` and the canonical TOML to \`research/rcs/data/\`, these comments became stale.

## Changes

| Line | Before | After |
|---|---|---|
| 5 | \`research/rcs/latex/rcs-definitions.tex\` | \`research/rcs/papers/p0-foundations/main.tex\` |
| 33 | \`research/rcs/latex/parameters.toml\` | \`research/rcs/data/parameters.toml\` + expanded sync-script reference |
| 86 | \`research/rcs/latex/rcs-definitions.tex\` | \`research/rcs/papers/p0-foundations/main.tex\` |

Also re-synced \`crates/autonomic/autonomic-core/data/rcs-parameters.toml\` from the paper repo's updated \`data/parameters.toml\` header (rcs#8 landed a companion comment update there). Only header lines changed; the TOML body is byte-identical — verified by \`cargo test -p autonomic-core --lib\` (62/62 pass, including \`margin_matches_paper_derived_values\`).

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test -p autonomic-core --lib\` — 62 passed
- [x] \`cargo fmt --all --check\`
- [ ] CI green

## Paired with

- rcs#8 (internal path refs in the paper repo) — already merged
- Workspace commit \`aee0d32\` on \`broomva/workspace\` main — already landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)