### PR TITLE
feat(arcan-prosopon): emit Arcan session through Prosopon (BRO-773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `arcan-prosopon` — Pneuma<L0ToExternal> bridge. Subscribes to KernelRuntime
+  events, translates to ProsoponEvents, publishes to prosopon-daemon fanout.
+  Opt-in via `cargo run -p arcan --features prosopon --prosopon-port <addr>`.
+  (BRO-773)
+
 ## 0.2.0
 
 - 1077/1077 tests passing, 37 crates, ~43K LOC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcan-prosopon"
+version = "0.1.0"
+dependencies = [
+ "aios-protocol",
+ "anyhow",
+ "chrono",
+ "prosopon-core",
+ "prosopon-daemon",
+ "prosopon-protocol",
+ "prosopon-runtime",
+ "prosopon-sdk",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "arcan-provider"
 version = "0.3.0"
 dependencies = [
@@ -1569,6 +1587,7 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1587,8 +1606,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1948,6 +1969,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -4175,6 +4197,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6335,7 +6376,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "toml",
  "tower-http",
  "tracing",
@@ -6924,6 +6965,88 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "prosopon-core"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "indexmap 2.13.1",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "prosopon-daemon"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "axum 0.8.8",
+ "clap",
+ "futures",
+ "include_dir",
+ "mime_guess",
+ "prosopon-core",
+ "prosopon-protocol",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "prosopon-protocol"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "prosopon-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "prosopon-runtime"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures",
+ "indexmap 2.13.1",
+ "prosopon-core",
+ "prosopon-protocol",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "prosopon-sdk"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "prosopon-core",
+ "prosopon-protocol",
+ "prosopon-runtime",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -7855,9 +7978,11 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "indexmap 2.13.1",
  "schemars_derive 0.8.22",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -8941,6 +9066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9205,7 +9340,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -9573,6 +9720,23 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "arcan-lago",
  "arcan-opsis",
  "arcan-praxis",
+ "arcan-prosopon",
  "arcan-provider",
  "arcan-provider-bubblewrap",
  "arcan-provider-local",
@@ -355,6 +356,8 @@ dependencies = [
  "praxis-mcp-bridge",
  "praxis-skills",
  "praxis-tools",
+ "prosopon-compositor-glass",
+ "prosopon-daemon",
  "reqwest",
  "reqwest-eventsource",
  "serde",
@@ -6965,6 +6968,25 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "prosopon-compositor-glass"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "include_dir",
+ "prosopon-core",
+ "prosopon-daemon",
+ "prosopon-protocol",
+ "prosopon-runtime",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6973,6 +6973,7 @@ dependencies = [
 [[package]]
 name = "prosopon-compositor-glass"
 version = "0.2.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "anyhow",
  "clap",
@@ -6992,6 +6993,7 @@ dependencies = [
 [[package]]
 name = "prosopon-core"
 version = "0.1.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "chrono",
  "indexmap 2.13.1",
@@ -7006,6 +7008,7 @@ dependencies = [
 [[package]]
 name = "prosopon-daemon"
 version = "0.2.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7030,6 +7033,7 @@ dependencies = [
 [[package]]
 name = "prosopon-protocol"
 version = "0.1.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "chrono",
  "prosopon-core",
@@ -7042,6 +7046,7 @@ dependencies = [
 [[package]]
 name = "prosopon-runtime"
 version = "0.1.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "chrono",
  "futures",
@@ -7060,6 +7065,7 @@ dependencies = [
 [[package]]
 name = "prosopon-sdk"
 version = "0.1.0"
+source = "git+https://github.com/broomva/prosopon.git?tag=v0.2.0-alpha.2#e669d2f794ddef49a603178d05827efdfafc25a9"
 dependencies = [
  "chrono",
  "prosopon-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/arcan/arcan-lago",
     "crates/arcan/arcan-opsis",
     "crates/arcan/arcan-praxis",
+    "crates/arcan/arcan-prosopon",
     "crates/arcan/arcan-provider",
     "crates/arcan/arcan-provider-bubblewrap",
     "crates/arcan/arcan-provider-local",

--- a/crates/arcan/arcan-prosopon/Cargo.toml
+++ b/crates/arcan/arcan-prosopon/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "arcan-prosopon"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+license = "Apache-2.0"
+description = "Pneuma<L0ToExternal> for Arcan — emits ProsoponEvents from the runtime's event stream."
+repository = "https://github.com/broomva/life"
+
+[dependencies]
+prosopon-core     = { path = "../../../../prosopon/crates/prosopon-core" }
+prosopon-protocol = { path = "../../../../prosopon/crates/prosopon-protocol" }
+prosopon-sdk      = { path = "../../../../prosopon/crates/prosopon-sdk" }
+prosopon-daemon   = { path = "../../../../prosopon/crates/prosopon-daemon" }
+
+aios-protocol = { path = "../../aios/aios-protocol" }
+
+tokio     = { workspace = true, features = ["sync", "rt", "macros"] }
+tracing   = { workspace = true }
+thiserror = { workspace = true }
+anyhow    = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/arcan/arcan-prosopon/Cargo.toml
+++ b/crates/arcan/arcan-prosopon/Cargo.toml
@@ -20,6 +20,7 @@ tracing   = { workspace = true }
 thiserror = { workspace = true }
 anyhow    = { workspace = true }
 serde_json = { workspace = true }
+chrono    = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/arcan/arcan-prosopon/Cargo.toml
+++ b/crates/arcan/arcan-prosopon/Cargo.toml
@@ -24,3 +24,4 @@ chrono    = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+prosopon-runtime = { path = "../../../../prosopon/crates/prosopon-runtime" }

--- a/crates/arcan/arcan-prosopon/Cargo.toml
+++ b/crates/arcan/arcan-prosopon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arcan-prosopon"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version.workspace = true
 license = "Apache-2.0"
 description = "Pneuma<L0ToExternal> for Arcan — emits ProsoponEvents from the runtime's event stream."
 repository = "https://github.com/broomva/life"

--- a/crates/arcan/arcan-prosopon/Cargo.toml
+++ b/crates/arcan/arcan-prosopon/Cargo.toml
@@ -8,10 +8,14 @@ description = "Pneuma<L0ToExternal> for Arcan — emits ProsoponEvents from the 
 repository = "https://github.com/broomva/life"
 
 [dependencies]
-prosopon-core     = { path = "../../../../prosopon/crates/prosopon-core" }
-prosopon-protocol = { path = "../../../../prosopon/crates/prosopon-protocol" }
-prosopon-sdk      = { path = "../../../../prosopon/crates/prosopon-sdk" }
-prosopon-daemon   = { path = "../../../../prosopon/crates/prosopon-daemon" }
+# Prosopon crates pinned to the v0.2.0-alpha.2 git tag so CI can resolve them
+# without needing the sibling `core/prosopon/` workspace to be checked out.
+# Local devs can override with a `[patch."https://github.com/broomva/prosopon.git"]`
+# block in their own .cargo/config.toml pointing at a local path clone.
+prosopon-core     = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2" }
+prosopon-protocol = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2" }
+prosopon-sdk      = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2" }
+prosopon-daemon   = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2" }
 
 aios-protocol = { path = "../../aios/aios-protocol" }
 
@@ -24,4 +28,4 @@ chrono    = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
-prosopon-runtime = { path = "../../../../prosopon/crates/prosopon-runtime" }
+prosopon-runtime = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2" }

--- a/crates/arcan/arcan-prosopon/README.md
+++ b/crates/arcan/arcan-prosopon/README.md
@@ -6,5 +6,71 @@
 `prosopon_daemon::EnvelopeFanout` for downstream compositors (text, glass,
 field, …).
 
-Full design: [`docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md`](../../../docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md).
-Linear: [BRO-773](https://linear.app/broomva/issue/BRO-773).
+## Architecture
+
+```
+KernelRuntime::subscribe_events()                   <- tokio::broadcast<EventRecord>
+        │
+        ▼
+translator::translate(&mut state, &record.kind) -> Vec<ProsoponEvent>
+        │
+        ▼
+prosopon_sdk::Session::envelope(event) -> Envelope
+        │
+        ▼
+EnvelopeFanout::send(envelope)                      -> fan out to compositors
+```
+
+`Bridge` is producer-only. A caller (e.g. `arcan` binary with `--features prosopon`) constructs the fanout + daemon and hands it to `ArcanProsoponBridge::new(fanout).spawn(events)`; the spawned task exits cleanly when the upstream broadcast closes.
+
+## Public API
+
+```rust
+use arcan_prosopon::{ArcanProsoponBridge, TranslationState, BridgeError};
+use prosopon_daemon::EnvelopeFanout;
+use tokio::sync::broadcast;
+
+let fanout = EnvelopeFanout::new();
+let bridge = ArcanProsoponBridge::new(fanout);
+let handle = bridge.spawn(event_rx);   // event_rx: broadcast::Receiver<aios_protocol::EventRecord>
+```
+
+## Translation table
+
+| `EventKind` (aios-protocol) | `ProsoponEvent`(s) emitted |
+|---|---|
+| `SessionCreated { name }` | `SceneReset { scene }` — root node has stable id `"session-root"` |
+| `RunStarted` | 3× `SignalChanged` — `run.status`, `run.provider`, `run.max_iterations` |
+| `RunErrored { error }` | `NodeAdded` error prose + `SignalChanged { topic: "run.status", value: "errored" }` |
+| `UserMessage { content }` | `NodeAdded` section("User") > prose |
+| `AssistantTextDelta` / `TextDelta { delta, index }` | First delta per iteration: `NodeAdded` `Intent::Stream` + `StreamChunk`. Subsequent deltas: `StreamChunk` only (monotonic per-stream `seq`) |
+| `AssistantMessageCommitted` / `Message { content }` | `NodeAdded` section("Assistant") > prose |
+| `ToolCallRequested { call_id, tool_name, arguments }` | `NodeAdded` `Intent::ToolCall` with stable id `tool:{call_id}` |
+| `ToolCallCompleted { call_id, result, status }` | `NodeUpdated` — appends `Intent::ToolResult` child. Orphan events (no `call_id`) are dropped. |
+| `ToolCallFailed { call_id, error }` | `NodeUpdated` — appends `Intent::ToolResult { success: false, payload: {"error": …} }` |
+| `ApprovalRequested { risk, .. }` | `NodeAdded` `Intent::Confirm` with mapped `Severity` |
+| `ApprovalResolved { decision }` | `NodeUpdated` lifecycle → `Resolved` + `SignalChanged { topic: approval.{id}, value: decision }` |
+| `StatePatched { revision }` | `SignalChanged { topic: state.revision }` |
+| `ContextCompacted { tokens_before, tokens_after }` | `SignalChanged { topic: context.tokens }` + low-emphasis prose node |
+| `StepStarted { index }` | `SignalChanged { topic: iteration }` |
+| `PolicyEvaluated { tool_name, decision }` | `SignalChanged { topic: policy.{tool_name} }` |
+| `KnowledgeSearched { query, result_count }` | `NodeAdded` low-emphasis prose |
+| every other variant | wildcard → empty `Vec` |
+
+Severity mapping: `RiskLevel::{Low → Info, Medium → Notice, High → Warning, Critical → Danger}`.
+
+## Integration with `arcan` (binary)
+
+Build with the `prosopon` feature and pass `--prosopon-port`:
+
+```sh
+cargo run -p arcan --features prosopon -- serve --prosopon-port 127.0.0.1:4321
+```
+
+Bind failure logs a warning and arcan continues normally — the `arcan-console` React UI keeps working independently of Prosopon.
+
+## Links
+
+- Design plan: [`docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md`](../../../docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md)
+- Linear: [BRO-773](https://linear.app/broomva/issue/BRO-773)
+- Prosopon repo: `core/prosopon` (v0.2.0-alpha.2)

--- a/crates/arcan/arcan-prosopon/README.md
+++ b/crates/arcan/arcan-prosopon/README.md
@@ -1,0 +1,10 @@
+# arcan-prosopon
+
+`Pneuma<L0ToExternal>` for [Arcan](../arcan). Subscribes to the runtime's
+`aios_protocol::EventRecord` broadcast, translates each `EventKind` into a
+`prosopon_core::ProsoponEvent`, and publishes envelopes into a
+`prosopon_daemon::EnvelopeFanout` for downstream compositors (text, glass,
+field, …).
+
+Full design: [`docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md`](../../../docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md).
+Linear: [BRO-773](https://linear.app/broomva/issue/BRO-773).

--- a/crates/arcan/arcan-prosopon/src/bridge.rs
+++ b/crates/arcan/arcan-prosopon/src/bridge.rs
@@ -1,23 +1,65 @@
 //! Bridge — spawns the subscriber task that drains arcan events into the
 //! prosopon fanout.
 
-use crate::TranslationState;
+use crate::{BridgeError, TranslationState, translator::translate};
+use aios_protocol::EventRecord;
 use prosopon_daemon::EnvelopeFanout;
 use prosopon_sdk::Session;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 /// Drains an `aios_protocol::EventRecord` broadcast into a Prosopon fanout.
+///
+/// Produced envelopes share a single Prosopon `SessionId` (minted by `Session::new`)
+/// regardless of the upstream `EventRecord.session_id` — compositors can multiplex
+/// Prosopon sessions separately if needed by upgrading this to a per-arcan-session
+/// `HashMap<SessionId, Session>` in a future revision.
 pub struct ArcanProsoponBridge {
-    _fanout: EnvelopeFanout,
-    _session: Session,
-    _state: TranslationState,
+    fanout: EnvelopeFanout,
+    session: Session,
+    state: TranslationState,
 }
 
 impl ArcanProsoponBridge {
+    /// Create a bridge that publishes to the supplied fanout.
     pub fn new(fanout: EnvelopeFanout) -> Self {
         Self {
-            _fanout: fanout,
-            _session: Session::new(),
-            _state: TranslationState::new(),
+            fanout,
+            session: Session::new(),
+            state: TranslationState::new(),
         }
+    }
+
+    /// Spawn the drain loop on the current tokio runtime. The loop exits when
+    /// the upstream broadcast closes.
+    pub fn spawn(mut self, mut events: broadcast::Receiver<EventRecord>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(record) => {
+                        if let Err(err) = self.drain_one(&record) {
+                            warn!(error = %err, "arcan-prosopon: translation/publish failed");
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(lagged = n, "arcan-prosopon: dropped events due to lag");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        debug!("arcan-prosopon: upstream closed, exiting bridge");
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    fn drain_one(&mut self, record: &EventRecord) -> Result<(), BridgeError> {
+        for event in translate(&mut self.state, &record.kind) {
+            let envelope = self.session.envelope(event);
+            self.fanout.send(envelope)?;
+        }
+        Ok(())
     }
 }

--- a/crates/arcan/arcan-prosopon/src/bridge.rs
+++ b/crates/arcan/arcan-prosopon/src/bridge.rs
@@ -1,0 +1,23 @@
+//! Bridge — spawns the subscriber task that drains arcan events into the
+//! prosopon fanout.
+
+use crate::TranslationState;
+use prosopon_daemon::EnvelopeFanout;
+use prosopon_sdk::Session;
+
+/// Drains an `aios_protocol::EventRecord` broadcast into a Prosopon fanout.
+pub struct ArcanProsoponBridge {
+    _fanout: EnvelopeFanout,
+    _session: Session,
+    _state: TranslationState,
+}
+
+impl ArcanProsoponBridge {
+    pub fn new(fanout: EnvelopeFanout) -> Self {
+        Self {
+            _fanout: fanout,
+            _session: Session::new(),
+            _state: TranslationState::new(),
+        }
+    }
+}

--- a/crates/arcan/arcan-prosopon/src/error.rs
+++ b/crates/arcan/arcan-prosopon/src/error.rs
@@ -1,0 +1,20 @@
+//! Error type for the arcan-prosopon bridge.
+
+use thiserror::Error;
+
+/// Errors raised while running the Arcan → Prosopon bridge.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BridgeError {
+    /// The upstream Arcan event broadcast closed.
+    #[error("arcan event stream closed")]
+    UpstreamClosed,
+
+    /// Publishing to the Prosopon fanout failed.
+    #[error("prosopon fanout send failed: {0}")]
+    Fanout(#[from] prosopon_daemon::FanoutError),
+
+    /// Envelope encoding failed (should be unreachable — JSON serialisation of known types).
+    #[error("envelope encoding failed: {0}")]
+    Encoding(#[from] prosopon_protocol::ProtocolError),
+}

--- a/crates/arcan/arcan-prosopon/src/lib.rs
+++ b/crates/arcan/arcan-prosopon/src/lib.rs
@@ -1,0 +1,20 @@
+//! # arcan-prosopon
+//!
+//! `Pneuma<L0ToExternal>` for Arcan. Subscribes to the runtime's
+//! `EventRecord` broadcast, translates each `EventKind` into a
+//! `ProsoponEvent`, and publishes envelopes to a `prosopon-daemon`
+//! `EnvelopeFanout` for downstream compositors.
+//!
+//! See `docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md` for the
+//! full design and the translation table.
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod state;
+pub mod translator;
+pub mod bridge;
+
+pub use bridge::ArcanProsoponBridge;
+pub use error::BridgeError;
+pub use state::TranslationState;

--- a/crates/arcan/arcan-prosopon/src/lib.rs
+++ b/crates/arcan/arcan-prosopon/src/lib.rs
@@ -10,10 +10,10 @@
 
 #![forbid(unsafe_code)]
 
+pub mod bridge;
 pub mod error;
 pub mod state;
 pub mod translator;
-pub mod bridge;
 
 pub use bridge::ArcanProsoponBridge;
 pub use error::BridgeError;

--- a/crates/arcan/arcan-prosopon/src/state.rs
+++ b/crates/arcan/arcan-prosopon/src/state.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 pub struct TranslationState {
     /// Active streaming intent id per iteration, for folding `*TextDelta` events.
     pub streams_by_iteration: HashMap<u32, StreamId>,
+    /// Monotonic sequence counter per stream, for `StreamChunk::seq`.
+    pub stream_seq: HashMap<StreamId, u64>,
     /// Current iteration number, if an assistant turn is in progress.
     pub current_iteration: Option<u32>,
     /// Stable id of the scene root, used as the parent for session-scoped
@@ -19,6 +21,7 @@ impl TranslationState {
     pub fn new() -> Self {
         Self {
             streams_by_iteration: HashMap::new(),
+            stream_seq: HashMap::new(),
             current_iteration: None,
             scene_root: NodeId::from_raw("session-root"),
         }

--- a/crates/arcan/arcan-prosopon/src/state.rs
+++ b/crates/arcan/arcan-prosopon/src/state.rs
@@ -1,0 +1,19 @@
+//! Per-session translator state (stream registry, iteration counter).
+
+use prosopon_core::StreamId;
+use std::collections::HashMap;
+
+/// Mutable state maintained across a single arcan session's event stream.
+#[derive(Debug, Default)]
+pub struct TranslationState {
+    /// Active streaming intent id per iteration, for folding `*TextDelta` events.
+    pub streams_by_iteration: HashMap<u32, StreamId>,
+    /// Current iteration number, if an assistant turn is in progress.
+    pub current_iteration: Option<u32>,
+}
+
+impl TranslationState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/arcan/arcan-prosopon/src/state.rs
+++ b/crates/arcan/arcan-prosopon/src/state.rs
@@ -1,19 +1,32 @@
 //! Per-session translator state (stream registry, iteration counter).
 
-use prosopon_core::StreamId;
+use prosopon_core::{NodeId, StreamId};
 use std::collections::HashMap;
 
 /// Mutable state maintained across a single arcan session's event stream.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TranslationState {
     /// Active streaming intent id per iteration, for folding `*TextDelta` events.
     pub streams_by_iteration: HashMap<u32, StreamId>,
     /// Current iteration number, if an assistant turn is in progress.
     pub current_iteration: Option<u32>,
+    /// Stable id of the scene root, used as the parent for session-scoped
+    /// `NodeAdded` events. Reset on every `SessionCreated`.
+    pub scene_root: NodeId,
 }
 
 impl TranslationState {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            streams_by_iteration: HashMap::new(),
+            current_iteration: None,
+            scene_root: NodeId::from_raw("session-root"),
+        }
+    }
+}
+
+impl Default for TranslationState {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -9,8 +9,113 @@ use crate::state::TranslationState;
 ///
 /// Total over every currently-known variant and includes a `_` wildcard
 /// for `#[non_exhaustive]` forward compatibility.
-pub fn translate(_state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
+pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
+    use prosopon_core::{Intent, Node, NodeId, Scene, SignalValue, Topic};
+
+    let _ = state; // used by future arms
+
     match kind {
+        EventKind::SessionCreated { name, .. } => {
+            let root = Node::new(Intent::Section {
+                title: Some(name.clone()),
+                collapsible: false,
+            });
+            vec![ProsoponEvent::SceneReset {
+                scene: Scene::new(root),
+            }]
+        }
+
+        EventKind::RunStarted {
+            provider,
+            max_iterations,
+        } => {
+            vec![
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.status"),
+                    value: SignalValue::Scalar(serde_json::json!("running")),
+                    ts: chrono::Utc::now(),
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.provider"),
+                    value: SignalValue::Scalar(serde_json::json!(provider)),
+                    ts: chrono::Utc::now(),
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.max_iterations"),
+                    value: SignalValue::Scalar(serde_json::json!(max_iterations)),
+                    ts: chrono::Utc::now(),
+                },
+            ]
+        }
+
+        EventKind::RunErrored { error } => {
+            let node = Node::new(Intent::Prose { text: error.clone() }).attr(
+                "semantic_role",
+                serde_json::json!("error"),
+            );
+            vec![
+                ProsoponEvent::NodeAdded {
+                    parent: NodeId::new(),
+                    node,
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.status"),
+                    value: SignalValue::Scalar(serde_json::json!("errored")),
+                    ts: chrono::Utc::now(),
+                },
+            ]
+        }
+
         _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aios_protocol::EventKind;
+    use prosopon_core::ProsoponEvent;
+
+    fn st() -> TranslationState {
+        TranslationState::new()
+    }
+
+    #[test]
+    fn session_created_emits_scene_reset() {
+        let kind = EventKind::SessionCreated {
+            name: "sess-a".into(),
+            config: serde_json::json!({}),
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::SceneReset { .. }));
+    }
+
+    #[test]
+    fn run_started_emits_three_signal_changes() {
+        let kind = EventKind::RunStarted {
+            provider: "anthropic".into(),
+            max_iterations: 8,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 3);
+        for e in &events {
+            assert!(matches!(e, ProsoponEvent::SignalChanged { .. }));
+        }
+    }
+
+    #[test]
+    fn run_errored_emits_error_prose_and_status_signal() {
+        let kind = EventKind::RunErrored { error: "boom".into() };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
+        assert!(matches!(events[1], ProsoponEvent::SignalChanged { .. }));
+    }
+
+    #[test]
+    fn unknown_variant_is_empty() {
+        let kind = EventKind::SessionClosed { reason: "idle".into() };
+        assert!(translate(&mut st(), &kind).is_empty());
     }
 }

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -131,8 +131,56 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             }]
         }
 
+        EventKind::ToolCallRequested { call_id, tool_name, arguments, .. } => {
+            let node = Node::new(Intent::ToolCall {
+                name: tool_name.clone(),
+                args: arguments.clone(),
+                stream: None,
+            })
+            .with_id(tool_node_id(call_id));
+            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+        }
+
+        EventKind::ToolCallCompleted { call_id, result, status, .. } => {
+            use aios_protocol::SpanStatus;
+            use prosopon_core::{ChildrenPatch, NodePatch};
+            let success = matches!(status, SpanStatus::Ok);
+            let result_node = Node::new(Intent::ToolResult { success, payload: result.clone() });
+            let id = match call_id.as_ref() {
+                Some(c) => tool_node_id(c),
+                None => state.scene_root.clone(),
+            };
+            vec![ProsoponEvent::NodeUpdated {
+                id,
+                patch: NodePatch {
+                    children: Some(ChildrenPatch::Append { children: vec![result_node] }),
+                    ..NodePatch::default()
+                },
+            }]
+        }
+
+        EventKind::ToolCallFailed { call_id, error, .. } => {
+            use prosopon_core::{ChildrenPatch, NodePatch};
+            let id = tool_node_id(call_id);
+            let result_node = Node::new(Intent::ToolResult {
+                success: false,
+                payload: serde_json::json!({ "error": error }),
+            });
+            vec![ProsoponEvent::NodeUpdated {
+                id,
+                patch: NodePatch {
+                    children: Some(ChildrenPatch::Append { children: vec![result_node] }),
+                    ..NodePatch::default()
+                },
+            }]
+        }
+
         _ => Vec::new(),
     }
+}
+
+fn tool_node_id(call_id: &str) -> prosopon_core::NodeId {
+    prosopon_core::NodeId::from_raw(format!("tool:{call_id}"))
 }
 
 #[cfg(test)]
@@ -300,5 +348,128 @@ mod tests {
         let events = translate(&mut st(), &kind);
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
+    }
+
+    #[test]
+    fn tool_call_requested_adds_tool_call_node() {
+        use prosopon_core::Intent;
+        let kind = EventKind::ToolCallRequested {
+            call_id: "call-1".into(),
+            tool_name: "shell".into(),
+            arguments: serde_json::json!({"cmd": "ls"}),
+            category: None,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeAdded { node, parent } => {
+                assert_eq!(parent, &st().scene_root);
+                assert!(matches!(node.intent, Intent::ToolCall { .. }));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn tool_call_completed_updates_node_with_child_result() {
+        use aios_protocol::SpanStatus;
+        use prosopon_core::Intent;
+        let kind = EventKind::ToolCallCompleted {
+            tool_run_id: aios_protocol::ToolRunId::default(),
+            call_id: Some("call-1".into()),
+            tool_name: "shell".into(),
+            result: serde_json::json!("ok"),
+            duration_ms: 12,
+            status: SpanStatus::Ok,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeUpdated { patch, .. } => {
+                let cp = patch.children.as_ref().expect("children patch set");
+                match cp {
+                    prosopon_core::ChildrenPatch::Append { children } => {
+                        assert_eq!(children.len(), 1);
+                        match &children[0].intent {
+                            Intent::ToolResult { success, .. } => assert!(*success),
+                            _ => panic!("expected ToolResult"),
+                        }
+                    }
+                    _ => panic!("expected Append"),
+                }
+            }
+            _ => panic!("expected NodeUpdated"),
+        }
+    }
+
+    #[test]
+    fn tool_call_failed_updates_with_unsuccess_result() {
+        use prosopon_core::Intent;
+        let kind = EventKind::ToolCallFailed {
+            call_id: "call-2".into(),
+            tool_name: "shell".into(),
+            error: "denied".into(),
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeUpdated { patch, .. } => {
+                let cp = patch.children.as_ref().unwrap();
+                if let prosopon_core::ChildrenPatch::Append { children } = cp {
+                    if let Intent::ToolResult { success, .. } = &children[0].intent {
+                        assert!(!success);
+                    } else {
+                        panic!()
+                    }
+                } else {
+                    panic!()
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn tool_call_round_trip_applies_to_scene_store() {
+        use aios_protocol::SpanStatus;
+        use prosopon_runtime::SceneStore;
+        let mut state = TranslationState::new();
+
+        let reset = translate(
+            &mut state,
+            &EventKind::SessionCreated { name: "s".into(), config: serde_json::json!({}) },
+        );
+        let ProsoponEvent::SceneReset { scene } = reset.into_iter().next().unwrap() else {
+            panic!()
+        };
+        let mut store = SceneStore::new(scene);
+
+        let req = translate(
+            &mut state,
+            &EventKind::ToolCallRequested {
+                call_id: "call-1".into(),
+                tool_name: "shell".into(),
+                arguments: serde_json::json!({}),
+                category: None,
+            },
+        );
+        for ev in req {
+            store.apply(ev).expect("tool request applies");
+        }
+
+        let done = translate(
+            &mut state,
+            &EventKind::ToolCallCompleted {
+                tool_run_id: aios_protocol::ToolRunId::default(),
+                call_id: Some("call-1".into()),
+                tool_name: "shell".into(),
+                result: serde_json::json!("ok"),
+                duration_ms: 1,
+                status: SpanStatus::Ok,
+            },
+        );
+        for ev in done {
+            store.apply(ev).expect("tool completion applies");
+        }
     }
 }

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -1,0 +1,16 @@
+//! Pure translation layer: `aios_protocol::EventKind` → `Vec<ProsoponEvent>`.
+
+use aios_protocol::EventKind;
+use prosopon_core::ProsoponEvent;
+
+use crate::state::TranslationState;
+
+/// Translate a single `EventKind` into zero or more `ProsoponEvent`s.
+///
+/// Total over every currently-known variant and includes a `_` wildcard
+/// for `#[non_exhaustive]` forward compatibility.
+pub fn translate(_state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
+    match kind {
+        _ => Vec::new(),
+    }
+}

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -10,16 +10,20 @@ use crate::state::TranslationState;
 /// Total over every currently-known variant and includes a `_` wildcard
 /// for `#[non_exhaustive]` forward compatibility.
 pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
-    use prosopon_core::{Intent, Node, NodeId, Scene, SignalValue, Topic};
-
-    let _ = state; // used by future arms
+    use prosopon_core::{Intent, Node, Scene, SignalValue, Topic};
 
     match kind {
         EventKind::SessionCreated { name, .. } => {
+            // A new session resets per-session bookkeeping so a resumed translator
+            // state doesn't carry prior streams into the new scene.
+            state.streams_by_iteration.clear();
+            state.current_iteration = None;
+
             let root = Node::new(Intent::Section {
                 title: Some(name.clone()),
                 collapsible: false,
-            });
+            })
+            .with_id(state.scene_root.clone());
             vec![ProsoponEvent::SceneReset {
                 scene: Scene::new(root),
             }]
@@ -49,13 +53,11 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
         }
 
         EventKind::RunErrored { error } => {
-            let node = Node::new(Intent::Prose { text: error.clone() }).attr(
-                "semantic_role",
-                serde_json::json!("error"),
-            );
+            let node = Node::new(Intent::Prose { text: error.clone() })
+                .attr("semantic_role", serde_json::json!("error"));
             vec![
                 ProsoponEvent::NodeAdded {
-                    parent: NodeId::new(),
+                    parent: state.scene_root.clone(),
                     node,
                 },
                 ProsoponEvent::SignalChanged {
@@ -117,5 +119,37 @@ mod tests {
     fn unknown_variant_is_empty() {
         let kind = EventKind::SessionClosed { reason: "idle".into() };
         assert!(translate(&mut st(), &kind).is_empty());
+    }
+
+    #[test]
+    fn translated_events_apply_cleanly_to_scene_store() {
+        use prosopon_runtime::SceneStore;
+
+        let mut state = TranslationState::new();
+
+        // Session first — establishes the scene root.
+        let reset = translate(
+            &mut state,
+            &EventKind::SessionCreated {
+                name: "test".into(),
+                config: serde_json::json!({}),
+            },
+        );
+        assert_eq!(reset.len(), 1);
+
+        // Build the scene from the SceneReset.
+        let ProsoponEvent::SceneReset { scene } = reset.into_iter().next().unwrap() else {
+            panic!("expected SceneReset");
+        };
+        let mut store = SceneStore::new(scene);
+
+        // Now a RunErrored — its NodeAdded must target the scene root.
+        let errs = translate(
+            &mut state,
+            &EventKind::RunErrored { error: "x".into() },
+        );
+        for ev in errs {
+            store.apply(ev).expect("event must apply cleanly");
+        }
     }
 }

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -10,7 +10,7 @@ use crate::state::TranslationState;
 /// Total over every currently-known variant and includes a `_` wildcard
 /// for `#[non_exhaustive]` forward compatibility.
 pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
-    use prosopon_core::{Intent, Node, Scene, SignalValue, Topic};
+    use prosopon_core::{ChildrenPatch, Intent, Node, NodePatch, Scene, SignalValue, Topic};
 
     match kind {
         EventKind::SessionCreated { name, .. } => {
@@ -143,15 +143,13 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
 
         EventKind::ToolCallCompleted { call_id, result, status, .. } => {
             use aios_protocol::SpanStatus;
-            use prosopon_core::{ChildrenPatch, NodePatch};
+            let Some(c) = call_id.as_ref() else {
+                return Vec::new(); // no call_id → can't match a prior ToolCall; drop
+            };
             let success = matches!(status, SpanStatus::Ok);
             let result_node = Node::new(Intent::ToolResult { success, payload: result.clone() });
-            let id = match call_id.as_ref() {
-                Some(c) => tool_node_id(c),
-                None => state.scene_root.clone(),
-            };
             vec![ProsoponEvent::NodeUpdated {
-                id,
+                id: tool_node_id(c),
                 patch: NodePatch {
                     children: Some(ChildrenPatch::Append { children: vec![result_node] }),
                     ..NodePatch::default()
@@ -160,7 +158,6 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
         }
 
         EventKind::ToolCallFailed { call_id, error, .. } => {
-            use prosopon_core::{ChildrenPatch, NodePatch};
             let id = tool_node_id(call_id);
             let result_node = Node::new(Intent::ToolResult {
                 success: false,
@@ -427,6 +424,20 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn tool_call_completed_with_no_call_id_emits_nothing() {
+        use aios_protocol::SpanStatus;
+        let kind = EventKind::ToolCallCompleted {
+            tool_run_id: aios_protocol::ToolRunId::default(),
+            call_id: None,
+            tool_name: "shell".into(),
+            result: serde_json::json!("orphan"),
+            duration_ms: 1,
+            status: SpanStatus::Ok,
+        };
+        assert!(translate(&mut st(), &kind).is_empty());
     }
 
     #[test]

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -172,12 +172,103 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             }]
         }
 
+        EventKind::ApprovalRequested { approval_id, tool_name, risk, .. } => {
+            let node = Node::new(Intent::Confirm {
+                message: format!("Approve {tool_name}?"),
+                severity: severity_for(*risk),
+            })
+            .with_id(approval_node_id(approval_id))
+            .attr("approval_id", serde_json::json!(approval_id.to_string()));
+            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+        }
+
+        EventKind::ApprovalResolved { approval_id, decision, .. } => {
+            use prosopon_core::{Lifecycle, NodeStatus};
+            let id = approval_node_id(approval_id);
+            let ts = chrono::Utc::now();
+            vec![
+                ProsoponEvent::NodeUpdated {
+                    id,
+                    patch: NodePatch {
+                        lifecycle: Some(Lifecycle::now().with_status(NodeStatus::Resolved)),
+                        ..NodePatch::default()
+                    },
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from(format!("approval.{approval_id}").as_str()),
+                    value: SignalValue::Scalar(serde_json::json!(format!("{decision:?}").to_lowercase())),
+                    ts,
+                },
+            ]
+        }
+
+        EventKind::StatePatched { revision, .. } => vec![ProsoponEvent::SignalChanged {
+            topic: Topic::from("state.revision"),
+            value: SignalValue::Scalar(serde_json::json!(*revision)),
+            ts: chrono::Utc::now(),
+        }],
+
+        EventKind::ContextCompacted { tokens_before, tokens_after, .. } => {
+            let ts = chrono::Utc::now();
+            let node = Node::new(Intent::Prose {
+                text: format!("Compacted {tokens_before}→{tokens_after} tokens"),
+            })
+            .attr("emphasis", serde_json::json!("low"));
+            vec![
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("context.tokens"),
+                    value: SignalValue::Scalar(serde_json::json!(*tokens_after)),
+                    ts,
+                },
+                ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node },
+            ]
+        }
+
+        EventKind::StepStarted { index } => vec![ProsoponEvent::SignalChanged {
+            topic: Topic::from("iteration"),
+            value: SignalValue::Scalar(serde_json::json!(*index)),
+            ts: chrono::Utc::now(),
+        }],
+
+        EventKind::PolicyEvaluated { tool_name, decision, .. } => vec![
+            ProsoponEvent::SignalChanged {
+                topic: Topic::from(format!("policy.{tool_name}").as_str()),
+                value: SignalValue::Scalar(
+                    serde_json::json!(format!("{decision:?}").to_lowercase()),
+                ),
+                ts: chrono::Utc::now(),
+            },
+        ],
+
+        EventKind::KnowledgeSearched { query, result_count, .. } => {
+            let node = Node::new(Intent::Prose {
+                text: format!("Searched: {query} ({result_count})"),
+            })
+            .attr("emphasis", serde_json::json!("low"));
+            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+        }
+
         _ => Vec::new(),
     }
 }
 
 fn tool_node_id(call_id: &str) -> prosopon_core::NodeId {
     prosopon_core::NodeId::from_raw(format!("tool:{call_id}"))
+}
+
+fn severity_for(risk: aios_protocol::RiskLevel) -> prosopon_core::Severity {
+    use aios_protocol::RiskLevel;
+    use prosopon_core::Severity;
+    match risk {
+        RiskLevel::Low => Severity::Info,
+        RiskLevel::Medium => Severity::Notice,
+        RiskLevel::High => Severity::Warning,
+        RiskLevel::Critical => Severity::Danger,
+    }
+}
+
+fn approval_node_id(id: &aios_protocol::ApprovalId) -> prosopon_core::NodeId {
+    prosopon_core::NodeId::from_raw(format!("approval:{id}"))
 }
 
 #[cfg(test)]
@@ -269,6 +360,35 @@ mod tests {
             translate(&mut state, &EventKind::TextDelta { delta: "a".into(), index: Some(0) });
         for ev in delta {
             store.apply(ev).expect("text delta should apply");
+        }
+
+        use aios_protocol::{ApprovalDecision, ApprovalId, RiskLevel};
+
+        let approval_id = ApprovalId::default();
+        let req = translate(
+            &mut state,
+            &EventKind::ApprovalRequested {
+                approval_id: approval_id.clone(),
+                call_id: "a".into(),
+                tool_name: "shell".into(),
+                arguments: serde_json::json!({}),
+                risk: RiskLevel::Medium,
+            },
+        );
+        for ev in req {
+            store.apply(ev).expect("approval request applies");
+        }
+
+        let res = translate(
+            &mut state,
+            &EventKind::ApprovalResolved {
+                approval_id,
+                decision: ApprovalDecision::Approved,
+                reason: None,
+            },
+        );
+        for ev in res {
+            store.apply(ev).expect("approval resolved applies");
         }
     }
 
@@ -438,6 +558,110 @@ mod tests {
             status: SpanStatus::Ok,
         };
         assert!(translate(&mut st(), &kind).is_empty());
+    }
+
+    #[test]
+    fn approval_requested_adds_confirm_node() {
+        use aios_protocol::{ApprovalId, RiskLevel};
+        use prosopon_core::{Intent, Severity};
+        let kind = EventKind::ApprovalRequested {
+            approval_id: ApprovalId::default(),
+            call_id: "c".into(),
+            tool_name: "shell".into(),
+            arguments: serde_json::json!({}),
+            risk: RiskLevel::High,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeAdded { node, parent } => {
+                assert_eq!(parent, &st().scene_root);
+                assert!(
+                    matches!(&node.intent, Intent::Confirm { severity, .. } if *severity == Severity::Warning)
+                );
+            }
+            _ => panic!("expected NodeAdded"),
+        }
+    }
+
+    #[test]
+    fn approval_resolved_updates_lifecycle_and_emits_decision_signal() {
+        use aios_protocol::{ApprovalDecision, ApprovalId};
+        use prosopon_core::NodeStatus;
+        let id = ApprovalId::default();
+        let kind = EventKind::ApprovalResolved {
+            approval_id: id.clone(),
+            decision: ApprovalDecision::Approved,
+            reason: None,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ProsoponEvent::NodeUpdated { patch, .. } => {
+                let lc = patch.lifecycle.as_ref().expect("lifecycle set");
+                assert!(matches!(lc.status, NodeStatus::Resolved));
+            }
+            _ => panic!("expected NodeUpdated"),
+        }
+        assert!(matches!(events[1], ProsoponEvent::SignalChanged { .. }));
+    }
+
+    #[test]
+    fn state_patched_emits_revision_signal() {
+        let kind = EventKind::StatePatched {
+            index: None,
+            patch: serde_json::json!([]),
+            revision: 42,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::SignalChanged { .. }));
+    }
+
+    #[test]
+    fn context_compacted_emits_signal_and_prose() {
+        let kind = EventKind::ContextCompacted {
+            dropped_count: 3,
+            tokens_before: 1000,
+            tokens_after: 500,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ProsoponEvent::SignalChanged { .. }));
+        match &events[1] {
+            ProsoponEvent::NodeAdded { parent, .. } => {
+                assert_eq!(parent, &st().scene_root);
+            }
+            _ => panic!("expected NodeAdded"),
+        }
+    }
+
+    #[test]
+    fn step_started_emits_iteration_signal() {
+        let kind = EventKind::StepStarted { index: 3 };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::SignalChanged { .. }));
+    }
+
+    #[test]
+    fn knowledge_searched_emits_prose() {
+        use prosopon_core::Intent;
+        let kind = EventKind::KnowledgeSearched {
+            query: "foo".into(),
+            result_count: 2,
+            top_relevance: 0.9,
+            duration_ms: 5,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeAdded { parent, node } => {
+                assert_eq!(parent, &st().scene_root);
+                assert!(matches!(node.intent, Intent::Prose { .. }));
+            }
+            _ => panic!("expected NodeAdded"),
+        }
     }
 
     #[test]

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -33,21 +33,22 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             provider,
             max_iterations,
         } => {
+            let ts = chrono::Utc::now();
             vec![
                 ProsoponEvent::SignalChanged {
                     topic: Topic::from("run.status"),
                     value: SignalValue::Scalar(serde_json::json!("running")),
-                    ts: chrono::Utc::now(),
+                    ts,
                 },
                 ProsoponEvent::SignalChanged {
                     topic: Topic::from("run.provider"),
                     value: SignalValue::Scalar(serde_json::json!(provider)),
-                    ts: chrono::Utc::now(),
+                    ts,
                 },
                 ProsoponEvent::SignalChanged {
                     topic: Topic::from("run.max_iterations"),
                     value: SignalValue::Scalar(serde_json::json!(max_iterations)),
-                    ts: chrono::Utc::now(),
+                    ts,
                 },
             ]
         }
@@ -66,6 +67,68 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                     ts: chrono::Utc::now(),
                 },
             ]
+        }
+
+        EventKind::UserMessage { content } => {
+            let prose = Node::new(Intent::Prose { text: content.clone() });
+            let section = Node::new(Intent::Section {
+                title: Some("User".into()),
+                collapsible: false,
+            })
+            .child(prose);
+            vec![ProsoponEvent::NodeAdded {
+                parent: state.scene_root.clone(),
+                node: section,
+            }]
+        }
+
+        EventKind::AssistantTextDelta { delta, index }
+        | EventKind::TextDelta { delta, index } => {
+            use prosopon_core::{ChunkPayload, StreamChunk, StreamId, StreamKind};
+            let iteration = index.or(state.current_iteration).unwrap_or(0);
+            let mut events = Vec::with_capacity(2);
+
+            let stream_id = match state.streams_by_iteration.get(&iteration) {
+                Some(id) => id.clone(),
+                None => {
+                    let id = StreamId::from_raw(format!("stream:iter-{iteration}"));
+                    let stream_node =
+                        Node::new(Intent::Stream { id: id.clone(), kind: StreamKind::Text });
+                    events.push(ProsoponEvent::NodeAdded {
+                        parent: state.scene_root.clone(),
+                        node: stream_node,
+                    });
+                    state.streams_by_iteration.insert(iteration, id.clone());
+                    id
+                }
+            };
+
+            let seq = state.stream_seq.entry(stream_id.clone()).or_insert(0);
+            let this_seq = *seq;
+            *seq += 1;
+
+            events.push(ProsoponEvent::StreamChunk {
+                id: stream_id,
+                chunk: StreamChunk {
+                    seq: this_seq,
+                    payload: ChunkPayload::Text { text: delta.clone() },
+                    final_: false,
+                },
+            });
+            events
+        }
+
+        EventKind::AssistantMessageCommitted { content, .. }
+        | EventKind::Message { content, .. } => {
+            let section = Node::new(Intent::Section {
+                title: Some("Assistant".into()),
+                collapsible: false,
+            })
+            .child(Node::new(Intent::Prose { text: content.clone() }));
+            vec![ProsoponEvent::NodeAdded {
+                parent: state.scene_root.clone(),
+                node: section,
+            }]
         }
 
         _ => Vec::new(),
@@ -151,5 +214,91 @@ mod tests {
         for ev in errs {
             store.apply(ev).expect("event must apply cleanly");
         }
+
+        let user = translate(&mut state, &EventKind::UserMessage { content: "q".into() });
+        for ev in user {
+            store.apply(ev).expect("user message should apply");
+        }
+
+        let delta =
+            translate(&mut state, &EventKind::TextDelta { delta: "a".into(), index: Some(0) });
+        for ev in delta {
+            store.apply(ev).expect("text delta should apply");
+        }
+    }
+
+    #[test]
+    fn user_message_adds_section_with_prose() {
+        use prosopon_core::Intent;
+        let kind = EventKind::UserMessage { content: "hi".into() };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ProsoponEvent::NodeAdded { node, .. } => {
+                assert!(matches!(node.intent, Intent::Section { .. }));
+                assert_eq!(node.children.len(), 1);
+                assert!(matches!(node.children[0].intent, Intent::Prose { .. }));
+            }
+            _ => panic!("expected NodeAdded"),
+        }
+    }
+
+    #[test]
+    fn first_text_delta_creates_stream_node_then_chunks() {
+        let mut s = st();
+        s.current_iteration = Some(3);
+        let first = EventKind::TextDelta { delta: "he".into(), index: Some(3) };
+        let second = EventKind::TextDelta { delta: "llo".into(), index: Some(3) };
+
+        let a = translate(&mut s, &first);
+        let b = translate(&mut s, &second);
+
+        // First delta: NodeAdded (stream) + StreamChunk.
+        assert_eq!(a.len(), 2);
+        assert!(matches!(a[0], ProsoponEvent::NodeAdded { .. }));
+        assert!(matches!(a[1], ProsoponEvent::StreamChunk { .. }));
+        // Second delta: StreamChunk only.
+        assert_eq!(b.len(), 1);
+        assert!(matches!(b[0], ProsoponEvent::StreamChunk { .. }));
+    }
+
+    #[test]
+    fn assistant_text_delta_uses_same_stream_as_text_delta() {
+        let mut s = st();
+        let a = translate(
+            &mut s,
+            &EventKind::AssistantTextDelta { delta: "x".into(), index: Some(1) },
+        );
+        let b =
+            translate(&mut s, &EventKind::TextDelta { delta: "y".into(), index: Some(1) });
+        // Same iteration (1) → a creates the stream, b only adds a chunk.
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 1);
+    }
+
+    #[test]
+    fn assistant_message_committed_adds_assistant_section() {
+        let kind = EventKind::AssistantMessageCommitted {
+            role: "assistant".into(),
+            content: "answer".into(),
+            model: None,
+            token_usage: None,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
+    }
+
+    #[test]
+    fn message_variant_also_adds_assistant_section() {
+        let kind = EventKind::Message {
+            role: "assistant".into(),
+            content: "answer".into(),
+            model: None,
+            token_usage: None,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
     }
 }

--- a/crates/arcan/arcan-prosopon/src/translator.rs
+++ b/crates/arcan/arcan-prosopon/src/translator.rs
@@ -54,8 +54,10 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
         }
 
         EventKind::RunErrored { error } => {
-            let node = Node::new(Intent::Prose { text: error.clone() })
-                .attr("semantic_role", serde_json::json!("error"));
+            let node = Node::new(Intent::Prose {
+                text: error.clone(),
+            })
+            .attr("semantic_role", serde_json::json!("error"));
             vec![
                 ProsoponEvent::NodeAdded {
                     parent: state.scene_root.clone(),
@@ -70,7 +72,9 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
         }
 
         EventKind::UserMessage { content } => {
-            let prose = Node::new(Intent::Prose { text: content.clone() });
+            let prose = Node::new(Intent::Prose {
+                text: content.clone(),
+            });
             let section = Node::new(Intent::Section {
                 title: Some("User".into()),
                 collapsible: false,
@@ -82,8 +86,7 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             }]
         }
 
-        EventKind::AssistantTextDelta { delta, index }
-        | EventKind::TextDelta { delta, index } => {
+        EventKind::AssistantTextDelta { delta, index } | EventKind::TextDelta { delta, index } => {
             use prosopon_core::{ChunkPayload, StreamChunk, StreamId, StreamKind};
             let iteration = index.or(state.current_iteration).unwrap_or(0);
             let mut events = Vec::with_capacity(2);
@@ -92,8 +95,10 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                 Some(id) => id.clone(),
                 None => {
                     let id = StreamId::from_raw(format!("stream:iter-{iteration}"));
-                    let stream_node =
-                        Node::new(Intent::Stream { id: id.clone(), kind: StreamKind::Text });
+                    let stream_node = Node::new(Intent::Stream {
+                        id: id.clone(),
+                        kind: StreamKind::Text,
+                    });
                     events.push(ProsoponEvent::NodeAdded {
                         parent: state.scene_root.clone(),
                         node: stream_node,
@@ -111,7 +116,9 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                 id: stream_id,
                 chunk: StreamChunk {
                     seq: this_seq,
-                    payload: ChunkPayload::Text { text: delta.clone() },
+                    payload: ChunkPayload::Text {
+                        text: delta.clone(),
+                    },
                     final_: false,
                 },
             });
@@ -124,34 +131,54 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                 title: Some("Assistant".into()),
                 collapsible: false,
             })
-            .child(Node::new(Intent::Prose { text: content.clone() }));
+            .child(Node::new(Intent::Prose {
+                text: content.clone(),
+            }));
             vec![ProsoponEvent::NodeAdded {
                 parent: state.scene_root.clone(),
                 node: section,
             }]
         }
 
-        EventKind::ToolCallRequested { call_id, tool_name, arguments, .. } => {
+        EventKind::ToolCallRequested {
+            call_id,
+            tool_name,
+            arguments,
+            ..
+        } => {
             let node = Node::new(Intent::ToolCall {
                 name: tool_name.clone(),
                 args: arguments.clone(),
                 stream: None,
             })
             .with_id(tool_node_id(call_id));
-            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+            vec![ProsoponEvent::NodeAdded {
+                parent: state.scene_root.clone(),
+                node,
+            }]
         }
 
-        EventKind::ToolCallCompleted { call_id, result, status, .. } => {
+        EventKind::ToolCallCompleted {
+            call_id,
+            result,
+            status,
+            ..
+        } => {
             use aios_protocol::SpanStatus;
             let Some(c) = call_id.as_ref() else {
                 return Vec::new(); // no call_id → can't match a prior ToolCall; drop
             };
             let success = matches!(status, SpanStatus::Ok);
-            let result_node = Node::new(Intent::ToolResult { success, payload: result.clone() });
+            let result_node = Node::new(Intent::ToolResult {
+                success,
+                payload: result.clone(),
+            });
             vec![ProsoponEvent::NodeUpdated {
                 id: tool_node_id(c),
                 patch: NodePatch {
-                    children: Some(ChildrenPatch::Append { children: vec![result_node] }),
+                    children: Some(ChildrenPatch::Append {
+                        children: vec![result_node],
+                    }),
                     ..NodePatch::default()
                 },
             }]
@@ -166,23 +193,37 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             vec![ProsoponEvent::NodeUpdated {
                 id,
                 patch: NodePatch {
-                    children: Some(ChildrenPatch::Append { children: vec![result_node] }),
+                    children: Some(ChildrenPatch::Append {
+                        children: vec![result_node],
+                    }),
                     ..NodePatch::default()
                 },
             }]
         }
 
-        EventKind::ApprovalRequested { approval_id, tool_name, risk, .. } => {
+        EventKind::ApprovalRequested {
+            approval_id,
+            tool_name,
+            risk,
+            ..
+        } => {
             let node = Node::new(Intent::Confirm {
                 message: format!("Approve {tool_name}?"),
                 severity: severity_for(*risk),
             })
             .with_id(approval_node_id(approval_id))
             .attr("approval_id", serde_json::json!(approval_id.to_string()));
-            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+            vec![ProsoponEvent::NodeAdded {
+                parent: state.scene_root.clone(),
+                node,
+            }]
         }
 
-        EventKind::ApprovalResolved { approval_id, decision, .. } => {
+        EventKind::ApprovalResolved {
+            approval_id,
+            decision,
+            ..
+        } => {
             use prosopon_core::{Lifecycle, NodeStatus};
             let id = approval_node_id(approval_id);
             let ts = chrono::Utc::now();
@@ -196,7 +237,9 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                 },
                 ProsoponEvent::SignalChanged {
                     topic: Topic::from(format!("approval.{approval_id}").as_str()),
-                    value: SignalValue::Scalar(serde_json::json!(format!("{decision:?}").to_lowercase())),
+                    value: SignalValue::Scalar(serde_json::json!(
+                        format!("{decision:?}").to_lowercase()
+                    )),
                     ts,
                 },
             ]
@@ -208,7 +251,11 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             ts: chrono::Utc::now(),
         }],
 
-        EventKind::ContextCompacted { tokens_before, tokens_after, .. } => {
+        EventKind::ContextCompacted {
+            tokens_before,
+            tokens_after,
+            ..
+        } => {
             let ts = chrono::Utc::now();
             let node = Node::new(Intent::Prose {
                 text: format!("Compacted {tokens_before}→{tokens_after} tokens"),
@@ -220,7 +267,10 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
                     value: SignalValue::Scalar(serde_json::json!(*tokens_after)),
                     ts,
                 },
-                ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node },
+                ProsoponEvent::NodeAdded {
+                    parent: state.scene_root.clone(),
+                    node,
+                },
             ]
         }
 
@@ -230,22 +280,29 @@ pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<Prosopon
             ts: chrono::Utc::now(),
         }],
 
-        EventKind::PolicyEvaluated { tool_name, decision, .. } => vec![
-            ProsoponEvent::SignalChanged {
-                topic: Topic::from(format!("policy.{tool_name}").as_str()),
-                value: SignalValue::Scalar(
-                    serde_json::json!(format!("{decision:?}").to_lowercase()),
-                ),
-                ts: chrono::Utc::now(),
-            },
-        ],
+        EventKind::PolicyEvaluated {
+            tool_name,
+            decision,
+            ..
+        } => vec![ProsoponEvent::SignalChanged {
+            topic: Topic::from(format!("policy.{tool_name}").as_str()),
+            value: SignalValue::Scalar(serde_json::json!(format!("{decision:?}").to_lowercase())),
+            ts: chrono::Utc::now(),
+        }],
 
-        EventKind::KnowledgeSearched { query, result_count, .. } => {
+        EventKind::KnowledgeSearched {
+            query,
+            result_count,
+            ..
+        } => {
             let node = Node::new(Intent::Prose {
                 text: format!("Searched: {query} ({result_count})"),
             })
             .attr("emphasis", serde_json::json!("low"));
-            vec![ProsoponEvent::NodeAdded { parent: state.scene_root.clone(), node }]
+            vec![ProsoponEvent::NodeAdded {
+                parent: state.scene_root.clone(),
+                node,
+            }]
         }
 
         _ => Vec::new(),
@@ -307,7 +364,9 @@ mod tests {
 
     #[test]
     fn run_errored_emits_error_prose_and_status_signal() {
-        let kind = EventKind::RunErrored { error: "boom".into() };
+        let kind = EventKind::RunErrored {
+            error: "boom".into(),
+        };
         let events = translate(&mut st(), &kind);
         assert_eq!(events.len(), 2);
         assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
@@ -316,7 +375,9 @@ mod tests {
 
     #[test]
     fn unknown_variant_is_empty() {
-        let kind = EventKind::SessionClosed { reason: "idle".into() };
+        let kind = EventKind::SessionClosed {
+            reason: "idle".into(),
+        };
         assert!(translate(&mut st(), &kind).is_empty());
     }
 
@@ -343,21 +404,28 @@ mod tests {
         let mut store = SceneStore::new(scene);
 
         // Now a RunErrored — its NodeAdded must target the scene root.
-        let errs = translate(
-            &mut state,
-            &EventKind::RunErrored { error: "x".into() },
-        );
+        let errs = translate(&mut state, &EventKind::RunErrored { error: "x".into() });
         for ev in errs {
             store.apply(ev).expect("event must apply cleanly");
         }
 
-        let user = translate(&mut state, &EventKind::UserMessage { content: "q".into() });
+        let user = translate(
+            &mut state,
+            &EventKind::UserMessage {
+                content: "q".into(),
+            },
+        );
         for ev in user {
             store.apply(ev).expect("user message should apply");
         }
 
-        let delta =
-            translate(&mut state, &EventKind::TextDelta { delta: "a".into(), index: Some(0) });
+        let delta = translate(
+            &mut state,
+            &EventKind::TextDelta {
+                delta: "a".into(),
+                index: Some(0),
+            },
+        );
         for ev in delta {
             store.apply(ev).expect("text delta should apply");
         }
@@ -395,7 +463,9 @@ mod tests {
     #[test]
     fn user_message_adds_section_with_prose() {
         use prosopon_core::Intent;
-        let kind = EventKind::UserMessage { content: "hi".into() };
+        let kind = EventKind::UserMessage {
+            content: "hi".into(),
+        };
         let events = translate(&mut st(), &kind);
         assert_eq!(events.len(), 1);
         match &events[0] {
@@ -412,8 +482,14 @@ mod tests {
     fn first_text_delta_creates_stream_node_then_chunks() {
         let mut s = st();
         s.current_iteration = Some(3);
-        let first = EventKind::TextDelta { delta: "he".into(), index: Some(3) };
-        let second = EventKind::TextDelta { delta: "llo".into(), index: Some(3) };
+        let first = EventKind::TextDelta {
+            delta: "he".into(),
+            index: Some(3),
+        };
+        let second = EventKind::TextDelta {
+            delta: "llo".into(),
+            index: Some(3),
+        };
 
         let a = translate(&mut s, &first);
         let b = translate(&mut s, &second);
@@ -432,10 +508,18 @@ mod tests {
         let mut s = st();
         let a = translate(
             &mut s,
-            &EventKind::AssistantTextDelta { delta: "x".into(), index: Some(1) },
+            &EventKind::AssistantTextDelta {
+                delta: "x".into(),
+                index: Some(1),
+            },
         );
-        let b =
-            translate(&mut s, &EventKind::TextDelta { delta: "y".into(), index: Some(1) });
+        let b = translate(
+            &mut s,
+            &EventKind::TextDelta {
+                delta: "y".into(),
+                index: Some(1),
+            },
+        );
         // Same iteration (1) → a creates the stream, b only adds a chunk.
         assert_eq!(a.len(), 2);
         assert_eq!(b.len(), 1);
@@ -672,7 +756,10 @@ mod tests {
 
         let reset = translate(
             &mut state,
-            &EventKind::SessionCreated { name: "s".into(), config: serde_json::json!({}) },
+            &EventKind::SessionCreated {
+                name: "s".into(),
+                config: serde_json::json!({}),
+            },
         );
         let ProsoponEvent::SceneReset { scene } = reset.into_iter().next().unwrap() else {
             panic!()

--- a/crates/arcan/arcan-prosopon/tests/bridge_integration.rs
+++ b/crates/arcan/arcan-prosopon/tests/bridge_integration.rs
@@ -1,0 +1,58 @@
+//! End-to-end: canned EventRecord stream → fanout subscriber sees translated envelopes.
+
+use aios_protocol::{BranchId, EventKind, EventRecord, SessionId};
+use arcan_prosopon::ArcanProsoponBridge;
+use prosopon_daemon::EnvelopeFanout;
+use tokio::sync::broadcast;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bridge_forwards_run_started_as_three_signal_envelopes() {
+    let (event_tx, event_rx) = broadcast::channel::<EventRecord>(16);
+    let fanout = EnvelopeFanout::new();
+    let mut subscriber = fanout.subscribe();
+
+    let bridge = ArcanProsoponBridge::new(fanout);
+    let handle = bridge.spawn(event_rx);
+
+    event_tx
+        .send(EventRecord::new(
+            SessionId::default(),
+            BranchId::main(),
+            1u64,
+            EventKind::RunStarted {
+                provider: "anthropic".into(),
+                max_iterations: 5,
+            },
+        ))
+        .expect("send ok");
+
+    for _ in 0..3 {
+        let env = tokio::time::timeout(std::time::Duration::from_secs(2), subscriber.recv())
+            .await
+            .expect("timeout waiting for envelope")
+            .expect("recv ok");
+        assert!(matches!(
+            env.event,
+            prosopon_core::ProsoponEvent::SignalChanged { .. }
+        ));
+    }
+
+    drop(event_tx);
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bridge_exits_when_upstream_closes() {
+    let (event_tx, event_rx) = broadcast::channel::<EventRecord>(4);
+    let fanout = EnvelopeFanout::new();
+
+    let bridge = ArcanProsoponBridge::new(fanout);
+    let handle = bridge.spawn(event_rx);
+
+    drop(event_tx);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    assert!(
+        result.is_ok(),
+        "bridge should exit promptly when upstream closes"
+    );
+}

--- a/crates/arcan/arcan/Cargo.toml
+++ b/crates/arcan/arcan/Cargo.toml
@@ -23,12 +23,16 @@ console = ["dep:arcan-console"]
 spaces = ["dep:arcan-spaces", "arcan-spaces/spacetimedb"]
 opsis = ["dep:arcan-opsis", "dep:opsis-core"]
 praxis = []
+prosopon = ["dep:arcan-prosopon", "dep:prosopon-daemon", "dep:prosopon-compositor-glass"]
 
 [dependencies]
 arcan-console = { path = "../arcan-console", version = "0.3.0", optional = true }
 arcan-opsis = { path = "../arcan-opsis", version = "0.3.0", optional = true }
 opsis-core = { path = "../../opsis/opsis-core", version = "0.3.0", optional = true }
 arcan-spaces = { path = "../arcan-spaces", version = "0.3.0", optional = true }
+arcan-prosopon = { path = "../arcan-prosopon", version = "0.1.0", optional = true }
+prosopon-daemon = { path = "../../../../prosopon/crates/prosopon-daemon", version = "0.2.0", optional = true }
+prosopon-compositor-glass = { path = "../../../../prosopon/crates/prosopon-compositor-glass", version = "0.2.0", optional = true }
 arcan-commands = { path = "../arcan-commands", version = "0.3.0" }
 arcan-praxis = { path = "../arcan-praxis", version = "0.3.0" }
 arcan-core = { path = "../arcan-core", version = "0.3.0" }

--- a/crates/arcan/arcan/Cargo.toml
+++ b/crates/arcan/arcan/Cargo.toml
@@ -31,8 +31,8 @@ arcan-opsis = { path = "../arcan-opsis", version = "0.3.0", optional = true }
 opsis-core = { path = "../../opsis/opsis-core", version = "0.3.0", optional = true }
 arcan-spaces = { path = "../arcan-spaces", version = "0.3.0", optional = true }
 arcan-prosopon = { path = "../arcan-prosopon", version = "0.1.0", optional = true }
-prosopon-daemon = { path = "../../../../prosopon/crates/prosopon-daemon", version = "0.2.0", optional = true }
-prosopon-compositor-glass = { path = "../../../../prosopon/crates/prosopon-compositor-glass", version = "0.2.0", optional = true }
+prosopon-daemon = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2", optional = true }
+prosopon-compositor-glass = { git = "https://github.com/broomva/prosopon.git", tag = "v0.2.0-alpha.2", optional = true }
 arcan-commands = { path = "../arcan-commands", version = "0.3.0" }
 arcan-praxis = { path = "../arcan-praxis", version = "0.3.0" }
 arcan-core = { path = "../arcan-core", version = "0.3.0" }

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -812,11 +812,10 @@ fn run_serve(
 
         let event_rx = runtime.subscribe_events();
 
-        let bind_result = tokio_runtime
-            .block_on(DaemonServer::bind(DaemonConfig {
-                addr,
-                surface: Some(glass_surface()),
-            }));
+        let bind_result = tokio_runtime.block_on(DaemonServer::bind(DaemonConfig {
+            addr,
+            surface: Some(glass_surface()),
+        }));
 
         match bind_result {
             Ok(server) => {
@@ -1380,7 +1379,13 @@ fn main() -> anyhow::Result<()> {
                 cli.default_tier.as_deref(),
             );
 
-            run_serve(&data_dir, &resolved, cli.console_dir, cli.prosopon_port, &tokio_runtime)
+            run_serve(
+                &data_dir,
+                &resolved,
+                cli.console_dir,
+                cli.prosopon_port,
+                &tokio_runtime,
+            )
         }
         Some(Command::Chat { session, url }) => {
             // File-based logging for TUI mode (don't clobber the terminal)

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -104,6 +104,11 @@ struct Cli {
     /// Set to "pro" for full local/OSS access without the auth stack.
     #[arg(long, global = true, env = "ARCAN_DEFAULT_TIER")]
     default_tier: Option<String>,
+
+    /// Enable the Prosopon display-server sidecar on this address.
+    /// Requires `--features prosopon` at build time; silently ignored otherwise.
+    #[arg(long, global = true, value_name = "ADDR")]
+    prosopon_port: Option<std::net::SocketAddr>,
 }
 
 #[derive(Subcommand)]
@@ -467,6 +472,7 @@ fn run_serve(
     data_dir: &Path,
     resolved: &ResolvedConfig,
     console_dir: Option<PathBuf>,
+    prosopon_port: Option<std::net::SocketAddr>,
     tokio_runtime: &tokio::runtime::Runtime,
 ) -> anyhow::Result<()> {
     // The Tokio runtime is entered (via `_rt_guard` in main) but NOT blocked
@@ -791,6 +797,56 @@ fn run_serve(
 
     // Wire the broadcast sender now that the runtime exists.
     *streaming_sender.lock().unwrap() = Some(runtime.event_sender());
+
+    // ── Prosopon display-server sidecar (opt-in via `--features prosopon`) ──
+    //
+    // The field `prosopon_port` is always present in the CLI struct so the flag
+    // is parseable in all builds. The boot logic is conditionally compiled; in a
+    // build without the feature the block below is a no-op and clippy won't
+    // complain about unused variables.
+    #[cfg(feature = "prosopon")]
+    if let Some(addr) = prosopon_port {
+        use arcan_prosopon::ArcanProsoponBridge;
+        use prosopon_compositor_glass::glass_surface;
+        use prosopon_daemon::{DaemonConfig, DaemonServer};
+
+        let event_rx = runtime.subscribe_events();
+
+        let bind_result = tokio_runtime
+            .block_on(DaemonServer::bind(DaemonConfig {
+                addr,
+                surface: Some(glass_surface()),
+            }));
+
+        match bind_result {
+            Ok(server) => {
+                let fanout = server.fanout();
+                let bridge = ArcanProsoponBridge::new(fanout);
+                let _bridge_handle = bridge.spawn(event_rx);
+                tokio_runtime.spawn(async move {
+                    if let Err(err) = server.serve().await {
+                        tracing::error!(error = %err, "prosopon-daemon serve failed");
+                    }
+                });
+                tracing::info!(%addr, "arcan-prosopon: bridge online");
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    %addr,
+                    "arcan-prosopon: failed to bind, arcan will continue without Prosopon"
+                );
+            }
+        }
+    }
+
+    #[cfg(not(feature = "prosopon"))]
+    if prosopon_port.is_some() {
+        tracing::warn!(
+            "--prosopon-port was set but arcan was not built with the `prosopon` feature; \
+             display-server sidecar is disabled"
+        );
+    }
 
     let data_dir_owned = data_dir.to_path_buf();
     let port = resolved.port;
@@ -1324,7 +1380,7 @@ fn main() -> anyhow::Result<()> {
                 cli.default_tier.as_deref(),
             );
 
-            run_serve(&data_dir, &resolved, cli.console_dir, &tokio_runtime)
+            run_serve(&data_dir, &resolved, cli.console_dir, cli.prosopon_port, &tokio_runtime)
         }
         Some(Command::Chat { session, url }) => {
             // File-based logging for TUI mode (don't clobber the terminal)

--- a/docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md
+++ b/docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md
@@ -1,0 +1,1144 @@
+# BRO-773 — arcan-prosopon Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `arcan-prosopon`, a new Rust crate in the Life monorepo that subscribes to Arcan's `KernelRuntime` event broadcast, translates each `aios_protocol::EventKind` into a `prosopon-core::ProsoponEvent` envelope, and publishes the stream to a `prosopon-daemon::EnvelopeFanout` so any Prosopon compositor (text, glass, field, …) can render a live Arcan session.
+
+**Architecture:** Producer-only sidecar (Pneuma<L0ToExternal> for Arcan). A `Translator` is a pure, per-session state machine that maps `EventKind → Vec<ProsoponEvent>`. A `Bridge` spawns a tokio task that pulls `EventRecord`s from a `broadcast::Receiver<EventRecord>`, runs them through the translator, mints `Envelope`s via `prosopon-sdk::Session`, and publishes to the fanout. Wiring into the `arcand` CLI is additive, gated on a `--prosopon-port <addr>` flag, and degrades gracefully (log on bind failure, never panic; existing `arcan-console` continues to work without Prosopon).
+
+**Tech Stack:** Rust 2024, tokio (broadcast + spawn), `prosopon-sdk`, `prosopon-daemon`, `prosopon-protocol`, `prosopon-core`, `aios-protocol` (for `EventRecord` / `EventKind`), `tracing`, `thiserror`, `anyhow`. Path dependency on sibling `core/prosopon/` workspace.
+
+**Linear:** [BRO-773](https://linear.app/broomva/issue/BRO-773) — v0.3.0 milestone.
+
+---
+
+## File structure
+
+```
+core/life/crates/arcan/arcan-prosopon/
+├── Cargo.toml
+├── README.md
+├── src/
+│   ├── lib.rs            ← public API: ArcanProsoponBridge, glass_surface() re-export
+│   ├── error.rs          ← BridgeError (thiserror)
+│   ├── state.rs          ← TranslationState (per-session seq, stream registry, root NodeId)
+│   ├── translator.rs     ← translate(&mut TranslationState, &EventKind) -> Vec<ProsoponEvent>
+│   └── bridge.rs         ← ArcanProsoponBridge — spawn / run loop
+└── tests/
+    └── bridge_integration.rs  ← end-to-end: mock EventRecord stream → fanout subscriber
+```
+
+`translator.rs` owns all `EventKind → ProsoponEvent` mapping logic and is pure (no I/O). It is easy to unit-test variant-by-variant. `bridge.rs` owns the tokio wiring, session id allocation, and graceful-shutdown plumbing. `state.rs` isolates mutable translator state so `translator.rs` can be a collection of stateless `fn`s.
+
+---
+
+## Dependencies (Cargo.toml for arcan-prosopon)
+
+```toml
+[package]
+name = "arcan-prosopon"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+license = "Apache-2.0"
+description = "Pneuma<L0ToExternal> for Arcan — emits ProsoponEvents from the runtime's event stream."
+repository = "https://github.com/broomva/life"
+
+[dependencies]
+# Prosopon — path dep on sibling workspace while v0.2.0-alpha.2 is unpublished.
+prosopon-core     = { path = "../../../../../prosopon/crates/prosopon-core" }
+prosopon-protocol = { path = "../../../../../prosopon/crates/prosopon-protocol" }
+prosopon-sdk      = { path = "../../../../../prosopon/crates/prosopon-sdk" }
+prosopon-daemon   = { path = "../../../../../prosopon/crates/prosopon-daemon" }
+
+# aiOS event source.
+aios-protocol = { path = "../../aios/aios-protocol" }
+
+# Runtime.
+tokio     = { workspace = true, features = ["sync", "rt", "macros"] }
+tracing   = { workspace = true }
+thiserror = { workspace = true }
+anyhow    = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+```
+
+Five path hops from `core/life/crates/arcan/arcan-prosopon/` to `core/prosopon/crates/…`:
+`../` → arcan-prosopon parent → `../../` → arcan/ → `../../../` → crates/ → `../../../../` → life/ → `../../../../../` → core/. Verify with `ls ../../../../../prosopon/crates/` from the new crate dir during Task 1.
+
+---
+
+## Translation table (authoritative; drives translator.rs)
+
+Every `EventKind` variant from `core/life/crates/aios/aios-protocol/src/event.rs` (declared `#[non_exhaustive]`) maps as follows. The translator MUST include a `_` wildcard arm that returns an empty `Vec` for forward-compat.
+
+| EventKind variant | ProsoponEvent(s) emitted | Notes |
+|---|---|---|
+| `UserMessage { content }` | `NodeAdded` under root, `ir::section("User").child(ir::prose(content))` with `attrs["semantic_role"]="info"` | One node per user turn |
+| `SessionCreated { name, .. }` | `SceneReset { scene: Scene::new(ir::section(name)) }` | Fresh scene per session |
+| `RunStarted { provider, max_iterations }` | `SignalChanged { topic="run.status", value="running" }`, `SignalChanged { topic="run.provider", value=provider }`, `SignalChanged { topic="run.max_iterations", value=max_iterations }` | Boot signals |
+| `RunFinished { reason, total_iterations, final_answer, .. }` | If `final_answer.is_some()`: `NodeAdded` with `ir::section("Answer").child(ir::prose(final_answer))`; then `SignalChanged { topic="run.status", value=reason }`; then `Heartbeat` | Status + final prose |
+| `RunErrored { error }` | `NodeAdded` with `ir::prose(error).attr("semantic_role","error").priority(Priority::Urgent)` + `SignalChanged { topic="run.status", value="errored" }` | |
+| `AssistantTextDelta { delta, .. }` / `TextDelta { delta, .. }` | First delta per iteration: `NodeAdded` with `ir::stream(<fresh StreamId>, StreamKind::Text)`; subsequent deltas: `StreamChunk { id, chunk: StreamChunk::Text(delta) }` | `TranslationState` holds active `StreamId` per iteration |
+| `AssistantMessageCommitted { content, .. }` / `Message { content, .. }` | `NodeAdded` with `ir::section("Assistant").child(ir::prose(content))` | Committed messages |
+| `ToolCallRequested { call_id, tool_name, arguments, .. }` | `NodeAdded` with `ir::tool_call(tool_name, arguments)`; node id = deterministic from `call_id` so follow-up events can update it | |
+| `ToolCallCompleted { call_id?, tool_name, result, status, .. }` | `NodeUpdated { id: tool_node_id(call_id.clone()), patch: NodePatch::child_append(ir::tool_result(status == SpanStatus::Ok, result)) }` if `call_id` set; else `NodeAdded` | `SpanStatus::Ok` → `success=true` |
+| `ToolCallFailed { call_id, tool_name, error }` | `NodeUpdated { id: tool_node_id(call_id), patch: NodePatch::child_append(ir::tool_result(false, json!({"error": error}))) }` | |
+| `ApprovalRequested { approval_id, tool_name, arguments, risk, .. }` | `NodeAdded` with `ir::confirm(format!("Approve {tool_name}?"), severity_for(risk))` carrying `attrs["approval_id"]=approval_id` | Severity maps: Low→Normal, Medium→High, High/Critical→Urgent |
+| `ApprovalResolved { approval_id, decision, .. }` | `NodeUpdated { id: approval_node_id(approval_id), patch: NodePatch::lifecycle(NodeStatus::Resolved) }` + `SignalChanged { topic=format!("approval.{approval_id}"), value=decision }` | |
+| `StatePatched { patch, revision, .. }` | `SignalChanged { topic="state.revision", value=revision }` (patch content not forwarded — too noisy) | |
+| `ContextCompacted { tokens_before, tokens_after, .. }` | `SignalChanged { topic="context.tokens", value=tokens_after }` + `NodeAdded` with `ir::prose(format!("Compacted {b}→{a} tokens", b=tokens_before, a=tokens_after)).attr("emphasis","low")` | |
+| `StepStarted { index }` | `SignalChanged { topic="iteration", value=index }` | |
+| `StepFinished { index, stop_reason, .. }` | No translation | Redundant with StateChanged + next StepStarted |
+| `PolicyEvaluated { tool_name, decision, .. }` | `SignalChanged { topic=format!("policy.{tool_name}"), value=decision }` | |
+| `KnowledgeSearched { query, result_count, .. }` | `NodeAdded` with `ir::prose(format!("Searched: {query} ({result_count})")).attr("emphasis","low")` | |
+| `FileWrite { path, size_bytes, .. }` / `FileDelete { path }` / `FileRename { .. }` / `FileMutated { .. }` | `NodeAdded` with `ir::prose(summary)` under a `ir::section("Files")` if present | Nice-to-have; acceptable to skip in v0.1 |
+| `SessionResumed`, `SessionClosed`, `BranchCreated`, `BranchMerged`, `PhaseEntered`, `DeliberationProposed`, `ToolCallStarted`, `KnowledgeRetrieved`, `KnowledgeEvaluated`, `StatePatchCommitted`, `ExternalSignal`, every future variant | Empty `Vec` via `_` wildcard | |
+
+Helper `tool_node_id(call_id) -> NodeId` = `NodeId::from(format!("tool:{call_id}"))` — stable so updates land on the same node.
+Helper `approval_node_id(approval_id)` analogous.
+
+---
+
+## Task 1: Scaffold the crate
+
+**Files:**
+- Create: `core/life/crates/arcan/arcan-prosopon/Cargo.toml`
+- Create: `core/life/crates/arcan/arcan-prosopon/src/lib.rs`
+- Create: `core/life/crates/arcan/arcan-prosopon/src/error.rs`
+- Create: `core/life/crates/arcan/arcan-prosopon/README.md`
+- Modify: `core/life/Cargo.toml` — add `"crates/arcan/arcan-prosopon"` to `members` under the `# Arcan` block.
+
+- [ ] **Step 1: Read `core/prosopon/crates/prosopon-sdk/src/session.rs` lines 1-120.**
+
+Run: `cat /Users/broomva/broomva/core/prosopon/crates/prosopon-sdk/src/session.rs | head -120`
+Expected: see the exact signature of `Session::new`, `Session::envelope`, `Session::signal`, etc. Confirm the public surface referenced in this plan still exists. If any method name differs, update the references below before proceeding.
+
+- [ ] **Step 2: Read `core/prosopon/crates/prosopon-daemon/src/fanout.rs` and `surface.rs`.**
+
+Run: `cat /Users/broomva/broomva/core/prosopon/crates/prosopon-daemon/src/fanout.rs /Users/broomva/broomva/core/prosopon/crates/prosopon-daemon/src/surface.rs`
+Expected: see `EnvelopeFanout::send`, `EnvelopeReceiver::recv`, `SurfaceBundle` constructor. Record exact signatures.
+
+- [ ] **Step 3: Create crate skeleton.**
+
+Write `core/life/crates/arcan/arcan-prosopon/Cargo.toml` using the content from the **Dependencies** section above exactly.
+
+Write `core/life/crates/arcan/arcan-prosopon/src/error.rs`:
+
+```rust
+//! Error type for the arcan-prosopon bridge.
+
+use thiserror::Error;
+
+/// Errors raised while running the Arcan → Prosopon bridge.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BridgeError {
+    /// The upstream Arcan event broadcast closed.
+    #[error("arcan event stream closed")]
+    UpstreamClosed,
+
+    /// Publishing to the Prosopon fanout failed.
+    #[error("prosopon fanout send failed: {0}")]
+    Fanout(#[from] prosopon_daemon::FanoutError),
+
+    /// Envelope encoding failed (should be unreachable — JSON serialisation of known types).
+    #[error("envelope encoding failed: {0}")]
+    Encoding(#[from] prosopon_protocol::ProtocolError),
+}
+```
+
+Write `core/life/crates/arcan/arcan-prosopon/src/lib.rs`:
+
+```rust
+//! # arcan-prosopon
+//!
+//! `Pneuma<L0ToExternal>` for Arcan. Subscribes to the runtime's
+//! `EventRecord` broadcast, translates each `EventKind` into a
+//! `ProsoponEvent`, and publishes envelopes to a `prosopon-daemon`
+//! `EnvelopeFanout` for downstream compositors.
+//!
+//! See `docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md` for the
+//! full design and the translation table.
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod state;
+pub mod translator;
+pub mod bridge;
+
+pub use bridge::ArcanProsoponBridge;
+pub use error::BridgeError;
+pub use state::TranslationState;
+```
+
+(`state`, `translator`, `bridge` modules will be stub files in this task; implementation follows in Tasks 2-7.)
+
+Stub `core/life/crates/arcan/arcan-prosopon/src/state.rs`:
+
+```rust
+//! Per-session translator state (stream registry, iteration counter).
+
+use prosopon_core::StreamId;
+use std::collections::HashMap;
+
+/// Mutable state maintained across a single arcan session's event stream.
+#[derive(Debug, Default)]
+pub struct TranslationState {
+    /// Active streaming intent id per iteration, for folding `*TextDelta` events.
+    pub streams_by_iteration: HashMap<u32, StreamId>,
+    /// Current iteration number, if an assistant turn is in progress.
+    pub current_iteration: Option<u32>,
+}
+
+impl TranslationState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+```
+
+Stub `core/life/crates/arcan/arcan-prosopon/src/translator.rs`:
+
+```rust
+//! Pure translation layer: `aios_protocol::EventKind` → `Vec<ProsoponEvent>`.
+
+use aios_protocol::EventKind;
+use prosopon_core::ProsoponEvent;
+
+use crate::state::TranslationState;
+
+/// Translate a single `EventKind` into zero or more `ProsoponEvent`s.
+///
+/// Total over every currently-known variant and includes a `_` wildcard
+/// for `#[non_exhaustive]` forward compatibility.
+pub fn translate(_state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
+    match kind {
+        _ => Vec::new(),
+    }
+}
+```
+
+Stub `core/life/crates/arcan/arcan-prosopon/src/bridge.rs`:
+
+```rust
+//! Bridge — spawns the subscriber task that drains arcan events into the
+//! prosopon fanout.
+
+use crate::{BridgeError, TranslationState};
+use prosopon_daemon::EnvelopeFanout;
+use prosopon_sdk::Session;
+
+/// Drains an `aios_protocol::EventRecord` broadcast into a Prosopon fanout.
+pub struct ArcanProsoponBridge {
+    _fanout: EnvelopeFanout,
+    _session: Session,
+    _state: TranslationState,
+}
+
+impl ArcanProsoponBridge {
+    pub fn new(fanout: EnvelopeFanout) -> Self {
+        Self {
+            _fanout: fanout,
+            _session: Session::new(),
+            _state: TranslationState::new(),
+        }
+    }
+}
+```
+
+Write a minimal `README.md` pointing to this plan and the Linear issue.
+
+Register the crate in `core/life/Cargo.toml` by inserting `"crates/arcan/arcan-prosopon",` in the arcan block (alphabetical — after `arcan-praxis`, before `arcan-provider`).
+
+- [ ] **Step 4: `cargo check -p arcan-prosopon`.**
+
+Run from `core/life/`: `cargo check -p arcan-prosopon`
+Expected: `Checking arcan-prosopon v0.1.0 … Finished dev profile …` with no errors (warnings on unused fields acceptable for the stub).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd /Users/broomva/broomva/core/life
+git checkout -b bro-773-arcan-prosopon
+git add crates/arcan/arcan-prosopon/ Cargo.toml
+git commit -m "feat(arcan-prosopon): scaffold crate (BRO-773)"
+```
+
+---
+
+## Task 2: Translator — session & run lifecycle
+
+**Files:**
+- Modify: `core/life/crates/arcan/arcan-prosopon/src/translator.rs`
+- Test: same file, `#[cfg(test)] mod tests` at bottom.
+
+- [ ] **Step 1: Write the failing tests.**
+
+Append to `translator.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aios_protocol::EventKind;
+    use prosopon_core::{Intent, ProsoponEvent};
+
+    fn st() -> TranslationState { TranslationState::new() }
+
+    #[test]
+    fn session_created_emits_scene_reset() {
+        let kind = EventKind::SessionCreated {
+            name: "sess-a".into(),
+            config: serde_json::json!({}),
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ProsoponEvent::SceneReset { .. }));
+    }
+
+    #[test]
+    fn run_started_emits_three_signal_changes() {
+        let kind = EventKind::RunStarted {
+            provider: "anthropic".into(),
+            max_iterations: 8,
+        };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 3);
+        for e in &events {
+            assert!(matches!(e, ProsoponEvent::SignalChanged { .. }));
+        }
+    }
+
+    #[test]
+    fn run_errored_emits_error_prose_and_status_signal() {
+        let kind = EventKind::RunErrored { error: "boom".into() };
+        let events = translate(&mut st(), &kind);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
+        assert!(matches!(events[1], ProsoponEvent::SignalChanged { .. }));
+    }
+
+    #[test]
+    fn unknown_variant_is_empty() {
+        // SessionClosed is in the wildcard set per the translation table.
+        let kind = EventKind::SessionClosed { reason: "idle".into() };
+        assert!(translate(&mut st(), &kind).is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests.**
+
+Run: `cargo test -p arcan-prosopon translator::`
+Expected: compilation fails because `translate` only returns `Vec::new()` — assertions like `events.len() == 1` fail.
+
+- [ ] **Step 3: Implement the three variants.**
+
+Replace the `match` in `translate` with:
+
+```rust
+pub fn translate(state: &mut TranslationState, kind: &EventKind) -> Vec<ProsoponEvent> {
+    use prosopon_core::{Intent, Node, NodeId, ProsoponEvent, Scene, SignalValue, Topic};
+
+    match kind {
+        EventKind::SessionCreated { name, .. } => {
+            let root = Node::new(Intent::Section {
+                title: Some(name.clone()),
+                collapsible: false,
+            });
+            vec![ProsoponEvent::SceneReset { scene: Scene::new(root) }]
+        }
+
+        EventKind::RunStarted { provider, max_iterations } => {
+            vec![
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.status"),
+                    value: SignalValue::Text("running".into()),
+                    ts: chrono::Utc::now(),
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.provider"),
+                    value: SignalValue::Text(provider.clone()),
+                    ts: chrono::Utc::now(),
+                },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.max_iterations"),
+                    value: SignalValue::Number(*max_iterations as f64),
+                    ts: chrono::Utc::now(),
+                },
+            ]
+        }
+
+        EventKind::RunErrored { error } => {
+            let mut node = Node::new(Intent::Prose { text: error.clone() });
+            node.attrs.insert("semantic_role".into(), serde_json::json!("error"));
+            vec![
+                ProsoponEvent::NodeAdded { parent: NodeId::root(), node },
+                ProsoponEvent::SignalChanged {
+                    topic: Topic::from("run.status"),
+                    value: SignalValue::Text("errored".into()),
+                    ts: chrono::Utc::now(),
+                },
+            ]
+        }
+
+        _ => Vec::new(),
+    }
+}
+```
+
+Note: the exact constructors (`NodeId::root`, `SignalValue::Text`, `Topic::from`, etc.) come from `prosopon-core`; Task 1 Step 1 verified them. If any signature differs, adjust here.
+
+- [ ] **Step 4: Run tests green.**
+
+Run: `cargo test -p arcan-prosopon translator::`
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/arcan/arcan-prosopon/src/translator.rs
+git commit -m "feat(arcan-prosopon): translate Session + Run lifecycle"
+```
+
+---
+
+## Task 3: Translator — user + assistant text
+
+**Files:** `translator.rs` (modify).
+
+- [ ] **Step 1: Tests.**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn user_message_adds_section_with_prose() {
+    let kind = EventKind::UserMessage { content: "hi".into() };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ProsoponEvent::NodeAdded { node, .. } => {
+            assert!(matches!(node.intent, Intent::Section { .. }));
+            assert_eq!(node.children.len(), 1);
+            assert!(matches!(node.children[0].intent, Intent::Prose { .. }));
+        }
+        _ => panic!("expected NodeAdded"),
+    }
+}
+
+#[test]
+fn first_text_delta_creates_stream_node_then_chunks() {
+    let mut s = st();
+    s.current_iteration = Some(3);
+    let first = EventKind::TextDelta { delta: "he".into(), index: Some(3) };
+    let second = EventKind::TextDelta { delta: "llo".into(), index: Some(3) };
+
+    let a = translate(&mut s, &first);
+    let b = translate(&mut s, &second);
+
+    // First delta: NodeAdded (stream) + StreamChunk.
+    assert_eq!(a.len(), 2);
+    assert!(matches!(a[0], ProsoponEvent::NodeAdded { .. }));
+    assert!(matches!(a[1], ProsoponEvent::StreamChunk { .. }));
+    // Second delta: StreamChunk only.
+    assert_eq!(b.len(), 1);
+    assert!(matches!(b[0], ProsoponEvent::StreamChunk { .. }));
+}
+
+#[test]
+fn assistant_message_committed_adds_assistant_section() {
+    let kind = EventKind::AssistantMessageCommitted {
+        role: "assistant".into(),
+        content: "answer".into(),
+        model: None,
+        token_usage: None,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], ProsoponEvent::NodeAdded { .. }));
+}
+```
+
+- [ ] **Step 2: Run — fails.**
+
+Run: `cargo test -p arcan-prosopon translator::`
+Expected: three new failures.
+
+- [ ] **Step 3: Implement.**
+
+Add these arms inside `translate`'s match (before the `_` wildcard):
+
+```rust
+EventKind::UserMessage { content } => {
+    let prose = Node::new(Intent::Prose { text: content.clone() });
+    let mut section = Node::new(Intent::Section {
+        title: Some("User".into()),
+        collapsible: false,
+    });
+    section.children.push(prose);
+    vec![ProsoponEvent::NodeAdded { parent: NodeId::root(), node: section }]
+}
+
+EventKind::AssistantTextDelta { delta, index, .. }
+| EventKind::TextDelta { delta, index, .. } => {
+    use prosopon_core::{StreamChunk, StreamId, StreamKind};
+    let iteration = index.or(state.current_iteration).unwrap_or(0);
+    let mut events = Vec::with_capacity(2);
+
+    let stream_id = state
+        .streams_by_iteration
+        .entry(iteration)
+        .or_insert_with(|| {
+            let id = StreamId::from(format!("stream:iter-{iteration}"));
+            let stream_node = Node::new(Intent::Stream { id: id.clone(), kind: StreamKind::Text });
+            events.push(ProsoponEvent::NodeAdded { parent: NodeId::root(), node: stream_node });
+            id
+        })
+        .clone();
+
+    events.push(ProsoponEvent::StreamChunk {
+        id: stream_id,
+        chunk: StreamChunk::Text(delta.clone()),
+    });
+    events
+}
+
+EventKind::AssistantMessageCommitted { content, .. } | EventKind::Message { content, .. } => {
+    let mut section = Node::new(Intent::Section {
+        title: Some("Assistant".into()),
+        collapsible: false,
+    });
+    section.children.push(Node::new(Intent::Prose { text: content.clone() }));
+    vec![ProsoponEvent::NodeAdded { parent: NodeId::root(), node: section }]
+}
+```
+
+If `StreamChunk` / `StreamKind` / `StreamId` constructor shapes differ from this, grep `core/prosopon/crates/prosopon-core/src/intent.rs` and adjust.
+
+- [ ] **Step 4: Run green.**
+
+Run: `cargo test -p arcan-prosopon translator::`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/arcan/arcan-prosopon/src/translator.rs
+git commit -m "feat(arcan-prosopon): translate user + assistant text events"
+```
+
+---
+
+## Task 4: Translator — tool calls
+
+**Files:** `translator.rs`.
+
+- [ ] **Step 1: Tests.**
+
+```rust
+#[test]
+fn tool_call_requested_adds_tool_call_node() {
+    let kind = EventKind::ToolCallRequested {
+        call_id: "call-1".into(),
+        tool_name: "shell".into(),
+        arguments: serde_json::json!({"cmd": "ls"}),
+        category: None,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ProsoponEvent::NodeAdded { node, .. } => {
+            assert!(matches!(node.intent, Intent::ToolCall { .. }));
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn tool_call_completed_updates_node() {
+    use aios_protocol::SpanStatus;
+    let kind = EventKind::ToolCallCompleted {
+        tool_run_id: aios_protocol::ToolRunId::default(),
+        call_id: Some("call-1".into()),
+        tool_name: "shell".into(),
+        result: serde_json::json!("ok"),
+        duration_ms: 12,
+        status: SpanStatus::Ok,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], ProsoponEvent::NodeUpdated { .. }));
+}
+
+#[test]
+fn tool_call_failed_updates_with_error_result() {
+    let kind = EventKind::ToolCallFailed {
+        call_id: "call-2".into(),
+        tool_name: "shell".into(),
+        error: "denied".into(),
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], ProsoponEvent::NodeUpdated { .. }));
+}
+```
+
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3: Implement.**
+
+Add a helper at the top of `translator.rs`:
+
+```rust
+fn tool_node_id(call_id: &str) -> prosopon_core::NodeId {
+    prosopon_core::NodeId::from(format!("tool:{call_id}"))
+}
+```
+
+Add arms:
+
+```rust
+EventKind::ToolCallRequested { call_id, tool_name, arguments, .. } => {
+    let mut node = Node::new(Intent::ToolCall {
+        name: tool_name.clone(),
+        args: arguments.clone(),
+        stream: None,
+    });
+    node.id = tool_node_id(call_id);
+    vec![ProsoponEvent::NodeAdded { parent: NodeId::root(), node }]
+}
+
+EventKind::ToolCallCompleted { call_id, result, status, .. } => {
+    use aios_protocol::SpanStatus;
+    use prosopon_core::NodePatch;
+    let id = call_id.as_ref().map(|c| tool_node_id(c)).unwrap_or_else(NodeId::root);
+    let success = matches!(status, SpanStatus::Ok);
+    let result_node = Node::new(Intent::ToolResult { success, payload: result.clone() });
+    vec![ProsoponEvent::NodeUpdated {
+        id,
+        patch: NodePatch {
+            append_children: vec![result_node],
+            ..NodePatch::default()
+        },
+    }]
+}
+
+EventKind::ToolCallFailed { call_id, error, .. } => {
+    use prosopon_core::NodePatch;
+    let id = tool_node_id(call_id);
+    let result_node = Node::new(Intent::ToolResult {
+        success: false,
+        payload: serde_json::json!({ "error": error }),
+    });
+    vec![ProsoponEvent::NodeUpdated {
+        id,
+        patch: NodePatch {
+            append_children: vec![result_node],
+            ..NodePatch::default()
+        },
+    }]
+}
+```
+
+If `NodePatch`'s field for child appends is named differently (e.g. `children_append` or `add_children`), inspect `core/prosopon/crates/prosopon-core/src/event.rs` and use the real name.
+
+- [ ] **Step 4: Run green.**
+- [ ] **Step 5: Commit.**
+
+```bash
+git commit -am "feat(arcan-prosopon): translate tool call lifecycle"
+```
+
+---
+
+## Task 5: Translator — approvals, state, compaction, wildcard
+
+**Files:** `translator.rs`.
+
+- [ ] **Step 1: Tests.**
+
+```rust
+#[test]
+fn approval_requested_adds_confirm_node() {
+    use aios_protocol::{ApprovalId, RiskLevel};
+    let kind = EventKind::ApprovalRequested {
+        approval_id: ApprovalId::default(),
+        call_id: "c".into(),
+        tool_name: "shell".into(),
+        arguments: serde_json::json!({}),
+        risk: RiskLevel::High,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ProsoponEvent::NodeAdded { node, .. } => {
+            assert!(matches!(node.intent, Intent::Confirm { .. }));
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn state_patched_emits_revision_signal() {
+    let kind = EventKind::StatePatched {
+        index: None,
+        patch: serde_json::json!([]),
+        revision: 42,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], ProsoponEvent::SignalChanged { .. }));
+}
+
+#[test]
+fn context_compacted_emits_signal_and_prose() {
+    let kind = EventKind::ContextCompacted {
+        dropped_count: 3,
+        tokens_before: 1000,
+        tokens_after: 500,
+    };
+    let events = translate(&mut st(), &kind);
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], ProsoponEvent::SignalChanged { .. }));
+    assert!(matches!(events[1], ProsoponEvent::NodeAdded { .. }));
+}
+```
+
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3: Implement.**
+
+Helpers:
+
+```rust
+fn severity_for(risk: &aios_protocol::RiskLevel) -> prosopon_core::Severity {
+    use aios_protocol::RiskLevel;
+    use prosopon_core::Severity;
+    match risk {
+        RiskLevel::Low => Severity::Normal,
+        RiskLevel::Medium => Severity::High,
+        RiskLevel::High | RiskLevel::Critical => Severity::Urgent,
+    }
+}
+
+fn approval_node_id(approval_id: &str) -> prosopon_core::NodeId {
+    prosopon_core::NodeId::from(format!("approval:{approval_id}"))
+}
+```
+
+Match arms:
+
+```rust
+EventKind::ApprovalRequested { approval_id, tool_name, risk, .. } => {
+    let message = format!("Approve {tool_name}?");
+    let mut node = Node::new(Intent::Confirm { message, severity: severity_for(risk) });
+    node.id = approval_node_id(&approval_id.to_string());
+    node.attrs.insert("approval_id".into(), serde_json::json!(approval_id.to_string()));
+    vec![ProsoponEvent::NodeAdded { parent: NodeId::root(), node }]
+}
+
+EventKind::ApprovalResolved { approval_id, decision, .. } => {
+    use prosopon_core::{NodePatch, Lifecycle, NodeStatus};
+    let id = approval_node_id(&approval_id.to_string());
+    vec![
+        ProsoponEvent::NodeUpdated {
+            id,
+            patch: NodePatch {
+                lifecycle: Some(Lifecycle { status: NodeStatus::Resolved, ..Default::default() }),
+                ..NodePatch::default()
+            },
+        },
+        ProsoponEvent::SignalChanged {
+            topic: Topic::from(format!("approval.{approval_id}")),
+            value: SignalValue::Text(decision.clone()),
+            ts: chrono::Utc::now(),
+        },
+    ]
+}
+
+EventKind::StatePatched { revision, .. } => vec![
+    ProsoponEvent::SignalChanged {
+        topic: Topic::from("state.revision"),
+        value: SignalValue::Number(*revision as f64),
+        ts: chrono::Utc::now(),
+    },
+],
+
+EventKind::ContextCompacted { tokens_before, tokens_after, .. } => {
+    let mut node = Node::new(Intent::Prose {
+        text: format!("Compacted {tokens_before}→{tokens_after} tokens"),
+    });
+    node.attrs.insert("emphasis".into(), serde_json::json!("low"));
+    vec![
+        ProsoponEvent::SignalChanged {
+            topic: Topic::from("context.tokens"),
+            value: SignalValue::Number(*tokens_after as f64),
+            ts: chrono::Utc::now(),
+        },
+        ProsoponEvent::NodeAdded { parent: NodeId::root(), node },
+    ]
+}
+
+EventKind::StepStarted { index } => vec![
+    ProsoponEvent::SignalChanged {
+        topic: Topic::from("iteration"),
+        value: SignalValue::Number(*index as f64),
+        ts: chrono::Utc::now(),
+    },
+],
+
+EventKind::PolicyEvaluated { tool_name, decision, .. } => vec![
+    ProsoponEvent::SignalChanged {
+        topic: Topic::from(format!("policy.{tool_name}")),
+        value: SignalValue::Text(format!("{decision:?}")),
+        ts: chrono::Utc::now(),
+    },
+],
+
+EventKind::KnowledgeSearched { query, result_count, .. } => {
+    let mut node = Node::new(Intent::Prose {
+        text: format!("Searched: {query} ({result_count})"),
+    });
+    node.attrs.insert("emphasis".into(), serde_json::json!("low"));
+    vec![ProsoponEvent::NodeAdded { parent: NodeId::root(), node }]
+}
+```
+
+Leave the `_ => Vec::new()` wildcard for all other variants.
+
+- [ ] **Step 4: Run green.**
+- [ ] **Step 5: Commit.**
+
+```bash
+git commit -am "feat(arcan-prosopon): translate approvals, state, compaction, policy"
+```
+
+---
+
+## Task 6: Bridge — subscribe, translate, publish
+
+**Files:**
+- Modify: `core/life/crates/arcan/arcan-prosopon/src/bridge.rs`
+- Test: `core/life/crates/arcan/arcan-prosopon/tests/bridge_integration.rs`
+
+- [ ] **Step 1: Integration test first.**
+
+Create `tests/bridge_integration.rs`:
+
+```rust
+//! End-to-end: feed a canned EventRecord stream, assert envelopes appear on the fanout.
+
+use aios_protocol::{BranchId, EventKind, EventRecord, SeqNo, SessionId};
+use arcan_prosopon::ArcanProsoponBridge;
+use prosopon_daemon::EnvelopeFanout;
+use tokio::sync::broadcast;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bridge_forwards_run_started_as_three_signal_envelopes() {
+    // Upstream = arcan's event broadcast.
+    let (event_tx, event_rx) = broadcast::channel::<EventRecord>(16);
+    // Downstream = prosopon fanout.
+    let fanout = EnvelopeFanout::new();
+    let mut subscriber = fanout.subscribe();
+
+    // Start the bridge.
+    let bridge = ArcanProsoponBridge::new(fanout);
+    let handle = bridge.spawn(event_rx);
+
+    // Emit one RunStarted event.
+    let record = EventRecord::new(
+        SessionId::default(),
+        BranchId::main(),
+        SeqNo::from(1u64),
+        EventKind::RunStarted { provider: "anthropic".into(), max_iterations: 5 },
+    );
+    event_tx.send(record).unwrap();
+
+    // Expect three SignalChanged envelopes.
+    for _ in 0..3 {
+        let env = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            subscriber.recv(),
+        )
+        .await
+        .expect("timeout waiting for envelope")
+        .expect("recv ok");
+        assert!(matches!(
+            env.event,
+            prosopon_core::ProsoponEvent::SignalChanged { .. }
+        ));
+    }
+
+    // Shut down.
+    drop(event_tx);
+    let _ = handle.await;
+}
+```
+
+Run: `cargo test -p arcan-prosopon --test bridge_integration`
+Expected: compilation fails because `ArcanProsoponBridge::spawn` doesn't exist.
+
+- [ ] **Step 2: Implement `spawn`.**
+
+Replace `bridge.rs` with:
+
+```rust
+//! Bridge — spawns the subscriber task that drains arcan events into the
+//! prosopon fanout.
+
+use crate::{translator::translate, BridgeError, TranslationState};
+use aios_protocol::EventRecord;
+use prosopon_daemon::EnvelopeFanout;
+use prosopon_sdk::Session;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// Drains an `aios_protocol::EventRecord` broadcast into a Prosopon fanout.
+pub struct ArcanProsoponBridge {
+    fanout: EnvelopeFanout,
+    session: Session,
+    state: TranslationState,
+}
+
+impl ArcanProsoponBridge {
+    pub fn new(fanout: EnvelopeFanout) -> Self {
+        Self {
+            fanout,
+            session: Session::new(),
+            state: TranslationState::new(),
+        }
+    }
+
+    /// Spawn the drain loop on the current tokio runtime. The loop exits when
+    /// the upstream broadcast closes.
+    pub fn spawn(mut self, mut events: broadcast::Receiver<EventRecord>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(record) => {
+                        if let Err(err) = self.drain_one(&record).await {
+                            warn!(error = %err, "arcan-prosopon: translation/publish failed");
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(lagged = n, "arcan-prosopon: dropped events due to lag");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        debug!("arcan-prosopon: upstream closed, exiting bridge");
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    async fn drain_one(&mut self, record: &EventRecord) -> Result<(), BridgeError> {
+        for event in translate(&mut self.state, &record.kind) {
+            let envelope = self.session.envelope(event);
+            self.fanout.send(envelope)?;
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 3: Run test.**
+
+Run: `cargo test -p arcan-prosopon --test bridge_integration`
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/arcan/arcan-prosopon/src/bridge.rs crates/arcan/arcan-prosopon/tests/bridge_integration.rs
+git commit -m "feat(arcan-prosopon): spawn bridge loop + integration test"
+```
+
+---
+
+## Task 7: Wire into arcand (optional daemon mode)
+
+**Files:**
+- Modify: `core/life/crates/arcan/arcand/Cargo.toml` — add optional `arcan-prosopon`, `prosopon-daemon`, `prosopon-compositor-glass` deps behind a `prosopon` feature.
+- Modify: `core/life/crates/arcan/arcand/src/main.rs` — add `--prosopon-port` CLI flag and conditional boot code.
+- Modify: `core/life/crates/arcan/arcand/src/canonical.rs` — no change if `subscribe_events()` is already public.
+
+- [ ] **Step 1: Add optional dependency block.**
+
+Edit `core/life/crates/arcan/arcand/Cargo.toml`:
+
+```toml
+[dependencies]
+# ... existing deps ...
+arcan-prosopon                 = { path = "../arcan-prosopon", optional = true }
+prosopon-daemon                = { path = "../../../../../prosopon/crates/prosopon-daemon", optional = true }
+prosopon-compositor-glass      = { path = "../../../../../prosopon/crates/prosopon-compositor-glass", optional = true }
+
+[features]
+default = []
+prosopon = ["dep:arcan-prosopon", "dep:prosopon-daemon", "dep:prosopon-compositor-glass"]
+```
+
+- [ ] **Step 2: Add CLI flag.**
+
+In the Clap struct inside `arcand/src/main.rs` (locate the `struct Cli` or `struct ServeArgs`; ~line 1283 for `fn main`), add:
+
+```rust
+/// Enable the Prosopon display-server sidecar on this address.
+/// Requires `--features prosopon` at build time.
+#[arg(long, value_name = "ADDR")]
+prosopon_port: Option<std::net::SocketAddr>,
+```
+
+- [ ] **Step 3: Conditional boot.**
+
+In the daemon bootstrap (after `CanonicalState` is constructed), add:
+
+```rust
+#[cfg(feature = "prosopon")]
+if let Some(addr) = args.prosopon_port {
+    use arcan_prosopon::ArcanProsoponBridge;
+    use prosopon_compositor_glass::glass_surface;
+    use prosopon_daemon::{DaemonConfig, DaemonServer};
+
+    match DaemonServer::bind(DaemonConfig { addr, surface: Some(glass_surface()) }).await {
+        Ok(server) => {
+            let fanout = server.fanout();
+            let event_rx = state.runtime.subscribe_events();
+            let bridge = ArcanProsoponBridge::new(fanout);
+            let _bridge_handle = bridge.spawn(event_rx);
+            let _daemon_handle = tokio::spawn(async move {
+                if let Err(err) = server.serve().await {
+                    tracing::error!(error = %err, "prosopon-daemon serve failed");
+                }
+            });
+            tracing::info!(addr = %addr, "arcan-prosopon: bridge online");
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                addr = %addr,
+                "arcan-prosopon: failed to bind, arcan will continue without Prosopon"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build with feature.**
+
+Run: `cargo build -p arcand --features prosopon`
+Expected: success.
+
+Run (no feature): `cargo build -p arcand`
+Expected: success (arcand compiles without any Prosopon code).
+
+- [ ] **Step 5: Smoke-run.**
+
+Run in one terminal: `cargo run -p arcand --features prosopon -- serve --prosopon-port 127.0.0.1:4321` (or whatever the serve subcommand is — verify from `arcand --help`).
+In another: `curl http://127.0.0.1:4321/healthz`
+Expected: `{"status":"ok"}` or similar from `prosopon-daemon`'s health endpoint. If a different health path, inspect `prosopon-daemon/src/server.rs`.
+
+Stop both.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git commit -am "feat(arcand): optional arcan-prosopon sidecar behind 'prosopon' feature"
+```
+
+---
+
+## Task 8: Docs + CHANGELOG + Linear + PR
+
+**Files:**
+- Create: `core/life/crates/arcan/arcan-prosopon/README.md`
+- Modify: `core/life/CHANGELOG.md` (if present) or crate-level CHANGELOG
+- Create: `/Users/broomva/broomva/research/entities/project/arcan-prosopon.md` (entity page for knowledge graph)
+- Linear: BRO-773 status update + PR link
+
+- [ ] **Step 1: Expand the README.**
+
+Write a concise README covering: what the crate is, the translation table (copy from this plan's Translation table), `Bridge::new` + `Bridge::spawn` API, feature-flag usage in `arcand`, the graceful-fallback contract, and links to prosopon-core + the plan.
+
+- [ ] **Step 2: Add entity page.**
+
+`/Users/broomva/broomva/research/entities/project/arcan-prosopon.md`:
+
+```markdown
+---
+name: arcan-prosopon
+description: Pneuma<L0ToExternal> for Arcan — translates aios EventKind to Prosopon envelopes and publishes to the prosopon-daemon fanout.
+type: project
+status: shipped
+layer: 3
+score: 8
+related:
+  - research/entities/project/prosopon.md
+  - research/entities/project/arcan.md
+  - research/entities/concept/pneuma.md
+  - research/entities/project/sensorium.md
+---
+
+# arcan-prosopon
+
+(summary + link to `core/life/docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md`)
+```
+
+- [ ] **Step 3: Run full life smoke.**
+
+Run: `make smoke -C /Users/broomva/broomva/core/life` (or the workspace's equivalent).
+Expected: all green.
+
+Run: `cargo test -p arcan-prosopon`
+Expected: all green.
+
+- [ ] **Step 4: Commit + push + PR.**
+
+```bash
+git add -A
+git commit -m "docs(arcan-prosopon): README + entity page + CHANGELOG"
+git push origin bro-773-arcan-prosopon
+gh pr create --title "BRO-773: arcan-prosopon — emit Arcan session through Prosopon" \
+  --body "$(cat <<'EOF'
+## Summary
+- New crate \`arcan-prosopon\` in Life — \`Pneuma<L0ToExternal>\` for Arcan.
+- Subscribes to \`KernelRuntime\` events, translates \`EventKind → ProsoponEvent\`, publishes to \`EnvelopeFanout\`.
+- Opt-in via \`arcand --features prosopon --prosopon-port <addr>\`. Graceful fallback if daemon can't bind.
+
+## Test Plan
+- [x] unit tests per EventKind family pass
+- [x] integration test: mock kernel → fanout subscriber observes expected envelopes
+- [x] \`arcand\` builds with and without the \`prosopon\` feature
+- [ ] Manual: glass compositor renders a live arcan session at http://127.0.0.1:4321/
+
+Linear: https://linear.app/broomva/issue/BRO-773
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Flip Linear BRO-773 to In Progress now, Done on merge.**
+
+Use MCP linear-server to set state = "In Progress" when the PR opens, then "Done" once merged.
+
+- [ ] **Step 6: Announce in docs.**
+
+Add one line to the workspace-level index at `/Users/broomva/broomva/docs/knowledge-index.md` if the index is updated on ship. Update `core/prosopon/PLANS.md` to mark BRO-773 `[x]`.
+
+---
+
+## Self-review checklist (executor: run this before opening the PR)
+
+- All `EventKind` variants present today are handled: covered in Tasks 2-5 + wildcard.
+- All tasks have TDD skeleton (failing test → implementation → passing test → commit).
+- Type / method / field names used in Task N referenced in Task M match. In particular: `NodePatch`'s field for child appends is called `append_children` in this plan. Verify during Task 4 Step 3 and correct in Task 5 if different.
+- Placeholder scan: plan contains no "TBD" / "fill in" / "similar to above" markers in implementation steps.
+- Graceful degradation proven: Task 7 Step 3's `warn!` path keeps arcand alive when the daemon can't bind.
+- Feature flag prevents arcand's hard dependency on Prosopon (verified in Task 7 Step 4).


### PR DESCRIPTION
## Summary

- New crate `arcan-prosopon` in Life — `Pneuma<L0ToExternal>` for Arcan.
- Subscribes to `KernelRuntime::subscribe_events()`, translates `aios_protocol::EventKind` → `prosopon_core::ProsoponEvent`, publishes to `prosopon_daemon::EnvelopeFanout`.
- Opt-in: build with `--features prosopon`, run with `--prosopon-port <addr>`.
- Graceful fallback: bind failure logs a warning and `arcan-console` keeps working unchanged.

## Coverage

- 21 translator unit tests + integration test `translated_events_apply_cleanly_to_scene_store` that round-trips events through `prosopon_runtime::SceneStore::apply`.
- 2 bridge integration tests (`bridge_forwards_run_started_as_three_signal_envelopes`, `bridge_exits_when_upstream_closes`).
- `arcan` builds clean with AND without the `prosopon` feature; workspace-wide `cargo check --workspace --all-targets` passes.

## Test plan

- [x] `cargo test -p arcan-prosopon` — 23/23 green.
- [x] `cargo clippy -p arcan-prosopon --all-targets -- -D warnings` — clean.
- [x] `cargo build -p arcan` (default) — succeeds.
- [x] `cargo build -p arcan --features prosopon` — succeeds.
- [x] `cargo check --workspace --all-targets` — clean.
- [ ] Manual: point a glass compositor at `http://127.0.0.1:4321/` while arcan runs a session; verify live updates.

Plan: `core/life/docs/superpowers/plans/2026-04-23-bro-773-arcan-prosopon.md`
Linear: https://linear.app/broomva/issue/BRO-773

🤖 Generated with [Claude Code](https://claude.com/claude-code)