### PR TITLE
feat(haima-wallet): implement EIP-712 + EIP-3009 transferWithAuthorization signing

### DIFF
--- a/crates/haima/haima-wallet/src/eip712.rs
+++ b/crates/haima/haima-wallet/src/eip712.rs
@@ -1,0 +1,346 @@
+//! EIP-712 typed-data hashing for EIP-3009 `transferWithAuthorization`.
+//!
+//! This module implements just enough of [EIP-712] and [EIP-3009] to produce
+//! the 32-byte digest that Haima signs when authorizing USDC transfers for
+//! x402 payments. The digest is built as:
+//!
+//! ```text
+//! digest = keccak256("\x19\x01" || domainSeparator || structHash)
+//! ```
+//!
+//! where:
+//!
+//! ```text
+//! domainSeparator = keccak256(abi.encode(
+//!     keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+//!     keccak256(name), keccak256(version), chainId, verifyingContract))
+//!
+//! structHash = keccak256(abi.encode(
+//!     keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"),
+//!     from, to, value, validAfter, validBefore, nonce))
+//! ```
+//!
+//! Solidity `abi.encode` left-pads `address` and `uint256` values to 32 bytes.
+//!
+//! Only Base mainnet and Base Sepolia USDC domains are registered here; other
+//! chains return [`HaimaError::Crypto`] from [`usdc_domain_for_chain`].
+//!
+//! [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
+//! [EIP-3009]: https://eips.ethereum.org/EIPS/eip-3009
+
+use haima_core::wallet::ChainId;
+use haima_core::{HaimaError, HaimaResult};
+use sha3::{Digest, Keccak256};
+
+/// USDC on Base mainnet (`eip155:8453`, [FiatTokenV2][usdc]).
+///
+/// [usdc]: https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+pub const USDC_BASE_MAINNET: Eip712Domain = Eip712Domain {
+    name: "USD Coin",
+    version: "2",
+    chain_id: 8453,
+    verifying_contract: [
+        0x83, 0x35, 0x89, 0xfc, 0xd6, 0xed, 0xb6, 0xe0, 0x8f, 0x4c, 0x7c, 0x32, 0xd4, 0xf7, 0x1b,
+        0x54, 0xbd, 0xa0, 0x29, 0x13,
+    ],
+};
+
+/// USDC on Base Sepolia (`eip155:84532`, [FiatTokenV2][usdc]).
+///
+/// [usdc]: https://sepolia.basescan.org/address/0x036CbD53842c5426634e7929541eC2318f3dCF7e
+pub const USDC_BASE_SEPOLIA: Eip712Domain = Eip712Domain {
+    name: "USDC",
+    version: "2",
+    chain_id: 84532,
+    verifying_contract: [
+        0x03, 0x6c, 0xbd, 0x53, 0x84, 0x2c, 0x54, 0x26, 0x63, 0x4e, 0x79, 0x29, 0x54, 0x1e, 0xc2,
+        0x31, 0x8f, 0x3d, 0xcf, 0x7e,
+    ],
+};
+
+/// Parameters that parameterize an EIP-712 domain separator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Eip712Domain {
+    /// Contract `name` (EIP-712 string field).
+    pub name: &'static str,
+    /// Contract `version` (EIP-712 string field).
+    pub version: &'static str,
+    /// EVM chain id.
+    pub chain_id: u64,
+    /// 20-byte verifying contract address.
+    pub verifying_contract: [u8; 20],
+}
+
+impl Eip712Domain {
+    /// Compute the EIP-712 domain separator for this domain.
+    pub fn separator(&self) -> [u8; 32] {
+        let mut buf = Vec::with_capacity(5 * 32);
+        buf.extend_from_slice(&domain_type_hash());
+        buf.extend_from_slice(&keccak256(self.name.as_bytes()));
+        buf.extend_from_slice(&keccak256(self.version.as_bytes()));
+        buf.extend_from_slice(&u64_as_u256_be(self.chain_id));
+        buf.extend_from_slice(&address_padded(&self.verifying_contract));
+        keccak256(&buf)
+    }
+}
+
+/// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`.
+pub fn domain_type_hash() -> [u8; 32] {
+    keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+}
+
+/// `keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")`.
+///
+/// Matches the constant in Circle's [FiatTokenV2][fiat] USDC contract.
+///
+/// [fiat]: https://github.com/circlefin/stablecoin-evm/blob/master/contracts/v2/FiatTokenV2.sol
+pub fn transfer_with_authorization_typehash() -> [u8; 32] {
+    keccak256(
+        b"TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)",
+    )
+}
+
+/// Compute the EIP-712 digest for an EIP-3009 `transferWithAuthorization`.
+///
+/// Returns the 32-byte prehash ready to be signed with a recoverable ECDSA
+/// signature over secp256k1.
+pub fn hash_transfer_authorization(
+    domain: &Eip712Domain,
+    from: &[u8; 20],
+    to: &[u8; 20],
+    value: u64,
+    valid_after: u64,
+    valid_before: u64,
+    nonce: &[u8; 32],
+) -> [u8; 32] {
+    let mut struct_buf = Vec::with_capacity(7 * 32);
+    struct_buf.extend_from_slice(&transfer_with_authorization_typehash());
+    struct_buf.extend_from_slice(&address_padded(from));
+    struct_buf.extend_from_slice(&address_padded(to));
+    struct_buf.extend_from_slice(&u64_as_u256_be(value));
+    struct_buf.extend_from_slice(&u64_as_u256_be(valid_after));
+    struct_buf.extend_from_slice(&u64_as_u256_be(valid_before));
+    struct_buf.extend_from_slice(nonce);
+    let struct_hash = keccak256(&struct_buf);
+
+    let mut digest_buf = Vec::with_capacity(2 + 64);
+    digest_buf.extend_from_slice(b"\x19\x01");
+    digest_buf.extend_from_slice(&domain.separator());
+    digest_buf.extend_from_slice(&struct_hash);
+    keccak256(&digest_buf)
+}
+
+/// Pick the USDC EIP-712 domain registered for a chain id.
+pub fn usdc_domain_for_chain(chain: &ChainId) -> HaimaResult<Eip712Domain> {
+    match chain.0.as_str() {
+        "eip155:8453" => Ok(USDC_BASE_MAINNET),
+        "eip155:84532" => Ok(USDC_BASE_SEPOLIA),
+        other => Err(HaimaError::Crypto(format!(
+            "no USDC EIP-712 domain registered for chain {other}"
+        ))),
+    }
+}
+
+/// Parse a `0x`-prefixed Ethereum address into 20 raw bytes.
+pub fn parse_eth_address(s: &str) -> HaimaResult<[u8; 20]> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(trimmed)
+        .map_err(|e| HaimaError::Crypto(format!("invalid hex in address '{s}': {e}")))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        HaimaError::Crypto(format!("address must be 20 bytes, got {}", v.len()))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let result = Keccak256::digest(data);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&result);
+    out
+}
+
+fn u64_as_u256_be(value: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&value.to_be_bytes());
+    out
+}
+
+fn address_padded(addr: &[u8; 20]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[12..].copy_from_slice(addr);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex32(hex_str: &str) -> [u8; 32] {
+        let bytes = hex::decode(hex_str.trim_start_matches("0x")).expect("valid hex");
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        out
+    }
+
+    /// Well-known EIP-712 constant — any deviation means our keccak256 wiring
+    /// is wrong, not the spec.
+    #[test]
+    fn domain_type_hash_matches_eip712_spec() {
+        let expected = hex32("8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f");
+        assert_eq!(domain_type_hash(), expected);
+    }
+
+    /// Matches the `TRANSFER_WITH_AUTHORIZATION_TYPEHASH` constant baked into
+    /// every Circle FiatTokenV2 deployment.
+    #[test]
+    fn transfer_with_authorization_typehash_matches_circle_fiattokenv2() {
+        let expected = hex32("7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267");
+        assert_eq!(transfer_with_authorization_typehash(), expected);
+    }
+
+    /// Domain separator must depend on every field — flipping one byte of the
+    /// verifying contract must produce a different separator.
+    #[test]
+    fn domain_separator_is_sensitive_to_every_field() {
+        let base = USDC_BASE_MAINNET;
+        let base_sep = base.separator();
+
+        let mut mutated = base;
+        mutated.verifying_contract[0] ^= 0x01;
+        let mutated_sep = mutated.separator();
+        assert_ne!(base_sep, mutated_sep);
+
+        let mut mutated_chain = base;
+        mutated_chain.chain_id = 1;
+        assert_ne!(base_sep, mutated_chain.separator());
+
+        let mut mutated_name = base;
+        mutated_name.name = "Tether";
+        assert_ne!(base_sep, mutated_name.separator());
+
+        let mut mutated_version = base;
+        mutated_version.version = "1";
+        assert_ne!(base_sep, mutated_version.separator());
+    }
+
+    /// Mainnet and Sepolia must produce different separators (chain id differs).
+    #[test]
+    fn mainnet_and_sepolia_separators_differ() {
+        assert_ne!(USDC_BASE_MAINNET.separator(), USDC_BASE_SEPOLIA.separator());
+    }
+
+    /// Deterministic: same inputs produce the same digest.
+    #[test]
+    fn transfer_authorization_digest_is_deterministic() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let nonce = [0x33u8; 32];
+        let d1 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        let d2 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        assert_eq!(d1, d2);
+    }
+
+    /// Digest is sensitive to each input — changing nonce changes digest.
+    #[test]
+    fn transfer_authorization_digest_is_nonce_sensitive() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let d1 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &[0x33u8; 32],
+        );
+        let d2 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &[0x44u8; 32],
+        );
+        assert_ne!(d1, d2);
+    }
+
+    /// Same EIP-3009 struct on different chains must produce different digests
+    /// (replay protection across chains).
+    #[test]
+    fn transfer_authorization_digest_is_chain_scoped() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let nonce = [0x33u8; 32];
+        let mainnet = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        let sepolia = hash_transfer_authorization(
+            &USDC_BASE_SEPOLIA,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        assert_ne!(mainnet, sepolia);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_supports_base_mainnet() {
+        let d = usdc_domain_for_chain(&ChainId::base()).unwrap();
+        assert_eq!(d.chain_id, 8453);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_supports_base_sepolia() {
+        let d = usdc_domain_for_chain(&ChainId::base_sepolia()).unwrap();
+        assert_eq!(d.chain_id, 84532);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_rejects_unsupported() {
+        let eth = ChainId::ethereum();
+        assert!(usdc_domain_for_chain(&eth).is_err());
+    }
+
+    #[test]
+    fn parse_eth_address_accepts_checksummed_and_lowercase() {
+        let a = parse_eth_address("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913").unwrap();
+        let b = parse_eth_address("833589fcd6edb6e08f4c7c32d4f71b54bda02913").unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, USDC_BASE_MAINNET.verifying_contract);
+    }
+
+    #[test]
+    fn parse_eth_address_rejects_wrong_length() {
+        assert!(parse_eth_address("0xdead").is_err());
+    }
+}

--- a/crates/haima/haima-wallet/src/lib.rs
+++ b/crates/haima/haima-wallet/src/lib.rs
@@ -8,9 +8,15 @@
 //! backends (e.g., Coinbase CDP MPC) through the `WalletBackend` trait.
 
 pub mod backend;
+pub mod eip712;
 pub mod evm;
 pub mod signer;
 
 pub use backend::WalletBackend;
+pub use eip712::{
+    Eip712Domain, USDC_BASE_MAINNET, USDC_BASE_SEPOLIA, domain_type_hash,
+    hash_transfer_authorization, parse_eth_address, transfer_with_authorization_typehash,
+    usdc_domain_for_chain,
+};
 pub use evm::{decrypt_private_key, derive_address, encrypt_private_key, generate_keypair};
 pub use signer::LocalSigner;

--- a/crates/haima/haima-wallet/src/signer.rs
+++ b/crates/haima/haima-wallet/src/signer.rs
@@ -8,6 +8,7 @@ use sha3::{Digest, Keccak256};
 use zeroize::Zeroizing;
 
 use crate::backend::WalletBackend;
+use crate::eip712::{hash_transfer_authorization, parse_eth_address, usdc_domain_for_chain};
 use crate::evm::derive_address;
 
 /// A local wallet that signs with an in-memory secp256k1 private key.
@@ -68,20 +69,43 @@ impl WalletBackend for LocalSigner {
 
     async fn sign_transfer_authorization(
         &self,
-        _from: &str,
-        _to: &str,
-        _value: u64,
-        _valid_after: u64,
-        _valid_before: u64,
-        _nonce: &[u8; 32],
+        from: &str,
+        to: &str,
+        value: u64,
+        valid_after: u64,
+        valid_before: u64,
+        nonce: &[u8; 32],
     ) -> HaimaResult<Vec<u8>> {
-        // EIP-3009 transferWithAuthorization signing.
-        // Full implementation requires EIP-712 typed data hashing with the
-        // USDC contract's domain separator. Stubbed for Phase F0 — will be
-        // completed when integrating x402-rs in Phase F1.
-        Err(haima_core::HaimaError::Crypto(
-            "EIP-3009 signing not yet implemented — pending x402-rs integration".into(),
-        ))
+        // Resolve the USDC EIP-712 domain for this signer's chain.
+        let domain = usdc_domain_for_chain(&self.address.chain)?;
+        let from_bytes = parse_eth_address(from)?;
+        let to_bytes = parse_eth_address(to)?;
+
+        let digest = hash_transfer_authorization(
+            &domain,
+            &from_bytes,
+            &to_bytes,
+            value,
+            valid_after,
+            valid_before,
+            nonce,
+        );
+
+        // Recoverable ECDSA over secp256k1 — produces (r, s, recovery_id).
+        // Callers / facilitators reconstruct the signer's address via ecrecover,
+        // so the recovery byte must be present.
+        let (sig, recid) = self
+            .signing_key
+            .sign_prehash_recoverable(&digest)
+            .map_err(|e| haima_core::HaimaError::Crypto(format!("EIP-3009 signing failed: {e}")))?;
+
+        // Concatenate r (32) || s (32) || v (1). Use the legacy v encoding
+        // ({27, 28}) that EIP-3009 verifiers and ecrecover both accept.
+        let rs = sig.to_bytes();
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(rs.as_slice());
+        out.push(recid.to_byte() + 27);
+        Ok(out)
     }
 
     fn backend_type(&self) -> &str {
@@ -92,7 +116,9 @@ impl WalletBackend for LocalSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eip712::{USDC_BASE_MAINNET, hash_transfer_authorization};
     use haima_core::wallet::ChainId;
+    use k256::ecdsa::{RecoveryId, Signature as EcdsaSignature, VerifyingKey};
     use zeroize::Zeroizing;
 
     #[test]
@@ -115,5 +141,99 @@ mod tests {
         let signer = LocalSigner::generate(ChainId::base()).unwrap();
         let sig = signer.sign_message(b"hello haima").await.unwrap();
         assert!(!sig.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_returns_65_byte_recoverable_signature() {
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let from = signer.address().address.clone();
+        let to = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+        let nonce = [0x42u8; 32];
+        let sig = signer
+            .sign_transfer_authorization(&from, to, 1_000_000, 1_700_000_000, 1_700_000_600, &nonce)
+            .await
+            .unwrap();
+        assert_eq!(sig.len(), 65, "recoverable ECDSA is r||s||v = 65 bytes");
+        let v = sig[64];
+        assert!(v == 27 || v == 28, "v must be 27 or 28 (legacy encoding)");
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_round_trips_via_ecrecover() {
+        // This is the functional test: the signature must recover to the
+        // signer's own address. If EIP-712 digest computation, signing, or
+        // v-byte encoding is off, this fails.
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let from = signer.address().address.clone();
+        let to = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+        let nonce = [0x13u8; 32];
+        let value = 50_000u64;
+        let valid_after = 1_700_000_000u64;
+        let valid_before = 1_700_000_600u64;
+
+        let sig_bytes = signer
+            .sign_transfer_authorization(&from, to, value, valid_after, valid_before, &nonce)
+            .await
+            .unwrap();
+
+        let from_bytes = crate::eip712::parse_eth_address(&from).unwrap();
+        let to_bytes = crate::eip712::parse_eth_address(to).unwrap();
+        let digest = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from_bytes,
+            &to_bytes,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+
+        let signature = EcdsaSignature::from_slice(&sig_bytes[..64]).unwrap();
+        let recid = RecoveryId::try_from(sig_bytes[64] - 27).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &signature, recid)
+            .expect("signature must recover");
+
+        // Derive EVM address from the recovered public key and compare to the
+        // signer's address. If the digest, signing, or v byte is wrong, this
+        // fails.
+        let pubkey = recovered.to_encoded_point(false);
+        let hash = Keccak256::digest(&pubkey.as_bytes()[1..]);
+        let recovered_address = format!("0x{}", hex::encode(&hash[12..]));
+        assert_eq!(recovered_address.to_lowercase(), from.to_lowercase());
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_rejects_unsupported_chain() {
+        let signer = LocalSigner::generate(ChainId::ethereum()).unwrap();
+        let result = signer
+            .sign_transfer_authorization(
+                "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                100,
+                0,
+                u64::MAX,
+                &[0u8; 32],
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "ethereum mainnet USDC domain not registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_rejects_malformed_address() {
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let result = signer
+            .sign_transfer_authorization(
+                "not-an-address",
+                "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                100,
+                0,
+                u64::MAX,
+                &[0u8; 32],
+            )
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/crates/lago/lago-knowledge/src/event_index.rs
+++ b/crates/lago/lago-knowledge/src/event_index.rs
@@ -412,7 +412,7 @@ mod tests {
         let idx = EventSearchIndex::build(entries);
 
         let results = idx.search("deployment production", 10);
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
         // Both deployment-related entries from different sessions
         let sessions: Vec<&str> = results.iter().map(|r| r.session_id.as_str()).collect();
         assert!(sessions.contains(&"session-A") || sessions.contains(&"session-B"));


### PR DESCRIPTION
## Summary

Replaces the Phase F0 stub in `WalletBackend::sign_transfer_authorization` with a real EIP-712 typed-data digest + recoverable ECDSA signature. Haima can now sign authorizations accepted by Coinbase CDP, x402.org, and self-hosted (second-state/x402-facilitator) facilitators.

**Linear:** [BRO-756](https://linear.app/broomva/issue/BRO-756)
**Part of stack:** this → #757 → #758

## What changed

### 1. New module `haima-wallet/src/eip712.rs`
Hand-rolled EIP-712 on `k256 + sha3` (no alloy/ethers dep to keep the deps minimal). Exports:
- `Eip712Domain` + `USDC_BASE_MAINNET` / `USDC_BASE_SEPOLIA` constants
- `domain_type_hash()` — EIP-712 spec constant
- `transfer_with_authorization_typehash()` — Circle FiatTokenV2 constant
- `hash_transfer_authorization(...)` — full digest
- `parse_eth_address(...)`, `usdc_domain_for_chain(...)`

### 2. `LocalSigner::sign_transfer_authorization`
Replaces the stub that returned `HaimaError::Crypto("not implemented")`. Resolves the signer's chain to the USDC domain, computes the digest, signs recoverably via `sign_prehash_recoverable`, returns `r || s || v` (65 bytes) with legacy `v ∈ {27, 28}` encoding.

### 3. Chore: `lago-knowledge/src/event_index.rs` — `len() >= 1` → `!is_empty()`
Rust 1.93's `clippy::len_zero` treats `x.len() >= 1` as an error under `-D warnings`. Pre-existing assertion; unblocks CI for the full PR stack.

## Tests (16 new, TDD)

- Type hash matches Circle FiatTokenV2 `TRANSFER_WITH_AUTHORIZATION_TYPEHASH`
- Domain separator is sensitive to every field (name, version, chain_id, verifying_contract)
- Chain-scoped replay protection (mainnet digest ≠ sepolia digest for same struct)
- Nonce-sensitive digest
- Signer returns 65-byte recoverable signature with `v ∈ {27, 28}`
- **Ecrecover round-trip** — recovered address equals the signer's own address (the functional smoke test)
- Rejects unregistered chains (e.g. Ethereum mainnet)
- Rejects malformed recipient addresses

## Test plan

- [x] `cargo test -p haima-wallet` — 23 pass (7 existing + 16 new)
- [x] `cargo test -p lago-knowledge` — 156 pass
- [x] `cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments` — clean
- [x] `cargo fmt --check` — clean

## Non-goals (deferred to follow-ups)

- Nonce generation / `X402Client` wiring — **BRO-757**
- EIP-3009 domains for Ethereum mainnet / other L2s — future
- Permit2 / arbitrary ERC-20 support — future

## References

- EIP-712: https://eips.ethereum.org/EIPS/eip-712
- EIP-3009: https://eips.ethereum.org/EIPS/eip-3009
- Circle FiatTokenV2: https://github.com/circlefin/stablecoin-evm/blob/master/contracts/v2/FiatTokenV2.sol

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for transfer authorization signing with chain-specific domain configuration and address validation.

* **Tests**
  * Added comprehensive test coverage for authorization signature generation, chain support validation, signature recovery, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->