### PR TITLE
test(haima-x402): E2E smoke for full x402 payment loop + Phase F1 status roll-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3705,6 +3705,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,6 +3697,7 @@ dependencies = [
  "haima-core",
  "haima-wallet",
  "hex",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/haima/CLAUDE.md
+++ b/crates/haima/CLAUDE.md
@@ -1,7 +1,7 @@
 # Haima — Agentic Finance Engine for the Agent OS
 
-**Version**: 0.1.0 | **Date**: 2026-03-19 | **Status**: Phase F0 COMPLETE (Foundation)
-**Tests**: 45 passing | 6 crates | Rust 2024 Edition (MSRV 1.85)
+**Version**: 0.1.0 | **Date**: 2026-04-21 | **Status**: Phase F1 IN PROGRESS (x402 real signing + discovery)
+**Tests**: 235 passing (haima-core 146, haima-wallet 23, haima-x402 61, e2e smoke 5) | 6 crates | Rust 2024 Edition (MSRV 1.85)
 
 Haima (αἷμα, Greek for "blood") is the circulatory system of the Agent OS —
 distributing economic resources (payments, revenue, credits) throughout the
@@ -18,9 +18,9 @@ cargo fmt && cargo clippy --workspace -- -D warnings && cargo test --workspace
 Rust 2024 | axum (HTTP API) | k256 (secp256k1) | x402 protocol | aios-protocol (canonical contract) | lago (event journal)
 
 ## Crates
-- `haima-core` (19 tests) — Types, traits, errors: payment schemes, receipts, wallets, policies, finance events
-- `haima-wallet` (7 tests) — secp256k1 keypair generation, EVM address derivation, ChaCha20-Poly1305 encrypted key storage, WalletBackend trait (local + MPC abstraction)
-- `haima-x402` (7 tests) — x402 protocol integration: client middleware (auto-pay on 402), server middleware (protect routes), facilitator client (Coinbase CDP / self-hosted)
+- `haima-core` (146 tests) — Types, traits, errors: payment schemes, receipts, wallets, policies, finance events. Includes `HaimaError::BazaarUnavailable` for discovery-layer failures.
+- `haima-wallet` (23 tests) — secp256k1 keypair generation, EVM address derivation, ChaCha20-Poly1305 encrypted key storage, WalletBackend trait (local + MPC abstraction), **EIP-712 typed-data hashing + EIP-3009 `transferWithAuthorization` signing** (`eip712.rs`, 12 tests validating Circle FiatTokenV2 type hashes + chain separation + ecrecover round-trip).
+- `haima-x402` (61 tests + 5 e2e smoke) — x402 protocol integration: client middleware with **real EIP-3009 signing** (`sign_payment` produces 65-byte recoverable signatures + structured `Eip3009Authorization`), server middleware scaffold, facilitator client (Coinbase CDP / self-hosted), **agentic.market bazaar discovery** (`bazaar.rs`, TTL cache, graceful degradation).
 - `haima-lago` (8 tests) — Lago bridge: finance event publishing, deterministic projection fold → FinancialState
 - `haima-api` (2 tests) — axum HTTP server: /health, /state endpoints
 - `haimad` (2 tests) — Daemon binary with CLI args, config, optional Lago journal
@@ -126,22 +126,23 @@ Autonomic consults Haima's events for:
 | Phase | Scope | Status |
 |-------|-------|--------|
 | **F0: Foundation** | Core types, wallet (k256), policy, events, API scaffold, projection fold | COMPLETE |
-| **F1: x402 Client** | x402-rs integration, header parsing, signing, facilitator settlement | PLANNED |
+| **F1: x402 Client + Discovery** | EIP-712 + EIP-3009 signing, real structured payload, agentic.market bazaar client, E2E smoke | IN PROGRESS (BRO-756 ✅ BRO-757 ✅ BRO-758 ✅) |
 | **F2: Ledger** | Wire to Lago EventStorePort, autonomic CostReason integration | PLANNED |
 | **F3: x402 Server** | Axum middleware, task billing, revenue collection | PLANNED |
 | **F4: Daemon** | Full haimad with Lago persistence, balance sync, transaction history | PLANNED |
 | **F5: Solana** | Solana chain support via x402-chain-solana | PLANNED |
 | **F6: MPP** | Stripe Machine Payments Protocol (when Rust SDK ships) | FUTURE |
 
-## Known Gaps (Post Phase F0)
+## Known Gaps (Post Phase F1 first pass)
 
-- x402 header parsing and signing stubbed (pending x402-rs integration in F1)
-- EIP-3009 transferWithAuthorization signing not implemented
-- Lago EventStorePort not wired (publisher logs only)
-- No arcan-haima bridge crate yet
+- x402 server middleware scaffolded but not axum-wired (F3)
+- Lago EventStorePort not wired (publisher logs only) (F2)
+- No arcan-haima bridge crate yet (F2)
 - No CLI commands (lago-cli style)
-- No on-chain balance query (requires RPC provider)
+- No on-chain balance query (requires RPC provider) (F4)
 - Identity not connected to Autonomic's EconomicIdentity
+- USDC EIP-712 domain only registered for Base mainnet + Base Sepolia; Ethereum mainnet + other L2s pending
+- Facilitator `verify_payment_header` still produces deterministic (not on-chain) tx hashes — real RPC integration in F4
 
 ## Rules
 - **Formatting**: `cargo fmt` before every commit

--- a/crates/haima/haima-api/src/routes.rs
+++ b/crates/haima/haima-api/src/routes.rs
@@ -398,6 +398,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: hex::encode([0xabu8; 64]),
+            authorization: None,
         };
         encode_payment_signature(&sig).unwrap()
     }

--- a/crates/haima/haima-core/src/error.rs
+++ b/crates/haima/haima-core/src/error.rs
@@ -42,6 +42,9 @@ pub enum HaimaError {
     #[error("crypto error: {0}")]
     Crypto(String),
 
+    #[error("bazaar unavailable: {0}")]
+    BazaarUnavailable(String),
+
     #[error("insufficient credit: {reason}")]
     InsufficientCredit { reason: String },
 

--- a/crates/haima/haima-wallet/src/eip712.rs
+++ b/crates/haima/haima-wallet/src/eip712.rs
@@ -1,0 +1,346 @@
+//! EIP-712 typed-data hashing for EIP-3009 `transferWithAuthorization`.
+//!
+//! This module implements just enough of [EIP-712] and [EIP-3009] to produce
+//! the 32-byte digest that Haima signs when authorizing USDC transfers for
+//! x402 payments. The digest is built as:
+//!
+//! ```text
+//! digest = keccak256("\x19\x01" || domainSeparator || structHash)
+//! ```
+//!
+//! where:
+//!
+//! ```text
+//! domainSeparator = keccak256(abi.encode(
+//!     keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+//!     keccak256(name), keccak256(version), chainId, verifyingContract))
+//!
+//! structHash = keccak256(abi.encode(
+//!     keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"),
+//!     from, to, value, validAfter, validBefore, nonce))
+//! ```
+//!
+//! Solidity `abi.encode` left-pads `address` and `uint256` values to 32 bytes.
+//!
+//! Only Base mainnet and Base Sepolia USDC domains are registered here; other
+//! chains return [`HaimaError::Crypto`] from [`usdc_domain_for_chain`].
+//!
+//! [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
+//! [EIP-3009]: https://eips.ethereum.org/EIPS/eip-3009
+
+use haima_core::wallet::ChainId;
+use haima_core::{HaimaError, HaimaResult};
+use sha3::{Digest, Keccak256};
+
+/// USDC on Base mainnet (`eip155:8453`, [FiatTokenV2][usdc]).
+///
+/// [usdc]: https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+pub const USDC_BASE_MAINNET: Eip712Domain = Eip712Domain {
+    name: "USD Coin",
+    version: "2",
+    chain_id: 8453,
+    verifying_contract: [
+        0x83, 0x35, 0x89, 0xfc, 0xd6, 0xed, 0xb6, 0xe0, 0x8f, 0x4c, 0x7c, 0x32, 0xd4, 0xf7, 0x1b,
+        0x54, 0xbd, 0xa0, 0x29, 0x13,
+    ],
+};
+
+/// USDC on Base Sepolia (`eip155:84532`, [FiatTokenV2][usdc]).
+///
+/// [usdc]: https://sepolia.basescan.org/address/0x036CbD53842c5426634e7929541eC2318f3dCF7e
+pub const USDC_BASE_SEPOLIA: Eip712Domain = Eip712Domain {
+    name: "USDC",
+    version: "2",
+    chain_id: 84532,
+    verifying_contract: [
+        0x03, 0x6c, 0xbd, 0x53, 0x84, 0x2c, 0x54, 0x26, 0x63, 0x4e, 0x79, 0x29, 0x54, 0x1e, 0xc2,
+        0x31, 0x8f, 0x3d, 0xcf, 0x7e,
+    ],
+};
+
+/// Parameters that parameterize an EIP-712 domain separator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Eip712Domain {
+    /// Contract `name` (EIP-712 string field).
+    pub name: &'static str,
+    /// Contract `version` (EIP-712 string field).
+    pub version: &'static str,
+    /// EVM chain id.
+    pub chain_id: u64,
+    /// 20-byte verifying contract address.
+    pub verifying_contract: [u8; 20],
+}
+
+impl Eip712Domain {
+    /// Compute the EIP-712 domain separator for this domain.
+    pub fn separator(&self) -> [u8; 32] {
+        let mut buf = Vec::with_capacity(5 * 32);
+        buf.extend_from_slice(&domain_type_hash());
+        buf.extend_from_slice(&keccak256(self.name.as_bytes()));
+        buf.extend_from_slice(&keccak256(self.version.as_bytes()));
+        buf.extend_from_slice(&u64_as_u256_be(self.chain_id));
+        buf.extend_from_slice(&address_padded(&self.verifying_contract));
+        keccak256(&buf)
+    }
+}
+
+/// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`.
+pub fn domain_type_hash() -> [u8; 32] {
+    keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+}
+
+/// `keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")`.
+///
+/// Matches the constant in Circle's [FiatTokenV2][fiat] USDC contract.
+///
+/// [fiat]: https://github.com/circlefin/stablecoin-evm/blob/master/contracts/v2/FiatTokenV2.sol
+pub fn transfer_with_authorization_typehash() -> [u8; 32] {
+    keccak256(
+        b"TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)",
+    )
+}
+
+/// Compute the EIP-712 digest for an EIP-3009 `transferWithAuthorization`.
+///
+/// Returns the 32-byte prehash ready to be signed with a recoverable ECDSA
+/// signature over secp256k1.
+pub fn hash_transfer_authorization(
+    domain: &Eip712Domain,
+    from: &[u8; 20],
+    to: &[u8; 20],
+    value: u64,
+    valid_after: u64,
+    valid_before: u64,
+    nonce: &[u8; 32],
+) -> [u8; 32] {
+    let mut struct_buf = Vec::with_capacity(7 * 32);
+    struct_buf.extend_from_slice(&transfer_with_authorization_typehash());
+    struct_buf.extend_from_slice(&address_padded(from));
+    struct_buf.extend_from_slice(&address_padded(to));
+    struct_buf.extend_from_slice(&u64_as_u256_be(value));
+    struct_buf.extend_from_slice(&u64_as_u256_be(valid_after));
+    struct_buf.extend_from_slice(&u64_as_u256_be(valid_before));
+    struct_buf.extend_from_slice(nonce);
+    let struct_hash = keccak256(&struct_buf);
+
+    let mut digest_buf = Vec::with_capacity(2 + 64);
+    digest_buf.extend_from_slice(b"\x19\x01");
+    digest_buf.extend_from_slice(&domain.separator());
+    digest_buf.extend_from_slice(&struct_hash);
+    keccak256(&digest_buf)
+}
+
+/// Pick the USDC EIP-712 domain registered for a chain id.
+pub fn usdc_domain_for_chain(chain: &ChainId) -> HaimaResult<Eip712Domain> {
+    match chain.0.as_str() {
+        "eip155:8453" => Ok(USDC_BASE_MAINNET),
+        "eip155:84532" => Ok(USDC_BASE_SEPOLIA),
+        other => Err(HaimaError::Crypto(format!(
+            "no USDC EIP-712 domain registered for chain {other}"
+        ))),
+    }
+}
+
+/// Parse a `0x`-prefixed Ethereum address into 20 raw bytes.
+pub fn parse_eth_address(s: &str) -> HaimaResult<[u8; 20]> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(trimmed)
+        .map_err(|e| HaimaError::Crypto(format!("invalid hex in address '{s}': {e}")))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        HaimaError::Crypto(format!("address must be 20 bytes, got {}", v.len()))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let result = Keccak256::digest(data);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&result);
+    out
+}
+
+fn u64_as_u256_be(value: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&value.to_be_bytes());
+    out
+}
+
+fn address_padded(addr: &[u8; 20]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[12..].copy_from_slice(addr);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex32(hex_str: &str) -> [u8; 32] {
+        let bytes = hex::decode(hex_str.trim_start_matches("0x")).expect("valid hex");
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        out
+    }
+
+    /// Well-known EIP-712 constant — any deviation means our keccak256 wiring
+    /// is wrong, not the spec.
+    #[test]
+    fn domain_type_hash_matches_eip712_spec() {
+        let expected = hex32("8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f");
+        assert_eq!(domain_type_hash(), expected);
+    }
+
+    /// Matches the `TRANSFER_WITH_AUTHORIZATION_TYPEHASH` constant baked into
+    /// every Circle FiatTokenV2 deployment.
+    #[test]
+    fn transfer_with_authorization_typehash_matches_circle_fiattokenv2() {
+        let expected = hex32("7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267");
+        assert_eq!(transfer_with_authorization_typehash(), expected);
+    }
+
+    /// Domain separator must depend on every field — flipping one byte of the
+    /// verifying contract must produce a different separator.
+    #[test]
+    fn domain_separator_is_sensitive_to_every_field() {
+        let base = USDC_BASE_MAINNET;
+        let base_sep = base.separator();
+
+        let mut mutated = base;
+        mutated.verifying_contract[0] ^= 0x01;
+        let mutated_sep = mutated.separator();
+        assert_ne!(base_sep, mutated_sep);
+
+        let mut mutated_chain = base;
+        mutated_chain.chain_id = 1;
+        assert_ne!(base_sep, mutated_chain.separator());
+
+        let mut mutated_name = base;
+        mutated_name.name = "Tether";
+        assert_ne!(base_sep, mutated_name.separator());
+
+        let mut mutated_version = base;
+        mutated_version.version = "1";
+        assert_ne!(base_sep, mutated_version.separator());
+    }
+
+    /// Mainnet and Sepolia must produce different separators (chain id differs).
+    #[test]
+    fn mainnet_and_sepolia_separators_differ() {
+        assert_ne!(USDC_BASE_MAINNET.separator(), USDC_BASE_SEPOLIA.separator());
+    }
+
+    /// Deterministic: same inputs produce the same digest.
+    #[test]
+    fn transfer_authorization_digest_is_deterministic() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let nonce = [0x33u8; 32];
+        let d1 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        let d2 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        assert_eq!(d1, d2);
+    }
+
+    /// Digest is sensitive to each input — changing nonce changes digest.
+    #[test]
+    fn transfer_authorization_digest_is_nonce_sensitive() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let d1 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &[0x33u8; 32],
+        );
+        let d2 = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &[0x44u8; 32],
+        );
+        assert_ne!(d1, d2);
+    }
+
+    /// Same EIP-3009 struct on different chains must produce different digests
+    /// (replay protection across chains).
+    #[test]
+    fn transfer_authorization_digest_is_chain_scoped() {
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let nonce = [0x33u8; 32];
+        let mainnet = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        let sepolia = hash_transfer_authorization(
+            &USDC_BASE_SEPOLIA,
+            &from,
+            &to,
+            1_000_000,
+            1_700_000_000,
+            1_700_000_600,
+            &nonce,
+        );
+        assert_ne!(mainnet, sepolia);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_supports_base_mainnet() {
+        let d = usdc_domain_for_chain(&ChainId::base()).unwrap();
+        assert_eq!(d.chain_id, 8453);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_supports_base_sepolia() {
+        let d = usdc_domain_for_chain(&ChainId::base_sepolia()).unwrap();
+        assert_eq!(d.chain_id, 84532);
+    }
+
+    #[test]
+    fn usdc_domain_for_chain_rejects_unsupported() {
+        let eth = ChainId::ethereum();
+        assert!(usdc_domain_for_chain(&eth).is_err());
+    }
+
+    #[test]
+    fn parse_eth_address_accepts_checksummed_and_lowercase() {
+        let a = parse_eth_address("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913").unwrap();
+        let b = parse_eth_address("833589fcd6edb6e08f4c7c32d4f71b54bda02913").unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, USDC_BASE_MAINNET.verifying_contract);
+    }
+
+    #[test]
+    fn parse_eth_address_rejects_wrong_length() {
+        assert!(parse_eth_address("0xdead").is_err());
+    }
+}

--- a/crates/haima/haima-wallet/src/lib.rs
+++ b/crates/haima/haima-wallet/src/lib.rs
@@ -8,9 +8,15 @@
 //! backends (e.g., Coinbase CDP MPC) through the `WalletBackend` trait.
 
 pub mod backend;
+pub mod eip712;
 pub mod evm;
 pub mod signer;
 
 pub use backend::WalletBackend;
+pub use eip712::{
+    Eip712Domain, USDC_BASE_MAINNET, USDC_BASE_SEPOLIA, domain_type_hash,
+    hash_transfer_authorization, parse_eth_address, transfer_with_authorization_typehash,
+    usdc_domain_for_chain,
+};
 pub use evm::{decrypt_private_key, derive_address, encrypt_private_key, generate_keypair};
 pub use signer::LocalSigner;

--- a/crates/haima/haima-wallet/src/signer.rs
+++ b/crates/haima/haima-wallet/src/signer.rs
@@ -8,6 +8,7 @@ use sha3::{Digest, Keccak256};
 use zeroize::Zeroizing;
 
 use crate::backend::WalletBackend;
+use crate::eip712::{hash_transfer_authorization, parse_eth_address, usdc_domain_for_chain};
 use crate::evm::derive_address;
 
 /// A local wallet that signs with an in-memory secp256k1 private key.
@@ -68,20 +69,43 @@ impl WalletBackend for LocalSigner {
 
     async fn sign_transfer_authorization(
         &self,
-        _from: &str,
-        _to: &str,
-        _value: u64,
-        _valid_after: u64,
-        _valid_before: u64,
-        _nonce: &[u8; 32],
+        from: &str,
+        to: &str,
+        value: u64,
+        valid_after: u64,
+        valid_before: u64,
+        nonce: &[u8; 32],
     ) -> HaimaResult<Vec<u8>> {
-        // EIP-3009 transferWithAuthorization signing.
-        // Full implementation requires EIP-712 typed data hashing with the
-        // USDC contract's domain separator. Stubbed for Phase F0 — will be
-        // completed when integrating x402-rs in Phase F1.
-        Err(haima_core::HaimaError::Crypto(
-            "EIP-3009 signing not yet implemented — pending x402-rs integration".into(),
-        ))
+        // Resolve the USDC EIP-712 domain for this signer's chain.
+        let domain = usdc_domain_for_chain(&self.address.chain)?;
+        let from_bytes = parse_eth_address(from)?;
+        let to_bytes = parse_eth_address(to)?;
+
+        let digest = hash_transfer_authorization(
+            &domain,
+            &from_bytes,
+            &to_bytes,
+            value,
+            valid_after,
+            valid_before,
+            nonce,
+        );
+
+        // Recoverable ECDSA over secp256k1 — produces (r, s, recovery_id).
+        // Callers / facilitators reconstruct the signer's address via ecrecover,
+        // so the recovery byte must be present.
+        let (sig, recid) = self
+            .signing_key
+            .sign_prehash_recoverable(&digest)
+            .map_err(|e| haima_core::HaimaError::Crypto(format!("EIP-3009 signing failed: {e}")))?;
+
+        // Concatenate r (32) || s (32) || v (1). Use the legacy v encoding
+        // ({27, 28}) that EIP-3009 verifiers and ecrecover both accept.
+        let rs = sig.to_bytes();
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(rs.as_slice());
+        out.push(recid.to_byte() + 27);
+        Ok(out)
     }
 
     fn backend_type(&self) -> &str {
@@ -92,7 +116,9 @@ impl WalletBackend for LocalSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eip712::{USDC_BASE_MAINNET, hash_transfer_authorization};
     use haima_core::wallet::ChainId;
+    use k256::ecdsa::{RecoveryId, Signature as EcdsaSignature, VerifyingKey};
     use zeroize::Zeroizing;
 
     #[test]
@@ -115,5 +141,99 @@ mod tests {
         let signer = LocalSigner::generate(ChainId::base()).unwrap();
         let sig = signer.sign_message(b"hello haima").await.unwrap();
         assert!(!sig.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_returns_65_byte_recoverable_signature() {
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let from = signer.address().address.clone();
+        let to = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+        let nonce = [0x42u8; 32];
+        let sig = signer
+            .sign_transfer_authorization(&from, to, 1_000_000, 1_700_000_000, 1_700_000_600, &nonce)
+            .await
+            .unwrap();
+        assert_eq!(sig.len(), 65, "recoverable ECDSA is r||s||v = 65 bytes");
+        let v = sig[64];
+        assert!(v == 27 || v == 28, "v must be 27 or 28 (legacy encoding)");
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_round_trips_via_ecrecover() {
+        // This is the functional test: the signature must recover to the
+        // signer's own address. If EIP-712 digest computation, signing, or
+        // v-byte encoding is off, this fails.
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let from = signer.address().address.clone();
+        let to = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+        let nonce = [0x13u8; 32];
+        let value = 50_000u64;
+        let valid_after = 1_700_000_000u64;
+        let valid_before = 1_700_000_600u64;
+
+        let sig_bytes = signer
+            .sign_transfer_authorization(&from, to, value, valid_after, valid_before, &nonce)
+            .await
+            .unwrap();
+
+        let from_bytes = crate::eip712::parse_eth_address(&from).unwrap();
+        let to_bytes = crate::eip712::parse_eth_address(to).unwrap();
+        let digest = hash_transfer_authorization(
+            &USDC_BASE_MAINNET,
+            &from_bytes,
+            &to_bytes,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+
+        let signature = EcdsaSignature::from_slice(&sig_bytes[..64]).unwrap();
+        let recid = RecoveryId::try_from(sig_bytes[64] - 27).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &signature, recid)
+            .expect("signature must recover");
+
+        // Derive EVM address from the recovered public key and compare to the
+        // signer's address. If the digest, signing, or v byte is wrong, this
+        // fails.
+        let pubkey = recovered.to_encoded_point(false);
+        let hash = Keccak256::digest(&pubkey.as_bytes()[1..]);
+        let recovered_address = format!("0x{}", hex::encode(&hash[12..]));
+        assert_eq!(recovered_address.to_lowercase(), from.to_lowercase());
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_rejects_unsupported_chain() {
+        let signer = LocalSigner::generate(ChainId::ethereum()).unwrap();
+        let result = signer
+            .sign_transfer_authorization(
+                "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                100,
+                0,
+                u64::MAX,
+                &[0u8; 32],
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "ethereum mainnet USDC domain not registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_transfer_authorization_rejects_malformed_address() {
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let result = signer
+            .sign_transfer_authorization(
+                "not-an-address",
+                "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                100,
+                0,
+                u64::MAX,
+                &[0u8; 32],
+            )
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/crates/haima/haima-x402/Cargo.toml
+++ b/crates/haima/haima-x402/Cargo.toml
@@ -22,6 +22,8 @@ reqwest.workspace = true
 base64.workspace = true
 url.workspace = true
 hex.workspace = true
+rand.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/haima/haima-x402/Cargo.toml
+++ b/crates/haima/haima-x402/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/haima/haima-x402/src/bazaar.rs
+++ b/crates/haima/haima-x402/src/bazaar.rs
@@ -1,0 +1,386 @@
+//! agentic.market bazaar discovery client.
+//!
+//! The [agentic.market] bazaar is a directory of x402-enabled HTTP endpoints.
+//! It hosts a catalog of services that accept payment via the x402 protocol,
+//! exposed through two simple endpoints:
+//!
+//! - `GET /v1/services` — full catalog
+//! - `GET /v1/services/search?q=…` — BM25 search over the catalog
+//!
+//! The bazaar never touches funds; it is purely a discovery layer. Consumer
+//! wallets sign x402 payment authorizations and send them directly to the
+//! listed services, which settle through whichever facilitator they choose.
+//!
+//! [`BazaarClient`] wraps these endpoints with a TTL cache (default 10 min)
+//! so Haima agents can look up services without hammering the upstream.
+//! Cache is process-local and opt-in per client.
+//!
+//! # Graceful degradation
+//!
+//! - On a cold cache + network failure → [`HaimaError::BazaarUnavailable`].
+//! - On a warm cache + expired TTL + network failure → **stale cache is
+//!   returned** (the `services` endpoint is idempotent and a stale directory
+//!   is strictly better than failing a payment-gated flow).
+//!
+//! [agentic.market]: https://agentic.market
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use haima_core::{HaimaError, HaimaResult};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+/// Default base URL for the agentic.market bazaar.
+pub const DEFAULT_BAZAAR_URL: &str = "https://agentic.market";
+
+/// Default cache TTL (10 minutes).
+pub const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(600);
+
+/// A single x402-enabled service listed in the bazaar.
+///
+/// Fields are `#[serde(default)]` because the upstream schema evolves and we
+/// never want a schema drift to break discovery entirely — unknown fields are
+/// ignored and missing optional ones default sensibly.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ServiceEntry {
+    /// Human-readable service name.
+    pub name: String,
+    /// Base URL or endpoint where a consumer sends the paid request.
+    pub url: String,
+    /// Category tag (e.g., `"inference"`, `"data"`, `"search"`).
+    pub category: String,
+    /// Short description.
+    pub description: String,
+    /// Human-readable price band (e.g., `"$0.001–$0.01"`). Varies in upstream
+    /// representation; kept as a free-form string.
+    pub price_range: String,
+    /// Networks this service accepts payment on (CAIP-2 format when known).
+    pub networks: Vec<String>,
+    /// Payment methods accepted (typically contains `"x402"`).
+    pub payment_methods: Vec<String>,
+}
+
+/// Response envelope for `GET /v1/services` and `/v1/services/search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServicesEnvelope {
+    #[serde(default)]
+    services: Vec<ServiceEntry>,
+}
+
+/// Bazaar client with TTL cache.
+///
+/// Cheap to clone (`Arc` internally) and safe to share across async tasks.
+#[derive(Debug, Clone)]
+pub struct BazaarClient {
+    base_url: String,
+    http: reqwest::Client,
+    cache: Arc<RwLock<CacheState>>,
+    ttl: Duration,
+}
+
+#[derive(Debug, Default)]
+struct CacheState {
+    services: Option<CachedServices>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedServices {
+    data: Vec<ServiceEntry>,
+    fetched_at: Instant,
+}
+
+impl BazaarClient {
+    /// Create a client pointed at the default `https://agentic.market` bazaar
+    /// with a 10-minute cache TTL.
+    pub fn new() -> Self {
+        Self::with_base_url(DEFAULT_BAZAAR_URL)
+    }
+
+    /// Create a client pointed at an arbitrary bazaar URL.
+    pub fn with_base_url(base_url: impl Into<String>) -> Self {
+        Self::builder().base_url(base_url).build()
+    }
+
+    /// Builder for customizing the client.
+    pub fn builder() -> BazaarClientBuilder {
+        BazaarClientBuilder::default()
+    }
+
+    /// List all services advertised by the bazaar.
+    ///
+    /// Serves from cache when fresh (< TTL). On cache miss, fetches from
+    /// the upstream and repopulates the cache. If the upstream fails and
+    /// stale data is available, returns the stale data with a warning.
+    pub async fn services(&self) -> HaimaResult<Vec<ServiceEntry>> {
+        if let Some(fresh) = self.cached_fresh().await {
+            debug!(count = fresh.len(), "bazaar cache hit for /v1/services");
+            return Ok(fresh);
+        }
+
+        match self.fetch_services().await {
+            Ok(services) => {
+                self.store(services.clone()).await;
+                Ok(services)
+            }
+            Err(fetch_err) => {
+                if let Some(stale) = self.cached_any().await {
+                    warn!(
+                        error = %fetch_err,
+                        count = stale.len(),
+                        "bazaar upstream failed, serving stale cache"
+                    );
+                    Ok(stale)
+                } else {
+                    Err(fetch_err)
+                }
+            }
+        }
+    }
+
+    /// Search the bazaar for services matching a query.
+    ///
+    /// Goes directly upstream — search results are not cached (queries are
+    /// unbounded and caching them wastes memory for little hit rate).
+    pub async fn search(&self, q: &str) -> HaimaResult<Vec<ServiceEntry>> {
+        let url = format!("{}/v1/services/search", self.base_url.trim_end_matches('/'));
+        debug!(%url, q, "bazaar search");
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("q", q)])
+            .send()
+            .await
+            .map_err(|e| HaimaError::BazaarUnavailable(format!("search '{q}' failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            return Err(HaimaError::BazaarUnavailable(format!(
+                "search returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let envelope: ServicesEnvelope = resp.json().await.map_err(|e| {
+            HaimaError::BazaarUnavailable(format!("malformed search response: {e}"))
+        })?;
+        Ok(envelope.services)
+    }
+
+    /// Manually invalidate the services cache. Useful for tests and for
+    /// forcing a refresh after a known upstream update.
+    pub async fn invalidate_cache(&self) {
+        let mut guard = self.cache.write().await;
+        guard.services = None;
+    }
+
+    // -- internals --
+
+    async fn fetch_services(&self) -> HaimaResult<Vec<ServiceEntry>> {
+        let url = format!("{}/v1/services", self.base_url.trim_end_matches('/'));
+        debug!(%url, "bazaar fetch");
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HaimaError::BazaarUnavailable(format!("fetch failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            return Err(HaimaError::BazaarUnavailable(format!(
+                "fetch returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let envelope: ServicesEnvelope = resp.json().await.map_err(|e| {
+            HaimaError::BazaarUnavailable(format!("malformed services response: {e}"))
+        })?;
+        Ok(envelope.services)
+    }
+
+    async fn cached_fresh(&self) -> Option<Vec<ServiceEntry>> {
+        let guard = self.cache.read().await;
+        guard.services.as_ref().and_then(|c| {
+            if c.fetched_at.elapsed() < self.ttl {
+                Some(c.data.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    async fn cached_any(&self) -> Option<Vec<ServiceEntry>> {
+        let guard = self.cache.read().await;
+        guard.services.as_ref().map(|c| c.data.clone())
+    }
+
+    async fn store(&self, data: Vec<ServiceEntry>) {
+        let mut guard = self.cache.write().await;
+        guard.services = Some(CachedServices {
+            data,
+            fetched_at: Instant::now(),
+        });
+    }
+}
+
+impl Default for BazaarClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for [`BazaarClient`].
+#[derive(Debug, Default)]
+pub struct BazaarClientBuilder {
+    base_url: Option<String>,
+    ttl: Option<Duration>,
+    http: Option<reqwest::Client>,
+}
+
+impl BazaarClientBuilder {
+    /// Override the base URL (defaults to `https://agentic.market`).
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    /// Override the cache TTL (defaults to 10 minutes).
+    pub fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Inject a custom `reqwest::Client` (useful for tests with custom timeouts).
+    pub fn http(mut self, http: reqwest::Client) -> Self {
+        self.http = Some(http);
+        self
+    }
+
+    /// Finalize the builder.
+    pub fn build(self) -> BazaarClient {
+        BazaarClient {
+            base_url: self.base_url.unwrap_or_else(|| DEFAULT_BAZAAR_URL.into()),
+            http: self.http.unwrap_or_default(),
+            cache: Arc::new(RwLock::new(CacheState::default())),
+            ttl: self.ttl.unwrap_or(DEFAULT_CACHE_TTL),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_entry_parses_minimal_json() {
+        let json = r#"{"name":"Claude","url":"https://api.example.com/claude","category":"inference","description":"","price_range":"$0.001","networks":["eip155:8453"],"payment_methods":["x402"]}"#;
+        let entry: ServiceEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.name, "Claude");
+        assert_eq!(entry.networks, vec!["eip155:8453"]);
+        assert_eq!(entry.payment_methods, vec!["x402"]);
+    }
+
+    #[test]
+    fn service_entry_tolerates_missing_optional_fields() {
+        // Upstream drift: no `networks` or `payment_methods` → defaults to empty.
+        let json = r#"{"name":"X","url":"https://x","category":"other","description":"","price_range":""}"#;
+        let entry: ServiceEntry = serde_json::from_str(json).unwrap();
+        assert!(entry.networks.is_empty());
+        assert!(entry.payment_methods.is_empty());
+    }
+
+    #[test]
+    fn service_entry_tolerates_unknown_fields() {
+        // Upstream drift: new fields we don't know about must not break parsing.
+        let json = r#"{"name":"X","url":"https://x","category":"","description":"","price_range":"","networks":[],"payment_methods":[],"completely_new_field":{"nested":true}}"#;
+        let entry: ServiceEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.name, "X");
+    }
+
+    #[test]
+    fn services_envelope_parses_array() {
+        let json = r#"{"services":[{"name":"A","url":"https://a","category":"","description":"","price_range":"","networks":[],"payment_methods":[]},{"name":"B","url":"https://b","category":"","description":"","price_range":"","networks":[],"payment_methods":[]}]}"#;
+        let envelope: ServicesEnvelope = serde_json::from_str(json).unwrap();
+        assert_eq!(envelope.services.len(), 2);
+    }
+
+    #[test]
+    fn builder_defaults_to_agentic_market() {
+        let c = BazaarClient::new();
+        assert_eq!(c.base_url, DEFAULT_BAZAAR_URL);
+        assert_eq!(c.ttl, DEFAULT_CACHE_TTL);
+    }
+
+    #[test]
+    fn builder_overrides_base_and_ttl() {
+        let c = BazaarClient::builder()
+            .base_url("https://example.test")
+            .ttl(Duration::from_secs(30))
+            .build();
+        assert_eq!(c.base_url, "https://example.test");
+        assert_eq!(c.ttl, Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn cache_is_empty_initially() {
+        let c = BazaarClient::new();
+        assert!(c.cached_fresh().await.is_none());
+        assert!(c.cached_any().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn store_then_cached_fresh_returns_data() {
+        let c = BazaarClient::builder().ttl(Duration::from_secs(60)).build();
+        let entry = ServiceEntry {
+            name: "A".into(),
+            url: "https://a".into(),
+            ..Default::default()
+        };
+        c.store(vec![entry.clone()]).await;
+
+        let got = c.cached_fresh().await.expect("should be fresh");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0], entry);
+    }
+
+    #[tokio::test]
+    async fn cached_fresh_returns_none_after_ttl_expiry() {
+        let c = BazaarClient::builder()
+            .ttl(Duration::from_millis(1))
+            .build();
+        c.store(vec![ServiceEntry::default()]).await;
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        assert!(c.cached_fresh().await.is_none());
+        // But stale data still available for graceful degradation.
+        assert!(c.cached_any().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn invalidate_cache_clears_even_fresh_data() {
+        let c = BazaarClient::builder().ttl(Duration::from_secs(60)).build();
+        c.store(vec![ServiceEntry::default()]).await;
+        assert!(c.cached_fresh().await.is_some());
+
+        c.invalidate_cache().await;
+
+        assert!(c.cached_fresh().await.is_none());
+        assert!(c.cached_any().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn services_returns_bazaar_unavailable_when_cold_and_offline() {
+        // Point at a definitely-dead local port; no cache → must error.
+        let c = BazaarClient::builder()
+            .base_url("http://127.0.0.1:1")
+            .build();
+        let result = c.services().await;
+        match result {
+            Err(HaimaError::BazaarUnavailable(_)) => {}
+            other => panic!("expected BazaarUnavailable, got {other:?}"),
+        }
+    }
+}

--- a/crates/haima/haima-x402/src/client.rs
+++ b/crates/haima/haima-x402/src/client.rs
@@ -20,9 +20,13 @@ use tracing::{debug, info, warn};
 
 use crate::facilitator::{Facilitator, VerifyRequest, VerifyResponse};
 use crate::header::{
-    PaymentRequiredHeader, PaymentResponseHeader, PaymentSignatureHeader, SchemeRequirement,
-    encode_payment_signature, parse_payment_required, parse_payment_response,
+    Eip3009Authorization, PaymentRequiredHeader, PaymentResponseHeader, PaymentSignatureHeader,
+    SchemeRequirement, encode_payment_signature, parse_payment_required, parse_payment_response,
 };
+
+/// Default validity window for signed EIP-3009 authorizations when the
+/// [`SchemeRequirement`] does not set `max_timeout_seconds`.
+const DEFAULT_AUTHORIZATION_WINDOW_SECS: u64 = 600;
 
 /// The result of processing an HTTP 402 response.
 ///
@@ -169,40 +173,70 @@ impl X402Client {
 
     /// Sign a payment for a given scheme requirement.
     ///
-    /// Produces a `PaymentSignatureHeader` ready for encoding and attachment
-    /// to the retry request. This can be called directly when the caller
-    /// has obtained human approval for a `RequiresApproval` decision.
+    /// Produces a `PaymentSignatureHeader` carrying a real EIP-3009
+    /// `transferWithAuthorization` signature plus the authorization payload.
+    /// Callers with an approved `RequiresApproval` decision can invoke this
+    /// directly after getting human sign-off.
+    ///
+    /// # Protocol
+    /// 1. Parse `requirement.amount` as `u64` (USDC's smallest unit).
+    /// 2. Generate a random 32-byte nonce — unique per authorization, so the
+    ///    same agent can submit multiple concurrent payments without collision.
+    /// 3. Set `validAfter = now` and `validBefore = now + max_timeout_seconds`
+    ///    (defaults to 10 minutes).
+    /// 4. Compute the EIP-712 digest and sign it recoverably with the wallet
+    ///    (`WalletBackend::sign_transfer_authorization`).
+    /// 5. Package the 65-byte `(r || s || v)` signature as hex in `payload`
+    ///    and attach the authorization fields so facilitators can reconstruct
+    ///    and verify the digest.
     pub async fn sign_payment(
         &self,
         requirement: &SchemeRequirement,
     ) -> HaimaResult<PaymentSignatureHeader> {
+        use rand::RngCore;
+
         let raw_amount: u64 = requirement.amount.parse().map_err(|e| {
             HaimaError::Protocol(format!("invalid amount '{}': {e}", requirement.amount))
         })?;
 
-        // Sign using EIP-191 personal sign over the payment payload.
-        // The payload is: scheme | network | token | amount | recipient | facilitator
-        // This is a simplified signing scheme. Full EIP-3009 transferWithAuthorization
-        // would use EIP-712 typed data, but that requires the USDC contract's domain
-        // separator which varies by chain. For now we sign a canonical message that
-        // the facilitator can verify.
-        let message = format!(
-            "x402:{}:{}:{}:{}:{}:{}",
-            requirement.scheme,
-            requirement.network,
-            requirement.token,
-            raw_amount,
-            requirement.recipient,
-            requirement.facilitator,
-        );
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let timeout = requirement
+            .max_timeout_seconds
+            .unwrap_or(DEFAULT_AUTHORIZATION_WINDOW_SECS);
+        let valid_after = now;
+        let valid_before = now.saturating_add(timeout);
 
-        let signature = self.wallet.sign_message(message.as_bytes()).await?;
-        let payload = hex::encode(&signature);
+        let mut nonce = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut nonce);
+
+        let from = self.wallet.address().address.clone();
+        let signature = self
+            .wallet
+            .sign_transfer_authorization(
+                &from,
+                &requirement.recipient,
+                raw_amount,
+                valid_after,
+                valid_before,
+                &nonce,
+            )
+            .await?;
 
         Ok(PaymentSignatureHeader {
             scheme: requirement.scheme.clone(),
             network: requirement.network.clone(),
-            payload,
+            payload: hex::encode(&signature),
+            authorization: Some(Eip3009Authorization {
+                from,
+                to: requirement.recipient.clone(),
+                value: raw_amount.to_string(),
+                valid_after: valid_after.to_string(),
+                valid_before: valid_before.to_string(),
+                nonce: format!("0x{}", hex::encode(nonce)),
+            }),
         })
     }
 
@@ -294,14 +328,19 @@ mod tests {
         X402Client::new(Arc::new(signer), facilitator, PaymentPolicy::default())
     }
 
+    /// Arbitrary valid checksummed 20-byte address used by tests that need a
+    /// parseable recipient (EIP-3009 signing rejects non-hex recipients).
+    const TEST_RECIPIENT: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
     fn sample_requirement() -> SchemeRequirement {
         SchemeRequirement {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into(),
             amount: "50".into(), // 50 micro-credits, below auto-approve cap of 100
-            recipient: "0xrecipient".into(),
+            recipient: TEST_RECIPIENT.into(),
             facilitator: "https://x402.org/facilitator".into(),
+            max_timeout_seconds: None,
         }
     }
 
@@ -312,8 +351,9 @@ mod tests {
                 network: "eip155:8453".into(),
                 token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into(),
                 amount: amount.into(),
-                recipient: "0xrecipient".into(),
+                recipient: TEST_RECIPIENT.into(),
                 facilitator: "https://x402.org/facilitator".into(),
+                max_timeout_seconds: None,
             }],
             version: "v2".into(),
         }
@@ -416,6 +456,7 @@ mod tests {
                 amount: "50".into(),
                 recipient: "SoLaNaAddr".into(),
                 facilitator: "https://x402.org/facilitator".into(),
+                max_timeout_seconds: None,
             }],
             version: "v2".into(),
         };
@@ -455,6 +496,65 @@ mod tests {
         assert_eq!(decoded, sig);
     }
 
+    #[tokio::test]
+    async fn sign_payment_populates_eip3009_authorization() {
+        let client = test_client();
+        let requirement = sample_requirement();
+
+        let sig = client.sign_payment(&requirement).await.unwrap();
+
+        let auth = sig
+            .authorization
+            .expect("EIP-3009 authorization must be present");
+        assert_eq!(auth.to.to_lowercase(), TEST_RECIPIENT.to_lowercase());
+        assert_eq!(auth.value, "50");
+        assert!(auth.from.starts_with("0x"));
+        assert!(auth.nonce.starts_with("0x") && auth.nonce.len() == 66);
+        // valid_before > valid_after by the default window
+        let after: u64 = auth.valid_after.parse().unwrap();
+        let before: u64 = auth.valid_before.parse().unwrap();
+        assert!(before > after);
+        assert_eq!(before - after, 600);
+    }
+
+    #[tokio::test]
+    async fn sign_payment_generates_unique_nonce_per_call() {
+        let client = test_client();
+        let requirement = sample_requirement();
+
+        let sig1 = client.sign_payment(&requirement).await.unwrap();
+        let sig2 = client.sign_payment(&requirement).await.unwrap();
+
+        let nonce1 = sig1.authorization.unwrap().nonce;
+        let nonce2 = sig2.authorization.unwrap().nonce;
+        assert_ne!(nonce1, nonce2, "each signature must use a fresh nonce");
+    }
+
+    #[tokio::test]
+    async fn sign_payment_produces_65_byte_recoverable_signature() {
+        let client = test_client();
+        let requirement = sample_requirement();
+
+        let sig = client.sign_payment(&requirement).await.unwrap();
+        let raw = hex::decode(&sig.payload).unwrap();
+        assert_eq!(raw.len(), 65);
+        let v = raw[64];
+        assert!(v == 27 || v == 28);
+    }
+
+    #[tokio::test]
+    async fn sign_payment_honors_custom_timeout() {
+        let client = test_client();
+        let mut requirement = sample_requirement();
+        requirement.max_timeout_seconds = Some(60);
+
+        let sig = client.sign_payment(&requirement).await.unwrap();
+        let auth = sig.authorization.unwrap();
+        let after: u64 = auth.valid_after.parse().unwrap();
+        let before: u64 = auth.valid_before.parse().unwrap();
+        assert_eq!(before - after, 60);
+    }
+
     // -- select_scheme tests --
 
     #[test]
@@ -468,6 +568,7 @@ mod tests {
                     amount: "100".into(),
                     recipient: "0xrecip".into(),
                     facilitator: "https://example.com".into(),
+                    max_timeout_seconds: None,
                 },
                 SchemeRequirement {
                     scheme: "exact".into(),
@@ -476,6 +577,7 @@ mod tests {
                     amount: "100".into(),
                     recipient: "0xrecip".into(),
                     facilitator: "https://example.com".into(),
+                    max_timeout_seconds: None,
                 },
             ],
             version: "v2".into(),
@@ -495,6 +597,7 @@ mod tests {
                 amount: "100".into(),
                 recipient: "SoLaNa".into(),
                 facilitator: "https://example.com".into(),
+                max_timeout_seconds: None,
             }],
             version: "v2".into(),
         };

--- a/crates/haima/haima-x402/src/facilitator.rs
+++ b/crates/haima/haima-x402/src/facilitator.rs
@@ -598,6 +598,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: hex::encode([0xabu8; 64]),
+            authorization: None,
         };
         encode_payment_signature(&sig).unwrap()
     }
@@ -647,6 +648,7 @@ mod tests {
             scheme: "streaming".into(),
             network: "eip155:8453".into(),
             payload: hex::encode([0xabu8; 64]),
+            authorization: None,
         };
         let header = encode_payment_signature(&sig).unwrap();
 
@@ -668,6 +670,7 @@ mod tests {
             scheme: "exact".into(),
             network: "solana:mainnet".into(),
             payload: hex::encode([0xabu8; 64]),
+            authorization: None,
         };
         let header = encode_payment_signature(&sig).unwrap();
 
@@ -689,6 +692,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: String::new(),
+            authorization: None,
         };
         let header = encode_payment_signature(&sig).unwrap();
 
@@ -710,6 +714,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: hex::encode([0xabu8; 10]), // Too short
+            authorization: None,
         };
         let header = encode_payment_signature(&sig).unwrap();
 
@@ -732,6 +737,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: "not-valid-hex!@#$".into(),
+            authorization: None,
         };
         let header = encode_payment_signature(&sig).unwrap();
 

--- a/crates/haima/haima-x402/src/header.rs
+++ b/crates/haima/haima-x402/src/header.rs
@@ -51,6 +51,9 @@ pub struct SchemeRequirement {
     pub recipient: String,
     /// Facilitator URL.
     pub facilitator: String,
+    /// Seconds of validity for the signed authorization. Defaults to 600 (10 min).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_timeout_seconds: Option<u64>,
 }
 
 /// Payment signature sent with a retry request.
@@ -63,8 +66,37 @@ pub struct PaymentSignatureHeader {
     pub scheme: String,
     /// Network in CAIP-2 format.
     pub network: String,
-    /// The cryptographic payload (hex-encoded signed authorization).
+    /// The cryptographic payload — hex-encoded (r || s || v) recoverable ECDSA
+    /// signature over the EIP-712 digest of [`authorization`](Self::authorization).
     pub payload: String,
+    /// EIP-3009 authorization context that the signature authorizes.
+    ///
+    /// Absent for legacy EIP-191 canonical-string signatures produced before
+    /// Phase F1. Facilitators reject authorizations that do not match the
+    /// signed digest when this field is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<Eip3009Authorization>,
+}
+
+/// EIP-3009 `TransferWithAuthorization` fields carried alongside the signature.
+///
+/// Uses string encoding for `uint256` values to avoid JSON precision issues and
+/// hex encoding for addresses and nonces to match the x402 on-wire format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Eip3009Authorization {
+    /// Payer address (`0x`-prefixed hex).
+    pub from: String,
+    /// Recipient address (`0x`-prefixed hex).
+    pub to: String,
+    /// Token amount in smallest unit (decimal string).
+    pub value: String,
+    /// Unix timestamp when the authorization becomes valid (decimal string).
+    pub valid_after: String,
+    /// Unix timestamp when the authorization expires (decimal string).
+    pub valid_before: String,
+    /// 32-byte nonce (`0x`-prefixed hex, 66 chars total).
+    pub nonce: String,
 }
 
 /// Settlement confirmation from a 200 response.
@@ -175,6 +207,7 @@ mod tests {
                 amount: "10000".into(),
                 recipient: "0xrecipient".into(),
                 facilitator: "https://x402.org/facilitator".into(),
+                max_timeout_seconds: None,
             }],
             version: "v2".into(),
         }
@@ -199,6 +232,7 @@ mod tests {
                     amount: "10000".into(),
                     recipient: "0xrecipient".into(),
                     facilitator: "https://x402.org/facilitator".into(),
+                    max_timeout_seconds: None,
                 },
                 SchemeRequirement {
                     scheme: "exact".into(),
@@ -207,6 +241,7 @@ mod tests {
                     amount: "10000".into(),
                     recipient: "0xrecipient".into(),
                     facilitator: "https://x402.org/facilitator".into(),
+                    max_timeout_seconds: None,
                 },
             ],
             version: "v2".into(),
@@ -249,6 +284,7 @@ mod tests {
             scheme: "exact".into(),
             network: "eip155:8453".into(),
             payload: "0xdeadbeef1234567890abcdef".into(),
+            authorization: None,
         }
     }
 

--- a/crates/haima/haima-x402/src/lib.rs
+++ b/crates/haima/haima-x402/src/lib.rs
@@ -19,11 +19,13 @@
 //!   -> Receive 200 + PAYMENT-RESPONSE header (settlement confirmation)
 //! ```
 
+pub mod bazaar;
 pub mod client;
 pub mod facilitator;
 pub mod header;
 pub mod server;
 
+pub use bazaar::{BazaarClient, BazaarClientBuilder, DEFAULT_BAZAAR_URL, ServiceEntry};
 pub use client::{HandleResult, SettlementResult, X402Client};
 pub use facilitator::{
     DEFAULT_FEE_BPS, FacilitateRequest, FacilitateResponse, FacilitationStatus, Facilitator,
@@ -31,9 +33,9 @@ pub use facilitator::{
     verify_payment_header,
 };
 pub use header::{
-    PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER, PAYMENT_SIGNATURE_HEADER,
-    PaymentRequiredHeader, PaymentResponseHeader, PaymentSignatureHeader, SchemeRequirement,
-    encode_payment_required, encode_payment_response, encode_payment_signature,
+    Eip3009Authorization, PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER,
+    PAYMENT_SIGNATURE_HEADER, PaymentRequiredHeader, PaymentResponseHeader, PaymentSignatureHeader,
+    SchemeRequirement, encode_payment_required, encode_payment_response, encode_payment_signature,
     parse_payment_required, parse_payment_response, parse_payment_signature,
 };
 pub use server::X402ServerMiddleware;

--- a/crates/haima/haima-x402/tests/e2e_smoke.rs
+++ b/crates/haima/haima-x402/tests/e2e_smoke.rs
@@ -1,0 +1,283 @@
+//! End-to-end smoke test for the full x402 payment flow.
+//!
+//! Boots a [`wiremock`] server that plays the role of a paid API, runs the
+//! Haima [`X402Client`] against it through the complete protocol loop, and
+//! asserts that the in-process facilitator produces a settlement receipt.
+//!
+//! No real mainnet, no real chain — the facilitator's on-chain submission is
+//! already stubbed in F0 (`verify_payment_header` returns a deterministic tx
+//! hash derived from the signature bytes). When F4 ships real RPC-backed
+//! settlement, this same test can be extended with a chain mock.
+//!
+//! These tests exercise real header encoding, real signing, real policy, and
+//! real facilitator verification logic — only the upstream API and the chain
+//! are mocked.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use haima_core::payment::PaymentDecision;
+use haima_core::policy::PaymentPolicy;
+use haima_core::wallet::ChainId;
+use haima_wallet::LocalSigner;
+use haima_x402::facilitator::{
+    DEFAULT_FEE_BPS, FacilitateRequest, FacilitationStatus, Facilitator, FacilitatorConfig,
+    FacilitatorStatsCounter, verify_payment_header,
+};
+use haima_x402::header::{
+    PaymentRequiredHeader, PaymentResponseHeader, SchemeRequirement, encode_payment_required,
+    encode_payment_response,
+};
+use haima_x402::{PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER, X402Client};
+use wiremock::matchers::{header_exists, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_RECIPIENT: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+const USDC_BASE_MAINNET: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+/// Build a test `X402Client` with a freshly-generated wallet on Base mainnet
+/// and the default `https://x402.org/facilitator` config (not contacted in
+/// these tests — settlement uses the in-process `verify_payment_header`).
+fn make_client() -> X402Client {
+    let signer = LocalSigner::generate(ChainId::base()).expect("signer");
+    let facilitator = Facilitator::new(FacilitatorConfig::default());
+    X402Client::new(Arc::new(signer), facilitator, PaymentPolicy::default())
+}
+
+fn requirement(amount: &str) -> SchemeRequirement {
+    SchemeRequirement {
+        scheme: "exact".into(),
+        network: "eip155:8453".into(),
+        token: USDC_BASE_MAINNET.into(),
+        amount: amount.into(),
+        recipient: TEST_RECIPIENT.into(),
+        facilitator: "https://x402.org/facilitator".into(),
+        max_timeout_seconds: Some(300),
+    }
+}
+
+fn payment_required_header(amount: &str) -> String {
+    let header = PaymentRequiredHeader {
+        schemes: vec![requirement(amount)],
+        version: "v2".into(),
+    };
+    encode_payment_required(&header).expect("encode header")
+}
+
+/// Full golden-path: 402 → parse → policy-approve → sign → retry → 200 + receipt.
+#[tokio::test]
+async fn e2e_auto_approved_payment_flow_succeeds() {
+    let server = MockServer::start().await;
+    let client = make_client();
+
+    // Stage 1: unauthenticated GET returns 402 with PAYMENT-REQUIRED.
+    Mock::given(method("GET"))
+        .and(path("/api/data"))
+        .respond_with(
+            ResponseTemplate::new(402)
+                .insert_header(PAYMENT_REQUIRED_HEADER, payment_required_header("50")),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Stage 2: authenticated GET (with PAYMENT-SIGNATURE) returns 200 +
+    // PAYMENT-RESPONSE. We don't need to verify the signature server-side in
+    // wiremock — the facilitator does that below.
+    let fake_response = PaymentResponseHeader {
+        tx_hash: "0xdeadbeef".into(),
+        network: "eip155:8453".into(),
+        settled: true,
+    };
+    let encoded_response = encode_payment_response(&fake_response).expect("encode response");
+    Mock::given(method("GET"))
+        .and(path("/api/data"))
+        .and(header_exists("payment-signature"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header(PAYMENT_RESPONSE_HEADER, encoded_response)
+                .set_body_string("{\"data\":\"ok\"}"),
+        )
+        .mount(&server)
+        .await;
+
+    // --- Drive the protocol ---
+    let http = reqwest::Client::new();
+    let url = format!("{}/api/data", server.uri());
+
+    let r1 = http.get(&url).send().await.expect("first request");
+    assert_eq!(r1.status(), 402);
+    let required = r1
+        .headers()
+        .get(PAYMENT_REQUIRED_HEADER)
+        .expect("402 must carry payment-required")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let handled = client
+        .handle_402(&url, &required)
+        .await
+        .expect("handle_402");
+    assert!(matches!(handled.decision, PaymentDecision::Approved { .. }));
+    let signature_header = handled
+        .signature_header
+        .expect("auto-approved decision must produce a signed header");
+
+    let r2 = http
+        .get(&url)
+        .header("payment-signature", &signature_header)
+        .send()
+        .await
+        .expect("retry request");
+    assert_eq!(r2.status(), 200);
+    let returned = r2
+        .headers()
+        .get(PAYMENT_RESPONSE_HEADER)
+        .expect("200 must carry payment-response");
+    let parsed = client
+        .parse_settlement_response(returned.to_str().unwrap())
+        .expect("parse settlement");
+    assert!(parsed.settled);
+    assert_eq!(parsed.tx_hash, "0xdeadbeef");
+
+    // --- Verify the signed authorization through the in-process facilitator ---
+    let stats = FacilitatorStatsCounter::new();
+    let facilitate_req = FacilitateRequest {
+        payment_header: signature_header,
+        resource_url: url.clone(),
+        amount_micro_usd: 50,
+        agent_id: None,
+    };
+    let resp = verify_payment_header(&facilitate_req, DEFAULT_FEE_BPS, &stats);
+    assert_eq!(resp.status, FacilitationStatus::Settled);
+    let receipt = resp.receipt.expect("settled → receipt");
+    assert_eq!(receipt.amount_micro_usd, 50);
+    assert_eq!(receipt.chain, "base");
+    assert!(receipt.tx_hash.starts_with("0x"));
+    assert_eq!(stats.snapshot().total_transactions, 1);
+}
+
+/// Amount above the hard cap → decision is Denied, no signing, no retry.
+#[tokio::test]
+async fn e2e_policy_denial_blocks_payment() {
+    let client = make_client();
+
+    // 2_000_000 micro-credits exceeds the default 1_000_000 hard cap.
+    let required = payment_required_header("2000000");
+    let handled = client
+        .handle_402("https://api.example.com/data", &required)
+        .await
+        .expect("handle_402");
+    assert!(matches!(handled.decision, PaymentDecision::Denied { .. }));
+    assert!(handled.signature_header.is_none());
+}
+
+/// Malformed `payment-required` header surfaces an error instead of silently
+/// signing. Important: silent failure here would let an attacker redirect
+/// payment elsewhere.
+#[tokio::test]
+async fn e2e_malformed_402_header_surfaces_error() {
+    let client = make_client();
+    let result = client
+        .handle_402("https://api.example.com/data", "not-valid-base64!!!")
+        .await;
+    assert!(result.is_err(), "malformed 402 header must not be ignored");
+}
+
+/// If the in-process facilitator rejects the signature (e.g., tampered
+/// payload), the rejection propagates with a structured reason.
+#[tokio::test]
+async fn e2e_facilitator_rejection_propagates() {
+    use haima_x402::header::{PaymentSignatureHeader, encode_payment_signature};
+
+    // Craft a header that looks syntactically valid but carries a too-short
+    // signature (facilitator validates sig length >= 64 bytes).
+    let tampered = PaymentSignatureHeader {
+        scheme: "exact".into(),
+        network: "eip155:8453".into(),
+        payload: hex::encode([0xabu8; 10]),
+        authorization: None,
+    };
+    let encoded = encode_payment_signature(&tampered).expect("encode");
+    let stats = FacilitatorStatsCounter::new();
+    let resp = verify_payment_header(
+        &FacilitateRequest {
+            payment_header: encoded,
+            resource_url: "https://api.example.com/data".into(),
+            amount_micro_usd: 50,
+            agent_id: None,
+        },
+        DEFAULT_FEE_BPS,
+        &stats,
+    );
+    assert_eq!(resp.status, FacilitationStatus::Rejected);
+    assert_eq!(
+        resp.reason.as_deref(),
+        Some("invalid_signature"),
+        "reason should identify the failure class"
+    );
+    assert_eq!(stats.snapshot().total_rejected, 1);
+}
+
+/// Sanity check: the happy-path flow completes well under the 3s budget
+/// called out in BRO-758. Duplicates the body of the golden-path test rather
+/// than calling it, because `#[tokio::test]`-decorated fns are not
+/// `async fn`s from the caller's perspective.
+#[tokio::test]
+async fn e2e_smoke_runs_quickly() {
+    let start = std::time::Instant::now();
+
+    let server = MockServer::start().await;
+    let client = make_client();
+
+    Mock::given(method("GET"))
+        .and(path("/api/data"))
+        .respond_with(
+            ResponseTemplate::new(402)
+                .insert_header(PAYMENT_REQUIRED_HEADER, payment_required_header("50")),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    let fake_response = PaymentResponseHeader {
+        tx_hash: "0xdeadbeef".into(),
+        network: "eip155:8453".into(),
+        settled: true,
+    };
+    let encoded_response = encode_payment_response(&fake_response).expect("encode response");
+    Mock::given(method("GET"))
+        .and(path("/api/data"))
+        .and(header_exists("payment-signature"))
+        .respond_with(
+            ResponseTemplate::new(200).insert_header(PAYMENT_RESPONSE_HEADER, encoded_response),
+        )
+        .mount(&server)
+        .await;
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/api/data", server.uri());
+    let r1 = http.get(&url).send().await.expect("first");
+    let required = r1
+        .headers()
+        .get(PAYMENT_REQUIRED_HEADER)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let handled = client.handle_402(&url, &required).await.expect("handle");
+    let sig = handled.signature_header.expect("signed");
+    let _r2 = http
+        .get(&url)
+        .header("payment-signature", &sig)
+        .send()
+        .await
+        .expect("retry");
+
+    assert!(
+        start.elapsed() < Duration::from_secs(3),
+        "e2e smoke should be fast (no real network/chain); took {:?}",
+        start.elapsed()
+    );
+}

--- a/crates/lago/lago-knowledge/src/event_index.rs
+++ b/crates/lago/lago-knowledge/src/event_index.rs
@@ -412,7 +412,7 @@ mod tests {
         let idx = EventSearchIndex::build(entries);
 
         let results = idx.search("deployment production", 10);
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
         // Both deployment-related entries from different sessions
         let sessions: Vec<&str> = results.iter().map(|r| r.session_id.as_str()).collect();
         assert!(sessions.contains(&"session-A") || sessions.contains(&"session-B"));


### PR DESCRIPTION
## Summary

Phase F1 Part 3 — stacked on #851. Adds an end-to-end smoke test that exercises the complete x402 protocol loop against a wiremock server, and rolls up Phase F1 status in \`haima/CLAUDE.md\`.

**Linear:** [BRO-758](https://linear.app/broomva/issue/BRO-758) (blocked-by BRO-757)
**Stack:** #850 → #851 → **this**

> **Note:** this PR targets \`bro-757-wire-bazaar\`. After #851 merges, the base will auto-update to \`main\`.

## E2E tests (5, < 150 ms total)

New \`haima-x402/tests/e2e_smoke.rs\` — boots a [wiremock](https://github.com/LukeMathWalker/wiremock-rs) server and drives the full protocol loop end-to-end:

| Test | Scenario |
|------|----------|
| \`e2e_auto_approved_payment_flow_succeeds\` | Golden path: 402 → parse → approve → sign EIP-3009 → retry → 200 + receipt |
| \`e2e_policy_denial_blocks_payment\` | Amount above hard cap → Denied, no signing |
| \`e2e_malformed_402_header_surfaces_error\` | Defensive: malformed header must error, not silently ignored |
| \`e2e_facilitator_rejection_propagates\` | Tampered signature → structured \`invalid_signature\` rejection |
| \`e2e_smoke_runs_quickly\` | Enforces < 3s budget; actual ~150 ms |

**Real components exercised:** header encode/decode, EIP-3009 signing, policy evaluation, facilitator verification logic.
**Mocked:** upstream API (wiremock), on-chain settlement (stubbed in F0; F4 adds real RPC).

New dev-dep: \`wiremock = \"0.6\"\` — already used in \`arcan-aios-adapters\` and \`arcan-tui\`, no new crate for the workspace.

## Docs roll-up

\`haima/CLAUDE.md\`:
- Phase status: \`F1 → IN PROGRESS\` (with BRO-756/757/758 checklist)
- Test counts refreshed: wallet 23 (+12 EIP-712 + 4 EIP-3009), x402 61 unit + 5 e2e
- Known Gaps section updated for post-F1-first-pass state (F2 ledger wiring, F3 server middleware, F4 on-chain RPC still outstanding)

## Test plan

- [x] \`cargo test -p haima-x402 --test e2e_smoke\` — 5 pass (0.15s)
- [x] \`cargo test -p haima-x402\` — 66 total pass (61 unit + 5 e2e)
- [x] \`cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments\` — clean
- [x] \`cargo fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented EIP-3009 transfer authorization signing for USDC payments, enabling secure pre-authorized transfers with cryptographic validation.
  * Added bazaar service discovery with TTL caching, search functionality, and graceful fallback during network unavailability.
  * Payment authorizations now include timestamp-based validity windows and unique nonces.

* **Tests**
  * Added end-to-end payment flow smoke tests covering successful payments, policy denials, malformed headers, and facilitator rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->