### PR TITLE
docs: Pneuma/Plexus specs + AGP alignment RFC (BRO-718)

### DIFF
--- a/docs/rfcs/0001-autogenesis-agp-alignment.md
+++ b/docs/rfcs/0001-autogenesis-agp-alignment.md
@@ -1,0 +1,312 @@
+# RFC 0001 — Autogenesis Protocol (AGP) Alignment
+
+**Status:** Draft
+**Created:** 2026-04-18
+**Author:** broomva (carlosdavidescobar)
+**Related paper:** [Autogenesis: A Self-Evolving Agent Protocol](https://arxiv.org/abs/2604.15034) (W. Zhang, NTU + Skywork AI, Apr 2026)
+**Related spec:** `docs/specs/pneuma-trait-surface.md`
+**Related synthesis:** `broomva/research/notes/2026-04-18-autogenesis-agp-rcs-life-alignment-synthesis.md`
+**Supersedes / depends on:** none (new)
+
+---
+
+## Summary
+
+Autogenesis Protocol (AGP) is the protocol-level formalization of an architectural pattern the self-evolving-agents field has been converging on for three years. It defines two layers: **RSPL** (five typed versioned resource entities — Prompt, Agent, Tool, Environment, Memory) and **SEPL** (five-operator algebra — Reflect, Select, Improve, Evaluate, Commit). AGP's near-isomorphic relationship to our existing Pneuma trait family and autoany EGRI loop means Life is already ~80% of the way there at the architectural level. This RFC proposes the remaining 20% as a four-phase sequenced implementation plan that minimizes coupling risk and respects the workspace's stability-budget discipline.
+
+## Motivation
+
+Three structural gaps in Life's current implementation map directly to concepts AGP defines cleanly:
+
+1. **No first-class learnability mask.** Life has implicit mutability via Rust `&mut` and `Proposer::propose()` discretion in `autoany-core`. There is no compile-time marker saying "this resource participates in SEPL evolution." This blocks auditable self-modification and makes EGRI Law 3 (Immutable Evaluator) a runtime convention rather than a type-level invariant.
+2. **EGRI loop lacks an explicit Reflect operator.** `autoany-core::loop_engine::EgriLoop` has propose → execute → evaluate → select → promote. There is no ρ (Reflect) step that consumes execution traces and produces hypotheses. `StrategyReport` exists as a design artifact but is not wired. Vigil is now shipped (v0.2.0) and emits contract-derived OTel spans — the trace substrate exists; the consumer does not.
+3. **Pneuma has a trait-surface spec (`docs/specs/pneuma-trait-surface.md`) but no implementation.** The spec is complete and mechanical-port-ready. Without landing it, RSPL and Evolvable cannot anchor to the broader substrate-invariant abstraction, and we risk re-inventing the boundary/axis machinery inside `aios-protocol::rspl`.
+
+AGP gives us the type signatures and operator algebra; we have the stability theorems (λᵢ > 0 per level), the homeostasis controller (Autonomic), and the event-sourced substrate (Lago) that AGP lacks. Closing the gap is small, crisp, and mutually reinforcing: AGP types + RCS rate bounds = a publishable protocol.
+
+## Non-goals
+
+- **Not a new evolution engine.** EGRI stays the execution model; SEPL is its type signature.
+- **Not a rewrite of Pneuma.** The existing spec at `docs/specs/pneuma-trait-surface.md` is authoritative; this RFC adds the depth-0 horizontal-0 RSPL layer on top.
+- **Not a benchmark chase.** We are not targeting GAIA numbers in this work. The value is protocol-level auditability and the RCS ↔ AGP reciprocal claim.
+- **Not a breaking change.** No existing public API is modified; everything proposed is additive.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| RSPL | Resource Substrate Protocol Layer — AGP's five-type resource taxonomy |
+| SEPL | Self-Evolution Protocol Layer — AGP's five-operator algebra |
+| ρ σ ι ε κ | Reflect, Select, Improve, Evaluate, Commit (SEPL operators) |
+| 𝒵 ℋ 𝒟 𝒢 𝒮 | Trace, Hypothesis, Modification, Objective, Evaluation state spaces |
+| `g_v` | Learnability mask — bit indicating whether a resource participates in 𝒱_evo |
+| Pneuma | Substrate-invariant trait family for inter-boundary flow (see `docs/specs/pneuma-trait-surface.md`) |
+| EGRI | Evaluator-Governed Recursive Improvement (autoany Level 2 meta-controller) |
+
+## Design
+
+### Architectural framing
+
+```
+         ┌──────────────────────────────────────────────┐
+         │   SEPL operator algebra (ρ σ ι ε κ)          │ ← autoany-core::loop_engine (+ reflect)
+         └──────────────────────────────────────────────┘
+                              │ operates on
+                              ▼
+         ┌──────────────────────────────────────────────┐
+         │   Evolvable<T> trait + g_v learnability mask │ ← aios-protocol::rspl::evolvable
+         └──────────────────────────────────────────────┘
+                              │ refines
+                              ▼
+         ┌──────────────────────────────────────────────┐
+         │   RSPL five entity types                     │
+         │   Prompt | Agent | Tool | Env | Memory       │ ← aios-protocol::rspl
+         └──────────────────────────────────────────────┘
+                              │ impl
+                              ▼
+         ┌──────────────────────────────────────────────┐
+         │   Pneuma trait family                        │
+         │   Axis | Boundary | Pneuma                   │ ← aios-protocol::pneuma
+         └──────────────────────────────────────────────┘
+```
+
+Four layers, bottom-up implementation order. Each layer is independently testable; each higher layer consumes the lower layer via typed interfaces; nothing below is breaking-change.
+
+### Layer 1 — Pneuma trait surface (`aios-protocol::pneuma`)
+
+**Status:** Spec complete at `docs/specs/pneuma-trait-surface.md` (1106 lines). Implementation not yet started.
+
+**Scope:** Mechanical port of the spec into `core/life/crates/aios/aios-protocol/src/pneuma.rs` plus re-exports from `lib.rs`. Spec explicitly states "Every symbol in this spec is intended to be ported verbatim."
+
+**Contents:** Axis markers (Vertical, Horizontal), Boundary markers (L0ToL1, L1ToL2, L2ToL3, L3ToExternal, D0ToD1, D1ToD2, D2ToD3), SubstrateProfile metadata (SubstrateKind, WarpFactors, ResourceCeiling, CoordinationRegime), `trait Pneuma` with associated types Signal/Aggregate/Directive, `trait PneumaError`, `trait SubstrateAware`.
+
+**Dependencies:** `serde`, `thiserror`, `std::fmt` only. No new crate deps.
+
+**Tests:** The spec lists 14 test scenarios (trait object safety, send/sync bounds, boundary-to-axis binding, substrate kind defaults, warp factor computation, etc.). All should land with the port.
+
+**Sequencing:** Land this first as an independent PR before anything below.
+
+### Layer 2 — RSPL five entity types (`aios-protocol::rspl`)
+
+**Status:** Not yet designed in code. This RFC proposes the shape.
+
+**Scope:** A new module `core/life/crates/aios/aios-protocol/src/rspl.rs` (or submodule directory) defining the five RSPL entity types from AGP §3.1.1 as Pneuma impls at depth 0.
+
+**Contents:**
+
+```rust
+//! RSPL — depth-0 horizontal-0 instantiation of Pneuma.
+//!
+//! The five entity types defined in AGP (Autogenesis Protocol, arXiv:2604.15034)
+//! are concrete Pneuma impls for an individual LLM-based agent. Each type
+//! names a boundary crossed during agent operation.
+
+use crate::pneuma::*;
+
+/// Prompt — instruction or context descending from controller to plant.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Prompt {
+    pub name: String,
+    pub description: String,
+    pub body: String,
+    pub version: String,
+    pub learnability: Learnability,   // g_v
+    pub metadata: serde_json::Value,
+}
+
+// Mirror struct for Agent, Tool, Environment, Memory with per-type φ semantics.
+```
+
+Each of the five types `impl Pneuma` with the appropriate boundary marker (Prompt → L1ToL0, Memory → L0ToL1, etc.) and with a shared `impl Evolvable`.
+
+**Dependencies:** `aios-protocol::pneuma` (Layer 1).
+
+**Tests:** Round-trip serde, boundary type-safety (compile-fail tests showing L0→L1 impl cannot be wired where L1→L0 is expected), Pneuma trait object safety.
+
+### Layer 3 — Evolvable trait + learnability mask (`aios-protocol::rspl::evolvable`)
+
+**Status:** Not yet designed in code. Proposed here.
+
+**Scope:** A trait marker + type encoding AGP's `g_v ∈ {0,1}` bit, plus a richer `MutationSchema` for declaring *what shape* of mutation is legal on each resource.
+
+**Contents:**
+
+```rust
+/// Learnability annotation — whether a resource participates in the
+/// SEPL evolvable variable set 𝒱_evo.
+///
+/// AGP defines `g_v ∈ {0,1}` per entity; we generalize to include a
+/// mutation-shape schema for richer auditability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Learnability {
+    /// Frozen — not in 𝒱_evo. Required for evaluators (EGRI Law 3).
+    Frozen,
+    /// Evolvable with an unrestricted mutation space.
+    Open,
+    /// Evolvable with a schema-constrained mutation space.
+    Constrained(MutationSchemaId),
+}
+
+pub trait Evolvable {
+    fn learnability(&self) -> Learnability;
+    fn mutation_schema(&self) -> Option<MutationSchema> {
+        None
+    }
+}
+
+/// Compile-time enforcement of EGRI Law 3 (Immutable Evaluator).
+pub trait ImmutableResource: Evolvable {
+    // sealed: auto-implemented when Learnability::Frozen
+}
+```
+
+**Dependencies:** `aios-protocol::rspl` (Layer 2).
+
+**Tests:** Compile-fail test that an `impl Evolvable` returning `Frozen` cannot be passed to SEPL's `ι` (Improve); round-trip of `Learnability` through serde; interaction with the stability-budget cost accounting (a `Frozen` resource contributes zero to `L_d · η`).
+
+### Layer 4 — SEPL operator algebra (`autoany-core::meta_controller`)
+
+**Status:** Partially present as EGRI (`loop_engine.rs` has σ, ι, ε, κ equivalents). Missing: explicit ρ Reflect, and a typed `MetaController<L, R>` trait.
+
+**Scope:** A new trait in `core/autoany/autoany-core/src/meta_controller.rs` that gives EGRI's existing propose/execute/evaluate/select/promote cycle a typed operator signature:
+
+```rust
+/// SEPL operator algebra as a typed trait.
+///
+/// Refines existing `EgriLoop` with explicit Reflect (ρ) and typed state spaces.
+pub trait MetaController<L, R>
+where
+    L: aios_protocol::rcs::Level,
+    R: aios_protocol::rspl::Evolvable,
+{
+    type Trace;         // 𝒵
+    type Hypothesis;    // ℋ
+    type Modification;  // 𝒟
+    type Objective;     // 𝒢
+    type Evaluation;    // 𝒮
+
+    fn reflect(&self, trace: &Self::Trace, state: &R) -> Vec<Self::Hypothesis>;
+    fn select(&self, state: &R, hypotheses: &[Self::Hypothesis]) -> Vec<Self::Modification>;
+    fn improve(&self, state: &R, mods: &[Self::Modification]) -> R;
+    fn evaluate(&self, candidate: &R, objective: &Self::Objective) -> Self::Evaluation;
+    fn commit(&self, candidate: R, eval: &Self::Evaluation) -> CommitDecision<R>;
+}
+```
+
+And a default `ReflectOperator` impl that consumes Vigil OTel span output (via a `Subscriber`) and produces natural-language hypotheses through an LLM call.
+
+**Dependencies:** `aios-protocol::rspl` (Layer 2, for `Evolvable` + `Learnability`), Vigil (for trace stream), existing `autoany-core::loop_engine` (to be refactored to impl this trait).
+
+**Tests:** EgriLoop can be type-viewed as a `MetaController<L2, _>`; Reflect consumes a canned trace + produces hypotheses; integration test that the existing loop is preserved behaviorally under the new signature.
+
+### Commit gate and stability budget coupling
+
+A key insight from the AGP ↔ RCS mapping (see synthesis note) is that AGP's κ (Commit) gate is heuristic, while RCS provides a quantitative stability budget `λᵢ > 0` per level. We should couple them:
+
+```rust
+pub enum CommitDecision<R> {
+    Accepted(R, StabilityBudgetUpdate),
+    RejectedUnsafe(UnsafeReason),
+    RejectedBudget(BudgetViolation),  // new — λ_i would go ≤ 0
+}
+```
+
+Every Commit consumes budget via `L_d · η` (adaptation cost); the Autonomic controller publishes the remaining margin; the MetaController must reject if commit would violate `λ_i > 0`. This is the control-theoretic grounding AGP lacks, contributed back from RCS. Formalization belongs in RCS Paper P2.
+
+## Alternatives considered
+
+**A. Do nothing — keep AGP as an external reference, don't add Pneuma/RSPL modules.**
+Rejected because: (1) EGRI's missing Reflect operator is a real gap that Vigil's trace stream can now fill; (2) the learnability mask is a small, high-value addition that removes a runtime convention in favor of a type-level invariant; (3) the Pneuma trait surface spec already exists and is idle.
+
+**B. Combined single PR (Pneuma + RSPL + Evolvable + MetaController) in one landing.**
+Rejected because: the workspace has 37 crates, 1077 tests, and a strict quality bar. A 2000+ LOC PR touching aios-protocol (depended on by arcan, lago, autonomic, praxis) is an unreasonable review burden. Four layered PRs in dependency order is cleaner.
+
+**C. Skip Pneuma, implement RSPL + Evolvable directly.**
+Rejected because: the Pneuma spec is authored, tested, and ready. Skipping it would force RSPL to re-invent the Axis/Boundary/SubstrateProfile machinery, creating two parallel abstractions that drift. The spec explicitly says "RSPL is the depth-0 horizontal-0 Pneuma instantiation."
+
+**D. Adopt AGP's operator algebra verbatim without the Evolvable mask.**
+Rejected because: the `g_v` bit is the smallest, most type-safe way to encode EGRI Law 3 (Immutable Evaluator). Without it, Law 3 remains a runtime convention, and every new resource type risks violating it.
+
+## Dependencies
+
+### Architectural
+
+```
+Layer 1: Pneuma        (no dependency)
+Layer 2: RSPL          (depends on Layer 1)
+Layer 3: Evolvable     (depends on Layer 2)
+Layer 4: MetaController (depends on Layer 3 + Vigil)
+```
+
+### Crate
+
+- `aios-protocol` — primary (all four layers live here or re-export from here)
+- `autoany-core` — Layer 4 implementation
+- `vigil` — Layer 4 consumes OTel span output (already shipped v0.2.0)
+- `autonomic-core` — Layer 4 coupling to stability budget (already shipped)
+
+### Data / schema
+
+None. All additions are type-level; no schema migrations.
+
+### CI / deployment
+
+- Pre-commit: `make smoke` continues to gate
+- Pre-push: `make check` runs format + clippy + test; must stay green
+- Each layer's PR adds its own tests; full `cargo test --workspace` must pass
+- No release-train impact; Layer 4 can bump `aios-protocol` to 0.3.0 if any public API shift materializes
+
+## Migration
+
+Zero. Everything additive. Existing code paths unchanged.
+
+## Security
+
+No new attack surface. RSPL's five types encapsulate concepts that already exist in the codebase (tools, environments, memory). The Evolvable trait *reduces* attack surface by making immutability type-enforceable where it was runtime-convention.
+
+The commit-gate coupling to stability budget (`RejectedBudget`) introduces a new failure mode for self-evolution — evolution can be blocked by budget exhaustion. This is **desirable** safety behavior; operators must understand it.
+
+## Rollout plan
+
+| Phase | Deliverable | PR size | Est. effort | Blocks next |
+|---|---|---|---|---|
+| P1 | Layer 1: Pneuma trait surface in aios-protocol | ~800 LOC + 300 LOC tests | 2-3 days | Yes |
+| P2 | Layer 2: RSPL five types as Pneuma impls | ~400 LOC + 200 LOC tests | 1-2 days | Yes |
+| P3 | Layer 3: Evolvable trait + Learnability enum | ~150 LOC + 150 LOC tests | 1 day | No (P4 depends) |
+| P4 | Layer 4: MetaController trait + Reflect operator | ~600 LOC + 400 LOC tests | 3-5 days | — |
+
+**Milestone**: `aios-protocol 0.3.0` release after P2 lands (Pneuma + RSPL both public).
+
+**P5 research-track (parallel)**: RCS Paper P2 (EGRI meta-controller) cites AGP and AgentOrchestra v4 explicitly, positions RCS stability budget as the rate bound AGP's operator algebra lacks. No code dependency.
+
+## Open questions
+
+- **Async in Pneuma trait.** The spec deliberately omits async methods (flagged as "open question"). This blocks wiring Pneuma to arcan's async runtime cleanly. Resolution before P1 lands.
+- **Backpressure / flow control.** Also flagged in Pneuma spec. Needs a concrete answer before P2 (RSPL emit/aggregate semantics).
+- **Evolvable granularity.** Is `Learnability::Constrained(MutationSchemaId)` adequate, or do we need a full `MutationAlgebra` type? Decided in P3 design review.
+- **Reflect operator default.** Should the LLM-based reflector live in `autoany-core` or move to a separate `autoany-reflect` crate? Decided in P4 design review.
+- **Commit-gate stability coupling.** Exact integration point between `MetaController::commit` and `autonomic-core::StabilityBudget` — do we pass a budget handle, or query Autonomic HTTP? Decided in P4.
+- **Naming.** `MetaController` vs `SeplController` vs `EgriController`. The term `MetaController` is used in RCS docs; `SeplController` makes the AGP lineage explicit; `EgriController` reflects autoany lineage. Pick one and cross-reference in docs.
+
+## Success criteria
+
+- `cargo build --workspace` + `cargo test --workspace` + `cargo clippy --workspace` all green after each phase
+- No public API of existing crates (arcan, lago, autonomic, praxis) regresses
+- Each of the four layers has ≥80% test coverage and doctest examples
+- The synthesis note's proposed `MetaController<L, R>` trait is ported into the code
+- An integration test demonstrates Pneuma → RSPL → Evolvable → MetaController composed end-to-end
+- `research/entities/concept/autogenesis-agp.md`, `sepl-operator-algebra.md`, `evolvable-resource.md` remain linked/accurate
+- RCS paper P2 draft cites AGP by the time P4 lands
+
+## References
+
+- Primary: [Autogenesis: A Self-Evolving Agent Protocol](https://arxiv.org/abs/2604.15034) (arXiv:2604.15034)
+- Predecessor: [AgentOrchestra (TEA Protocol)](https://arxiv.org/abs/2506.12508) (arXiv:2506.12508)
+- Reference impl: [SkyworkAI/DeepResearchAgent](https://github.com/SkyworkAI/DeepResearchAgent)
+- Local spec: `docs/specs/pneuma-trait-surface.md`
+- Local synthesis: `broomva/research/notes/2026-04-18-autogenesis-agp-rcs-life-alignment-synthesis.md`
+- Entity pages: `research/entities/concept/{autogenesis-agp,sepl-operator-algebra,rspl-resource-substrate,evolvable-resource,tea-protocol}.md`
+
+## Changelog
+
+- 2026-04-18: Initial draft (broomva).

--- a/docs/specs/life-plexus-implementation.md
+++ b/docs/specs/life-plexus-implementation.md
@@ -1,0 +1,1247 @@
+---
+title: "life-plexus Implementation Specification"
+tags:
+  - spec
+  - implementation
+  - rust
+  - pneuma
+  - plexus
+  - life-os
+  - rcs
+created: "2026-04-18"
+updated: "2026-04-18"
+status: draft
+axis: horizontal
+boundary: D0→D1
+related:
+  - "[[pneuma-plexus-architecture]]"
+  - "[[p6-horizontal-composition]]"
+  - "[[p7-thermodynamic-limits]]"
+  - "[[plexus]]"
+  - "[[pneuma]]"
+---
+
+# life-plexus Implementation Specification
+
+> **Scope.** This spec tells a contributor exactly how to land the `life-plexus` crate
+> in the Life Agent OS monorepo. It is the implementation layer under the architecture
+> spec at `core/life/docs/specs/pneuma-plexus-architecture.md` and is gated on
+> Paper 6 (`research/rcs/papers/p6-horizontal-composition/`), whose four stability
+> conditions C1–C4 this spec must satisfy.
+>
+> `life-plexus` is the first **horizontal** Pneuma impl: the d0→d1 boundary between
+> individual Life agent instances and a depth-1 collective controller.
+> The vertical impls (`Pneuma<L0→L1>`, `Pneuma<L1→L2>`, …) are already planned as
+> retrofits of existing crates; this crate is net-new.
+
+## 0. Prerequisites
+
+This spec assumes the following have landed **before** `life-plexus` starts:
+
+1. `aios-protocol::pneuma` module with `Axis`, `Boundary`, `Pneuma`, `SubstrateProfile`,
+   `PneumaError` (Phase 1 of the architecture spec).
+2. Nous-as-inline-L3 (L3 compression). Without it, the depth-0 L3 cadence is too slow
+   for any useful d1 control cadence (C1 fails trivially).
+3. Canonical parameters (`data/parameters.toml`) extended with a `[horizontal]`
+   section carrying default δ, τ_p, α, N caps, σ that satisfy C1–C4 for a reference
+   10-agent configuration.
+
+If any of the above is missing, land it first; do **not** stub.
+
+## 1. Crate layout
+
+### 1.1 Directory
+
+```
+core/life/crates/plexus/
+└── life-plexus/
+    ├── Cargo.toml
+    ├── CHANGELOG.md
+    ├── README.md
+    └── src/
+        ├── lib.rs               # public API + `register_plexus_tools`
+        ├── error.rs             # PlexusError (wraps PneumaError)
+        ├── signal.rs            # PlexusSignal enum + serialization
+        ├── locus.rs             # AgentLocus, Posture, FieldCoord, CapabilityId
+        ├── formation.rs         # Formation, FormationTopology, FormationLifecycle, FormationRole
+        ├── field.rs             # PopulationState, GradientField, QuorumReading, Trace, Pheromone
+        ├── directive.rs         # CollectiveDirective
+        ├── physics/
+        │   ├── mod.rs           # module root
+        │   ├── decay.rs         # exponential decay, half-life bookkeeping
+        │   ├── propagation.rs   # k-NN via rstar R*-tree over FieldCoord
+        │   ├── gradient.rs      # local gradient computation per agent
+        │   ├── stigmergy.rs     # append-only trace store + TTL cleanup
+        │   └── quorum.rs        # quorum detection within sense radius
+        ├── transport/
+        │   ├── mod.rs           # PlexusTransport trait + selector
+        │   ├── in_process.rs    # tokio::broadcast + Arc<RwLock<_>> (default feature)
+        │   ├── nats.rs          # async-nats JetStream backend (feature = "nats")
+        │   └── mock.rs          # deterministic, configurable (feature = "mock")
+        ├── plexus.rs            # AgentFieldPlexus struct + Pneuma impl
+        ├── tools.rs             # arcan Tool wrappers (sense/emit/join/leave/mark/quorum)
+        ├── trace_store.rs       # redb-backed pheromone persistence (feature = "persist")
+        ├── config.rs            # PlexusConfig (population cap, decay defaults, TTLs)
+        └── budget.rs            # horizontal stability budget helpers (λ_H)
+```
+
+File-based modules (`name.rs`) per `.claude/rules/code-style.md`, no `mod.rs` outside
+the `physics/` and `transport/` subdirectories (where a `mod.rs` root is the
+cleanest Rust-2024 approach for submodules).
+
+### 1.2 Cargo.toml
+
+```toml
+[package]
+name = "life-plexus"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["agent", "swarm", "plexus", "pneuma", "rcs"]
+categories = ["asynchronous", "network-programming"]
+description = "Plexus — horizontal d0→d1 Pneuma impl: field physics for inter-agent coordination"
+
+[lints]
+workspace = true
+
+[features]
+default = ["in-process"]
+in-process = []               # tokio::broadcast + in-memory state
+nats = ["dep:async-nats", "dep:futures-util"]
+mock = []                     # deterministic test backend
+persist = ["dep:redb"]        # redb-backed pheromone trace store (optional)
+
+[dependencies]
+# Internal
+aios-protocol = { workspace = true }
+arcan-core    = { workspace = true }          # for Tool/ToolRegistry surface (optional gate?)
+
+# Core
+serde         = { workspace = true, features = ["derive"] }
+serde_json    = { workspace = true }
+thiserror     = { workspace = true }
+tracing       = { workspace = true }
+tokio         = { workspace = true, features = ["sync", "time", "rt"] }
+parking_lot   = { workspace = true }
+chrono        = { workspace = true, features = ["serde"] }
+ulid          = { workspace = true, features = ["serde"] }
+
+# Spatial index for capability-space k-NN (already in workspace for Opsis)
+rstar         = { workspace = true }
+
+# Optional feature deps
+async-nats    = { version = "0.39", optional = true }
+futures-util  = { workspace = true, optional = true }
+redb          = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio         = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+proptest      = "1"
+tempfile      = { workspace = true }
+serde_json    = { workspace = true }
+```
+
+**Notes on deps:**
+- `async-nats` is new to the workspace; add it to `[workspace.dependencies]` in the
+  same PR that lands `life-plexus`.
+- `rstar` is already a workspace dep (used by Opsis).
+- `arcan-core` is imported only so `register_plexus_tools` can implement the `Tool`
+  trait; it is **not** a forward dep of Arcan — Arcan depends on `life-plexus`, not
+  the other way around. We import `arcan-core` to preserve the `arcan-spaces`
+  precedent. If this creates a dep-cycle concern, move the tool surface into a
+  separate `arcan-plexus` bridge crate (symmetric to `arcan-spaces`).
+
+### 1.3 Workspace wiring
+
+Add to `core/life/Cargo.toml`:
+
+```toml
+# in [workspace.members] — after the "# Spaces A2A" block
+"crates/plexus/life-plexus",
+
+# in [workspace.dependencies]
+life-plexus = { path = "crates/plexus/life-plexus", version = "0.3.0" }
+async-nats  = "0.39"     # new
+```
+
+No facade crate yet (parity with `arcan-spaces` — promote to a facade only once
+a second horizontal Pneuma impl exists).
+
+## 2. Core types
+
+All types below live in the modules indicated in §1.1. They all derive
+`Clone + Debug + Serialize + Deserialize` unless noted.
+
+### 2.1 Signals — `src/signal.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use crate::locus::{CapabilityId, DomainId, GoalId};
+use crate::formation::FormationId;
+
+/// Micro-credit unit (1 credit = 1e-6 USDC). Re-exported from haima-core in prod;
+/// declared here as a newtype so life-plexus does not depend on haima.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct Micro(pub i64);
+
+/// Stigmergic trace discriminator. Separates pheromone lanes so that unrelated
+/// agent activities (e.g. "I explored this capability" vs "I failed this domain")
+/// do not share the same gradient field.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceType {
+    Explored,
+    Succeeded,
+    Failed,
+    Recruited,
+    Abandoned,
+    Custom(u16),     // reserved for downstream projects
+}
+
+/// How far a signal is allowed to propagate through capability-space.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Reach {
+    Local,       // k nearest in capability-space (default: 8)
+    Regional,    // cluster that includes this emitter
+    Global,      // the entire population (rate-limited, expensive)
+}
+
+/// The field-physics primitives that cross the d0→d1 boundary.
+///
+/// Each variant carries its own decay parameters — the plexus does **not**
+/// enforce a default half-life; defaults live in `PlexusConfig`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PlexusSignal {
+    /// A belief assertion, decays toward uncertainty.
+    /// Typical emitter: an L1-healthy agent reporting a Nous-evaluated belief.
+    /// Typical sensor : any agent whose goal overlaps the belief domain.
+    BeliefClaim {
+        claim: String,
+        confidence: f32,         // [0, 1]
+        half_life_ms: u64,
+    },
+
+    /// Offer of a capability for recruitment.
+    /// Emitter: a lightly-loaded agent that owns `capability`.
+    /// Sensor : any agent in the Recruiting phase of a formation.
+    CapabilityOffer {
+        capability: CapabilityId,
+        cost: Option<Micro>,
+        half_life_ms: u64,
+    },
+
+    /// Intent to pursue `goal` with `urgency`.
+    /// Emitter: any agent that has just planned a goal.
+    /// Sensor : nearby agents checking for coordination opportunities.
+    IntentDeclaration {
+        goal: GoalId,
+        urgency: f32,            // [0, 1]; amplifies gradient
+        half_life_ms: u64,
+    },
+
+    /// Raw observation injected into the shared field.
+    /// Emitter: an agent that has just produced a high-signal output.
+    /// Sensor : aggregators and the d1 controller's `aggregate()`.
+    Observation {
+        domain: DomainId,
+        datum: Value,
+        half_life_ms: u64,
+    },
+
+    /// Active recruitment request for members of a formation.
+    /// Emitter: the would-be hub (for star/hierarchy) or any member (for mesh).
+    /// Sensor : any agent whose capability set intersects `required`.
+    Recruit {
+        required: Vec<CapabilityId>,
+        formation: FormationId,
+        half_life_ms: u64,
+    },
+
+    /// Stigmergic marking — persists past the emitter's lifetime.
+    /// Emitter: any agent completing a notable action (exploration, failure).
+    /// Sensor : future agents navigating the same capability-space neighborhood.
+    Pheromone {
+        trace_type: TraceType,
+        intensity: f32,          // initial strength; decays exponentially
+        decay_ms: u64,           // different from other half_life_ms: pheromones
+                                 //   persist long after the emitter drops
+    },
+}
+
+impl PlexusSignal {
+    /// The decay half-life (ms) of this signal, regardless of variant.
+    pub fn half_life_ms(&self) -> u64 {
+        match self {
+            Self::BeliefClaim       { half_life_ms, .. } => *half_life_ms,
+            Self::CapabilityOffer   { half_life_ms, .. } => *half_life_ms,
+            Self::IntentDeclaration { half_life_ms, .. } => *half_life_ms,
+            Self::Observation       { half_life_ms, .. } => *half_life_ms,
+            Self::Recruit           { half_life_ms, .. } => *half_life_ms,
+            Self::Pheromone         { decay_ms,     .. } => *decay_ms,
+        }
+    }
+
+    pub fn default_reach(&self) -> Reach {
+        match self {
+            Self::BeliefClaim       { .. } => Reach::Regional,
+            Self::CapabilityOffer   { .. } => Reach::Local,
+            Self::IntentDeclaration { .. } => Reach::Local,
+            Self::Observation       { .. } => Reach::Regional,
+            Self::Recruit           { .. } => Reach::Regional,
+            Self::Pheromone         { .. } => Reach::Local,
+        }
+    }
+}
+```
+
+**Serialization format.** All signals serialize to JSON via serde; NATS payloads use
+JSON by default (MessagePack optional behind `feature = "msgpack"` later). Every
+signal is wrapped in an `EmittedSignal` envelope when it enters the field:
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EmittedSignal {
+    pub id: ulid::Ulid,          // content-addressed would be an anti-pattern here
+                                 //   because two identical signals from different
+                                 //   agents are meaningfully distinct events
+    pub emitted_by: AgentId,
+    pub emitted_at_ms: i64,      // unix millis
+    pub emitter_pos: FieldCoord, // snapshot at emit time
+    pub reach: Reach,
+    pub payload: PlexusSignal,
+}
+```
+
+**Propagation rule per variant:**
+
+| Variant             | Default Reach | Who emits                            | Who senses                                |
+|---------------------|---------------|--------------------------------------|-------------------------------------------|
+| BeliefClaim         | Regional      | Nous-validated agents                | Agents with goal overlap                  |
+| CapabilityOffer     | Local (k=8)   | Lightly loaded agents                | Recruiting formations                     |
+| IntentDeclaration   | Local (k=8)   | Any agent post-plan                  | Nearby agents (coordination)              |
+| Observation         | Regional      | High-signal producers                | Aggregators, d1 controller                |
+| Recruit             | Regional      | Formation hubs / mesh members        | Agents with matching capability           |
+| Pheromone           | Local (k=16)  | Any agent on action boundary         | Future navigators of same neighborhood    |
+
+**Decay function** (shared by all variants, applied at read-time in §3.1):
+`strength(t) = initial · 0.5^((t − emit_t) / half_life_ms)` with `initial = 1.0`
+for signals and `initial = pheromone.intensity` for pheromones.
+
+### 2.2 Agent identity & position — `src/locus.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use aios_protocol::ids::AgentId;
+
+/// Strongly-typed capability identifier. Mirrors the bstack capability
+/// taxonomy; we use a string newtype to avoid locking in the bstack enum.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CapabilityId(pub String);
+
+/// Semantic domain (e.g. "rust-codegen", "rocket-sim", "eDNA-metabarcoding").
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DomainId(pub String);
+
+/// A goal identifier — usually mirrors a Linear ticket or skill invocation.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GoalId(pub String);
+
+/// Agent posture — roughly homologous to Autonomic's OperatingMode but
+/// describes the agent's *relationship to the field* rather than its
+/// internal operating point.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Posture {
+    /// Reading signals, not yet emitting. Default start-up state.
+    Receptive,
+    /// Concentrated on one goal; sensing is narrowed to that capability neighborhood.
+    Focused,
+    /// Actively emitting (e.g. publishing an observation stream).
+    Broadcasting,
+    /// Paused — senses nothing, emits nothing. Used for budget recovery.
+    Dormant,
+    /// In an active formation; directives come from the formation's coordinator.
+    Swarming(crate::formation::FormationId),
+}
+
+/// Position in capability-space. Not geographic — a learned or declared
+/// embedding of the agent's capability vector. 32-dim is a reasonable default;
+/// see §10 open question on dimensionality choice.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FieldCoord {
+    pub dims: [f32; FIELD_DIM],
+}
+
+pub const FIELD_DIM: usize = 32;
+
+impl FieldCoord {
+    pub fn zero() -> Self { Self { dims: [0.0; FIELD_DIM] } }
+
+    /// L2 distance to another coordinate.
+    pub fn distance(&self, other: &Self) -> f32 {
+        self.dims.iter()
+            .zip(other.dims.iter())
+            .map(|(a, b)| (a - b).powi(2))
+            .sum::<f32>()
+            .sqrt()
+    }
+}
+
+/// R*-tree point adapter. Implemented in `src/physics/propagation.rs`.
+impl rstar::Point for FieldCoord {
+    type Scalar = f32;
+    const DIMENSIONS: usize = FIELD_DIM;
+    fn generate(mut gen: impl FnMut(usize) -> Self::Scalar) -> Self {
+        let mut dims = [0.0; FIELD_DIM];
+        for (i, slot) in dims.iter_mut().enumerate() { *slot = gen(i); }
+        Self { dims }
+    }
+    fn nth(&self, idx: usize) -> Self::Scalar { self.dims[idx] }
+    fn nth_mut(&mut self, idx: usize) -> &mut Self::Scalar { &mut self.dims[idx] }
+}
+
+/// An agent's full presence in the field.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentLocus {
+    pub id: AgentId,
+    pub capabilities: Vec<CapabilityId>,
+    pub posture: Posture,
+    /// Normalized load \in [0, 1]; 1.0 == saturated.
+    pub load: f32,
+    /// Ephemeral budget for sensing/emitting this cycle (micro-credits or
+    /// arbitrary scalar; see §10 open question on budget enforcement).
+    pub attention_budget: u32,
+    pub field_position: FieldCoord,
+}
+```
+
+### 2.3 Formations — `src/formation.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use aios_protocol::ids::AgentId;
+use crate::locus::{CapabilityId, GoalId};
+use std::time::Duration;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FormationId(pub ulid::Ulid);
+
+impl FormationId { pub fn new() -> Self { Self(ulid::Ulid::new()) } }
+
+/// Topology of the formation's internal coordination graph.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum FormationTopology {
+    Mesh,                                     // all-to-all, at most ~8 members
+    Star   { hub: AgentId },                  // hub aggregates, workers report
+    Chain,                                    // ordered pipeline
+    Ring,                                     // ordered cyclic
+    Hierarchy { depth: u8 },                  // tree of coordinators
+}
+
+/// Role within a formation. One agent may hold multiple roles across formations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FormationRole {
+    Hub,
+    Worker,
+    Observer,     // passive presence — counts for quorum but does not execute
+    Coordinator,  // subset-leader in Hierarchy topology
+}
+
+/// Lifecycle state. Always monotonic: Recruiting → Active → Dispersing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FormationLifecycle {
+    Recruiting,
+    Active,
+    Dispersing,
+}
+
+/// A transient swarm structure. Formations die on TTL expiry unless renewed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Formation {
+    pub id: FormationId,
+    pub purpose: GoalId,
+    pub topology: FormationTopology,
+    pub lifecycle: FormationLifecycle,
+    /// Minimum members required to transition Recruiting → Active.
+    pub quorum_min: u8,
+    /// Time-to-live from most recent keepalive.
+    pub ttl: Duration,
+    /// (agent, role) pairs. Vec not HashMap because order matters for Chain/Ring.
+    pub members: Vec<(AgentId, FormationRole)>,
+    /// Capabilities the formation still needs (filled as members join).
+    pub required_capabilities: Vec<CapabilityId>,
+    /// Unix-millis of most recent keepalive; TTL is relative to this.
+    pub last_keepalive_ms: i64,
+}
+
+impl Formation {
+    pub fn is_expired(&self, now_ms: i64) -> bool {
+        let elapsed_ms = now_ms.saturating_sub(self.last_keepalive_ms) as u128;
+        elapsed_ms > self.ttl.as_millis()
+    }
+}
+```
+
+### 2.4 Aggregate — `src/field.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use aios_protocol::ids::AgentId;
+use crate::locus::{AgentLocus, CapabilityId, FieldCoord};
+use crate::formation::Formation;
+use crate::signal::{TraceType, Reach};
+
+/// What the depth-1 controller reads when it calls `aggregate()`.
+///
+/// Snapshot type — the aggregate operator (`AgentFieldPlexus::aggregate()`)
+/// returns a fresh copy every call; this is never mutated in place.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PopulationState {
+    pub members: Vec<AgentLocus>,
+    pub active_formations: Vec<Formation>,
+    pub gradient_fields: HashMap<CapabilityId, GradientField>,
+    pub pheromone_map: HashMap<TraceType, Vec<Trace>>,
+    pub quorum_readings: HashMap<CapabilityId, QuorumReading>,
+    /// Wall-clock time of this snapshot, for drift detection at d1.
+    pub sampled_at_ms: i64,
+    /// Which reach bucket(s) the aggregator covered. A partial aggregate
+    /// labeled `Local` is still a valid response — the d1 controller uses
+    /// this to decide whether to resample.
+    pub coverage: Reach,
+}
+
+/// Sampled scalar field over capability-space, keyed by capability.
+///
+/// We store a sparse set of (coord, scalar) samples rather than a dense grid —
+/// capability-space is high-dim (FIELD_DIM=32) so a dense grid is intractable.
+/// Interpolation/smoothing is a d1-controller responsibility; the plexus
+/// returns raw samples and lets the consumer pick the reducer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GradientField {
+    pub capability: CapabilityId,
+    pub samples: Vec<(FieldCoord, f32)>,
+}
+
+/// Density reading for one capability, centered at the sampling agent.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct QuorumReading {
+    pub capability_digest: u64,     // FNV-64 of CapabilityId for compact logs
+    pub density: f32,               // #matching agents / sense-radius volume
+    pub neighbors_with_capability: u32,
+    pub sense_radius: f32,          // field-space units
+}
+
+/// Stigmergic marking. Differs from a PlexusSignal::Pheromone in that a Trace
+/// is already *in the field* — this is the stored form after ingest.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Trace {
+    pub id: ulid::Ulid,
+    pub trace_type: TraceType,
+    pub position: FieldCoord,
+    pub initial_intensity: f32,
+    pub emitted_at_ms: i64,
+    pub decay_ms: u64,
+    /// Original emitter, retained for audit only — Traces outlive their emitters.
+    pub emitted_by: AgentId,
+}
+
+impl Trace {
+    /// Current intensity at time `now_ms`, applying exponential decay.
+    pub fn intensity(&self, now_ms: i64) -> f32 {
+        let dt = (now_ms.saturating_sub(self.emitted_at_ms)) as f64;
+        let hl = self.decay_ms.max(1) as f64;
+        (self.initial_intensity as f64 * 0.5_f64.powf(dt / hl)) as f32
+    }
+
+    /// True when intensity would be below the log-noise floor.
+    pub fn is_expired(&self, now_ms: i64, floor: f32) -> bool {
+        self.intensity(now_ms) < floor
+    }
+}
+```
+
+### 2.5 Directives — `src/directive.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use aios_protocol::ids::AgentId;
+use crate::formation::{FormationId, FormationTopology};
+use crate::locus::{GoalId, Posture};
+use crate::signal::{Micro, Reach};
+
+/// What the depth-1 controller sends down through the plexus.
+///
+/// A CollectiveDirective is **advisory** by default and subject to the
+/// receiving agent's L0 safety shield. This is the implementation of P6's C2
+/// (bounded directive authority): a CollectiveDirective cannot override a
+/// depth-0 agent's local shields.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CollectiveDirective {
+    AdjustPosture     { target: AgentId, posture: Posture },
+    RequestFormation  { purpose: GoalId, topology: FormationTopology,
+                        members: Vec<AgentId> },
+    DissolveFormation { id: FormationId, reason: String },
+    AllocateBudget    { target: AgentId, delta: Micro },
+    BroadcastNarrative{ narrative: String, reach: Reach },
+}
+```
+
+## 3. Physics implementation
+
+Every physics primitive below lives in `src/physics/*.rs` and is tested in isolation
+(see §8.1).
+
+### 3.1 Signal decay — `physics/decay.rs`
+
+```rust
+/// Exponential decay with half-life.
+///
+/// strength(t) = initial · 0.5^((t − emit_t_ms) / half_life_ms)
+///
+/// Half-life, not time-constant, because it is easier for humans to reason about
+/// ("this signal is irrelevant in ~3 minutes") than τ.
+#[inline]
+pub fn decayed(initial: f32, emit_t_ms: i64, now_ms: i64, half_life_ms: u64) -> f32 {
+    if half_life_ms == 0 { return 0.0; }
+    let dt = now_ms.saturating_sub(emit_t_ms) as f64;
+    if dt <= 0.0 { return initial; }
+    let exponent = dt / half_life_ms as f64;
+    (initial as f64 * 0.5_f64.powf(exponent)) as f32
+}
+```
+
+Applied at read-time, never at write-time — that way there is only ever one
+copy of `initial` to reason about and no distributed clock-correction issues.
+
+### 3.2 Propagation — `physics/propagation.rs`
+
+Signals have a `Reach` bound; propagation selects *which agents* actually see a
+signal. This uses capability-space distance, not wall-clock distance.
+
+**Algorithmic approach.** An `rstar::RTree<FieldCoord>` indexed by agent.
+- `Reach::Local` — `tree.nearest_neighbors(&emitter_pos).take(k_local)`
+  (default `k_local = 8`).
+- `Reach::Regional` — expanding-radius sphere query
+  (`tree.locate_within_distance(pos, r)`) until we have `k_regional = 32` or the
+  radius hits the `PlexusConfig::regional_radius` cap.
+- `Reach::Global` — return all agents; rate-limited in `PlexusConfig` to at
+  most `global_per_sec`, default 1/sec.
+
+Tree is rebuilt **lazily** on a tick cadence (`PlexusConfig::rebuild_ms`,
+default 250ms); individual updates are appended to a pending-insertion buffer
+between rebuilds.
+
+### 3.3 Gradient computation — `physics/gradient.rs`
+
+Each agent computes its own local gradient from the signals within its reach:
+
+```rust
+/// Weighted sum of sensed signals, projected onto one capability axis.
+///
+/// For each signal s sensed by this agent:
+///   w_s = decayed_strength(s)
+///       · relevance(s, capability)
+///       · (1 / (1 + distance(s.emitter, self_pos)))
+///
+/// `relevance` is a cheap scalar: 1.0 if the signal is explicitly tagged with
+/// `capability`, 0.5 if tagged with a capability sharing a prefix, 0.0 otherwise.
+pub fn local_gradient(
+    me: &AgentLocus,
+    capability: &CapabilityId,
+    sensed: &[EmittedSignal],
+    now_ms: i64,
+) -> Vec<(FieldCoord, f32)> { /* implementation */ }
+```
+
+Aggregation at d1 is the union of these local samples — explicitly sparse, per
+§2.4 rationale. A d1 controller that wants a dense field runs its own
+interpolation on the returned `Vec<(FieldCoord, f32)>`.
+
+### 3.4 Stigmergy — `physics/stigmergy.rs`
+
+Append-only `Vec<Trace>` per TraceType, behind a `parking_lot::RwLock`.
+Two background tasks:
+
+1. **TTL sweep**. Every `trace_sweep_ms` (default 5000), drop traces whose
+   current intensity is below a noise floor (`trace_noise_floor`, default 0.01).
+2. **Compaction**. If the trace count exceeds `trace_cap_per_type` (default
+   4096), drop the oldest `N / 4` regardless of intensity. This is lossy by
+   design — stigmergic systems tolerate pruning.
+
+Persistence (`feature = "persist"`) shadows the in-memory store into a redb
+table `plexus_traces` keyed by `(TraceType, Ulid)`. Intentionally **not**
+lago-journal-backed — traces are ephemeral field state, not ground-truth events.
+A fresh restart with `feature = "persist"` loads the last compacted snapshot;
+without the feature, restart means an empty field, consistent with §9 scope.
+
+### 3.5 Quorum detection — `physics/quorum.rs`
+
+```rust
+/// Count neighbors (within `radius`) that possess `capability`.
+///
+/// The R*-tree returns candidates by spatial proximity; we then filter by
+/// capability list. O(k + m) where k = spatial neighbors, m = capabilities
+/// per agent.
+pub fn quorum_reading(
+    tree: &rstar::RTree<AgentIndex>,
+    center: FieldCoord,
+    radius: f32,
+    capability: &CapabilityId,
+    loci: &HashMap<AgentId, AgentLocus>,
+) -> QuorumReading;
+```
+
+`density` = `neighbors_with_capability / ((4/3)π·radius³)` with the caveat that
+FIELD_DIM > 3, so we use the analogous n-ball volume formula. In practice the
+absolute density is uncalibrated; what matters is *relative* quorum across
+capabilities and time.
+
+## 4. Pneuma trait impl — `src/plexus.rs`
+
+```rust
+use std::sync::Arc;
+use parking_lot::RwLock;
+use aios_protocol::pneuma::{
+    Pneuma, PneumaError, SubstrateProfile, SubstrateKind, WarpFactors,
+    CoordinationScaling, ResourceCeiling, D0ToD1,
+};
+use crate::config::PlexusConfig;
+use crate::directive::CollectiveDirective;
+use crate::field::PopulationState;
+use crate::signal::{EmittedSignal, PlexusSignal, Reach};
+use crate::transport::PlexusTransport;
+
+/// The horizontal Pneuma impl. Owns the in-process field state; delegates
+/// cross-process fanout to the [`PlexusTransport`] it was constructed with.
+///
+/// One `AgentFieldPlexus` represents the view from **one** participating
+/// agent. A depth-1 controller holding N agent views is a separate concern
+/// (see `PlexusFleet` in §9 future work).
+pub struct AgentFieldPlexus {
+    config: PlexusConfig,
+    transport: Arc<dyn PlexusTransport>,
+    state: Arc<RwLock<PlexusState>>,
+    pending_directives: Arc<RwLock<Vec<CollectiveDirective>>>,
+}
+
+/// Internal state — tree, caches, timestamps.
+struct PlexusState { /* locus table, RTree, trace store, etc. */ }
+
+impl Pneuma for AgentFieldPlexus {
+    type B         = D0ToD1;
+    type Signal    = PlexusSignal;
+    type Aggregate = PopulationState;
+    type Directive = CollectiveDirective;
+
+    fn emit(&self, signal: Self::Signal) -> Result<(), PneumaError> {
+        // 1. Respect population cap (C4).
+        let state = self.state.read();
+        if state.loci_count() > self.config.population_cap {
+            return Err(PneumaError::ShieldRejection(
+                format!("population cap {} exceeded", self.config.population_cap)));
+        }
+        drop(state);
+
+        // 2. Respect per-agent attention budget.
+        //    Implementation reads `me.attention_budget`; if 0, reject.
+
+        // 3. Wrap into EmittedSignal with emitter pos + reach.
+        let emitted = EmittedSignal {
+            id: ulid::Ulid::new(),
+            emitted_by: self.config.agent_id.clone(),
+            emitted_at_ms: now_ms(),
+            emitter_pos: self.current_pos(),
+            reach: signal.default_reach(),
+            payload: signal,
+        };
+
+        // 4. Dispatch to transport — the only place where "real" propagation
+        //    happens. Transport errors bubble up as PneumaError::Transport.
+        self.transport.publish(&emitted)
+            .map_err(|e| PneumaError::Transport(e.to_string()))?;
+
+        // 5. Also ingest locally so this agent's own aggregate sees it.
+        self.ingest_local(emitted);
+        Ok(())
+    }
+
+    fn aggregate(&self) -> Self::Aggregate {
+        let state = self.state.read();
+        let now = now_ms();
+
+        PopulationState {
+            members:           state.loci.values().cloned().collect(),
+            active_formations: state.formations.values().cloned().collect(),
+            gradient_fields:   state.compute_gradient_fields(now, &self.config),
+            pheromone_map:     state.live_pheromones(now, &self.config),
+            quorum_readings:   state.compute_quorums(&self.config),
+            sampled_at_ms:     now,
+            coverage:          Reach::Regional, // default for full aggregate
+        }
+    }
+
+    fn receive(&self) -> Option<Self::Directive> {
+        self.pending_directives.write().pop()
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors {
+                time: 1.0,
+                energy: 1.0,
+                coordination: CoordinationScaling::NLogN, // R*-tree k-NN
+                memory: 1.0,
+                branching: None,                          // classical
+            },
+            ceiling: ResourceCeiling::Propagation {
+                max_radius_m: self.config.nats_max_cluster_diameter_m
+                                    .unwrap_or(1_000.0),
+            },
+        }
+    }
+}
+```
+
+The `ingest_local` hook is also invoked by the transport's **subscribe** side
+when a remote agent publishes a signal — that is how other agents' signals
+land in this agent's view.
+
+## 5. Transport layer — `src/transport/`
+
+```rust
+/// Abstracts "publish this emitted signal to peers" and "subscribe to their
+/// emissions." Transport is explicit because the transport *is* the physics
+/// boundary: propagation delay τ_p and decay δ are transport properties.
+pub trait PlexusTransport: Send + Sync {
+    /// Fire-and-forget publish. Errors are transient; retry is caller-side.
+    fn publish(&self, emitted: &EmittedSignal) -> Result<(), TransportError>;
+
+    /// Install a subscriber closure. Called once per received EmittedSignal.
+    /// The closure must be `Send + 'static` because NATS drives it from its
+    /// own task.
+    fn subscribe(&self, f: Box<dyn Fn(EmittedSignal) + Send + Sync + 'static>);
+
+    /// Publish a directive — the d1 → d0 channel. Orthogonal to `publish`
+    /// because directives are different subjects and carry different auth.
+    fn publish_directive(&self, dir: &CollectiveDirective) -> Result<(), TransportError>;
+
+    /// Subscribe to directives.
+    fn subscribe_directives(&self, f: Box<dyn Fn(CollectiveDirective) + Send + Sync + 'static>);
+}
+```
+
+Selection is by constructor:
+
+```rust
+impl AgentFieldPlexus {
+    pub fn in_process(cfg: PlexusConfig) -> Self {
+        let transport = Arc::new(transport::in_process::InProcessTransport::new(&cfg));
+        Self::with_transport(cfg, transport)
+    }
+
+    #[cfg(feature = "nats")]
+    pub async fn with_nats(cfg: PlexusConfig, url: &str) -> Result<Self, TransportError> {
+        let transport = Arc::new(transport::nats::NatsTransport::connect(url, &cfg).await?);
+        Ok(Self::with_transport(cfg, transport))
+    }
+
+    #[cfg(feature = "mock")]
+    pub fn mock(cfg: PlexusConfig) -> (Self, Arc<transport::mock::MockTransport>) {
+        let mock = Arc::new(transport::mock::MockTransport::new(&cfg));
+        let this = Self::with_transport(cfg, mock.clone());
+        (this, mock)   // return mock handle so tests can introspect
+    }
+}
+```
+
+### 5.1 NATS JetStream backend — `transport/nats.rs`
+
+**Subject encoding:** `plexus.<deploy>.<field_cell>.<signal_kind>.<agent_id>`
+where:
+- `<deploy>` is from `PlexusConfig::deploy_id` (prod / staging / test-run-$run).
+- `<field_cell>` is a coarse spatial hash of the emitter's FieldCoord (default
+  8 bins/axis, so `2^8` cells per dim — but we hash the **sign-bit of each
+  axis** only, giving `2^FIELD_DIM = 2^32` cells at most; the cell key is a
+  hex string of the 32 sign bits, producing a subject like
+  `plexus.prod.f0a12d3e.intent.AGT-abc`).
+- `<signal_kind>` is `belief|offer|intent|obs|recruit|pheromone`.
+- `<agent_id>` is the emitter; receivers subscribe with wildcards.
+
+**Directive subject:** `plexus.<deploy>.d1-directive.<target_agent_id>`.
+
+**TTL on messages:** JetStream stream configured with
+`max_age = longest_half_life * 4` so that stale signals are rolled out of the
+server even if a consumer is slow. Plexus still applies per-signal decay at
+read; the server TTL is belt-and-suspenders.
+
+**Shared state via NATS KV:** `plexus.<deploy>.loci` KV bucket — agents write
+their own `AgentLocus` here with a 30s heartbeat. Absence of heartbeat ⇒ the
+locus expires out of the KV. This is what enables peer discovery without a
+registry service.
+
+### 5.2 In-process backend — `transport/in_process.rs`
+
+- `tokio::sync::broadcast::channel::<EmittedSignal>(cap)` with
+  `cap = config.broadcast_buffer` (default 1024).
+- Shared state: `Arc<RwLock<Vec<AgentLocus>>>`.
+- Sole consumer of the `default` feature flag, so single-machine testing needs
+  no NATS cluster.
+
+### 5.3 Mock backend — `transport/mock.rs`
+
+- In-memory `Vec<EmittedSignal>` append log; `publish` appends synchronously.
+- Deterministic: emission timestamps come from a `MockClock` that advances
+  only when `MockTransport::tick(Duration)` is called.
+- Configurable failure modes: `fail_next_n`, `drop_directives`, `delay_ms`.
+
+## 6. Constraints from P6
+
+The four horizontal-stability conditions from `research/rcs/papers/p6-horizontal-composition/README.md`
+map onto `life-plexus` as follows:
+
+### C1 — Time-scale dilation: `τ₀^(d1) ≥ κ · max_i τ₃^(d0)`, `κ ≥ 10`
+
+Implementation:
+- `PlexusConfig::directive_min_interval_ms` enforced at
+  `AgentFieldPlexus::receive_directive` — if a directive arrives less than
+  this interval after the previous one for the same target agent, it is
+  **buffered** and coalesced rather than delivered.
+- Default `directive_min_interval_ms = 10 × depth_0_l3_cadence_ms`
+  (pulled from canonical `parameters.toml`, e.g. 10× 30s Nous cadence = 5min).
+- Health endpoint surfaces the actual observed `directive_rate_hz` so P6
+  compliance can be verified at runtime by Vigil.
+
+### C2 — Bounded directive authority: `α · L_d^(k) < min_i λ₀^(k, i)`
+
+Implementation:
+- Every `CollectiveDirective` traverses the receiving agent's L0 shield
+  (`RecursiveControlledSystem::<L0>::shield`) **before** being applied.
+  `life-plexus` ships a helper `apply_directive_with_shield()` that enforces
+  this; agents that integrate plexus must use it (lint rule in review).
+- Hard cap: directives that adjust budgets (`AllocateBudget`) are clamped to
+  `PlexusConfig::max_budget_delta_per_directive` (default: 10% of the
+  target's current budget).
+- `BroadcastNarrative` directives with `Reach::Global` require the target
+  set to opt in via `PlexusConfig::accept_global_narrative` (default false).
+
+### C3 — Signal decay exceeds propagation: `δ > 1/τ_p`
+
+Implementation:
+- Default half-lives in `PlexusConfig` are sized **10× the measured
+  propagation delay**. NATS clusters typically run τ_p ∈ [5, 50] ms at
+  intra-region distances, so defaults are:
+  - Pheromone: `60_000 ms` (60s) — slow decay
+  - BeliefClaim: `30_000 ms` (30s)
+  - Observation: `15_000 ms`
+  - Recruit: `10_000 ms`
+  - CapabilityOffer: `5_000 ms`
+  - IntentDeclaration: `2_000 ms` — fastest
+- The fastest default half-life (2s) is 40× the worst-case τ_p (50ms), so
+  C3 is satisfied with ~4× margin.
+- `PlexusConfig::min_half_life_ms` is a hard lower bound (default 500ms);
+  signals emitted with shorter half-lives are rejected with
+  `PneumaError::ShieldRejection`.
+
+### C4 — Sub-critical coupling: `N · σ < reserve_budget(k+1)`
+
+Implementation:
+- `PlexusConfig::population_cap` (default: 50) is enforced in
+  `AgentFieldPlexus::emit` — if the locus count exceeds it, new emissions are
+  rejected (but reads continue to work, preserving observability).
+- `σ` is controlled indirectly by `PlexusConfig::coupling_weights` — a
+  per-signal-kind multiplier in `[0, 1]`. Defaults sum to < 1 so that the
+  aggregate coupling strength across kinds remains bounded.
+- Runtime metric `plexus.coupling_product = population * mean_coupling` is
+  emitted to Vigil; d1 controllers observing it above a threshold should
+  request `DissolveFormation` directives or raise `population_cap` gates.
+
+All four of these are expressed as setpoints in
+`core/life/crates/plexus/life-plexus/data/horizontal-parameters.toml`
+(mirror of the authoritative `research/rcs/data/parameters.toml` under a new
+`[horizontal]` section, synced via the existing
+`life/scripts/sync-rcs-parameters.sh`).
+
+## 7. Integration with Arcan — `src/tools.rs`
+
+Following the `arcan-spaces` precedent exactly: one public
+`register_plexus_tools(&mut ToolRegistry, Arc<AgentFieldPlexus>)` function,
+one `Tool` impl per verb.
+
+| Tool name              | Read/Write | Description                                              |
+|------------------------|------------|----------------------------------------------------------|
+| `plexus_sense_field`   | R          | Return recent signals within current attention budget    |
+| `plexus_emit_signal`   | W          | Write a PlexusSignal to the field                        |
+| `plexus_join_formation`| W          | Join a Recruiting formation as `FormationRole::Worker`   |
+| `plexus_leave_formation`| W         | Exit a formation (idempotent)                            |
+| `plexus_mark_pheromone`| W          | Stigmergic emit — shorthand for `emit_signal(Pheromone)` |
+| `plexus_query_quorum`  | R          | Count nearby agents with a given capability              |
+
+### 7.1 Example — `plexus_sense_field`
+
+```rust
+pub struct PlexusSenseFieldTool {
+    plexus: Arc<AgentFieldPlexus>,
+}
+
+impl Tool for PlexusSenseFieldTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "plexus_sense_field".into(),
+            description: "Return signals recently emitted into the plexus field \
+                          within this agent's attention budget.".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "max_signals": { "type": "integer", "default": 32, "maximum": 128 },
+                    "kinds": {
+                        "type": "array",
+                        "items": { "type": "string",
+                                   "enum": ["belief_claim","capability_offer",
+                                            "intent_declaration","observation",
+                                            "recruit","pheromone"] }
+                    },
+                    "since_ms": { "type": "integer",
+                                  "description": "Unix millis lower bound" }
+                }
+            }),
+            annotations: Some(ToolAnnotations {
+                read_only: true,
+                destructive: false,
+                idempotent: true,
+                open_world: true,
+                requires_confirmation: false,
+            }),
+            category: Some("plexus".into()),
+            tags: vec!["plexus".into(), "sensing".into()],
+            timeout_secs: Some(5),
+            title: None,
+            output_schema: None,
+        }
+    }
+
+    fn execute(&self, call: &ToolCall, _ctx: &ToolContext) -> Result<ToolResult, CoreError> {
+        // 1. Decrement attention budget, reject if 0.
+        // 2. Query field for matching signals.
+        // 3. Apply decay and return JSON array.
+    }
+}
+```
+
+Remaining five tools follow the same pattern and live in `src/tools.rs`.
+They are defined here rather than in `arcan-plexus` to match the
+`arcan-spaces` precedent — revisit this if a dep-cycle appears.
+
+## 8. Test strategy
+
+### 8.1 Unit tests (per primitive)
+
+Each `physics/*.rs` has a `#[cfg(test)]` module with at least:
+- **`decay`**: `decayed(1.0, 0, HL, HL) == 0.5`; `decayed(1.0, 0, 2·HL, HL) == 0.25`;
+  monotonic decrease; symmetry across `half_life` scales.
+- **`propagation`**: seed 100 random agents, emit from one, assert
+  `Reach::Local` returns exactly `k_local` receivers sorted by distance.
+- **`gradient`**: synthetic field with a known signal, assert gradient
+  samples are proportional to `decayed_strength · relevance`.
+- **`stigmergy`**: emit 4096 traces over 1 hour of simulated time, assert
+  compaction never drops a trace whose current intensity > 0.5·floor.
+- **`quorum`**: fixed 10-agent grid, assert `neighbors_with_capability` is
+  exactly `k` for capabilities held by `k` neighbors.
+
+All deterministic — no wall-clock dependencies; `now_ms` is injected.
+
+### 8.2 Integration: two-agent chain formation (in-process)
+
+```rust
+#[tokio::test]
+async fn two_agents_form_chain_and_propagate_signals() {
+    let (a_plex, _a_mock) = AgentFieldPlexus::mock(cfg_for("agent-A"));
+    let (b_plex, _b_mock) = AgentFieldPlexus::mock(cfg_for("agent-B"));
+    // Wire the two mocks into a shared field.
+    MockTransport::join(&a_plex, &b_plex);
+
+    // A emits Recruit for a Chain formation.
+    a_plex.emit(recruit_chain_signal()).unwrap();
+
+    // B's aggregate should reflect the pending formation.
+    let state = b_plex.aggregate();
+    assert_eq!(state.active_formations.len(), 1);
+    assert_eq!(state.active_formations[0].lifecycle, FormationLifecycle::Recruiting);
+
+    // B joins via the plexus_join_formation tool path.
+    b_plex.join_formation(state.active_formations[0].id).unwrap();
+
+    // After the next tick, formation should transition to Active (quorum met).
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let state = b_plex.aggregate();
+    assert_eq!(state.active_formations[0].lifecycle, FormationLifecycle::Active);
+}
+```
+
+### 8.3 Physics sanity
+
+- **Signal-decay curve fit**: emit 1000 signals at `t=0`, query at
+  `t ∈ {HL/2, HL, 2HL, 4HL}`, fit an exponential, assert the recovered
+  half-life is within 1% of the emit-time `half_life_ms`.
+- **Propagation distance**: plot the receive-count histogram vs distance,
+  assert it is flat within `Reach::Local.k` and zero beyond.
+- **Formation dissolution on TTL**: create a formation with 500ms TTL, never
+  keepalive, assert it transitions Recruiting → Dispersing → (gone) within
+  2×TTL.
+
+### 8.4 End-to-end: two Life instances on NATS
+
+Gated by `feature = "nats"` and the presence of `NATS_URL` env var in CI.
+The test spawns:
+- `life-plexus` agent A, configured with `agent_id = "AGT-e2e-A"`.
+- `life-plexus` agent B, configured with `agent_id = "AGT-e2e-B"`.
+- A mock depth-1 controller that calls `aggregate()` every 500ms and, when
+  the observed `IntentDeclaration` count exceeds 3, issues a
+  `RequestFormation` directive targeting both.
+
+Assertions:
+- Both A and B observe the other's `IntentDeclaration` signals within
+  τ_p ≤ 100ms.
+- Both receive the directive within ≤ 500ms.
+- After TTL, the formation dissolves without controller intervention.
+- Total wall time of the test ≤ 5s.
+
+## 9. Deferred / out of scope
+
+1. **Persistence of signals across agent restarts.** Signals are ephemeral by
+   design — C3 demands they decay faster than they propagate, and persisting
+   them would create standing waves. The `feature = "persist"` flag only
+   persists **compacted pheromone trace snapshots**, not signal history.
+2. **Cross-deployment federation.** A depth-1 plexus is single-cluster
+   initially. Multi-cluster (e.g. one NATS in us-east-1, another in eu-west-1)
+   is a depth-2 concern and would live in a separate crate.
+3. **Quantum or neuromorphic backends.** Classical silicon only. The
+   `SubstrateProfile` API supports reporting alternative substrates, but
+   `life-plexus` itself does not implement any.
+4. **Learned capability-space embeddings.** `FieldCoord` is populated by the
+   agent itself (declared) in v1. A learned embedding (capability2vec) is
+   explicitly future work.
+5. **Voting/consensus primitives.** No `Raft`, no quorum voting on directives.
+   The plexus is stigmergic — agents act on gradients, not votes. A future
+   `life-synod` crate can sit on top if voting semantics are required.
+6. **Economic settlement.** `Micro` appears in `CapabilityOffer` and
+   `AllocateBudget`, but actual payment rails live in `haima`. The plexus
+   announces costs; `haima` executes them.
+7. **Formation topology evolution.** A formation is born with one
+   `FormationTopology` and keeps it until dispersed. No migration
+   `Chain → Mesh` in v1.
+8. **Automatic backpressure on d1 directives.** If directives arrive faster
+   than C1 allows, we coalesce. We do not push-back on the d1 controller
+   itself — that is a d1-side concern. A future version could emit a
+   `PneumaError::DirectiveRateExceeded` that the d1 controller handles.
+9. **Cryptographic attribution.** Signals carry `emitted_by: AgentId` but are
+   not signed. A future `feature = "signed"` can require ed25519 signatures
+   via `aios_protocol::identity::BasicIdentity`.
+
+## 10. Open questions
+
+1. **Attention budget enforcement** — should `attention_budget` be consumed
+   per-signal-emitted, per-signal-sensed, or both? Current design says both
+   (1 credit each), but sensing 32 signals costs 32× more than one, which
+   might starve observers; alternative is a free-read, paid-write model.
+2. **Capability-space dimensionality** — `FIELD_DIM = 32` is a guess. Too few
+   and distinct capabilities collide; too many and R*-tree k-NN degrades.
+   Empirical tuning on a 50-agent testbed is needed.
+3. **Formation topology during lifecycle** — do we allow Recruiting
+   formations to switch topology (e.g. start as Star, devolve to Mesh if the
+   hub overloads)? Current design says no; may need revisiting.
+4. **Gradient sampling vs full aggregation** — `aggregate()` currently
+   returns sparse samples. Should there be a `dense_aggregate()` variant
+   that does KDE interpolation server-side, or is that always a
+   d1-controller concern?
+5. **Relationship with Spaces** — when both are present:
+   (a) fallback: plexus uses Spaces when NATS is unavailable,
+   (b) mirror: plexus emits to both, or
+   (c) disjoint: plexus is agent-native, Spaces is human-visible, no crosstalk.
+   Current architecture spec says (c); this may not survive contact with
+   operators who want a single pane of glass.
+6. **Heterogeneous populations** — P6 Theorem 1 assumes homogeneous
+   `λᵢ` across agents. If one agent in the population has `λ₀ < α·L_d`, does
+   `life-plexus` refuse to admit it (shield), or degrade gracefully? Current
+   design admits silently; may need a `peer_stability_gate` config.
+7. **Reach inflation by hub formations** — a Star formation hub, by
+   definition, sees everything its workers see. Does the hub's
+   `attention_budget` need to be `workers·budget` or just `budget`? Current
+   design says one budget per agent regardless of formation role.
+8. **Directive replay under partial network** — if the transport drops a
+   `DissolveFormation` directive, is the formation expected to dissolve
+   anyway via TTL? Current design says yes (TTL is the source of truth);
+   double-check this preserves C2 under packet loss.
+9. **Cross-feature interaction** — `feature = "persist"` + `feature = "mock"`
+   is a meaningful combination for test reproducibility but is not currently
+   tested. Need a matrix test in CI.
+10. **Nous evaluator access** — should the plexus call Nous on a
+    `BeliefClaim` before admitting it, or trust the emitter's self-score?
+    Trust-by-default is faster but allows belief-spam; Nous-gating is safer
+    but creates a hot dependency. Likely answer: trust, but rate-limit per
+    emitter via `coupling_weights[BeliefClaim]`.
+11. **Budget units** — `AllocateBudget` uses `Micro` (1e-6 USDC). Is the
+    plexus the right place to carry monetary units, or should this be
+    `haima::BudgetDelta`? Import from haima creates a workspace cycle
+    (haima → plexus → haima via Tool integration); defining locally is the
+    current compromise.
+12. **Naming of capability-space origin** — who decides `(0, 0, …, 0)`? If
+    every agent picks its own `FieldCoord::zero()` as "itself", all agents
+    claim the center and k-NN breaks. Current design requires every agent to
+    receive a `FieldCoord` from a bstack-issued embedding at startup;
+    unclear who owns that embedding service.
+
+## Appendix A — Public API surface at v0.1
+
+```rust
+// re-exports from src/lib.rs
+pub use aios_protocol::pneuma::{Pneuma, PneumaError, SubstrateProfile};
+
+pub use crate::{
+    config::PlexusConfig,
+    directive::CollectiveDirective,
+    error::PlexusError,
+    field::{GradientField, PopulationState, QuorumReading, Trace},
+    formation::{Formation, FormationId, FormationLifecycle,
+                FormationRole, FormationTopology},
+    locus::{AgentLocus, CapabilityId, DomainId, FieldCoord, GoalId, Posture},
+    plexus::AgentFieldPlexus,
+    signal::{EmittedSignal, Micro, PlexusSignal, Reach, TraceType},
+    tools::register_plexus_tools,
+    transport::{PlexusTransport, TransportError},
+};
+```
+
+## Appendix B — Minimum viable contributor checklist
+
+1. ☐ Scaffold `crates/plexus/life-plexus/` with `Cargo.toml`, `src/lib.rs`, README.
+2. ☐ Add `"crates/plexus/life-plexus"` to workspace members.
+3. ☐ Implement `aios-protocol::pneuma` module (prerequisite, may precede this PR).
+4. ☐ Implement §2 types in their respective files; `cargo check` green.
+5. ☐ Implement §3 physics primitives with unit tests (§8.1); `cargo test -p life-plexus` green.
+6. ☐ Implement `InProcessTransport` (no feature flag); wire to `AgentFieldPlexus`.
+7. ☐ Implement §8.2 in-process integration test.
+8. ☐ Implement `MockTransport` under `feature = "mock"`.
+9. ☐ Implement NATS transport under `feature = "nats"` with a manual README test.
+10. ☐ Implement §7 tool wrappers; register in `arcan` via `register_plexus_tools`.
+11. ☐ Add horizontal params to `research/rcs/data/parameters.toml`; run `make params`
+     and `bash core/life/scripts/sync-rcs-parameters.sh`.
+12. ☐ Wire §8.4 e2e test behind `feature = "nats"`.
+13. ☐ Update `pneuma-plexus-architecture.md` "Status" from `draft` to `phase-3-shipping`.

--- a/docs/specs/pneuma-plexus-architecture.md
+++ b/docs/specs/pneuma-plexus-architecture.md
@@ -1,0 +1,385 @@
+---
+title: "Pneuma/Plexus Architecture Specification"
+tags:
+  - spec
+  - architecture
+  - pneuma
+  - plexus
+  - rcs
+  - life-os
+created: "2026-04-18"
+updated: "2026-04-18"
+status: draft
+related:
+  - "[[2026-04-18-pneuma-plexus-recursion-synthesis]]"
+  - "[[p6-horizontal-composition]]"
+  - "[[p7-thermodynamic-limits]]"
+  - "[[LAGO_ARCHITECTURE]]"
+  - "[[METALAYER]]"
+---
+
+# Pneuma/Plexus Architecture Specification
+
+## Overview
+
+This specification defines the **Pneuma trait family** — a substrate-invariant abstraction for inter-boundary observation and control flow in the Life Agent OS — and **`life-plexus`**, its first horizontal (inter-agent) implementation.
+
+Pneuma formalizes what already exists: the mechanisms by which Life's existing crates carry observations up and directives down between levels of the RCS hierarchy. Plexus extends this pattern to a new boundary: between depth-0 Life instances (individual agents) and a depth-1 controller stack (collective swarm intelligence).
+
+**Design principle:** formalize, don't rename. Existing types (`EventKind`, `GatingProfile`, `HomeostaticState`) become associated-type slots of Pneuma impls. The existing architecture is made explicit, not replaced.
+
+## Motivation
+
+The Life Agent OS has two orthogonal recursion axes:
+
+- **Vertical** — L0 → L1 → L2 → L3 within one instance. Formalized in `aios-protocol::rcs::RecursiveControlledSystem<L>`. Stability budget saturated: ω = 0.006.
+- **Horizontal** — depth-k → depth-(k+1) between instances. A population of depth-k Life instances becomes the L0 plant of a depth-(k+1) Life instance.
+
+Both axes are instances of the same pattern: **aggregate observations cross a boundary upward, directives cross the same boundary downward**. The Pneuma trait family names this pattern. Specific impls handle specific boundaries.
+
+## Terminology
+
+- **Pneuma** (πνεῦμα, breath): the abstract inter-boundary substrate. A trait family.
+- **Plexus** (Latin, braid): one specific anatomical realization of Pneuma at the depth-0→depth-1 horizontal boundary. A Rust crate (`life-plexus`).
+- **Axis**: Vertical (within an instance) or Horizontal (between instances at different depths).
+- **Boundary**: the specific interface (L_n → L_{n+1} or Depth_k → Depth_{k+1}).
+- **Signal**: a typed, decaying observation or intent that crosses a boundary.
+- **Aggregate**: the observation-side readout of a boundary (what the higher side sees).
+- **Directive**: the control-side input crossing a boundary downward.
+
+## Architecture
+
+### 1. Core trait family (in `aios-protocol`)
+
+```rust
+// aios-protocol/src/pneuma.rs (NEW)
+
+/// Marker for which recursion axis a Pneuma impl operates on.
+pub trait Axis: Send + Sync + 'static {}
+
+pub struct Vertical;    impl Axis for Vertical {}
+pub struct Horizontal;  impl Axis for Horizontal {}
+
+/// Marker for the specific boundary a Pneuma impl crosses.
+pub trait Boundary: Send + Sync + 'static {
+    fn axis_name() -> &'static str;
+    fn boundary_name() -> &'static str;
+}
+
+/// Vertical boundaries within a single instance.
+pub struct L0ToL1;
+pub struct L1ToL2;
+pub struct L2ToL3;
+pub struct L3ToExternal;
+
+impl Boundary for L0ToL1 {
+    fn axis_name() -> &'static str { "vertical" }
+    fn boundary_name() -> &'static str { "L0→L1" }
+}
+// ...same for L1ToL2, L2ToL3, L3ToExternal
+
+/// Horizontal boundaries between instances.
+pub struct D0ToD1;
+pub struct D1ToD2;
+pub struct D2ToD3;
+
+impl Boundary for D0ToD1 {
+    fn axis_name() -> &'static str { "horizontal" }
+    fn boundary_name() -> &'static str { "depth-0 → depth-1" }
+}
+// ...same for D1ToD2, D2ToD3
+
+/// The core trait: an implementation carries signals across one boundary.
+pub trait Pneuma: Send + Sync {
+    type B: Boundary;
+
+    /// Typed signal crossing the boundary (payload).
+    type Signal: Send + Sync + 'static;
+
+    /// What the upward side observes (h output).
+    type Aggregate: Send + Sync + 'static;
+
+    /// What the upward side sends downward (U input).
+    type Directive: Send + Sync + 'static;
+
+    /// Emit a signal into the substrate.
+    fn emit(&self, signal: Self::Signal) -> Result<(), PneumaError>;
+
+    /// Read the current aggregate observation.
+    fn aggregate(&self) -> Self::Aggregate;
+
+    /// Check for and consume pending directive (non-blocking).
+    fn receive(&self) -> Option<Self::Directive>;
+
+    /// Substrate metadata — enables depth-(k+1) planners to reason
+    /// about which resources are cheap here.
+    fn substrate(&self) -> SubstrateProfile;
+}
+
+/// Substrate characteristics that affect scaling laws.
+#[derive(Clone, Debug)]
+pub struct SubstrateProfile {
+    pub kind: SubstrateKind,
+    pub warp_factors: WarpFactors,
+    pub ceiling: ResourceCeiling,
+}
+
+#[derive(Clone, Debug)]
+pub enum SubstrateKind {
+    ClassicalSilicon,
+    Neuromorphic,
+    Quantum { qubits: u32, coherence_us: u32 },
+    Biological,
+    Hybrid(Vec<SubstrateKind>),
+}
+
+#[derive(Clone, Debug)]
+pub struct WarpFactors {
+    pub time: f64,          // tempo multiplier vs classical baseline
+    pub energy: f64,        // energy/op multiplier
+    pub coordination: CoordinationScaling,
+    pub memory: f64,
+    pub branching: Option<f64>,  // None for classical (impossible)
+}
+
+#[derive(Clone, Debug)]
+pub enum CoordinationScaling {
+    Linear,         // O(N)
+    NLogN,          // O(N log N)
+    Quadratic,      // O(N²)
+    Entangled,      // quantum — no classical analog
+}
+
+#[derive(Clone, Debug)]
+pub enum ResourceCeiling {
+    Thermodynamic { max_watts: f64 },
+    Coherence { max_duration_us: u32 },
+    Propagation { max_radius_m: f64 },
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PneumaError {
+    #[error("substrate unavailable: {0}")]
+    SubstrateUnavailable(String),
+    #[error("signal rejected by shield: {0}")]
+    ShieldRejection(String),
+    #[error("transport error: {0}")]
+    Transport(String),
+}
+```
+
+### 2. Vertical implementations (existing crates gain Pneuma impls)
+
+No renames. Existing types stay. Each crate adds a Pneuma impl for its boundary:
+
+```rust
+// crates/lago/lago-journal/src/pneuma_impl.rs (NEW)
+use aios_protocol::pneuma::*;
+
+impl Pneuma for LagoJournal {
+    type B = L0ToL1;
+    type Signal = EventKind;           // unchanged — already the canonical L0→L1 payload
+    type Aggregate = EventSlice;       // existing query type
+    type Directive = ReplayRequest;    // existing replay API
+
+    fn emit(&self, e: EventKind) -> Result<(), PneumaError> {
+        self.append(e).map_err(|e| PneumaError::Transport(e.to_string()))
+    }
+    fn aggregate(&self) -> EventSlice { self.latest_slice() }
+    fn receive(&self) -> Option<ReplayRequest> { self.pending_replays().pop() }
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors::classical_baseline(),
+            ceiling: ResourceCeiling::Thermodynamic { max_watts: 500.0 },
+        }
+    }
+}
+```
+
+```rust
+// crates/autonomic/autonomic-controller/src/pneuma_impl.rs (NEW)
+impl Pneuma for AutonomicProjection {
+    type B = L1ToL2;
+    type Signal = HomeostaticDelta;    // the events fold() consumes
+    type Aggregate = HomeostaticState; // unchanged — the fold output
+    type Directive = GatingProfile;    // unchanged — what engine.rs emits
+
+    fn emit(&self, d: HomeostaticDelta) -> Result<(), PneumaError> { /* ... */ }
+    fn aggregate(&self) -> HomeostaticState { self.current_state() }
+    fn receive(&self) -> Option<GatingProfile> { self.latest_gate() }
+    fn substrate(&self) -> SubstrateProfile { /* classical baseline */ }
+}
+```
+
+Same pattern for:
+- `egri` (from autoany): `impl Pneuma<B = L2ToL3>`
+- `bstack-policy`: `impl Pneuma<B = L3ToExternal>`
+
+### 3. Horizontal implementation: `life-plexus` (new crate)
+
+```rust
+// crates/plexus/life-plexus/src/lib.rs (NEW)
+
+/// Plexus signals — the typed field physics units.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PlexusSignal {
+    BeliefClaim { claim: String, confidence: f32, half_life_ms: u64 },
+    CapabilityOffer { capability: CapabilityId, cost: Option<Micro> },
+    IntentDeclaration { goal: GoalId, urgency: f32 },
+    Observation { domain: DomainId, datum: Value },
+    Recruit { required: Vec<CapabilityId>, formation: FormationId },
+    Pheromone { trace_type: TraceType, intensity: f32, decay_ms: u64 },
+}
+
+/// Population-level aggregate — what the depth-1 controller sees.
+#[derive(Clone, Debug)]
+pub struct PopulationState {
+    pub members: Vec<AgentLocus>,
+    pub active_formations: Vec<Formation>,
+    pub gradient_fields: HashMap<CapabilityId, GradientField>,
+    pub pheromone_map: HashMap<TraceType, Vec<Trace>>,
+    pub quorum_readings: HashMap<CapabilityId, QuorumReading>,
+}
+
+/// Depth-1 → depth-0 directives.
+#[derive(Clone, Debug)]
+pub enum CollectiveDirective {
+    AdjustPosture { target: AgentId, posture: Posture },
+    RequestFormation { purpose: GoalId, topology: FormationTopology, members: Vec<AgentId> },
+    DissolveFormation { id: FormationId },
+    AllocateBudget { target: AgentId, delta: Micro },
+    BroadcastNarrative { narrative: String, reach: Reach },
+}
+
+pub struct AgentFieldPlexus { /* ... */ }
+
+impl Pneuma for AgentFieldPlexus {
+    type B = D0ToD1;
+    type Signal = PlexusSignal;
+    type Aggregate = PopulationState;
+    type Directive = CollectiveDirective;
+
+    fn emit(&self, s: PlexusSignal) -> Result<(), PneumaError> {
+        // apply decay, propagate through field, respect reach
+    }
+    fn aggregate(&self) -> PopulationState {
+        // compute gradient fields, quorum readings, formation states
+    }
+    fn receive(&self) -> Option<CollectiveDirective> { /* ... */ }
+    fn substrate(&self) -> SubstrateProfile { /* classical + NATS transport */ }
+}
+```
+
+**Design parameters constrained by P6:**
+
+- Signal half-lives (δ) must satisfy `δ > 1/τ_p` (decay faster than propagation)
+- Directive rate bounded by `1/τ₀^(d1) ≤ 1/(κ · τ₃^(d0))`
+- Population size N bounded by coupling-strength reserve
+- Aggregate operator choice (mean / max / gradient) affects λ_H directly
+
+### 4. Integration with Arcan
+
+Arcan doesn't import pneuma directly. It receives `Arc<dyn Pneuma<B = ...>>` at construction time. Tools wrap pneuma operations:
+
+```rust
+pub fn register_pneuma_tools<P: Pneuma + 'static>(
+    registry: &mut ToolRegistry,
+    pneuma: Arc<P>,
+) {
+    // For vertical (L0→L1): tools expose emit_event, read_events
+    // For horizontal (d0→d1): tools expose emit_signal, sense_field, join_formation
+}
+```
+
+This mirrors the existing `SpacesPort` pattern in `arcan-spaces` — proven precedent for substrate-abstract tool interfaces.
+
+### 5. Payload type ownership
+
+Each controller crate owns its payload types. Payloads flow through Pneuma:
+
+| Crate | Payload types | Pneuma role |
+|---|---|---|
+| lago | EventKind, EventSlice | substrate (vertical) |
+| autonomic | HomeostaticDelta, GatingProfile | substrate (vertical) |
+| haima | HaimaDelta, TaskBilled | controller → contributes payloads |
+| anima | AnimaClaim | controller → contributes payloads |
+| nous | NousScore, Evaluation | controller → contributes payloads |
+| vigil | ObservationTrace | controller → contributes payloads |
+| plexus | PlexusSignal, PopulationState, CollectiveDirective | substrate (horizontal) |
+
+## Sequencing
+
+### Phase 0: Prerequisites
+1. **Write P6** (`research/rcs/papers/p6-horizontal-composition/`). Horizontal stability theorem.
+2. **Write P7** (`research/rcs/papers/p7-thermodynamic-limits/`). Substrate scaling + depth-Kardashev.
+3. **L3 compression project**. Nous-as-L3-evaluator inline. Prerequisite for fast horizontal recursion.
+
+### Phase 1: Land Pneuma trait
+4. Add `aios-protocol::pneuma` module with traits and markers.
+5. Unit tests for `SubstrateProfile`, `WarpFactors`.
+
+### Phase 2: Retrofit vertical impls
+6. `lago-journal` implements `Pneuma<B = L0ToL1>`. Validates the trait doesn't break existing behavior.
+7. `autonomic-controller` implements `Pneuma<B = L1ToL2>`.
+8. `egri` implements `Pneuma<B = L2ToL3>`.
+9. `bstack-policy` implements `Pneuma<B = L3ToExternal>`.
+
+### Phase 3: Build `life-plexus`
+10. New crate `crates/plexus/life-plexus/` with field physics primitives.
+11. `AgentFieldPlexus` implements `Pneuma<B = D0ToD1>`.
+12. NATS-based transport (or in-process broadcast for single-machine).
+13. Integration with Arcan tools via `register_pneuma_tools`.
+14. Horizontal-composition integration test — two depth-0 Life instances coordinating through a depth-1 plexus.
+
+### Phase 4: Substrate-aware planning
+15. `bstack plan --depth=N` CLI querying `depth-cost-scale.toml` + `substrate-warp.toml`.
+16. Per-substrate Pneuma impls as they become available (neuromorphic, quantum).
+
+## Non-goals
+
+- **Not replacing Spaces.** Spaces stays as human-visible communication. Plexus is agent-native coordination. They coexist.
+- **Not introducing depth as a type parameter on `RecursiveControlledSystem<L>`.** Depth is instantiation: `RCS<L0, State = Vec<D0Instance>>`. Trait stays clean.
+- **Not renaming EventKind, GatingProfile, HomeostaticState, or any existing payload types.** Only adding Pneuma impls on top.
+
+## Open questions
+
+1. **Tool surface for horizontal pneuma.** What abstractions does Arcan expose? `emit_signal` is low-level; higher-level abstractions (`recruit`, `join_formation`, `leave_trace`) may be worth first-classing.
+2. **Feature flags.** Should `Pneuma` be feature-gated in aios-protocol, or always present? Probably always present once stable.
+3. **Serialization.** All Pneuma associated types must be `Serialize + Deserialize` for cross-instance transport. Constraint or freedom?
+4. **Testing pattern.** A `MockPneuma` is obvious; what about a "physics sandbox" that simulates decay + propagation for unit tests without real transport?
+5. **Failure semantics.** If `emit()` fails (substrate down, shield rejection), should the calling agent treat it as soft (log and continue) or hard (halt)? Per-boundary policy.
+
+## Companion specifications (agent-team outputs, 2026-04-18)
+
+This architecture overview is complemented by four deeper specs produced in parallel:
+
+- **Trait surface (full Rust):** `core/life/docs/specs/pneuma-trait-surface.md` — 1,106-line complete `aios-protocol::pneuma` module spec, ready for direct port to Rust. Associated types over generics, zero-sized boundary markers with `Boundary::A: Axis` pinning, synchronous trait with dyn-compatibility verified, `MockPneuma` testing impl, 13 unit tests.
+- **Vertical retrofits (per-crate plans):** `core/life/docs/specs/pneuma-vertical-retrofits.md` — detailed additive-only plans for four crates. **Surfaces important corrections from code audit** (see below).
+- **Plexus implementation:** `core/life/docs/specs/life-plexus-implementation.md` — full crate spec with field physics primitives, three transport backends (NATS / in-process / mock), P6-compliance by construction.
+- **P6 proof sketch:** `research/rcs/papers/p6-horizontal-composition/proof-sketch.md` — horizontal stability theorem with Lyapunov composition, four-step proof outline, worked numerical example showing floor inheritance.
+
+## Corrections from retrofit audit (important)
+
+The retrofit agent's code exploration surfaced three corrections to earlier naming assumptions in this spec:
+
+1. **`HomeostaticDelta` does not exist as a Rust type.** The autonomic-controller has `fold()` + `evaluate()` as standalone functions operating on `HomeostaticState`. The spec's earlier sketch of `HomeostaticDelta` was aspirational naming. The retrofit plan uses `EventKind` directly as the Signal type for the L1→L2 boundary, consistent with trait-not-rename discipline.
+
+2. **`AutonomicProjection` does not exist as a Rust type.** It was conceptual. The retrofit plan adds a new wrapper struct (`AutonomicProjection`) as an additive host for the Pneuma impl — without changing any existing function signature in autonomic-controller.
+
+3. **`bstack-policy` does not exist as a Rust crate.** Governance currently lives as `.control/policy.yaml` + `skills/bookkeeping/scripts/bookkeeping.py`. The retrofit plan scaffolds a new Rust crate from scratch for this boundary.
+
+4. **`autoany-core` lives in a separate workspace** (`core/autoany/`, published to crates.io). Adding an `aios-protocol` path dependency would break its publishing pipeline. **The retrofit uses an adapter crate pattern** — a new `autoany-aios-pneuma` crate inside `core/life/crates/autoany/`, mirroring the existing `autoany-aios` and `autoany-lago` adapter precedent.
+
+These corrections don't change the architectural thesis (pneuma as substrate-invariant trait family) but they do tighten the implementation path. See `pneuma-vertical-retrofits.md` for the detailed per-crate plans.
+
+## References
+
+- Session synthesis: `research/notes/2026-04-18-pneuma-plexus-recursion-synthesis.md`
+- Horizontal stability theorem: `research/rcs/papers/p6-horizontal-composition/README.md` + `proof-sketch.md`
+- Thermodynamic limits: `research/rcs/papers/p7-thermodynamic-limits/README.md`
+- Paper 5 SCOPE (dormant): `research/rcs/papers/p5-categorical-foundations/SCOPE.md`
+- RCS foundations: `research/rcs/papers/p0-foundations/main.tex`
+- SpacesPort precedent: `core/life/crates/arcan/arcan-spaces/src/port.rs`
+- EGRI L2 implementation: `core/autoany/autoany-core/src/loop_engine.rs`
+- Autonomic L1 implementation: `core/life/crates/autonomic/autonomic-controller/src/engine.rs`

--- a/docs/specs/pneuma-trait-surface.md
+++ b/docs/specs/pneuma-trait-surface.md
@@ -1,0 +1,1106 @@
+---
+title: "Pneuma — Rust Trait Surface Specification"
+tags:
+  - spec
+  - rust
+  - pneuma
+  - rcs
+  - aios-protocol
+  - trait-surface
+created: "2026-04-18"
+updated: "2026-04-18"
+status: draft
+related:
+  - "[[pneuma-plexus-architecture]]"
+  - "[[concept/pneuma]]"
+  - "[[rcs]]"
+  - "[[trait-not-rename]]"
+---
+
+# Pneuma — Rust Trait Surface Specification
+
+This document is the canonical Rust specification for the `aios-protocol::pneuma` module. It defines the substrate-invariant trait family for inter-boundary observation and control flow. Every symbol in this spec is intended to be ported verbatim into `core/life/crates/aios/aios-protocol/src/pneuma.rs` (and a corresponding `pub mod pneuma;` + re-exports in `src/lib.rs`).
+
+**Scope:** this spec defines the *trait surface only* — no transports, no concrete crates, no wire formats. Horizontal impls (`life-plexus`) and vertical retrofits (`lago-journal`, `autonomic-controller`, `egri`, `bstack-policy`) live in their own crates and will depend on this surface.
+
+**Non-scope:** the spec deliberately omits:
+- Async methods (open question — see end of doc).
+- Backpressure / flow control primitives (open question).
+- Cross-instance wire formats (P6 deliverable).
+- Per-substrate impls (Phase 4 in architecture spec).
+
+**Design invariants:**
+1. **Trait, not rename.** Existing types stay. Pneuma adds a thin trait surface on top.
+2. **Substrate-invariant.** Same trait shape works for silicon, neuromorphic, quantum, biological.
+3. **Associated types over generics.** A Pneuma impl crosses *one* boundary; its Signal/Aggregate/Directive are implementation-determined, not caller-selected.
+4. **Zero-sized markers.** All `Boundary` impls and `Axis` impls are ZSTs, used only for type-level dispatch.
+5. **`Send + Sync + 'static`** on all payload types (enables cross-thread transport).
+
+---
+
+## 0. File header & module docstring
+
+```rust
+//! Pneuma — substrate-invariant inter-boundary observation and control flow.
+//!
+//! Pneuma (πνεῦμα, "breath") is the abstract pattern by which aggregate
+//! observations cross a boundary upward and directives cross the same boundary
+//! downward. It operates on two orthogonal recursion axes:
+//!
+//! - **Vertical** — L0→L1→L2→L3 within a single Life instance (formalized in
+//!   [`crate::rcs::RecursiveControlledSystem`]).
+//! - **Horizontal** — depth-k→depth-(k+1) between instances (a population of
+//!   depth-k Life instances becomes the L0 plant of a depth-(k+1) instance).
+//!
+//! # Design
+//!
+//! `Pneuma` is a trait family, not a concrete implementation. Existing crates
+//! retain their payload types (`EventKind`, `GatingProfile`, `HomeostaticState`,
+//! etc.) and gain Pneuma impls. No renames.
+//!
+//! Each Pneuma impl crosses exactly one [`Boundary`]. The boundary is a
+//! zero-sized type marker used to prevent cross-boundary miswiring at compile
+//! time (e.g., an `L1→L2` impl cannot be passed where an `L0→L1` impl is
+//! required).
+//!
+//! # Hierarchy
+//!
+//! ```text
+//! trait Axis: Send + Sync + 'static
+//!   ├── struct Vertical
+//!   └── struct Horizontal
+//!
+//! trait Boundary: Send + Sync + 'static
+//!   ├── (vertical) L0ToL1, L1ToL2, L2ToL3, L3ToExternal
+//!   └── (horizontal) D0ToD1, D1ToD2, D2ToD3
+//!
+//! trait Pneuma: Send + Sync
+//!   type B: Boundary
+//!   type Signal, Aggregate, Directive: Send + Sync + 'static
+//!   fn emit, aggregate, receive, substrate
+//! ```
+//!
+//! # References
+//!
+//! - Architecture spec: `core/life/docs/specs/pneuma-plexus-architecture.md`
+//! - Concept page: `research/entities/concept/pneuma.md`
+//! - Horizontal stability theorem (planned): `research/rcs/papers/p6-horizontal-composition/`
+//! - Substrate warp factors (planned): `research/rcs/papers/p7-thermodynamic-limits/`
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+```
+
+---
+
+## 1. Axis markers
+
+Two axes of recursion — vertical (within one instance) and horizontal (between instances). Both are zero-sized marker types implementing the `Axis` trait. They exist so callers can statically assert which recursion they are operating on when composing multiple Pneuma impls.
+
+```rust
+// ---------------------------------------------------------------------------
+// Axis markers
+// ---------------------------------------------------------------------------
+
+/// Marker trait for a recursion axis.
+///
+/// An axis is the direction of recursion in the Life Agent OS:
+/// [`Vertical`] (levels within one instance) or [`Horizontal`] (depths between
+/// instances). Implementations are zero-sized types used purely for type-level
+/// dispatch; there is no runtime representation.
+pub trait Axis: Send + Sync + 'static + fmt::Debug {
+    /// Human-readable name of the axis (e.g., `"vertical"`).
+    fn name() -> &'static str;
+}
+
+/// Vertical axis — recursion across levels within a single Life instance
+/// (L0 → L1 → L2 → L3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Vertical;
+
+/// Horizontal axis — recursion across depths between Life instances
+/// (depth-k → depth-(k+1)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Horizontal;
+
+impl Axis for Vertical {
+    fn name() -> &'static str {
+        "vertical"
+    }
+}
+
+impl Axis for Horizontal {
+    fn name() -> &'static str {
+        "horizontal"
+    }
+}
+```
+
+---
+
+## 2. Boundary markers
+
+A `Boundary` names a specific interface (e.g., `L0→L1`, `D0→D1`) and has an associated axis. Boundaries are zero-sized markers used as associated types on `Pneuma` impls to prevent a caller from wiring, say, a plexus (`D0→D1`) where a journal (`L0→L1`) is expected.
+
+```rust
+// ---------------------------------------------------------------------------
+// Boundary markers
+// ---------------------------------------------------------------------------
+
+/// Marker trait for a specific boundary crossed by a [`Pneuma`] impl.
+///
+/// A boundary is the pair `(axis, interface)` where `interface` names which
+/// levels or depths the implementation connects. Like [`Axis`], every impl is a
+/// zero-sized type — boundaries are compile-time tags, not runtime objects.
+///
+/// The `A` associated type pins each boundary to exactly one axis, preventing
+/// nonsensical combinations (e.g., a "vertical depth-0 to depth-1" boundary).
+pub trait Boundary: Send + Sync + 'static + fmt::Debug {
+    /// The axis this boundary lives on ([`Vertical`] or [`Horizontal`]).
+    type A: Axis;
+
+    /// Name of the axis (e.g., `"vertical"`). Delegates to `Self::A::name()`.
+    fn axis_name() -> &'static str {
+        Self::A::name()
+    }
+
+    /// Name of the boundary (e.g., `"L0→L1"`, `"depth-0 → depth-1"`).
+    fn boundary_name() -> &'static str;
+}
+
+// --- Vertical boundaries ---------------------------------------------------
+
+/// Vertical boundary between L0 (external plant) and L1 (agent internal).
+///
+/// Typical impl: `lago-journal::LagoJournal`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L0ToL1;
+
+/// Vertical boundary between L1 (agent internal) and L2 (meta-control / EGRI).
+///
+/// Typical impl: `autonomic-controller::AutonomicProjection`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L1ToL2;
+
+/// Vertical boundary between L2 (EGRI) and L3 (governance).
+///
+/// Typical impl: `autoany-core::EgriLoop`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L2ToL3;
+
+/// Vertical boundary between L3 (governance) and the external world.
+///
+/// Typical impl: `bstack-policy::BstackPolicy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L3ToExternal;
+
+impl Boundary for L0ToL1 {
+    type A = Vertical;
+    fn boundary_name() -> &'static str {
+        "L0→L1"
+    }
+}
+
+impl Boundary for L1ToL2 {
+    type A = Vertical;
+    fn boundary_name() -> &'static str {
+        "L1→L2"
+    }
+}
+
+impl Boundary for L2ToL3 {
+    type A = Vertical;
+    fn boundary_name() -> &'static str {
+        "L2→L3"
+    }
+}
+
+impl Boundary for L3ToExternal {
+    type A = Vertical;
+    fn boundary_name() -> &'static str {
+        "L3→External"
+    }
+}
+
+// --- Horizontal boundaries -------------------------------------------------
+
+/// Horizontal boundary between depth-0 (individual agent) and depth-1
+/// (collective / swarm).
+///
+/// Typical impl: `life-plexus::AgentFieldPlexus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct D0ToD1;
+
+/// Horizontal boundary between depth-1 (collective) and depth-2 (federation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct D1ToD2;
+
+/// Horizontal boundary between depth-2 (federation) and depth-3 (civilization).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct D2ToD3;
+
+impl Boundary for D0ToD1 {
+    type A = Horizontal;
+    fn boundary_name() -> &'static str {
+        "depth-0 → depth-1"
+    }
+}
+
+impl Boundary for D1ToD2 {
+    type A = Horizontal;
+    fn boundary_name() -> &'static str {
+        "depth-1 → depth-2"
+    }
+}
+
+impl Boundary for D2ToD3 {
+    type A = Horizontal;
+    fn boundary_name() -> &'static str {
+        "depth-2 → depth-3"
+    }
+}
+```
+
+---
+
+## 3. Substrate metadata
+
+`SubstrateProfile` is the runtime description of the physical substrate a Pneuma impl executes on. It exists so depth-(k+1) planners can reason about scaling laws (linear vs quadratic coordination, thermodynamic vs coherence-limited, etc.) without knowing the substrate statically.
+
+All types in this section are network-transportable and therefore implement `Serialize + Deserialize`. They are `#[non_exhaustive]` where plausible growth is expected (new substrate kinds, new coordination regimes, new ceiling types).
+
+```rust
+// ---------------------------------------------------------------------------
+// Substrate metadata
+// ---------------------------------------------------------------------------
+
+/// Runtime description of the physical substrate a [`Pneuma`] impl uses.
+///
+/// Consumed by depth-(k+1) planners to select boundaries by cost profile
+/// (e.g., prefer a neuromorphic plexus for energy-bounded workloads, a
+/// quantum plexus for branching/superposition workloads).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use aios_protocol::pneuma::*;
+///
+/// let profile = SubstrateProfile {
+///     kind: SubstrateKind::ClassicalSilicon,
+///     warp_factors: WarpFactors::classical_baseline(),
+///     ceiling: ResourceCeiling::Thermodynamic { max_watts: 500.0 },
+/// };
+/// assert_eq!(profile.kind.family(), "classical");
+/// ```
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SubstrateProfile {
+    /// Substrate family (classical silicon, neuromorphic, quantum, biological,
+    /// hybrid).
+    pub kind: SubstrateKind,
+
+    /// Per-dimension warp factors relative to the classical baseline
+    /// (time, energy, coordination, memory, branching).
+    pub warp_factors: WarpFactors,
+
+    /// The binding resource constraint on this substrate (thermodynamic,
+    /// coherence, propagation).
+    pub ceiling: ResourceCeiling,
+}
+
+/// The physical family a substrate belongs to.
+///
+/// New variants may be added as new substrate classes are integrated. Consumers
+/// should handle unknown kinds gracefully; see `#[non_exhaustive]`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "family", rename_all = "snake_case")]
+pub enum SubstrateKind {
+    /// Classical silicon (CPU/GPU). The baseline against which warp factors
+    /// are measured.
+    ClassicalSilicon,
+
+    /// Spiking neural hardware (Loihi, SpiNNaker, Akida) — event-driven,
+    /// low-power, coordination is O(N).
+    Neuromorphic,
+
+    /// Quantum processor. `qubits` is the usable qubit count; `coherence_us`
+    /// is the nominal decoherence window in microseconds.
+    Quantum {
+        /// Number of usable qubits.
+        qubits: u32,
+        /// Nominal coherence window in microseconds.
+        coherence_us: u32,
+    },
+
+    /// Biological substrate (wetware, organoid intelligence, DishBrain-style
+    /// biological neural networks). Warp factors are highly speculative.
+    Biological,
+
+    /// Heterogeneous stack (e.g., classical + neuromorphic co-processor).
+    /// The order expresses preference: earlier substrates are tried first.
+    Hybrid(Vec<SubstrateKind>),
+}
+
+impl SubstrateKind {
+    /// Returns a short family label (`"classical"`, `"neuromorphic"`,
+    /// `"quantum"`, `"biological"`, `"hybrid"`).
+    pub fn family(&self) -> &'static str {
+        match self {
+            Self::ClassicalSilicon => "classical",
+            Self::Neuromorphic => "neuromorphic",
+            Self::Quantum { .. } => "quantum",
+            Self::Biological => "biological",
+            Self::Hybrid(_) => "hybrid",
+        }
+    }
+}
+
+/// Multiplicative cost/capability factors relative to classical silicon.
+///
+/// All multipliers use the convention **"classical baseline = 1.0"**. Values
+/// less than 1.0 indicate the substrate is *cheaper* on that dimension; greater
+/// than 1.0 indicate the substrate is *more expensive*.
+///
+/// # Example
+///
+/// A neuromorphic substrate might have `energy: 0.01` (100× cheaper) and
+/// `time: 2.0` (2× slower) relative to classical. A quantum substrate might
+/// have `branching: Some(1e6)` (a million-way superposition) where classical
+/// has `None`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WarpFactors {
+    /// Tempo multiplier — `0.1` means 10× faster, `10.0` means 10× slower.
+    pub time: f64,
+
+    /// Energy-per-op multiplier — `0.01` means 100× cheaper.
+    pub energy: f64,
+
+    /// How coordination cost scales with population size N.
+    pub coordination: CoordinationScaling,
+
+    /// Memory-per-op multiplier.
+    pub memory: f64,
+
+    /// Branching factor — `Some(k)` means k-way parallel branches are cheap
+    /// (superposition, speculation). `None` means no native branching
+    /// (classical case).
+    pub branching: Option<f64>,
+}
+
+impl WarpFactors {
+    /// The reference baseline: classical silicon with all factors at 1.0,
+    /// linear coordination, and no native branching.
+    pub fn classical_baseline() -> Self {
+        Self {
+            time: 1.0,
+            energy: 1.0,
+            coordination: CoordinationScaling::Linear,
+            memory: 1.0,
+            branching: None,
+        }
+    }
+}
+
+/// How the cost of coordinating N participants scales with N.
+///
+/// This directly bounds the maximum stable population size for a horizontal
+/// Pneuma impl (see P6 horizontal composition theorem).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationScaling {
+    /// O(N) — gossip, pheromones, gradient fields. Scales to large
+    /// populations.
+    Linear,
+
+    /// O(N log N) — hierarchical aggregation, tree overlays.
+    NLogN,
+
+    /// O(N²) — full pairwise messaging. Hard upper bound on population size.
+    Quadratic,
+
+    /// Entangled / superposed coordination with no classical complexity
+    /// analog (quantum substrates).
+    Entangled,
+}
+
+/// The binding resource constraint on a substrate.
+///
+/// Exactly one resource is the bottleneck at steady state; the other
+/// dimensions have slack. This selects which physical limit the planner must
+/// respect.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "ceiling", rename_all = "snake_case")]
+pub enum ResourceCeiling {
+    /// Thermodynamic ceiling — max sustainable power draw in watts.
+    /// Classical silicon, especially at scale.
+    Thermodynamic {
+        /// Maximum sustained power draw, in watts.
+        max_watts: f64,
+    },
+
+    /// Coherence ceiling — maximum operation duration before decoherence.
+    /// Quantum substrates.
+    Coherence {
+        /// Maximum coherent-operation duration, in microseconds.
+        max_duration_us: u32,
+    },
+
+    /// Propagation ceiling — maximum radius within which signals stay useful.
+    /// Biological substrates, also cellular-scale neuromorphic meshes.
+    Propagation {
+        /// Maximum useful signal radius, in meters.
+        max_radius_m: f64,
+    },
+}
+```
+
+---
+
+## 4. Error type
+
+A single error type for all Pneuma operations. Uses `thiserror::Error` to match the style of `KernelError` in this crate. `#[non_exhaustive]` so new error classes can be added without breaking downstream matches.
+
+```rust
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`Pneuma`] operations.
+///
+/// The variants are intentionally coarse-grained; implementations may attach
+/// richer context by constructing via `PneumaError::transport(e)` style helpers
+/// or by using the inner `String` payloads.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PneumaError {
+    /// The underlying substrate is unavailable (down, disconnected,
+    /// not initialized). Typically retriable.
+    #[error("substrate unavailable: {0}")]
+    SubstrateUnavailable(String),
+
+    /// A safety shield (S in the RCS 7-tuple) rejected the signal or
+    /// directive. Non-retriable at this boundary without modification.
+    #[error("rejected by shield: {0}")]
+    ShieldRejection(String),
+
+    /// Transport-layer failure (NATS, SpacetimeDB, local channel, etc.).
+    /// Retriability is transport-dependent; the string contains details.
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    /// The signal was syntactically or semantically invalid for this boundary
+    /// (e.g., wrong payload type, missing required field, out-of-range value).
+    /// Non-retriable without changing the signal.
+    #[error("invalid signal: {0}")]
+    InvalidSignal(String),
+}
+
+impl PneumaError {
+    /// Convenience constructor for [`PneumaError::Transport`].
+    pub fn transport(msg: impl Into<String>) -> Self {
+        Self::Transport(msg.into())
+    }
+
+    /// Convenience constructor for [`PneumaError::SubstrateUnavailable`].
+    pub fn substrate_unavailable(msg: impl Into<String>) -> Self {
+        Self::SubstrateUnavailable(msg.into())
+    }
+
+    /// Convenience constructor for [`PneumaError::ShieldRejection`].
+    pub fn shield_rejection(msg: impl Into<String>) -> Self {
+        Self::ShieldRejection(msg.into())
+    }
+
+    /// Convenience constructor for [`PneumaError::InvalidSignal`].
+    pub fn invalid_signal(msg: impl Into<String>) -> Self {
+        Self::InvalidSignal(msg.into())
+    }
+}
+```
+
+---
+
+## 5. The `Pneuma` trait
+
+The canonical trait. Four methods; four associated types. A Pneuma impl is an object that knows how to carry signals across *exactly one* boundary.
+
+**Why associated types (not generics):** an impl targets one specific boundary — a `LagoJournal` does not choose at call site whether to be L0→L1 or L1→L2. The signal, aggregate, and directive types are fixed for that impl. Associated types express "each impl has one choice" better than generics, which express "each call has one choice".
+
+**Why no `self: &mut`:** most impls hold their state behind an `Arc<Mutex<_>>` or SpacetimeDB connection, so `&self` is sufficient. An impl that genuinely needs exclusive access can wrap itself. This keeps `Arc<dyn Pneuma<...>>` workable.
+
+**Why `Option<Directive>` for `receive`:** non-blocking poll semantics. Async variants are an open question — see end of doc.
+
+```rust
+// ---------------------------------------------------------------------------
+// Core Pneuma trait
+// ---------------------------------------------------------------------------
+
+/// Substrate-invariant inter-boundary substrate.
+///
+/// A `Pneuma` impl carries typed [`Signal`](Pneuma::Signal)s across a single
+/// [`Boundary`], exposes the current [`Aggregate`](Pneuma::Aggregate) observation
+/// to the upward side, and delivers [`Directive`](Pneuma::Directive)s downward.
+///
+/// # Associated types
+///
+/// - `B: Boundary` — which boundary this impl crosses. Compile-time tag.
+/// - `Signal` — the upward-flowing payload (events, observations, beliefs).
+/// - `Aggregate` — the upward-readable state (projection, population state).
+/// - `Directive` — the downward-flowing control input.
+///
+/// All three payload types must be `Send + Sync + 'static` so they can traverse
+/// thread and task boundaries.
+///
+/// # Example
+///
+/// A minimal in-memory impl for unit testing:
+///
+/// ```rust,ignore
+/// use aios_protocol::pneuma::*;
+///
+/// // See MockPneuma later in this spec.
+/// let p = MockPneuma::<L0ToL1, String, Vec<String>, ()>::new();
+/// p.emit("hello".to_string()).unwrap();
+/// assert_eq!(p.aggregate(), vec!["hello".to_string()]);
+/// ```
+pub trait Pneuma: Send + Sync {
+    /// The boundary this impl crosses (zero-sized compile-time tag).
+    type B: Boundary;
+
+    /// Upward-flowing typed payload crossing the boundary.
+    ///
+    /// For `L0ToL1`, this is typically `crate::event::EventKind`. For
+    /// `D0ToD1`, this is typically a `PlexusSignal` variant.
+    type Signal: Send + Sync + 'static;
+
+    /// What the upward side observes (the `h` output in the RCS 7-tuple).
+    ///
+    /// For `L1ToL2`, this is typically `crate::state::AgentStateVector` or
+    /// autonomic's `HomeostaticState`.
+    type Aggregate: Send + Sync + 'static;
+
+    /// What the upward side sends downward (the `U` input in the RCS 7-tuple).
+    ///
+    /// For `L1ToL2`, this is typically `crate::mode::GatingProfile`.
+    type Directive: Send + Sync + 'static;
+
+    /// Emit a signal upward through the substrate.
+    ///
+    /// Implementations SHOULD apply decay, shields, and shaping before
+    /// accepting the signal. Rejections are returned as [`PneumaError`].
+    fn emit(&self, signal: Self::Signal) -> Result<(), PneumaError>;
+
+    /// Read the current aggregate observation.
+    ///
+    /// This is a pure read — it MUST NOT mutate substrate state.
+    /// Implementations SHOULD return a snapshot, not a live view.
+    fn aggregate(&self) -> Self::Aggregate;
+
+    /// Poll for a pending directive, if any.
+    ///
+    /// Non-blocking. Returns `None` if no directive is currently pending.
+    /// Calling `receive` MAY consume the directive from an internal queue;
+    /// callers that need idempotent reads should wrap the impl.
+    fn receive(&self) -> Option<Self::Directive>;
+
+    /// Describe the substrate this impl runs on.
+    ///
+    /// Used by planners and schedulers to reason about scaling laws and
+    /// resource ceilings. The profile SHOULD be approximately constant over
+    /// the lifetime of the impl (slow-changing runtime introspection is
+    /// acceptable; per-call variation is not).
+    fn substrate(&self) -> SubstrateProfile;
+}
+```
+
+---
+
+## 6. Example impl — `MockPneuma`
+
+A minimal, configurable, in-memory implementation used across unit tests. It:
+- Buffers emitted signals in a `Mutex<Vec<_>>`.
+- Takes configurable functions for `aggregate` and `receive`.
+- Returns a caller-supplied `SubstrateProfile`.
+
+Because `MockPneuma` must be generic over `B: Boundary`, `S`, `A`, `D`, and carry function pointers, the impl is slightly busier than production code — but it covers all trait surfaces without pulling in real transport.
+
+```rust
+// ---------------------------------------------------------------------------
+// MockPneuma — testing substrate
+// ---------------------------------------------------------------------------
+
+/// A configurable in-memory [`Pneuma`] impl for unit tests.
+///
+/// - `emit` pushes onto an internal `Vec<S>`.
+/// - `aggregate` returns a caller-supplied snapshot (or a clone of the
+///   emitted buffer if the snapshot fn is `None`).
+/// - `receive` pops from a caller-populated directive queue.
+/// - `substrate` returns a caller-supplied profile.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use aios_protocol::pneuma::*;
+///
+/// let p: MockPneuma<L0ToL1, i32, Vec<i32>, ()> = MockPneuma::new(
+///     SubstrateProfile {
+///         kind: SubstrateKind::ClassicalSilicon,
+///         warp_factors: WarpFactors::classical_baseline(),
+///         ceiling: ResourceCeiling::Thermodynamic { max_watts: 10.0 },
+///     },
+/// );
+/// p.emit(1).unwrap();
+/// p.emit(2).unwrap();
+/// assert_eq!(p.aggregate(), vec![1, 2]);
+/// ```
+pub struct MockPneuma<B, S, A, D>
+where
+    B: Boundary,
+    S: Send + Sync + 'static + Clone,
+    A: Send + Sync + 'static,
+    D: Send + Sync + 'static,
+{
+    buffer: std::sync::Mutex<Vec<S>>,
+    directives: std::sync::Mutex<std::collections::VecDeque<D>>,
+    aggregate_fn: std::sync::Mutex<
+        Option<Box<dyn Fn(&[S]) -> A + Send + Sync + 'static>>,
+    >,
+    default_aggregate: std::sync::Mutex<Option<A>>,
+    substrate: SubstrateProfile,
+    _boundary: std::marker::PhantomData<fn() -> B>,
+}
+
+impl<B, S, A, D> MockPneuma<B, S, A, D>
+where
+    B: Boundary,
+    S: Send + Sync + 'static + Clone,
+    A: Send + Sync + 'static,
+    D: Send + Sync + 'static,
+{
+    /// Create a new `MockPneuma` with the given substrate profile, no
+    /// aggregator function, and no pending directives.
+    pub fn new(substrate: SubstrateProfile) -> Self {
+        Self {
+            buffer: std::sync::Mutex::new(Vec::new()),
+            directives: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            aggregate_fn: std::sync::Mutex::new(None),
+            default_aggregate: std::sync::Mutex::new(None),
+            substrate,
+            _boundary: std::marker::PhantomData,
+        }
+    }
+
+    /// Install an aggregator function that maps the emitted buffer to an
+    /// `A`. Takes precedence over `set_aggregate`.
+    pub fn with_aggregator<F>(self, f: F) -> Self
+    where
+        F: Fn(&[S]) -> A + Send + Sync + 'static,
+    {
+        *self.aggregate_fn.lock().unwrap() = Some(Box::new(f));
+        self
+    }
+
+    /// Set a fixed aggregate value to return when no aggregator is installed.
+    pub fn set_aggregate(&self, value: A) {
+        *self.default_aggregate.lock().unwrap() = Some(value);
+    }
+
+    /// Push a directive onto the outbound queue. Consumed by `receive`.
+    pub fn push_directive(&self, directive: D) {
+        self.directives.lock().unwrap().push_back(directive);
+    }
+
+    /// Number of emitted signals currently buffered.
+    pub fn emitted_count(&self) -> usize {
+        self.buffer.lock().unwrap().len()
+    }
+
+    /// Snapshot of the emitted buffer (cloned).
+    pub fn emitted(&self) -> Vec<S> {
+        self.buffer.lock().unwrap().clone()
+    }
+}
+
+impl<B, S, A, D> Pneuma for MockPneuma<B, S, A, D>
+where
+    B: Boundary,
+    S: Send + Sync + 'static + Clone,
+    A: Send + Sync + 'static + Clone,
+    D: Send + Sync + 'static,
+{
+    type B = B;
+    type Signal = S;
+    type Aggregate = A;
+    type Directive = D;
+
+    fn emit(&self, signal: Self::Signal) -> Result<(), PneumaError> {
+        self.buffer
+            .lock()
+            .map_err(|e| PneumaError::transport(format!("mock mutex poisoned: {e}")))?
+            .push(signal);
+        Ok(())
+    }
+
+    fn aggregate(&self) -> Self::Aggregate {
+        // Preference order: aggregator fn > default value > panic with a
+        // descriptive message (mock-only behavior; production impls must
+        // always return a meaningful aggregate).
+        let buf = self.buffer.lock().unwrap();
+        let agg_fn = self.aggregate_fn.lock().unwrap();
+        if let Some(f) = agg_fn.as_ref() {
+            return f(&buf);
+        }
+        drop(agg_fn);
+        let default = self.default_aggregate.lock().unwrap();
+        if let Some(a) = default.as_ref() {
+            return a.clone();
+        }
+        panic!(
+            "MockPneuma::aggregate called with no aggregator and no default; \
+             call with_aggregator() or set_aggregate() first"
+        );
+    }
+
+    fn receive(&self) -> Option<Self::Directive> {
+        self.directives.lock().unwrap().pop_front()
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        self.substrate.clone()
+    }
+}
+```
+
+---
+
+## 7. Unit tests
+
+Coverage targets:
+1. Axis markers return the expected strings.
+2. Boundary markers return the expected names and axis delegation works.
+3. `SubstrateProfile` serializes and deserializes losslessly.
+4. `WarpFactors::classical_baseline()` returns the documented identity values.
+5. `MockPneuma` emit / aggregate / receive roundtrip.
+6. `MockPneuma` aggregator function overrides default aggregate.
+7. `PneumaError` variants format correctly via `Display`.
+8. Zero-sized boundary markers are actually zero-sized.
+
+```rust
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Axis markers ------------------------------------------------------
+
+    #[test]
+    fn axis_names() {
+        assert_eq!(Vertical::name(), "vertical");
+        assert_eq!(Horizontal::name(), "horizontal");
+    }
+
+    // --- Boundary markers --------------------------------------------------
+
+    #[test]
+    fn vertical_boundary_names() {
+        assert_eq!(L0ToL1::boundary_name(), "L0→L1");
+        assert_eq!(L1ToL2::boundary_name(), "L1→L2");
+        assert_eq!(L2ToL3::boundary_name(), "L2→L3");
+        assert_eq!(L3ToExternal::boundary_name(), "L3→External");
+    }
+
+    #[test]
+    fn horizontal_boundary_names() {
+        assert_eq!(D0ToD1::boundary_name(), "depth-0 → depth-1");
+        assert_eq!(D1ToD2::boundary_name(), "depth-1 → depth-2");
+        assert_eq!(D2ToD3::boundary_name(), "depth-2 → depth-3");
+    }
+
+    #[test]
+    fn boundary_axis_delegation() {
+        // Vertical boundaries report "vertical".
+        assert_eq!(L0ToL1::axis_name(), "vertical");
+        assert_eq!(L1ToL2::axis_name(), "vertical");
+        assert_eq!(L2ToL3::axis_name(), "vertical");
+        assert_eq!(L3ToExternal::axis_name(), "vertical");
+
+        // Horizontal boundaries report "horizontal".
+        assert_eq!(D0ToD1::axis_name(), "horizontal");
+        assert_eq!(D1ToD2::axis_name(), "horizontal");
+        assert_eq!(D2ToD3::axis_name(), "horizontal");
+    }
+
+    #[test]
+    fn boundary_markers_are_zero_sized() {
+        use std::mem::size_of;
+        assert_eq!(size_of::<L0ToL1>(), 0);
+        assert_eq!(size_of::<L1ToL2>(), 0);
+        assert_eq!(size_of::<L2ToL3>(), 0);
+        assert_eq!(size_of::<L3ToExternal>(), 0);
+        assert_eq!(size_of::<D0ToD1>(), 0);
+        assert_eq!(size_of::<D1ToD2>(), 0);
+        assert_eq!(size_of::<D2ToD3>(), 0);
+        assert_eq!(size_of::<Vertical>(), 0);
+        assert_eq!(size_of::<Horizontal>(), 0);
+    }
+
+    #[test]
+    fn boundary_markers_are_send_sync() {
+        // Compile-time check — if a marker is not Send+Sync, this fails to
+        // compile. The assertion itself is trivial.
+        fn assert_send_sync<T: Send + Sync + 'static>() {}
+        assert_send_sync::<L0ToL1>();
+        assert_send_sync::<L1ToL2>();
+        assert_send_sync::<L2ToL3>();
+        assert_send_sync::<L3ToExternal>();
+        assert_send_sync::<D0ToD1>();
+        assert_send_sync::<D1ToD2>();
+        assert_send_sync::<D2ToD3>();
+    }
+
+    // --- SubstrateProfile serde -------------------------------------------
+
+    #[test]
+    fn substrate_profile_serde_roundtrip() {
+        let profile = SubstrateProfile {
+            kind: SubstrateKind::Quantum {
+                qubits: 127,
+                coherence_us: 100,
+            },
+            warp_factors: WarpFactors {
+                time: 0.5,
+                energy: 2.0,
+                coordination: CoordinationScaling::Entangled,
+                memory: 0.25,
+                branching: Some(1e6),
+            },
+            ceiling: ResourceCeiling::Coherence {
+                max_duration_us: 100,
+            },
+        };
+
+        let json = serde_json::to_string(&profile).unwrap();
+        let back: SubstrateProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(profile, back);
+    }
+
+    #[test]
+    fn substrate_kind_family_labels() {
+        assert_eq!(SubstrateKind::ClassicalSilicon.family(), "classical");
+        assert_eq!(SubstrateKind::Neuromorphic.family(), "neuromorphic");
+        assert_eq!(
+            SubstrateKind::Quantum {
+                qubits: 2,
+                coherence_us: 10
+            }
+            .family(),
+            "quantum"
+        );
+        assert_eq!(SubstrateKind::Biological.family(), "biological");
+        assert_eq!(
+            SubstrateKind::Hybrid(vec![SubstrateKind::ClassicalSilicon]).family(),
+            "hybrid"
+        );
+    }
+
+    #[test]
+    fn warp_factors_classical_baseline_is_identity() {
+        let w = WarpFactors::classical_baseline();
+        assert!((w.time - 1.0).abs() < 1e-12);
+        assert!((w.energy - 1.0).abs() < 1e-12);
+        assert!((w.memory - 1.0).abs() < 1e-12);
+        assert_eq!(w.coordination, CoordinationScaling::Linear);
+        assert!(w.branching.is_none());
+    }
+
+    // --- PneumaError -------------------------------------------------------
+
+    #[test]
+    fn pneuma_error_display() {
+        let e = PneumaError::transport("nats down");
+        assert_eq!(format!("{e}"), "transport error: nats down");
+
+        let e = PneumaError::shield_rejection("budget exhausted");
+        assert_eq!(format!("{e}"), "rejected by shield: budget exhausted");
+
+        let e = PneumaError::substrate_unavailable("not initialized");
+        assert_eq!(format!("{e}"), "substrate unavailable: not initialized");
+
+        let e = PneumaError::invalid_signal("missing field 'domain'");
+        assert_eq!(
+            format!("{e}"),
+            "invalid signal: missing field 'domain'"
+        );
+    }
+
+    // --- MockPneuma --------------------------------------------------------
+
+    fn classical_profile() -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors::classical_baseline(),
+            ceiling: ResourceCeiling::Thermodynamic { max_watts: 10.0 },
+        }
+    }
+
+    #[test]
+    fn mock_pneuma_emit_aggregate_roundtrip() {
+        let p: MockPneuma<L0ToL1, i32, Vec<i32>, ()> =
+            MockPneuma::new(classical_profile())
+                .with_aggregator(|buf: &[i32]| buf.to_vec());
+
+        p.emit(1).unwrap();
+        p.emit(2).unwrap();
+        p.emit(3).unwrap();
+
+        assert_eq!(p.emitted_count(), 3);
+        assert_eq!(p.aggregate(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn mock_pneuma_default_aggregate() {
+        let p: MockPneuma<L1ToL2, &'static str, i32, ()> =
+            MockPneuma::new(classical_profile());
+        p.set_aggregate(42);
+
+        p.emit("x").unwrap();
+        assert_eq!(p.aggregate(), 42);
+    }
+
+    #[test]
+    fn mock_pneuma_receive_fifo() {
+        let p: MockPneuma<L1ToL2, (), (), &'static str> =
+            MockPneuma::new(classical_profile());
+        p.set_aggregate(());
+
+        p.push_directive("first");
+        p.push_directive("second");
+
+        assert_eq!(p.receive(), Some("first"));
+        assert_eq!(p.receive(), Some("second"));
+        assert_eq!(p.receive(), None);
+    }
+
+    #[test]
+    fn mock_pneuma_substrate_passthrough() {
+        let p: MockPneuma<D0ToD1, (), (), ()> =
+            MockPneuma::new(classical_profile());
+        let profile = p.substrate();
+        assert_eq!(profile.kind.family(), "classical");
+    }
+
+    #[test]
+    fn mock_pneuma_trait_object_is_usable() {
+        // Verify Pneuma is dyn-compatible for its intended boundary types.
+        let p: MockPneuma<L0ToL1, i32, i32, ()> =
+            MockPneuma::new(classical_profile());
+        p.set_aggregate(0);
+
+        let dyn_p: &dyn Pneuma<
+            B = L0ToL1,
+            Signal = i32,
+            Aggregate = i32,
+            Directive = (),
+        > = &p;
+
+        dyn_p.emit(7).unwrap();
+        assert_eq!(dyn_p.aggregate(), 0);
+        assert!(dyn_p.receive().is_none());
+    }
+
+    #[test]
+    fn mock_pneuma_aggregator_sees_emitted_buffer() {
+        let p: MockPneuma<D0ToD1, u32, u32, ()> =
+            MockPneuma::new(classical_profile())
+                .with_aggregator(|buf: &[u32]| buf.iter().sum());
+        for i in 1..=5 {
+            p.emit(i).unwrap();
+        }
+        assert_eq!(p.aggregate(), 15);
+    }
+}
+```
+
+---
+
+## 8. `lib.rs` integration
+
+The following two edits land the module in the crate:
+
+```rust
+// In core/life/crates/aios/aios-protocol/src/lib.rs
+
+// Add to the module overview:
+// - [`pneuma`] — Substrate-invariant inter-boundary observation/control flow
+
+pub mod pneuma; // add alongside `pub mod rcs;`
+
+// Add to the re-export block:
+pub use pneuma::{
+    Axis, Boundary, CoordinationScaling, D0ToD1, D1ToD2, D2ToD3, Horizontal, L0ToL1, L1ToL2,
+    L2ToL3, L3ToExternal, MockPneuma, Pneuma, PneumaError, ResourceCeiling, SubstrateKind,
+    SubstrateProfile, Vertical, WarpFactors,
+};
+```
+
+No `Cargo.toml` changes are required — `serde`, `serde_json`, and `thiserror` are already workspace dependencies.
+
+---
+
+## 9. Open design questions
+
+These are review-gate questions. The spec above picks defaults; each question may reopen the spec after discussion.
+
+1. **Should `Pneuma` methods be async?**
+   Current: synchronous with non-blocking `receive`. Rationale: `lago-journal` and `autonomic-controller` already expose sync surfaces; forcing async propagates runtime coupling to `aios-protocol`, which is deliberately runtime-free. Alternative: add a parallel `AsyncPneuma` trait gated on a feature flag, deferring the choice to impl crates. **Proposed decision: keep sync for now; revisit in Phase 3 after horizontal transport is real.**
+
+2. **How should backpressure be signaled?**
+   Current: `emit` returns `Result<(), PneumaError>` with no explicit "try again later" variant. A busy substrate must either buffer silently or return `Transport("full")`. Should we add a dedicated `PneumaError::Backpressure { retry_after_ms }` variant, or a `try_emit` that returns `Result<EmitOutcome, _>` where `EmitOutcome` distinguishes `Accepted`, `Queued`, `Dropped`? **Open.**
+
+3. **Should we require `Clone` on associated types?**
+   Current: no. `Send + Sync + 'static` only. `Aggregate` is often expensive to clone (large state vectors). But unit-testing impls and multi-consumer fanout both want clone. Alternative: require `Clone` on `Signal` (cheap) and `Directive` (cheap), leave `Aggregate` unconstrained. **Proposed decision: require `Clone` on `Signal` and `Directive`; leave `Aggregate` unconstrained.** (Not yet reflected in the trait above; deferred for discussion.)
+
+4. **Per-boundary feature flags?**
+   Current: all boundaries are always compiled in. A `no_default_features` caller gets everything. Since boundary markers are ZSTs and the trait is trivial, there is ~zero cost. Alternative: gate horizontal boundaries behind `feature = "horizontal"` for crates that only ever do vertical work. **Proposed decision: no feature flags until we measure a real cost.**
+
+5. **Substrate runtime introspection vs compile-time typing?**
+   Current: `SubstrateProfile` is runtime data returned from `substrate()`. Alternative: `type Substrate: SubstrateTrait` as a fourth associated type so the planner has compile-time substrate specialization. Runtime wins for hybrid/heterogeneous deployments; compile-time wins for zero-cost dispatch. **Open — likely resolved by a `SubstrateKind` enum + runtime probe, as currently specified.**
+
+6. **Should `receive` return `Vec<Directive>` or `Option<Directive>`?**
+   Current: `Option`. Bulk receive (draining a queue) would be `while let Some(d) = p.receive() {}`. Alternative: `fn drain(&self) -> Vec<Self::Directive>` for batch processing. **Proposed decision: add `drain` as a provided method with a default `Option`-loop implementation in a later revision.**
+
+7. **Should `emit` consume or borrow the signal?**
+   Current: `fn emit(&self, signal: Self::Signal)` — consumes. This matches `EventEnvelope` emission in `lago-journal`. Alternative: `fn emit(&self, signal: &Self::Signal)` — borrows; impls that need ownership call `.clone()` internally. Consuming is more ergonomic for producers; borrowing is more flexible for fanout. **Proposed decision: keep consuming. Fanout is the impl's problem.**
+
+8. **Should `Signal`, `Aggregate`, `Directive` require `Debug`?**
+   Current: no. `Debug` is useful for logs and tracing. Alternative: require `Debug` (ergonomic for `tracing`, `format!`), or make it a separate `PneumaDebug` marker trait for impls that opt in. **Proposed decision: require `Debug` on all three associated types.** (Not yet reflected in the trait above.)
+
+9. **Should `substrate()` be `fn substrate(&self) -> &SubstrateProfile` (borrow) instead?**
+   Current: clones. Rationale: planners sometimes want to move the profile into a dedicated data structure. Alternative: return `Cow<'_, SubstrateProfile>` to let impls choose. **Proposed decision: keep `-> SubstrateProfile` and rely on cheap clone of small enum/struct.**
+
+10. **Should there be a `PneumaExt` trait with combinators?**
+    E.g., `map_signal`, `filter`, `compose`, `instrument`. These mirror `Stream` combinators and would reduce boilerplate at call sites. **Proposed decision: defer until three or more real impls exist; combinators should be discovered, not invented.**
+
+---
+
+## Appendix A — Full module file (copy-paste target)
+
+For reviewers: the sections above, in order, form a single `pneuma.rs` file. The assembly order is:
+
+1. Header docstring + imports (§0).
+2. Axis markers (§1).
+3. Boundary markers (§2).
+4. Substrate metadata (§3).
+5. `PneumaError` (§4).
+6. `Pneuma` trait (§5).
+7. `MockPneuma` (§6).
+8. `#[cfg(test)] mod tests` (§7).
+
+Once landed, proceed with the retrofit sequence documented in `pneuma-plexus-architecture.md` §Sequencing Phase 2 (lago-journal → autonomic-controller → egri → bstack-policy).

--- a/docs/specs/pneuma-vertical-retrofits.md
+++ b/docs/specs/pneuma-vertical-retrofits.md
@@ -1,0 +1,1505 @@
+---
+title: "Pneuma Vertical Retrofits — Per-Crate Implementation Plans"
+tags:
+  - spec
+  - architecture
+  - pneuma
+  - rcs
+  - retrofit
+  - life-os
+created: "2026-04-18"
+updated: "2026-04-18"
+status: draft
+related:
+  - "[[pneuma-plexus-architecture]]"
+  - "[[pneuma]]"
+  - "[[trait-not-rename]]"
+  - "[[recursive-controlled-system]]"
+---
+
+# Pneuma Vertical Retrofits — Per-Crate Implementation Plans
+
+## Overview
+
+This document specifies **per-crate retrofit plans** for adding `Pneuma` trait implementations to the four vertical-boundary crates in the Life Agent OS monorepo. Each retrofit crosses one RCS hierarchy boundary:
+
+| Crate | Boundary | Status |
+|---|---|---|
+| `lago-journal` | L0 → L1 | Exists. First retrofit (canonical validator). |
+| `autonomic-controller` | L1 → L2 | Exists. Contains `fold()` reducer — the load-bearing mechanism. |
+| `autoany-core` (EGRI) | L2 → L3 | Exists as standalone workspace (not in `core/life`). |
+| `bstack-policy` | L3 → External | **Does not exist as a Rust crate** — currently lives as `policy.yaml` + Python in `skills/bookkeeping`. Must be scaffolded. |
+
+**Non-goals (invariant):** no renames. `EventKind`, `GatingProfile`, `HomeostaticState`, `TrialRecord`, `Action` all keep their current names and API surface. Pneuma impls sit on top.
+
+**Prerequisite:** the `aios-protocol::pneuma` module (trait family + boundary markers + `SubstrateProfile`) must land first. See Phase 1 in `pneuma-plexus-architecture.md`. This document assumes that landing; impls here reference types defined in that module.
+
+---
+
+## Crate 1 — `lago-journal` (L0 → L1 boundary)
+
+### Current state
+
+- **Location:** `/Users/broomva/broomva/core/life/crates/lago/lago-journal/`
+- **Workspace parent:** `core/life/crates/lago/` (the Lago persistence project)
+- **Public API (`src/lib.rs:1-27`):**
+  - `redb_journal::RedbJournal` — primary type, implements `lago_core::Journal`
+  - `redb_journal::EventNotification` — broadcast payload
+  - `snapshot::{SNAPSHOT_THRESHOLD, create_snapshot, load_snapshot, should_snapshot}`
+  - `stream::EventTailStream`
+  - `wal::Wal`
+- **Core type:** `RedbJournal` (`src/redb_journal.rs:33-36`):
+  ```rust
+  pub struct RedbJournal {
+      db: Arc<Database>,
+      notify_tx: broadcast::Sender<EventNotification>,
+  }
+  ```
+- **What it does:** append-only event journal backed by `redb` v2. Stores `EventEnvelope` records (compound key: session+branch+seq). Exposes `Journal` trait methods (`append`, `append_batch`, `read(EventQuery)`, `get_event`, `head_seq`, `stream`, session CRUD). Publishes `EventNotification` on every append via `tokio::sync::broadcast`.
+- **Boundary served:** **L0 → L1** — observations flowing up from the external plant (L0: conversation, codebase, tool execution) into the agent's internal state (L1: homeostatic regulation via Autonomic, which subscribes to the journal).
+- **Payload type alignment:** `lago_core::EventEnvelope.payload: EventPayload` where `EventPayload = aios_protocol::EventKind` via type alias (`lago-core/src/event.rs:17`). So `EventKind` is **already the canonical L0→L1 Signal**. Good: the Pneuma associated type lands cleanly.
+
+### Mapping to Pneuma
+
+| Pneuma slot | Existing type | Location | Notes |
+|---|---|---|---|
+| `Signal` | `aios_protocol::EventKind` | `aios-protocol/src/event.rs:206` | Already the canonical event payload. No change. |
+| `Aggregate` | `EventSlice` (NEW — thin newtype) | `lago-journal/src/pneuma_impl.rs` | Wraps `Vec<EventEnvelope>` + the query that produced it. Non-destructive — does not replace `Vec<EventEnvelope>` as `read()` return. |
+| `Directive` | `ReplayRequest` (NEW) | `lago-journal/src/pneuma_impl.rs` | Typed replay intent — declarative query for re-reading events. |
+| `B` (Boundary) | `aios_protocol::pneuma::L0ToL1` | `aios-protocol/src/pneuma.rs` | Zero-sized marker. |
+
+**Design note:** `Aggregate` cannot just be `Vec<EventEnvelope>` directly because the spec mandates a readout type distinct from the raw event list (callers at L1 want a slice + provenance). A thin newtype preserves the trait shape without breaking callers of `Journal::read`.
+
+### Concrete impl block
+
+```rust
+// core/life/crates/lago/lago-journal/src/pneuma_impl.rs (NEW)
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use aios_protocol::EventKind;
+use aios_protocol::pneuma::{
+    CoordinationScaling, L0ToL1, Pneuma, PneumaError, ResourceCeiling, SubstrateKind,
+    SubstrateProfile, WarpFactors,
+};
+use lago_core::{BranchId, EventEnvelope, EventQuery, SessionId};
+
+use crate::redb_journal::RedbJournal;
+
+/// Aggregate observation at the L0→L1 boundary: the slice of events
+/// most recently appended, plus the query used to obtain it.
+///
+/// This is a thin newtype around `Vec<EventEnvelope>` — it deliberately
+/// does NOT replace the `Journal::read` return type. The existing API is
+/// preserved verbatim; `EventSlice` is an L1-facing readout.
+#[derive(Debug, Clone)]
+pub struct EventSlice {
+    pub query: EventQuery,
+    pub events: Vec<EventEnvelope>,
+    /// Head sequence number for (session, branch) at time of read.
+    pub head_seq: u64,
+}
+
+/// Directive from L1 down to the journal — a typed replay intent.
+///
+/// The L1 controller (Autonomic) may request replay of a specific
+/// session/branch range, e.g. to rebuild a projection after a
+/// snapshot restore. This is the canonical "push to L0" directive.
+#[derive(Debug, Clone)]
+pub struct ReplayRequest {
+    pub session_id: SessionId,
+    pub branch_id: BranchId,
+    pub from_seq: u64,
+    pub to_seq: Option<u64>,
+    /// Opaque correlation for tracing.
+    pub request_id: String,
+}
+
+/// Pending replay queue — bounded, FIFO. Held inline on the journal
+/// so `receive()` can non-blockingly pop the next request.
+#[derive(Default)]
+struct ReplayQueue {
+    pending: Vec<ReplayRequest>,
+}
+
+/// Extension wrapper holding Pneuma state alongside a journal.
+///
+/// This keeps `RedbJournal` itself unchanged (no new fields on the
+/// primary type). Pneuma state is layered in a sibling struct.
+#[derive(Clone)]
+pub struct LagoJournalPneuma {
+    journal: RedbJournal,
+    replays: Arc<Mutex<ReplayQueue>>,
+    /// The last slice we computed (cached for `aggregate()`).
+    last_slice: Arc<Mutex<Option<EventSlice>>>,
+}
+
+impl LagoJournalPneuma {
+    pub fn wrap(journal: RedbJournal) -> Self {
+        Self {
+            journal,
+            replays: Arc::new(Mutex::new(ReplayQueue::default())),
+            last_slice: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn inner(&self) -> &RedbJournal {
+        &self.journal
+    }
+
+    /// Queue a replay request from L1. Returns Ok(()) even when queue is empty.
+    pub fn request_replay(&self, req: ReplayRequest) -> Result<(), PneumaError> {
+        self.replays
+            .lock()
+            .map_err(|e| PneumaError::Transport(format!("replay queue poisoned: {e}")))?
+            .pending
+            .push(req);
+        Ok(())
+    }
+
+    /// Record a slice after a successful read. Allows `aggregate()` to
+    /// return the most recent readout without re-querying redb.
+    pub fn record_slice(&self, slice: EventSlice) {
+        if let Ok(mut cell) = self.last_slice.lock() {
+            *cell = Some(slice);
+        }
+    }
+}
+
+impl Pneuma for LagoJournalPneuma {
+    type B = L0ToL1;
+    type Signal = EventKind;
+    type Aggregate = EventSlice;
+    type Directive = ReplayRequest;
+
+    /// Emit an event into the journal.
+    ///
+    /// The Pneuma API is synchronous and fire-and-forget — we use the
+    /// tokio blocking bridge to materialize an `EventEnvelope` and append.
+    /// Callers that need the assigned seq should keep using `Journal::append`
+    /// directly; `emit` returns `Ok(())` when the append succeeds.
+    fn emit(&self, signal: EventKind) -> Result<(), PneumaError> {
+        // Build a minimal envelope with the canonical payload.
+        // The journal assigns seq on append; caller-provided seq is ignored.
+        let envelope = EventEnvelope {
+            event_id: lago_core::EventId::new(),
+            session_id: SessionId::from_string("pneuma-emit"),
+            branch_id: BranchId::from_string("main"),
+            run_id: None,
+            seq: 0,
+            timestamp: EventEnvelope::now_micros(),
+            parent_id: None,
+            payload: signal,
+            metadata: std::collections::HashMap::new(),
+            schema_version: 1,
+        };
+
+        // Bridge the sync Pneuma contract to the async Journal API.
+        // Use a blocking current-thread runtime (bounded, no tokio context).
+        let journal = self.journal.clone();
+        let result = futures::executor::block_on(async move {
+            use lago_core::Journal;
+            journal.append(envelope).await
+        });
+
+        result
+            .map(|_| ())
+            .map_err(|e| PneumaError::Transport(e.to_string()))
+    }
+
+    fn aggregate(&self) -> EventSlice {
+        self.last_slice
+            .lock()
+            .ok()
+            .and_then(|c| c.clone())
+            .unwrap_or_else(|| EventSlice {
+                query: EventQuery::new(),
+                events: Vec::new(),
+                head_seq: 0,
+            })
+    }
+
+    fn receive(&self) -> Option<ReplayRequest> {
+        let mut q = self.replays.lock().ok()?;
+        if q.pending.is_empty() {
+            None
+        } else {
+            Some(q.pending.remove(0))
+        }
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors {
+                time: 1.0,
+                energy: 1.0,
+                coordination: CoordinationScaling::Linear,
+                memory: 1.0,
+                branching: None,
+            },
+            ceiling: ResourceCeiling::Thermodynamic { max_watts: 500.0 },
+        }
+    }
+}
+```
+
+Then in `lago-journal/src/lib.rs`, add:
+
+```rust
+pub mod pneuma_impl;
+
+pub use pneuma_impl::{EventSlice, LagoJournalPneuma, ReplayRequest};
+```
+
+### Required changes to existing code
+
+- **`lago-journal/Cargo.toml`:** add `aios-protocol.workspace = true` dependency and `futures = { workspace = true }` (likely already present — confirmed via `redb_journal.rs:1-9` using `futures`).
+- **`lago-journal/src/lib.rs`:** add `pub mod pneuma_impl;` + re-exports. Nothing else changes.
+- **`RedbJournal`:** no changes. The impl sits on a wrapper (`LagoJournalPneuma`) that holds `RedbJournal` by value (`Clone`-able, since `RedbJournal` is already `Clone`).
+- **No visibility changes needed.** The existing `Journal` trait keeps its entire surface; Pneuma adds an orthogonal interface.
+- **No method refactors.** `append`, `read`, `get_event`, `head_seq`, `stream`, session CRUD all keep signatures.
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `EventSlice` name collision with a future aiOS type | Medium | Namespace it under `lago_journal::pneuma_impl::EventSlice`. Keep the name local and un-exported from the crate root unless explicitly imported. |
+| `futures::executor::block_on` inside `emit()` deadlocks when called from a tokio runtime | **High** | Document: Pneuma `emit` is for synchronous contexts only. Async callers should use `Journal::append` directly. Consider an `AsyncPneuma` trait extension in a later iteration (captured in open questions). |
+| `EventNotification` broadcast channel pressure if replay queue grows unbounded | Low | Cap `ReplayQueue.pending` at 1024; drop oldest (log + metric) on overflow. |
+| Breaking the invariant "journal assigns seq" | Low | `emit()` sets `seq: 0` and relies on `append_batch_blocking` assigning the real seq (line 127 in `redb_journal.rs`). This is already the established pattern — the existing test `append_ignores_caller_provided_seq` (line 858) proves it. |
+| Regression in `redb` transaction semantics | Critical | No change to transactional code paths; Pneuma only adds a wrapper. Existing 20+ journal tests must still pass. |
+
+### Test plan
+
+**Unit tests** (`lago-journal/src/pneuma_impl.rs` + inline `#[cfg(test)]`):
+
+1. `pneuma_emit_appends_event` — call `emit(EventKind::UserMessage { content: "hi" })` → inspect journal → event present.
+2. `pneuma_aggregate_returns_cached_slice` — after `record_slice`, `aggregate()` returns the same slice.
+3. `pneuma_aggregate_empty_default` — without prior slice, returns empty default.
+4. `pneuma_receive_fifo_pop` — push 3 `ReplayRequest`s via `request_replay`, drain via `receive()` → arrives in FIFO order.
+5. `pneuma_receive_none_when_empty` — initial `receive()` returns `None`.
+6. `pneuma_substrate_classical_baseline` — `substrate()` returns `ClassicalSilicon` with linear coordination scaling.
+7. `pneuma_emit_sync_inside_tokio_runtime_fails_gracefully` — verify documented failure mode; may be `#[ignore]` if harness incompatibility.
+
+**Integration tests** (`lago-journal/tests/pneuma_roundtrip.rs` — NEW):
+
+1. `pneuma_emit_then_read_via_journal` — spawn `RedbJournal` on tempdir, wrap in `LagoJournalPneuma`, `emit()` 5 events, then use `Journal::read` directly and assert 5 events present with the emitted `EventKind` values.
+2. `pneuma_receive_after_request_replay` — queue a `ReplayRequest`, assert `receive()` returns it.
+
+**Existing tests must pass unchanged.** The full `cargo test -p lago-journal` suite (currently 20+ tests) must continue passing. This is the canonical regression check for "the trait doesn't break existing behavior."
+
+### Rollout checklist
+
+1. [ ] Land `aios-protocol::pneuma` module first (separate PR).
+2. [ ] Create `lago-journal/src/pneuma_impl.rs` with the types above.
+3. [ ] Add `pub mod pneuma_impl;` + re-exports to `lago-journal/src/lib.rs`.
+4. [ ] Update `lago-journal/Cargo.toml` to add `aios-protocol` dependency.
+5. [ ] Run `cargo fmt && cargo clippy --workspace -- -D warnings` inside `core/life/`.
+6. [ ] Run `cargo test -p lago-journal` — all existing + new tests must pass.
+7. [ ] Run full Lago verify: `cd core/life && cargo test --workspace`.
+8. [ ] Add integration test `lago-journal/tests/pneuma_roundtrip.rs`.
+9. [ ] Update `core/life/docs/STATUS.md` with new test count for lago-journal.
+10. [ ] Commit with message `feat(lago-journal): Pneuma<L0ToL1> impl` — NO rename churn.
+11. [ ] Open PR; CI must pass before merging.
+
+---
+
+## Crate 2 — `autonomic-controller` (L1 → L2 boundary)
+
+### Current state
+
+- **Location:** `/Users/broomva/broomva/core/life/crates/autonomic/autonomic-controller/`
+- **Public API (`src/lib.rs:1-30`):** pure rule engine + projection reducer. No I/O.
+  - `projection::fold` — the canonical reducer (`HomeostaticState → EventKind → HomeostaticState`)
+  - `engine::evaluate` — rules → `AutonomicGatingProfile`
+  - Rule modules: `belief_rules`, `cognitive_rules`, `economic_rules`, `eval_rules`, `knowledge_rules`, `operational_rules`, `strategy_rules`
+  - `trust_scoring::compute_trust_score`
+- **Core function (`src/projection.rs:23-158`):**
+  ```rust
+  pub fn fold(
+      mut state: HomeostaticState,
+      kind: &EventKind,
+      seq: u64,
+      ts_ms: u64,
+  ) -> HomeostaticState { ... }
+  ```
+- **Core engine (`src/engine.rs:17-29`):**
+  ```rust
+  pub fn evaluate(state: &HomeostaticState, rules: &RuleSet) -> AutonomicGatingProfile { ... }
+  ```
+- **Output types** (in `autonomic-core`, not `autonomic-controller`):
+  - `HomeostaticState` (`autonomic-core/src/gating.rs:271`) — folded state, 7 pillars
+  - `AutonomicGatingProfile` (`autonomic-core/src/gating.rs:46`) — contains canonical `GatingProfile` + economic gates + rationale + advisory events
+- **Boundary served:** **L1 → L2** — folded homeostatic observations flowing up to the meta-controller; gating decisions flowing back down to the agent loop.
+
+### Assumption correction
+
+The architecture spec says the existing `AutonomicProjection` type becomes the Pneuma impl host. **That type does not exist.** `autonomic-controller` is a library of pure functions — there is no stateful struct that owns both a `HomeostaticState` and the ability to produce `AutonomicGatingProfile`.
+
+**Proposed fix:** introduce a new **non-breaking** struct `AutonomicProjection` in `autonomic-controller/src/projection.rs` that holds `HomeostaticState` + `Arc<RuleSet>`. This struct is **additive** — existing callers (`autonomic-api::state::AppState`, `autonomic-lago::subscriber`) keep using the raw `HomeostaticState` + standalone `fold()`/`evaluate()` functions; new Pneuma users construct the struct.
+
+Also **important:** `HomeostaticDelta` **does not exist** in the codebase. The reducer consumes `EventKind` directly. The spec's claim that "HomeostaticDelta — events that drive the fold() reducer" is aspirational naming. **Decision: use `EventKind` as the Signal type, not invent `HomeostaticDelta`.** Rationale: honoring the trait-not-rename discipline, and there is no existing domain type named `HomeostaticDelta` to preserve.
+
+### Mapping to Pneuma
+
+| Pneuma slot | Existing type | Location | Notes |
+|---|---|---|---|
+| `Signal` | `aios_protocol::EventKind` | `aios-protocol/src/event.rs:206` | The reducer's input. No new type. |
+| `Aggregate` | `autonomic_core::gating::HomeostaticState` | `autonomic-core/src/gating.rs:271` | Unchanged. 7-pillar state snapshot. |
+| `Directive` | `autonomic_core::gating::AutonomicGatingProfile` | `autonomic-core/src/gating.rs:46` | Unchanged. Embeds canonical `GatingProfile`. |
+| `B` (Boundary) | `aios_protocol::pneuma::L1ToL2` | `aios-protocol/src/pneuma.rs` | — |
+
+### Concrete impl block
+
+```rust
+// core/life/crates/autonomic/autonomic-controller/src/pneuma_impl.rs (NEW)
+
+use std::sync::{Arc, Mutex};
+
+use aios_protocol::EventKind;
+use aios_protocol::pneuma::{
+    CoordinationScaling, L1ToL2, Pneuma, PneumaError, ResourceCeiling, SubstrateKind,
+    SubstrateProfile, WarpFactors,
+};
+use autonomic_core::gating::{AutonomicGatingProfile, HomeostaticState};
+use autonomic_core::rules::RuleSet;
+
+use crate::engine;
+use crate::projection;
+
+/// Stateful L1→L2 Pneuma host. Wraps a `HomeostaticState` and a `RuleSet`.
+///
+/// This struct is ADDITIVE — existing callers that use `fold()` + `evaluate()`
+/// directly continue to work. New callers that need Pneuma semantics
+/// construct this struct and interact through the `Pneuma` trait.
+pub struct AutonomicProjection {
+    state: Arc<Mutex<HomeostaticState>>,
+    rules: Arc<RuleSet>,
+    /// Sequence counter for events seen via `emit()`. Monotonic.
+    seq_counter: Arc<Mutex<u64>>,
+    /// Cached latest gating profile from the last `evaluate()` pass.
+    cached_gate: Arc<Mutex<Option<AutonomicGatingProfile>>>,
+}
+
+impl AutonomicProjection {
+    pub fn new(agent_id: impl Into<String>, rules: RuleSet) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HomeostaticState::for_agent(agent_id))),
+            rules: Arc::new(rules),
+            seq_counter: Arc::new(Mutex::new(0)),
+            cached_gate: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn from_existing(state: HomeostaticState, rules: Arc<RuleSet>) -> Self {
+        let seq = state.last_event_seq;
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            rules,
+            seq_counter: Arc::new(Mutex::new(seq)),
+            cached_gate: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Apply an event manually (convenience; the `Pneuma::emit` path
+    /// eventually calls this). Returns the new state.
+    pub fn apply(&self, kind: &EventKind, ts_ms: u64) -> HomeostaticState {
+        let mut state = self.state.lock().expect("state mutex poisoned");
+        let mut seq = self.seq_counter.lock().expect("seq mutex poisoned");
+        *seq = seq.saturating_add(1);
+        *state = projection::fold(state.clone(), kind, *seq, ts_ms);
+        state.clone()
+    }
+
+    /// Force a rules evaluation now; caches the resulting profile so
+    /// `receive()` will return it on next call.
+    pub fn evaluate_now(&self) -> AutonomicGatingProfile {
+        let state = self.state.lock().expect("state mutex poisoned").clone();
+        let profile = engine::evaluate(&state, &self.rules);
+        *self.cached_gate.lock().expect("gate mutex poisoned") = Some(profile.clone());
+        profile
+    }
+}
+
+impl Pneuma for AutonomicProjection {
+    type B = L1ToL2;
+    type Signal = EventKind;
+    type Aggregate = HomeostaticState;
+    type Directive = AutonomicGatingProfile;
+
+    /// Fold a signal into the projected state.
+    ///
+    /// This is a pure update of the Mutex-protected `HomeostaticState`.
+    /// Does not evaluate rules — call `evaluate_now()` or wait for a
+    /// scheduled tick to convert state into a directive.
+    fn emit(&self, signal: EventKind) -> Result<(), PneumaError> {
+        let ts_ms = current_ms();
+        let _new_state = self.apply(&signal, ts_ms);
+        Ok(())
+    }
+
+    fn aggregate(&self) -> HomeostaticState {
+        self.state
+            .lock()
+            .expect("state mutex poisoned")
+            .clone()
+    }
+
+    /// Non-blocking — returns the cached gate if one is ready.
+    ///
+    /// The convention is: the operator of L2 (or a scheduler) calls
+    /// `evaluate_now()` periodically; consumers of the directive stream
+    /// call `receive()` to pop the latest profile.
+    ///
+    /// Each `receive()` consumes the cached gate (take semantics).
+    fn receive(&self) -> Option<AutonomicGatingProfile> {
+        self.cached_gate
+            .lock()
+            .ok()
+            .and_then(|mut g| g.take())
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors {
+                time: 1.0,
+                energy: 1.0,
+                coordination: CoordinationScaling::Linear,
+                memory: 1.0,
+                branching: None,
+            },
+            // L1 is memory-cheap (in-process folds); expose a coherence-style
+            // ceiling reflecting the projection cache lifetime.
+            ceiling: ResourceCeiling::Thermodynamic { max_watts: 200.0 },
+        }
+    }
+}
+
+fn current_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+```
+
+Then in `autonomic-controller/src/lib.rs`, add:
+
+```rust
+pub mod pneuma_impl;
+
+pub use pneuma_impl::AutonomicProjection;
+```
+
+### Required changes to existing code
+
+- **`autonomic-controller/Cargo.toml`:** `aios-protocol` is already a workspace dep (`Cargo.toml:13`). No change needed except to make sure `aios-protocol::pneuma` is reachable after Phase 1 lands.
+- **`autonomic-controller/src/lib.rs`:** add `pub mod pneuma_impl;` + re-export of `AutonomicProjection`. Other re-exports (`fold`, `evaluate`, rules) are untouched.
+- **`projection::fold`:** **no signature change, no refactor.** The impl calls it directly.
+- **`engine::evaluate`:** **no signature change, no refactor.**
+- **`HomeostaticState` / `AutonomicGatingProfile`:** **zero changes.**
+- **`autonomic-api::AppState`:** no immediate change required. Once the integration lands, `AppState.projections` can migrate from `HashMap<String, HomeostaticState>` to `HashMap<String, Arc<AutonomicProjection>>`, but this is a **separate follow-up PR**, not part of the Pneuma retrofit.
+- **Visibility:** `AutonomicProjection` is public. Its internal `seq_counter` and `cached_gate` remain private.
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `Mutex` lock contention if many producers emit concurrently | Medium | Use `parking_lot::Mutex` (already a workspace dep in Life) OR switch to `tokio::sync::Mutex` and require async context. First pass: `std::sync::Mutex` is fine (L2 controllers emit per-tick, not per-event). |
+| `receive()` "take semantics" surprises a caller expecting latest-read | Medium | Document in rustdoc: `receive()` is a drain op. If peek is needed, callers use `aggregate()` + `evaluate_now()`. |
+| `emit()` swallows the seq returned by `fold()` | Low | Tolerable. The projection's own counter is monotonic; the journal seq is already preserved upstream at L0. |
+| `AutonomicProjection` name collides with future type | Low | Fully qualified usage: `autonomic_controller::AutonomicProjection`. |
+| `apply()` panics on poisoned mutex | Low | Use `.lock().map_err(...)` and propagate as `PneumaError::Transport`. The shown impl uses `.expect()` for brevity — production code should map errors. |
+| Existing projection callers find the new struct confusing | Low | Clear rustdoc on both `fold` (pure function, reducer) and `AutonomicProjection` (stateful owner for Pneuma). Document that they coexist. |
+
+### Test plan
+
+**Unit tests** (`autonomic-controller/src/pneuma_impl.rs` inline `#[cfg(test)]`):
+
+1. `projection_new_has_default_state` — `AutonomicProjection::new("a", RuleSet::new())` starts with `HomeostaticState::for_agent("a")`.
+2. `emit_updates_aggregate` — `emit(RunFinished { usage: Some(...) })` → `aggregate().cognitive.total_tokens_used` non-zero.
+3. `emit_is_deterministic` — emit the same `EventKind` sequence from two clones → both yield the same `HomeostaticState` (matching the `fold_sequence_produces_deterministic_state` test in `projection.rs:648`).
+4. `receive_returns_none_before_evaluate` — fresh projection, `receive()` == `None`.
+5. `evaluate_now_caches_profile` — after `evaluate_now()`, `receive()` returns `Some(profile)`.
+6. `receive_drains_cache` — call `receive()` twice; second returns `None`.
+7. `substrate_is_classical` — `substrate()` returns `SubstrateKind::ClassicalSilicon`.
+8. `apply_increments_seq_counter` — apply 3 events → internal seq_counter == 3.
+
+**Integration tests** (`autonomic-controller/tests/pneuma_integration.rs` — NEW):
+
+1. `full_l1_to_l2_flow` — build projection with default `RuleSet`, emit `RunErrored` ×5 → error_streak rule fires → `evaluate_now()` → `receive()` returns an `AutonomicGatingProfile` with operational restrictions applied.
+2. `pneuma_and_raw_fold_agree` — run the same `EventKind` sequence through `fold()` alone and through `AutonomicProjection::emit()`. Final `HomeostaticState`s must be identical (aside from the `last_event_seq` value — the projection's internal counter differs from a caller-supplied one; use `evaluate_now()` + compare structural fields only).
+
+**Existing tests:** all 31 tests in `autonomic-controller` must continue to pass.
+
+### Rollout checklist
+
+1. [ ] Land lago-journal Pneuma first (landing validates the pattern).
+2. [ ] Create `autonomic-controller/src/pneuma_impl.rs`.
+3. [ ] Add `pub mod pneuma_impl;` + re-export to `autonomic-controller/src/lib.rs`.
+4. [ ] Run `cd core/life && cargo fmt && cargo clippy --workspace -- -D warnings && cargo test --workspace`.
+5. [ ] Add `autonomic-controller/tests/pneuma_integration.rs`.
+6. [ ] Update `core/life/docs/STATUS.md` with new test count.
+7. [ ] Commit: `feat(autonomic-controller): Pneuma<L1ToL2> impl via AutonomicProjection`.
+8. [ ] Later follow-up (separate PR): migrate `autonomic-api::AppState` to hold `Arc<AutonomicProjection>` instead of raw `HomeostaticState` — ONLY if there is a concrete caller needing the trait.
+
+---
+
+## Crate 3 — `autoany_core` (L2 → L3 boundary)
+
+### Current state
+
+- **Location:** `/Users/broomva/broomva/core/autoany/autoany-core/`
+- **Important:** this is a **separate workspace** from `core/life/`. The crate name on crates.io is `autoany_core` (underscore) per `Cargo.toml:2`. Adding `aios-protocol` as a dependency crosses a repository boundary — see Risks.
+- **Core trait/engine (`src/loop_engine.rs:28-279`):**
+  ```rust
+  pub struct EgriLoop<A, P, X, E, S>
+  where
+      A: Clone,
+      P: Proposer<Artifact = A>,
+      X: Executor<Artifact = A>,
+      E: Evaluator<Artifact = A>,
+      S: Selector,
+  { ... }
+  ```
+- **Key types (`src/types.rs`):**
+  - `TrialRecord` (line 144) — full record per trial: mutation + outcome + decision + lineage
+  - `Mutation` (line 80) — operator + description + diff + hypothesis
+  - `Outcome` (line 103) — score + constraints_passed + violations
+  - `Decision` (line 135) — action (`Promoted | Discarded | Branched | Escalated`) + reason + new state id
+  - `Action` (line 115) — the decision taxonomy
+- **Ledger (`src/ledger.rs`):** append-only `Vec<TrialRecord>`, optionally file-backed (JSONL).
+- **Boundary served:** **L2 → L3** — trial outcomes flow up to the governance layer (which decides whether to accept new policy parameters, artifacts, or thresholds); promotion/rollback decisions flow down from governance.
+
+### Mapping to Pneuma
+
+| Pneuma slot | Existing type | Location | Notes |
+|---|---|---|---|
+| `Signal` | `TrialRecord` | `types.rs:144` | Each trial is a signal from L2 to L3: "here is evidence about a mutation." Mutation alone is not enough — governance wants outcome too. |
+| `Aggregate` | `LedgerSummary` (NEW thin struct) | `pneuma_impl.rs` | Derived from `Ledger` — trial_count, baseline_score, best_score, promoted_count, recent_actions. Does not replace `LoopSummary` from `loop_engine.rs:48`, which is a per-loop reporting type. |
+| `Directive` | `GovernanceDirective` (NEW) | `pneuma_impl.rs` | Wraps the enum of {Promote, Rollback, FreezeLoop, AdjustBudget, EscalateToHuman}. Governance at L3 pushes these down. |
+| `B` (Boundary) | `aios_protocol::pneuma::L2ToL3` | `aios-protocol/src/pneuma.rs` | — |
+
+**Why `TrialRecord` as Signal, not `Mutation`?** A mutation without outcome is a proposal, not an observation. The spec's "trial record or mutation proposal" option should resolve to trial record — that is what L3 actually consumes. Mutations alone are L2-internal.
+
+### Concrete impl block
+
+```rust
+// core/autoany/autoany-core/src/pneuma_impl.rs (NEW, optional feature)
+
+#[cfg(feature = "pneuma")]
+use aios_protocol::pneuma::{
+    CoordinationScaling, L2ToL3, Pneuma, PneumaError, ResourceCeiling, SubstrateKind,
+    SubstrateProfile, WarpFactors,
+};
+
+use std::sync::{Arc, Mutex};
+
+use crate::ledger::Ledger;
+use crate::types::{Action, Score, TrialRecord};
+
+/// L3-facing aggregate view of a running EGRI loop.
+///
+/// Derived entirely from the `Ledger`. Read-only; does not store copies
+/// of trial records (they live in the ledger).
+#[derive(Debug, Clone)]
+pub struct LedgerSummary {
+    pub trial_count: usize,
+    pub promoted_count: usize,
+    pub discarded_count: usize,
+    pub escalated_count: usize,
+    pub branched_count: usize,
+    pub baseline_score: Option<Score>,
+    pub best_score: Option<Score>,
+    /// Last up to 8 actions, newest first.
+    pub recent_actions: Vec<Action>,
+    /// Consecutive non-improvements (stagnation signal).
+    pub consecutive_non_improvements: usize,
+}
+
+impl LedgerSummary {
+    pub fn from_ledger(ledger: &Ledger) -> Self {
+        let records = ledger.records();
+        let baseline_score = records.first().map(|r| r.outcome.score.clone());
+        let best_score = ledger.last_promoted().map(|r| r.outcome.score.clone());
+        let recent_actions: Vec<Action> = records
+            .iter()
+            .rev()
+            .take(8)
+            .map(|r| r.decision.action)
+            .collect();
+
+        Self {
+            trial_count: ledger.trial_count(),
+            promoted_count: ledger.by_action(Action::Promoted).len(),
+            discarded_count: ledger.by_action(Action::Discarded).len(),
+            escalated_count: ledger.by_action(Action::Escalated).len(),
+            branched_count: ledger.by_action(Action::Branched).len(),
+            baseline_score,
+            best_score,
+            recent_actions,
+            consecutive_non_improvements: ledger.consecutive_non_improvements(),
+        }
+    }
+}
+
+/// Governance directive pushed from L3 down into the EGRI loop.
+///
+/// Not a mutation on the artifact — a control intent on the loop itself.
+#[derive(Debug, Clone)]
+pub enum GovernanceDirective {
+    /// Accept a trial's candidate as the new promoted state.
+    Promote { trial_id: String, reason: String },
+    /// Roll back to the last promoted state.
+    Rollback { reason: String },
+    /// Freeze the loop; do not consume any more budget.
+    FreezeLoop { reason: String },
+    /// Adjust the remaining budget quota (signed delta).
+    AdjustBudget { delta_trials: i32, reason: String },
+    /// Escalate a trial decision to a human (pause until resolved).
+    EscalateToHuman { trial_id: String, reason: String },
+    /// Update a policy parameter (free-form key-value).
+    UpdatePolicy {
+        parameter: String,
+        value: serde_json::Value,
+        reason: String,
+    },
+}
+
+/// L2→L3 Pneuma host. Wraps a `Ledger` and a directive queue.
+///
+/// Keeps the `Ledger` borrowable — the caller (a running `EgriLoop`)
+/// retains primary ownership. `EgriLedgerPneuma` accepts signals
+/// (trial records) via `emit()` and forwards to the wrapped ledger.
+pub struct EgriLedgerPneuma {
+    ledger: Arc<Mutex<Ledger>>,
+    directives: Arc<Mutex<Vec<GovernanceDirective>>>,
+}
+
+impl EgriLedgerPneuma {
+    pub fn new(ledger: Ledger) -> Self {
+        Self {
+            ledger: Arc::new(Mutex::new(ledger)),
+            directives: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn ledger_arc(&self) -> Arc<Mutex<Ledger>> {
+        Arc::clone(&self.ledger)
+    }
+
+    /// Push a governance directive from L3. Used by a governance actor.
+    pub fn push_directive(&self, dir: GovernanceDirective) {
+        self.directives
+            .lock()
+            .expect("directive mutex poisoned")
+            .push(dir);
+    }
+}
+
+#[cfg(feature = "pneuma")]
+impl Pneuma for EgriLedgerPneuma {
+    type B = L2ToL3;
+    type Signal = TrialRecord;
+    type Aggregate = LedgerSummary;
+    type Directive = GovernanceDirective;
+
+    fn emit(&self, record: TrialRecord) -> Result<(), PneumaError> {
+        let mut ledger = self
+            .ledger
+            .lock()
+            .map_err(|e| PneumaError::Transport(format!("ledger poisoned: {e}")))?;
+        ledger
+            .append(record)
+            .map_err(|e| PneumaError::Transport(e.to_string()))?;
+        Ok(())
+    }
+
+    fn aggregate(&self) -> LedgerSummary {
+        let ledger = self.ledger.lock().expect("ledger mutex poisoned");
+        LedgerSummary::from_ledger(&ledger)
+    }
+
+    fn receive(&self) -> Option<GovernanceDirective> {
+        let mut q = self.directives.lock().ok()?;
+        if q.is_empty() { None } else { Some(q.remove(0)) }
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors {
+                time: 1.0,
+                energy: 1.0,
+                coordination: CoordinationScaling::Linear,
+                memory: 1.0,
+                branching: None,
+            },
+            // L2 thermodynamic budget is dominated by LLM inference for
+            // proposer/evaluator — allow a higher watt ceiling.
+            ceiling: ResourceCeiling::Thermodynamic { max_watts: 1500.0 },
+        }
+    }
+}
+```
+
+Then in `autoany-core/src/lib.rs`, add (conditional):
+
+```rust
+#[cfg(feature = "pneuma")]
+pub mod pneuma_impl;
+#[cfg(feature = "pneuma")]
+pub use pneuma_impl::{EgriLedgerPneuma, GovernanceDirective, LedgerSummary};
+```
+
+### Required changes to existing code
+
+- **`autoany-core/Cargo.toml`:** add an optional feature `pneuma = ["aios-protocol"]` and a conditional dependency:
+  ```toml
+  [dependencies]
+  # ...existing...
+  aios-protocol = { version = "*", optional = true, path = "../../life/crates/aios/aios-protocol" }
+
+  [features]
+  default = []
+  async = ["tokio"]
+  pneuma = ["aios-protocol"]
+  ```
+  **Open question:** `aios-protocol` is inside `core/life/`, but `autoany_core` is published to crates.io and shouldn't carry a path dependency. Options:
+    - Option A: publish `aios-protocol` to crates.io first; `autoany_core` then uses a versioned dep.
+    - Option B: keep the Pneuma impl in a **separate adapter crate** (`autoany-aios-pneuma` — new, in `core/life/crates/autoany/`), mirroring how `autoany-aios` and `autoany-lago` already live outside the core workspace.
+  - **Recommendation: Option B.** `autoany-core` stays free of Life workspace deps. The adapter crate `autoany-aios-pneuma` implements `Pneuma` for a wrapper type that owns a `Ledger`.
+
+- **`autoany-core/src/lib.rs`:** no change required if we go with Option B (the Pneuma impl lives in the adapter crate).
+- **`Ledger`:** no changes. Its existing methods (`append`, `records`, `by_action`, `last_promoted`, `trial_count`, `consecutive_non_improvements`) are all read-compatible with `LedgerSummary::from_ledger`.
+- **`TrialRecord`, `Mutation`, `Outcome`, `Action`:** zero changes.
+- **`EgriLoop`:** no changes. The impl sits alongside the loop — a governance actor consumes `aggregate()` and produces directives.
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Cross-workspace dependency pollution | **High** | Use Option B: adapter crate in `core/life/crates/autoany/`. `autoany-core` stays published independently. |
+| `Mutex<Ledger>` locking blocks `EgriLoop::step()` | Medium | Step execution already holds the ledger exclusively during `append()` (single-threaded loop). If parallelism is introduced later, revisit. |
+| `LedgerSummary::recent_actions` iteration cost if ledger grows to millions of records | Low | Bounded to 8 elements; `ledger.records().iter().rev().take(8)` is O(8). |
+| `GovernanceDirective` variants drift from real governance use cases | Medium | Mark the enum `#[non_exhaustive]`. Start with the 6 variants shown; extend only when a real L3 caller demands. |
+| Feature-gating adds complexity to CI | Low | Mitigated by Option B — the adapter crate builds unconditionally in Life's workspace. |
+
+### Test plan
+
+**Unit tests** (`autoany-aios-pneuma/src/lib.rs` — adapter crate, new):
+
+1. `summary_empty_ledger` — empty ledger → `trial_count == 0`, `baseline_score == None`, `recent_actions.is_empty()`.
+2. `summary_with_baseline` — baseline trial → `baseline_score == Some(Scalar(1.0))`.
+3. `summary_counts_actions` — append mixed actions → counts correct.
+4. `summary_recent_actions_reversed` — append 10 records → `recent_actions.len() == 8` and newest first.
+5. `summary_consecutive_non_improvements` — tracks the same logic as `Ledger::consecutive_non_improvements`.
+6. `emit_appends_to_ledger` — `emit(record)` → inner ledger contains record.
+7. `push_then_receive_directive` — `push_directive(Promote{...})` → `receive()` returns `Some(Promote{...})`.
+8. `receive_fifo_order` — push 3 directives → receive in order.
+9. `substrate_reports_high_watts` — `substrate().ceiling` is `Thermodynamic { max_watts: 1500.0 }`.
+
+**Integration tests** (`autoany-aios-pneuma/tests/egri_pneuma_flow.rs`):
+
+1. `egri_loop_emits_trials_as_signals` — run a toy `EgriLoop` (using the example's `Proposer`/`Evaluator`) for 5 trials; feed each returned `TrialRecord` via `pneuma.emit`; assert `pneuma.aggregate().trial_count == 5`.
+2. `governance_rollback_directive_received` — push `GovernanceDirective::Rollback`; consumer (a governance actor mock) receives it.
+
+### Rollout checklist
+
+1. [ ] Ensure `aios-protocol` is usable from `core/life/` workspace (already true — the L0→L1 retrofit gets there first).
+2. [ ] Create `core/life/crates/autoany/autoany-aios-pneuma/` as a new crate (NOT in `core/autoany/`).
+3. [ ] Add it to `core/life/Cargo.toml` workspace members if applicable.
+4. [ ] Implement `EgriLedgerPneuma`, `LedgerSummary`, `GovernanceDirective` + `impl Pneuma`.
+5. [ ] Add unit + integration tests.
+6. [ ] Run `cd core/life && cargo fmt && cargo clippy --workspace -- -D warnings && cargo test --workspace`.
+7. [ ] Cross-verify `cd core/autoany && make check && make test` — **autoany-core must remain untouched** (verified by running its tests with its own `Cargo.lock`).
+8. [ ] Commit: `feat(autoany-aios-pneuma): Pneuma<L2ToL3> adapter crate`.
+
+---
+
+## Crate 4 — `bstack-policy` (L3 → External boundary)
+
+### Current state
+
+**`bstack-policy` does not exist as a Rust crate.** The governance layer is currently realized across:
+
+- `.control/policy.yaml` — declarative policy (G1–G11 gates, profiles, setpoints) at `/Users/broomva/broomva/.control/policy.yaml`
+- `skills/bookkeeping/scripts/bookkeeping.py` — Python pipeline that enforces knowledge-graph scoring and lint rules
+- `skills/bookkeeping/SKILL.md` — authoritative spec for the 7-stage pipeline and scoring thresholds
+- `skills/control-metalayer/` — metalayer skills (control-metalayer-loop, agent-consciousness, knowledge-graph-memory)
+- Pre-commit hooks at `.githooks/` — gate enforcement
+- `core/life/crates/lago/lago-policy/` — **different crate** — RBAC and tool-governance for the Lago runtime; **not** the L3 governance layer.
+
+**Confirmed via search:** the string `bstack-policy` / `BstackPolicy` appears only in the Pneuma architecture spec itself (`core/life/docs/specs/pneuma-plexus-architecture.md`) and entity pages — no Rust code references it. This retrofit must **scaffold the crate first**, then add Pneuma.
+
+### Decision: scaffold a new crate
+
+Create `core/life/crates/bstack/bstack-policy/` (mirroring other Life crates layout). This crate will:
+
+1. Parse `.control/policy.yaml` into typed Rust structs.
+2. Expose a `PolicyState` aggregate that reflects current setpoint status, gate pass/fail counts, and profile (baseline/governed/autonomous).
+3. Emit policy violation events, promotion acceptance events, audit findings.
+4. Receive governance rule updates from the external human/process boundary.
+
+### Mapping to Pneuma
+
+| Pneuma slot | Proposed type | Location | Notes |
+|---|---|---|---|
+| `Signal` | `PolicyObservation` (NEW) | `bstack-policy/src/pneuma_impl.rs` | Union of {violation, audit-finding, setpoint-deviation, gate-blocked}. |
+| `Aggregate` | `PolicyState` (NEW) | `bstack-policy/src/state.rs` | Current profile, setpoint values, violation counters, recent audit findings. |
+| `Directive` | `GovernanceUpdate` (NEW) | `bstack-policy/src/pneuma_impl.rs` | Profile switch, setpoint adjust, gate add/remove, rule revision. |
+| `B` (Boundary) | `aios_protocol::pneuma::L3ToExternal` | `aios-protocol/src/pneuma.rs` | — |
+
+### Concrete impl block (scaffold + impl)
+
+```rust
+// core/life/crates/bstack/bstack-policy/Cargo.toml
+[package]
+name = "bstack-policy"
+description = "L3 governance layer: policy parsing, setpoint tracking, gate enforcement"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+aios-protocol.workspace = true
+serde.workspace = true
+serde_yaml = "0.9"
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/lib.rs (NEW)
+//! L3 governance layer — policy parsing, setpoint tracking, gate enforcement.
+//!
+//! This crate sits at the top of the RCS hierarchy. It is where the control
+//! metalayer (CLAUDE.md + AGENTS.md + policy.yaml) crystallizes into Rust
+//! runtime types. Pneuma<B = L3ToExternal> exposes it to the outside world.
+
+pub mod config;
+pub mod gates;
+pub mod pneuma_impl;
+pub mod setpoints;
+pub mod state;
+
+pub use config::PolicyDocument;
+pub use gates::{Gate, GateEnforcement, HardGate, SoftGate};
+pub use pneuma_impl::{BstackPolicy, GovernanceUpdate, PolicyObservation};
+pub use setpoints::{Setpoint, SetpointSeverity};
+pub use state::PolicyState;
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/config.rs (NEW)
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Top-level policy document — deserialized from `.control/policy.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDocument {
+    pub version: String,
+    pub profile: String, // baseline | governed | autonomous
+    pub workspace: String,
+    pub setpoints: Vec<crate::setpoints::Setpoint>,
+    pub gates: GatesDoc,
+    pub profiles: std::collections::HashMap<String, ProfileDoc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatesDoc {
+    pub hard: Vec<crate::gates::HardGate>,
+    #[serde(default)]
+    pub soft: Vec<crate::gates::SoftGate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileDoc {
+    pub description: String,
+    #[serde(default)]
+    pub gates: Vec<String>,
+    #[serde(default)]
+    pub egri: Option<String>,
+}
+
+impl PolicyDocument {
+    pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, crate::pneuma_impl::BstackPolicyError> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| crate::pneuma_impl::BstackPolicyError::Io(e.to_string()))?;
+        Self::from_yaml(&content)
+            .map_err(|e| crate::pneuma_impl::BstackPolicyError::Parse(e.to_string()))
+    }
+}
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/setpoints.rs (NEW)
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SetpointSeverity {
+    Blocking,
+    Informational,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Setpoint {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub target: Option<serde_yaml::Value>,
+    #[serde(default)]
+    pub alert_below: Option<f64>,
+    #[serde(default)]
+    pub alert_above: Option<f64>,
+    pub measurement: String,
+    pub severity: SetpointSeverity,
+}
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/gates.rs (NEW)
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HardGate {
+    pub id: String,
+    pub rule: String,
+    #[serde(default)]
+    pub pattern: Option<String>,
+    pub measurement: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SoftGate {
+    pub id: String,
+    pub rule: String,
+    pub measurement: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum Gate {
+    Hard(HardGate),
+    Soft(SoftGate),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateEnforcement {
+    Passed,
+    Blocked,
+    Advisory,
+}
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/state.rs (NEW)
+use std::collections::HashMap;
+
+use crate::config::PolicyDocument;
+use crate::pneuma_impl::PolicyObservation;
+
+/// Compliance state — derived from the policy document + recent observations.
+#[derive(Debug, Clone)]
+pub struct PolicyState {
+    pub profile: String,
+    /// Setpoint id → latest measured value. Populated by observations.
+    pub setpoint_values: HashMap<String, f64>,
+    /// Gate id → trigger count (cumulative).
+    pub gate_trigger_counts: HashMap<String, u64>,
+    /// Recent violations (bounded, newest first).
+    pub recent_violations: Vec<PolicyObservation>,
+    /// Setpoint id → alert flag.
+    pub setpoint_alerts: HashMap<String, bool>,
+}
+
+impl PolicyState {
+    pub fn from_document(doc: &PolicyDocument) -> Self {
+        Self {
+            profile: doc.profile.clone(),
+            setpoint_values: HashMap::new(),
+            gate_trigger_counts: HashMap::new(),
+            recent_violations: Vec::new(),
+            setpoint_alerts: HashMap::new(),
+        }
+    }
+}
+```
+
+```rust
+// core/life/crates/bstack/bstack-policy/src/pneuma_impl.rs (NEW)
+
+use std::sync::{Arc, Mutex};
+
+use aios_protocol::pneuma::{
+    CoordinationScaling, L3ToExternal, Pneuma, PneumaError, ResourceCeiling, SubstrateKind,
+    SubstrateProfile, WarpFactors,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::config::PolicyDocument;
+use crate::state::PolicyState;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BstackPolicyError {
+    #[error("io: {0}")]
+    Io(String),
+    #[error("parse: {0}")]
+    Parse(String),
+}
+
+/// Typed L3 → External observation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PolicyObservation {
+    GateBlocked {
+        gate_id: String,
+        action_description: String,
+        timestamp_ms: u64,
+    },
+    SetpointDeviation {
+        setpoint_id: String,
+        measured: f64,
+        expected: Option<f64>,
+        timestamp_ms: u64,
+    },
+    AuditFinding {
+        check_id: String,
+        severity: String,
+        detail: String,
+        timestamp_ms: u64,
+    },
+    PolicyViolation {
+        rule: String,
+        detail: String,
+        timestamp_ms: u64,
+    },
+    PromotionAccepted {
+        entity_slug: String,
+        score: u32,
+        timestamp_ms: u64,
+    },
+}
+
+/// Typed External → L3 directive (governance update).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GovernanceUpdate {
+    SwitchProfile {
+        new_profile: String, // baseline | governed | autonomous
+        reason: String,
+    },
+    AdjustSetpoint {
+        setpoint_id: String,
+        new_target: f64,
+        reason: String,
+    },
+    AddHardGate {
+        gate: crate::gates::HardGate,
+        reason: String,
+    },
+    RemoveGate {
+        gate_id: String,
+        reason: String,
+    },
+    RevisePolicyDocument {
+        new_document: PolicyDocument,
+        reason: String,
+    },
+}
+
+/// The L3 governance Pneuma host.
+pub struct BstackPolicy {
+    doc: Arc<Mutex<PolicyDocument>>,
+    state: Arc<Mutex<PolicyState>>,
+    directives: Arc<Mutex<Vec<GovernanceUpdate>>>,
+    max_recent_violations: usize,
+}
+
+impl BstackPolicy {
+    /// Load from a yaml file.
+    pub fn from_yaml_file(path: &std::path::Path) -> Result<Self, BstackPolicyError> {
+        let doc = PolicyDocument::from_file(path)?;
+        let state = PolicyState::from_document(&doc);
+        Ok(Self {
+            doc: Arc::new(Mutex::new(doc)),
+            state: Arc::new(Mutex::new(state)),
+            directives: Arc::new(Mutex::new(Vec::new())),
+            max_recent_violations: 64,
+        })
+    }
+
+    pub fn push_directive(&self, u: GovernanceUpdate) {
+        self.directives
+            .lock()
+            .expect("directive mutex poisoned")
+            .push(u);
+    }
+
+    /// Apply a policy update — e.g. profile switch. Pure function on the doc.
+    /// Returns true if the doc was modified.
+    pub fn apply(&self, u: &GovernanceUpdate) -> bool {
+        let mut doc = self.doc.lock().expect("doc mutex poisoned");
+        let mut state = self.state.lock().expect("state mutex poisoned");
+        match u {
+            GovernanceUpdate::SwitchProfile { new_profile, .. } => {
+                doc.profile = new_profile.clone();
+                state.profile = new_profile.clone();
+                true
+            }
+            GovernanceUpdate::AdjustSetpoint {
+                setpoint_id,
+                new_target,
+                ..
+            } => {
+                if let Some(sp) = doc.setpoints.iter_mut().find(|s| &s.id == setpoint_id) {
+                    sp.target = Some(serde_yaml::to_value(new_target).unwrap_or_default());
+                    true
+                } else {
+                    false
+                }
+            }
+            GovernanceUpdate::AddHardGate { gate, .. } => {
+                doc.gates.hard.push(gate.clone());
+                true
+            }
+            GovernanceUpdate::RemoveGate { gate_id, .. } => {
+                let before = doc.gates.hard.len() + doc.gates.soft.len();
+                doc.gates.hard.retain(|g| &g.id != gate_id);
+                doc.gates.soft.retain(|g| &g.id != gate_id);
+                let after = doc.gates.hard.len() + doc.gates.soft.len();
+                before != after
+            }
+            GovernanceUpdate::RevisePolicyDocument { new_document, .. } => {
+                *doc = new_document.clone();
+                *state = PolicyState::from_document(&doc);
+                true
+            }
+        }
+    }
+}
+
+impl Pneuma for BstackPolicy {
+    type B = L3ToExternal;
+    type Signal = PolicyObservation;
+    type Aggregate = PolicyState;
+    type Directive = GovernanceUpdate;
+
+    fn emit(&self, obs: PolicyObservation) -> Result<(), PneumaError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| PneumaError::Transport(format!("state poisoned: {e}")))?;
+
+        match &obs {
+            PolicyObservation::GateBlocked { gate_id, .. } => {
+                *state
+                    .gate_trigger_counts
+                    .entry(gate_id.clone())
+                    .or_insert(0) += 1;
+                state.recent_violations.insert(0, obs.clone());
+            }
+            PolicyObservation::SetpointDeviation {
+                setpoint_id,
+                measured,
+                ..
+            } => {
+                state
+                    .setpoint_values
+                    .insert(setpoint_id.clone(), *measured);
+                state.setpoint_alerts.insert(setpoint_id.clone(), true);
+            }
+            PolicyObservation::AuditFinding { .. }
+            | PolicyObservation::PolicyViolation { .. } => {
+                state.recent_violations.insert(0, obs.clone());
+            }
+            PolicyObservation::PromotionAccepted { .. } => {
+                // informational, no state mutation
+            }
+        }
+
+        // Bound recent_violations.
+        if state.recent_violations.len() > self.max_recent_violations {
+            state.recent_violations.truncate(self.max_recent_violations);
+        }
+
+        Ok(())
+    }
+
+    fn aggregate(&self) -> PolicyState {
+        self.state.lock().expect("state mutex poisoned").clone()
+    }
+
+    fn receive(&self) -> Option<GovernanceUpdate> {
+        let mut q = self.directives.lock().ok()?;
+        if q.is_empty() { None } else { Some(q.remove(0)) }
+    }
+
+    fn substrate(&self) -> SubstrateProfile {
+        SubstrateProfile {
+            kind: SubstrateKind::ClassicalSilicon,
+            warp_factors: WarpFactors {
+                time: 1.0,
+                energy: 0.1, // governance is cheap — few bits per decision
+                coordination: CoordinationScaling::Linear,
+                memory: 1.0,
+                branching: None,
+            },
+            // L3 is rate-limited by human/process cycle time — use the
+            // Propagation ceiling as a proxy for "governance radius."
+            ceiling: ResourceCeiling::Propagation { max_radius_m: 1.0e7 },
+        }
+    }
+}
+```
+
+### Required changes to existing code
+
+- **Workspace membership:** add `core/life/crates/bstack/bstack-policy` to `core/life/Cargo.toml` `[workspace.members]`.
+- **`.control/policy.yaml`:** **no changes.** The crate parses the existing YAML as-is. If fields the crate can't parse are added later, serde's `#[serde(default)]` handles missing fields.
+- **`skills/bookkeeping/scripts/bookkeeping.py`:** no changes required immediately. Later, the Python pipeline may emit `PolicyObservation` events via the Rust crate — but that is a **follow-up** beyond the Pneuma retrofit.
+- **`lago-policy`:** unaffected — different crate, different purpose (RBAC for tool governance).
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Crate doesn't exist yet — creating it is the retrofit | **High** | This is an integration-point risk. Start with a minimal skeleton; only claim Pneuma wiring works when the full test suite passes. |
+| `.control/policy.yaml` schema drift over time breaking the parser | Medium | Use `#[serde(default)]` everywhere, `#[non_exhaustive]` on user-facing enums, reject-on-strict optional (`from_yaml_strict` variant). |
+| Conflicting "policy" types with `lago-policy` | Low | Distinct crate names (`bstack-policy` vs `lago-policy`), distinct type names (`BstackPolicy` vs `PolicyEngine`). |
+| `PolicyState.recent_violations` unbounded growth | Low | Bounded at 64 (configurable via `max_recent_violations`). |
+| Governance directives crossing process boundaries with no transport | **High** | `BstackPolicy` is in-process today. External callers (CI systems, human governance actors) need an HTTP/IPC shim. Not part of this retrofit — follow-up. |
+| `serde_yaml` is deprecated; yaml-rust alternatives | Medium | Use a maintained alternative if `serde_yaml` 0.9 is unmaintained at landing time. Check `cargo tree` before merging. |
+
+### Test plan
+
+**Unit tests** (inline `#[cfg(test)]` in each module):
+
+1. `config::from_yaml_parses_real_policy_yaml` — parse the existing `.control/policy.yaml` verbatim; assert version/profile/setpoints loaded.
+2. `state::from_document_initializes_empty_counters` — new state has no violations, no alerts.
+3. `emit_gate_blocked_increments_counter` — emit 3 `GateBlocked{gate_id:"G1"}` → `gate_trigger_counts["G1"] == 3`.
+4. `emit_setpoint_deviation_sets_alert` — emit → `setpoint_alerts[id] == true`.
+5. `recent_violations_bounded` — emit 100 violations → `recent_violations.len() == max_recent_violations` (default 64).
+6. `receive_drains_directives_fifo` — push 3 → receive in order.
+7. `apply_switch_profile_changes_document` — `apply(SwitchProfile{"autonomous"})` → `doc.profile == "autonomous"`.
+8. `apply_remove_gate_removes_from_doc` — add then remove by id → gate absent.
+9. `substrate_reports_governance_propagation_ceiling` — ceiling is `Propagation`.
+
+**Integration tests** (`bstack-policy/tests/policy_roundtrip.rs`):
+
+1. `end_to_end_policy_update_flow` — load real `.control/policy.yaml`, push `SwitchProfile("autonomous")`, call `apply()`, re-read `aggregate()`, assert profile flipped.
+2. `emit_observations_then_aggregate_reflects_state` — emit mixed observations, assert final `PolicyState` matches expected counts and alerts.
+
+### Rollout checklist
+
+1. [ ] Confirm decision to scaffold `bstack-policy` as a new Life crate (vs. keeping policy in Python only).
+2. [ ] Create directory `core/life/crates/bstack/bstack-policy/` with `Cargo.toml`, `src/lib.rs`, `src/config.rs`, `src/setpoints.rs`, `src/gates.rs`, `src/state.rs`, `src/pneuma_impl.rs`.
+3. [ ] Register in `core/life/Cargo.toml` workspace.
+4. [ ] Copy `.control/policy.yaml` into `tests/fixtures/policy.yaml` for round-trip parse tests.
+5. [ ] Implement the scaffold; run `cargo test -p bstack-policy`.
+6. [ ] Implement `impl Pneuma for BstackPolicy`; add pneuma unit + integration tests.
+7. [ ] Run full workspace verify: `cd core/life && cargo fmt && cargo clippy --workspace -- -D warnings && cargo test --workspace`.
+8. [ ] Update `core/life/docs/STATUS.md` — new crate, new tests.
+9. [ ] Update `core/life/CLAUDE.md` — add bstack crate family section under "Projects".
+10. [ ] Commit: `feat(bstack-policy): scaffold + Pneuma<L3ToExternal> impl`.
+11. [ ] Follow-up (separate PR): wire `bookkeeping.py` to emit `PolicyObservation::PromotionAccepted` over a thin Python→Rust IPC (FFI or stdout JSON).
+
+---
+
+## Dependency ordering
+
+Retrofits should land in this sequence:
+
+1. **Phase 0 prerequisite: `aios-protocol::pneuma` module.** This is the single biggest hazard — the trait family, boundary markers, and `SubstrateProfile` must exist before any impl can reference them. No retrofit is possible without this. Should be its own PR with unit tests on `SubstrateProfile`/`WarpFactors` construction.
+
+2. **`lago-journal` (L0→L1).** Canonical validator. If the trait shape is wrong, lago-journal will reveal it first because:
+   - `EventKind` is already the L0→L1 payload (lowest risk of semantic mismatch)
+   - The wrapper approach (`LagoJournalPneuma`) is the pattern other crates will copy
+   - 20+ existing tests provide a strong regression net
+   - Failure here blocks everything else; success here proves the trait design
+
+3. **`autonomic-controller` (L1→L2).** Builds on the validated pattern. `HomeostaticState` and `AutonomicGatingProfile` are the most mature existing types in Life, so this retrofit exercises the "preserve existing types" discipline.
+
+4. **`autoany-aios-pneuma` (L2→L3 adapter).** Deferred because:
+   - `autoany-core` lives in a separate workspace (`core/autoany/`) with its own `Cargo.lock` and publishing pipeline
+   - The adapter crate approach means autoany-core itself stays unchanged
+   - Allows L2 semantics to be tuned without destabilizing the published crate
+
+5. **`bstack-policy` (L3→External).** Last because:
+   - The crate doesn't exist yet — **scaffolding + retrofit in one step**
+   - L3 has the narrowest stability margin (λ₃ ≈ 0.006) — must not destabilize governance cadence
+   - Requires external-boundary thinking (CI, human actors) that is genuinely speculative
+
+**Strict rule:** do NOT land any retrofit if the previous step's CI is red. Each retrofit must hold the invariant that all previous tests still pass.
+
+---
+
+## Migration strategy
+
+### How to ship one at a time without breaking existing tests
+
+The core discipline is **additive only**:
+
+- Each retrofit adds code; no existing file's public API changes.
+- New types live in NEW files (`pneuma_impl.rs`, `state.rs`, etc.), not by modifying existing files.
+- `lib.rs` in each crate gets exactly one added `pub mod` declaration per retrofit.
+- Zero changes to existing `struct` / `enum` definitions, including field layout, derives, and method signatures.
+- New fields are never added to existing structs. If a Pneuma impl needs extra state, it lives on a wrapper struct.
+
+### Per-retrofit commit hygiene
+
+- One PR per crate. Each PR includes:
+  - The new `pneuma_impl.rs` file
+  - The `Cargo.toml` dependency addition (if any)
+  - The `lib.rs` re-export
+  - Unit tests inline + one integration test file
+  - A STATUS.md update reflecting the new test count
+- Commit message format: `feat({crate}): Pneuma<{boundary}> impl` — no other verbs.
+- If any existing test fails in a retrofit PR, the retrofit is wrong. Debug, don't paper over.
+
+### Fallback plan if a retrofit reveals a trait problem
+
+If lago-journal's retrofit reveals that the `Pneuma` trait shape is wrong (e.g., `emit` should be async, `receive` should return `Vec<Directive>` not `Option`), the correct response is:
+
+1. Land NO retrofits.
+2. Revise `aios-protocol::pneuma` (it's a prerequisite PR, still revisable).
+3. Re-attempt lago-journal.
+
+Do not ship a broken trait and retrofit against it; that forces churn later across all four crates.
+
+---
+
+## CI verification
+
+At each retrofit landing, the following must be green:
+
+### For lago-journal (retrofit 1)
+- `cd core/life && cargo fmt -- --check`
+- `cd core/life && cargo clippy --workspace -- -D warnings`
+- `cd core/life && cargo test -p lago-journal`
+- `cd core/life && cargo test -p lago-api -p lago-cli -p lagod` (downstream consumers)
+- `cd core/life && cargo build --workspace`
+
+### For autonomic-controller (retrofit 2)
+- All of the above, plus:
+- `cd core/life && cargo test -p autonomic-controller`
+- `cd core/life && cargo test -p autonomic-api -p autonomic-lago -p autonomicd`
+- `cd core/life && cargo test --workspace` (full regression)
+
+### For autoany-aios-pneuma (retrofit 3)
+- `cd core/life && cargo test -p autoany-aios-pneuma` (new crate)
+- `cd core/life && cargo test --workspace`
+- Cross-check `cd core/autoany && make check && make test` — **autoany-core tests must be unchanged** (prove the adapter approach didn't leak into autoany-core)
+
+### For bstack-policy (retrofit 4)
+- `cd core/life && cargo test -p bstack-policy` (new crate)
+- `cd core/life && cargo test --workspace`
+- Ensure `.control/policy.yaml` parses via a test fixture
+- `make control-audit` still green at the workspace root
+
+### Cross-cutting
+- Pre-commit hooks (smoke gate) pass
+- `make bstack-check` (27-skill validation) still passes
+- `python3 skills/bookkeeping/scripts/bookkeeping.py lint --all` passes
+
+---
+
+## Cross-cutting concerns
+
+### Serialization
+
+The architecture spec flags this as open question #3. Concrete answer for the four retrofits:
+
+- **`EventKind`** is already `Serialize + Deserialize` (with a forward-compatible deserializer). No change.
+- **`HomeostaticState`** is already `Serialize + Deserialize` (derived on `autonomic-core/src/gating.rs:271`).
+- **`AutonomicGatingProfile`** is already `Serialize + Deserialize`.
+- **`TrialRecord`** is already `Serialize + Deserialize` (derived on `autoany-core/src/types.rs:144`).
+- **`EventSlice`, `ReplayRequest`**: derive `Serialize + Deserialize` in the new types to preserve horizontal-transport compatibility.
+- **`LedgerSummary`, `GovernanceDirective`**: derive `Serialize + Deserialize`.
+- **`PolicyObservation`, `GovernanceUpdate`, `PolicyState`**: derive `Serialize + Deserialize`.
+
+Policy: **all Pneuma associated types must be `Serialize + Deserialize`** to prepare for the horizontal plexus layer. This is a hard constraint on new types; existing types that already satisfy it are unchanged.
+
+### Feature flags
+
+- `aios-protocol::pneuma` should be **always present** once stable. Feature-gating the trait family would create incompatible crate combinations — one consumer with `pneuma` enabled, another without, leads to subtle breakage.
+- The **adapter crate approach** for autoany-core (retrofit 3) is the only place where feature gating is considered, and even there, Option B (separate adapter crate) removes the need for a feature flag on `autoany-core`.
+- `bstack-policy` is unconditional inside `core/life/` — it's a Life workspace member.
+
+### Backwards compatibility
+
+**Invariants (all four retrofits must preserve):**
+
+1. **No existing type is renamed.**
+2. **No existing method signature changes.**
+3. **No existing trait bound changes.**
+4. **No existing public field visibility changes.**
+5. **`cargo test --workspace` at `core/life/` must pass before and after each retrofit.**
+6. **`cargo test --workspace` at `core/autoany/` must pass before and after retrofit 3** (the adapter crate is the mechanism that makes this true).
+7. **Schema versions on `EventEnvelope` are not incremented** — no on-disk format change.
+
+**Forward-compatibility:**
+
+- `EventKind::Custom` remains the fallback for unknown payload types. Pneuma doesn't change this.
+- New `PolicyObservation` variants should be added via `#[non_exhaustive]` to allow variant addition without breaking consumers.
+
+### Observability
+
+Existing tracing instrumentation (in `fold`, `RedbJournal::append`, etc.) is **not modified**. Pneuma methods should add their own spans:
+
+```rust
+#[instrument(skip(self), fields(pneuma.boundary = "L0->L1"))]
+fn emit(&self, signal: EventKind) -> Result<(), PneumaError> { ... }
+```
+
+Spans attribute names: `pneuma.boundary`, `pneuma.op` (`emit | aggregate | receive`), `pneuma.substrate_kind`.
+
+### Interaction with existing RCS types
+
+The retrofits do NOT implement `RecursiveControlledSystem<L>` on the new Pneuma hosts. The RCS trait is about state/observation/control dynamics (`f`, `h`); the Pneuma trait is about substrate transport (`emit`, `aggregate`, `receive`). These are orthogonal:
+
+- A Pneuma impl can optionally ALSO be an RCS impl (future — not required).
+- A crate that implements RCS (like `arcand/src/rcs_observer.rs`) can consume a Pneuma impl for its transport needs (future).
+
+Keep the two trait families loosely coupled; do not prematurely couple them in the first retrofits.
+
+---
+
+## Open Questions Specific to Retrofits
+
+1. **Sync vs. async `emit`?** The Pneuma trait as specified in `pneuma-plexus-architecture.md` is synchronous. lago-journal is naturally async (redb + tokio). The lago retrofit uses `futures::executor::block_on`, which is brittle inside tokio. **Proposal:** add an `AsyncPneuma` trait extension later; keep sync for now to match the spec.
+
+2. **Should `AutonomicProjection` own its `RuleSet`, or borrow it?** Chosen: owns `Arc<RuleSet>`. Rationale: `RuleSet` contains boxed trait objects (`Box<dyn HomeostaticRule>`), cloning is nontrivial; `Arc` sharing is the idiomatic path.
+
+3. **Directive buffering depth?** lago-journal replays, autoany directives, bstack-policy updates all use unbounded `Vec`. **Proposal:** cap each at 1024 with "drop oldest + log" on overflow. Out of scope for the initial retrofit; add in a follow-up.
+
+4. **Does `bstack-policy` need to be a Rust crate at all?** The current governance realization is 90% YAML + Python. Making it Rust gains: typed API, in-process callers (Arcan, Autonomic) can read policy without subprocess cost. Costs: duplicates Python logic; maintenance burden. **Proposal:** land a minimal Rust crate (parse-only + Pneuma) to establish the interface; keep Python enforcement until a Rust caller exists.
+
+5. **Should retrofits emit `EventKind` variants for their own activity?** e.g., `AutonomicProjection` could emit `EventKind::Custom{event_type: "pneuma.l1_emit", ...}` on every `emit()`. **Proposal: No, not in the retrofits.** Observability lives in tracing spans (cheaper, structured). EventKind pollution is a separate discussion.
+
+---
+
+## References
+
+- `/Users/broomva/broomva/core/life/docs/specs/pneuma-plexus-architecture.md` — parent architecture
+- `/Users/broomva/broomva/research/entities/concept/pneuma.md` — conceptual entity
+- `/Users/broomva/broomva/research/entities/pattern/trait-not-rename.md` — design discipline
+- `/Users/broomva/broomva/research/entities/concept/recursive-controlled-system.md` — RCS framework
+- `/Users/broomva/broomva/core/life/crates/aios/aios-protocol/src/rcs.rs` — existing RCS traits
+- `/Users/broomva/broomva/core/life/crates/aios/aios-protocol/src/event.rs` — canonical `EventKind`
+- `/Users/broomva/broomva/core/life/crates/lago/lago-journal/src/redb_journal.rs:33-36` — `RedbJournal` struct
+- `/Users/broomva/broomva/core/life/crates/autonomic/autonomic-controller/src/projection.rs:23-158` — `fold()` reducer
+- `/Users/broomva/broomva/core/life/crates/autonomic/autonomic-core/src/gating.rs:271-300` — `HomeostaticState`
+- `/Users/broomva/broomva/core/autoany/autoany-core/src/loop_engine.rs:28-279` — `EgriLoop`
+- `/Users/broomva/broomva/core/autoany/autoany-core/src/types.rs:144-156` — `TrialRecord`
+- `/Users/broomva/broomva/.control/policy.yaml` — current L3 governance document
+- `/Users/broomva/broomva/skills/bookkeeping/SKILL.md` — Python governance pipeline


### PR DESCRIPTION
## Summary

- **Versions 4 previously-untracked Pneuma/Plexus design specs** (4243 lines) — now reviewable, citable from code
- **Adds RFC 0001**: four-layer implementation plan aligning Autogenesis Protocol ([arXiv:2604.15034](https://arxiv.org/abs/2604.15034)) with our existing Pneuma + autoany EGRI stack
- **Docs-only** — no code changes, no new deps, no schema migrations

## Context

The Autogenesis paper landed on arXiv Apr 16, 2026. Synthesis research (in broomva/research/) shows it is near-isomorphic to our existing Pneuma trait family + autoany EGRI loop. This PR files the design foundation that sequences the implementation across four dependent layers, each an independent Linear ticket:

| Layer | Ticket | Estimate | Blocks |
|---|---|---|---|
| 1: Pneuma trait surface | [BRO-719](https://linear.app/broomva/issue/BRO-719) | 5pt | BRO-720 |
| 2: RSPL five types | [BRO-720](https://linear.app/broomva/issue/BRO-720) | 3pt | BRO-721 |
| 3: Evolvable + g_v mask | [BRO-721](https://linear.app/broomva/issue/BRO-721) | 2pt | BRO-722 |
| 4: MetaController + Reflect | [BRO-722](https://linear.app/broomva/issue/BRO-722) | 5pt | — |

Parent epic: [BRO-718](https://linear.app/broomva/issue/BRO-718)

## What's in the specs

- **pneuma-plexus-architecture.md** (385 lines) — two-axis (vertical L0→L3 + horizontal D0→D3) recursion framing
- **pneuma-trait-surface.md** (1106 lines) — canonical Rust trait spec, explicitly marked verbatim-port-ready for `aios-protocol::pneuma`
- **pneuma-vertical-retrofits.md** (1505 lines) — how existing crates (lago, autonomic, autoany, bstack-policy) gain Pneuma impls without breaking changes
- **life-plexus-implementation.md** (1247 lines) — horizontal depth-0→depth-1 field-physics plexus plan

## What's in the RFC

RFC 0001 maps the AGP paper's RSPL + SEPL + Evolvable concepts onto our Pneuma trait family and EGRI loop, with:
- Explicit architectural framing (4 layered abstractions)
- Per-layer scope, dependencies, tests, effort estimates
- Alternatives considered (4) and why each was rejected
- Open questions scoped to each phase
- Commit-gate ↔ stability-budget coupling proposal (the RCS rate bound AGP lacks)

## Test plan

- [x] `git diff` reviewed — all changes are additions to docs/ directories
- [x] No code files touched
- [x] No new deps or Cargo.toml changes
- [ ] CI gates:
  - [ ] Format (no Rust diff = pass)
  - [ ] Lint (no Rust diff = pass)
  - [ ] Test Linux (existing 1077 tests continue to pass)
  - [ ] Test macOS
  - [ ] MSRV check

## Follow-up

Once this lands, work can start on BRO-719 (Pneuma trait surface port) in parallel with BRO-718 research companion (RCS Paper P2 citing AGP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)