### PR TITLE
docs(life-kernel): reflect Phase 1 shipped state in cluster CLAUDE.md

### DIFF
--- a/crates/life-kernel/CLAUDE.md
+++ b/crates/life-kernel/CLAUDE.md
@@ -4,20 +4,28 @@ Implementation of the aiOS kernel contract for the µVM isolation tier.
 
 Spec: `../../../../docs/superpowers/specs/2026-04-23-lifed-kernel-daemon-design.md`
 
-## Crates (Phase 1 will flesh these out)
+## Crates
 
-- `life-kernel-proto` — ttrpc wire contract (NOT YET CREATED; Phase 1)
-- `life-kernel-core` — `KernelPort` impl + gate chain + metering (NOT YET CREATED; Phase 1)
-- `life-kernel-gate` — gate port impls (NOT YET CREATED; Phase 1)
-- `life-kernel-conformance` — per-backend test harness (SCAFFOLD ONLY in Phase 0)
-- `lifed` (binary) — the daemon (NOT YET CREATED; Phase 2)
+- `life-kernel-proto` — tonic wire contract for `KernelService` (SHIPPED in Phase 1, #974). The Phase 1 spec called for ttrpc-rust; `ttrpc-codegen 0.6` is incompatible with the `prost 0.14` ecosystem the workspace has standardised on, so the crate emits tonic client + server stubs from the same `.proto`. See the `build.rs` header for the full rationale.
+- `life-kernel-core` — `KernelPort` engine composing `BackendRegistry` + `GateChain` + `MeteringWrapper` over any `HypervisorBackend`. Pure state machine; reconstructable from the Lago event stream via `KernelEngine::replay`. (SHIPPED in Phase 1, #974.)
+- `life-kernel-gate` — Phase 1 MVS gate impls: `NoOpBudgetGate`, `NoOpNetworkIsolation`, `StaticPolicyGate` (wraps `aios-policy::PolicyGatePort`). Real budget + network impls land in Phase 4. (SHIPPED in Phase 1, #974.)
+- `life-kernel-conformance` — backend-agnostic conformance battery (lifecycle / errors / metering / events). 100% green against `arcan-provider-local` through `life-kernel-core`. (SCAFFOLDED in Phase 0, FLESHED OUT in Phase 1.)
+- `lifed` (binary) — the daemon. **NOT YET CREATED; Phase 2.**
+- `lifectl` (binary) — operator CLI over the tonic contract. **NOT YET CREATED; Phase 2.**
 
-## Phase 0 status
+## Phase status
 
-Only `life-kernel-conformance` exists as an empty scaffold, so the workspace
-resolves and downstream tooling works. Phase 1 fills in the actual suite.
+- **Phase 0** — ABI Foundation: shipped (#963). `aios-protocol` additive extensions, `HypervisorBackend` promotion, conformance scaffold.
+- **Phase 1** — Kernel Proto + Core Library: shipped (#974). Four library-tier crates live; engine proven as a deterministic fold over the event journal.
+- **Phase 2** — lifed Daemon + Observability: in progress. Boxes the Phase 1 library inside a systemd-managed binary; Lago + Vigil wiring; `lifectl` CLI. Plan: `docs/superpowers/plans/2026-04-24-lifed-phase-2-daemon.md`.
+- **Phases 3–5** — `arcan-provider-cube`, real gates, arcand cutover. Parallelisable after Phase 2.
 
 ## Dependency rules
 
-- life-kernel-* MAY depend on: aios-protocol, arcan-sandbox, arcan-provider-*, lago-core, life-vigil
-- life-kernel-* MUST NOT depend on: arcand, arcan-core, arcan-harness
+- `life-kernel-proto` MAY depend on: `aios-protocol` (plus `prost` / `tonic` generated scaffolding).
+- `life-kernel-core` MAY depend on: `aios-protocol`, `arcan-sandbox`, `arcan-provider-*`, `life-kernel-proto`, `life-kernel-gate`, `lago-core`, `life-vigil`.
+- `life-kernel-gate` MAY depend on: `aios-protocol`, `aios-policy`, `autonomic-core` (behind feature).
+- `lifed` binary MAY depend on every crate above.
+- `life-kernel-*` MUST NOT depend on: `arcand`, `arcan-core`, `arcan-harness`, `arcan-aios-adapters`.
+
+Enforced by `scripts/verify_dependencies_lifed.sh`.


### PR DESCRIPTION
## Summary

Pre-work tidying ahead of Phase 2 work. The `crates/life-kernel/CLAUDE.md` cluster doc was authored at Phase 0 and still claimed the four Phase 1 crates (`life-kernel-proto`, `life-kernel-core`, `life-kernel-gate`, `life-kernel-conformance`) were "NOT YET CREATED". Phase 1 (#974) shipped them. Updates the file to reflect reality:

- Marks the four library-tier crates as shipped in Phase 1.
- Documents the ttrpc → tonic transport switch (rationale lives on the Phase 1 build.rs header).
- Notes the two binaries (`lifed`, `lifectl`) still pending in Phase 2.
- Points to the Phase 2 plan at `docs/superpowers/plans/2026-04-24-lifed-phase-2-daemon.md`.
- Tightens dependency-rule listings.

Single-commit branch — should fast-forward cleanly onto `main`.

## Test plan

- [x] Reading-only doc change; no code touched.
- [ ] Reviewer skims the diff for accuracy against shipped Phase 1 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap and phase status documentation to reflect current development progress
  * Expanded architectural descriptions for core components and their roles
  * Added dependency constraint documentation and verification framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->