### PR TITLE
feat(arcan-provider-cube): HypervisorBackend lifecycle impl (BRO-915, M2 Tasks 6+7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "aios-protocol",
  "arcan-sandbox",
  "async-trait",
+ "base64",
  "bitflags 2.11.0",
  "chrono",
  "mockito",

--- a/crates/arcan/arcan-provider-cube/Cargo.toml
+++ b/crates/arcan/arcan-provider-cube/Cargo.toml
@@ -20,6 +20,7 @@ sandbox-cube = []
 aios-protocol.workspace = true
 arcan-sandbox.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 bitflags.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 # reqwest is pinned to rustls (no native-tls) for static builds + cross-compile

--- a/crates/arcan/arcan-provider-cube/src/convert.rs
+++ b/crates/arcan/arcan-provider-cube/src/convert.rs
@@ -1,0 +1,315 @@
+//! Conversions between the canonical `aios_protocol::hypervisor` types and
+//! the private CubeAPI v1 wire types in [`crate::types`].
+//!
+//! The boundary between protocol and wire is intentionally narrow: every
+//! function here is a pure, total mapping with no I/O, so it can be unit
+//! tested without spinning up an HTTP layer.
+
+use aios_protocol::hypervisor::{
+    BackendId, ExecRequest, ExecResult, Mount, RuntimeHint, VmHandle, VmId, VmSpec, VmStatus,
+};
+use aios_protocol::ids::{AgentId, SessionId};
+use aios_protocol::sandbox::NetworkPolicy;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+use crate::error::CubeError;
+use crate::types::{
+    CreateVmReq, ExecReq, ExecResp, MountReq, NetworkPolicyReq, RuntimeKind, VmResp, VmStatusResp,
+};
+
+/// Build a [`CreateVmReq`] from a canonical [`VmSpec`].
+///
+/// Cube's HTTP API exposes memory + disk as megabytes, while the canonical
+/// vocabulary keeps everything in kilobytes for forward compatibility with
+/// nano-VMs and lightweight WASM guests. The conversion divides by 1024 and
+/// rounds toward zero — callers wanting a precise floor MUST pass already
+/// MiB-aligned values.
+pub(crate) fn create_vm_req_from_spec(spec: &VmSpec) -> CreateVmReq {
+    CreateVmReq {
+        vcpus: spec.resources.vcpus,
+        memory_mb: spec.resources.memory_kb / 1024,
+        disk_mb: spec.resources.disk_kb / 1024,
+        timeout_secs: spec.resources.timeout_secs,
+        runtime: runtime_from_hint(&spec.runtime_hint),
+        env: spec.env.clone(),
+        mounts: spec.mounts.iter().map(mount_to_req).collect(),
+        tags: spec.labels.clone(),
+        network: network_to_req(&spec.network_policy),
+    }
+}
+
+/// Map a [`RuntimeHint`] into Cube's runtime selector.
+///
+/// `RuntimeHint` is `#[non_exhaustive]`; new variants are coerced to
+/// [`RuntimeKind::Shell`] so a future kernel version that adds, say, a
+/// `RuntimeHint::Bun` does not break Cube backends pinned to v0.3 — the
+/// provider degrades gracefully instead of panicking.
+pub(crate) fn runtime_from_hint(hint: &RuntimeHint) -> RuntimeKind {
+    match hint {
+        RuntimeHint::Shell => RuntimeKind::Shell,
+        RuntimeHint::Node { version } => RuntimeKind::Node {
+            version: version.clone(),
+        },
+        RuntimeHint::Python { version } => RuntimeKind::Python {
+            version: version.clone(),
+        },
+        RuntimeHint::Custom { image } => RuntimeKind::Custom {
+            image: image.clone(),
+        },
+        // `RuntimeHint` is `#[non_exhaustive]` — fall through gracefully
+        // when a new variant lands upstream before the Cube backend has
+        // been updated.
+        _ => RuntimeKind::Shell,
+    }
+}
+
+/// Map a canonical [`Mount`] into the Cube wire shape.
+pub(crate) fn mount_to_req(m: &Mount) -> MountReq {
+    MountReq {
+        source: m.source.clone(),
+        target: m.target.clone(),
+        read_only: m.read_only,
+    }
+}
+
+/// Map a canonical [`NetworkPolicy`] (from `aios_protocol::sandbox`) into
+/// the Cube wire shape.
+///
+/// Cube exposes "no restrictions" as `Open` and "explicit allow-list" as
+/// `AllowList { cidrs }`. The canonical vocabulary calls the open variant
+/// `AllowAll` and threads the allow-list as `hosts` — the conversion
+/// preserves the values verbatim because Cube treats CIDR strings and
+/// host strings interchangeably (it parses each entry as either a CIDR
+/// network or an FQDN).
+pub(crate) fn network_to_req(p: &NetworkPolicy) -> NetworkPolicyReq {
+    match p {
+        NetworkPolicy::Disabled => NetworkPolicyReq::Disabled,
+        NetworkPolicy::AllowAll => NetworkPolicyReq::Open,
+        NetworkPolicy::AllowList { hosts } => NetworkPolicyReq::AllowList {
+            cidrs: hosts.clone(),
+        },
+    }
+}
+
+/// Encode a canonical [`ExecRequest`] into the Cube wire shape.
+///
+/// `stdin` is base64-encoded because the Cube envelope is JSON; raw bytes
+/// would otherwise need lossy UTF-8 coercion.
+pub(crate) fn exec_req_from(req: &ExecRequest) -> ExecReq {
+    ExecReq {
+        command: req.command.clone(),
+        working_dir: req.working_dir.clone(),
+        env: req.env.clone(),
+        timeout_secs: req.timeout_secs,
+        stdin_b64: req.stdin.as_ref().map(|s| STANDARD.encode(s)),
+    }
+}
+
+/// Decode an [`ExecResp`] back into a canonical [`ExecResult`].
+///
+/// Returns [`CubeError::Decode`] when stdout/stderr are not valid base64 —
+/// the kernel turns this into [`aios_protocol::hypervisor::BackendError::Transport`]
+/// at the trait boundary, which matches Cube's actual failure mode (a
+/// corrupt response was already a transport-level fault).
+pub(crate) fn exec_result_from_resp(resp: ExecResp) -> Result<ExecResult, CubeError> {
+    let stdout = STANDARD
+        .decode(&resp.stdout_b64)
+        .map_err(|e| CubeError::Decode(format!("stdout: {e}")))?;
+    let stderr = STANDARD
+        .decode(&resp.stderr_b64)
+        .map_err(|e| CubeError::Decode(format!("stderr: {e}")))?;
+    Ok(ExecResult {
+        stdout,
+        stderr,
+        exit_code: resp.exit_code,
+        duration_ms: resp.duration_ms,
+    })
+}
+
+/// Build a canonical [`VmHandle`] from a [`VmResp`] plus the session +
+/// agent attribution captured by the provider.
+pub(crate) fn vm_handle_from_resp(
+    resp: VmResp,
+    backend_name: &'static str,
+    session: &SessionId,
+    agent: &AgentId,
+) -> VmHandle {
+    VmHandle {
+        vm_id: VmId::from(resp.id),
+        backend: BackendId::from(backend_name),
+        session_id: session.clone(),
+        agent_id: agent.clone(),
+        status: status_from_resp(resp.status),
+        created_at: resp.created_at,
+        metadata: resp.metadata,
+    }
+}
+
+/// Map Cube's status enum onto the canonical [`VmStatus`].
+///
+/// Cube does not currently expose a `Hibernated` state — backends advertise
+/// `BackendCapabilitySet::HIBERNATE` separately, so omitting the variant
+/// here is correct (a Cube response cannot decode into `Hibernated`).
+pub(crate) fn status_from_resp(s: VmStatusResp) -> VmStatus {
+    match s {
+        VmStatusResp::Starting => VmStatus::Starting,
+        VmStatusResp::Running => VmStatus::Running,
+        VmStatusResp::Snapshotted => VmStatus::Snapshotted,
+        VmStatusResp::Stopping => VmStatus::Stopping,
+        VmStatusResp::Stopped => VmStatus::Stopped,
+        VmStatusResp::Failed { reason } => VmStatus::Failed { reason },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use aios_protocol::hypervisor::{BackendSelector, VmResources, VmSpec};
+
+    use super::*;
+
+    #[test]
+    fn create_req_converts_kb_to_mb() {
+        let spec = VmSpec {
+            backend_selector: BackendSelector::Auto,
+            resources: VmResources {
+                vcpus: 4,
+                memory_kb: 2 * 1024 * 1024,
+                disk_kb: 8 * 1024 * 1024,
+                timeout_secs: 120,
+            },
+            network_policy: NetworkPolicy::Disabled,
+            mounts: Vec::new(),
+            env: HashMap::new(),
+            runtime_hint: RuntimeHint::Shell,
+            labels: HashMap::new(),
+        };
+        let req = create_vm_req_from_spec(&spec);
+        assert_eq!(req.vcpus, 4);
+        assert_eq!(req.memory_mb, 2048);
+        assert_eq!(req.disk_mb, 8192);
+        assert_eq!(req.timeout_secs, 120);
+    }
+
+    #[test]
+    fn runtime_hint_maps_to_runtime_kind_node() {
+        let kind = runtime_from_hint(&RuntimeHint::Node {
+            version: "20.11".into(),
+        });
+        let json = serde_json::to_string(&kind).unwrap();
+        assert!(json.contains("\"kind\":\"node\""));
+        assert!(json.contains("20.11"));
+    }
+
+    #[test]
+    fn mount_round_trips_read_only_flag() {
+        let m = Mount {
+            source: "/host".into(),
+            target: "/guest".into(),
+            read_only: true,
+        };
+        let req = mount_to_req(&m);
+        assert_eq!(req.source, "/host");
+        assert_eq!(req.target, "/guest");
+        assert!(req.read_only);
+    }
+
+    #[test]
+    fn network_disabled_maps_to_disabled() {
+        let req = network_to_req(&NetworkPolicy::Disabled);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"kind\":\"disabled\""));
+    }
+
+    #[test]
+    fn network_allow_all_maps_to_open() {
+        let req = network_to_req(&NetworkPolicy::AllowAll);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"kind\":\"open\""));
+    }
+
+    #[test]
+    fn network_allow_list_threads_hosts_into_cidrs() {
+        let req = network_to_req(&NetworkPolicy::AllowList {
+            hosts: vec!["api.anthropic.com".into(), "10.0.0.0/8".into()],
+        });
+        match req {
+            NetworkPolicyReq::AllowList { cidrs } => {
+                assert_eq!(cidrs, vec!["api.anthropic.com", "10.0.0.0/8"]);
+            }
+            _ => panic!("expected AllowList"),
+        }
+    }
+
+    #[test]
+    fn exec_req_base64_encodes_stdin() {
+        let req = ExecRequest {
+            command: vec!["cat".into()],
+            working_dir: None,
+            env: HashMap::new(),
+            timeout_secs: None,
+            stdin: Some(b"hi".to_vec()),
+        };
+        let encoded = exec_req_from(&req);
+        assert_eq!(encoded.stdin_b64.as_deref(), Some("aGk="));
+    }
+
+    #[test]
+    fn exec_result_decodes_base64_stdout() {
+        let resp = ExecResp {
+            stdout_b64: "aGVsbG8=".into(),
+            stderr_b64: String::new(),
+            exit_code: 0,
+            duration_ms: 12,
+        };
+        let result = exec_result_from_resp(resp).unwrap();
+        assert_eq!(result.stdout, b"hello");
+        assert!(result.stderr.is_empty());
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.duration_ms, 12);
+    }
+
+    #[test]
+    fn exec_result_rejects_invalid_base64() {
+        let resp = ExecResp {
+            stdout_b64: "@@not-base64@@".into(),
+            stderr_b64: String::new(),
+            exit_code: 0,
+            duration_ms: 0,
+        };
+        assert!(matches!(
+            exec_result_from_resp(resp),
+            Err(CubeError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn vm_handle_carries_session_and_agent_attribution() {
+        let resp = VmResp {
+            id: "vm-1".into(),
+            status: VmStatusResp::Running,
+            created_at: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+        };
+        let session = SessionId::from_string("sess-1");
+        let agent = AgentId::from_string("agent-1");
+        let handle = vm_handle_from_resp(resp, "cube", &session, &agent);
+        assert_eq!(handle.vm_id.0, "vm-1");
+        assert_eq!(handle.backend.0, "cube");
+        assert_eq!(handle.session_id.as_str(), "sess-1");
+        assert_eq!(handle.agent_id.as_str(), "agent-1");
+        assert!(matches!(handle.status, VmStatus::Running));
+    }
+
+    #[test]
+    fn status_failed_preserves_reason() {
+        let mapped = status_from_resp(VmStatusResp::Failed {
+            reason: "oom".into(),
+        });
+        match mapped {
+            VmStatus::Failed { reason } => assert_eq!(reason, "oom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/crates/arcan/arcan-provider-cube/src/lib.rs
+++ b/crates/arcan/arcan-provider-cube/src/lib.rs
@@ -52,9 +52,7 @@ use tracing::{debug, instrument};
 pub use error::CubeError;
 
 use client::CubeClient;
-use convert::{
-    create_vm_req_from_spec, exec_req_from, exec_result_from_resp, vm_handle_from_resp,
-};
+use convert::{create_vm_req_from_spec, exec_req_from, exec_result_from_resp, vm_handle_from_resp};
 use types::{SnapshotResp, VmResp};
 
 /// Stable backend name used by the kernel for routing + observability.

--- a/crates/arcan/arcan-provider-cube/src/lib.rs
+++ b/crates/arcan/arcan-provider-cube/src/lib.rs
@@ -2,15 +2,317 @@
 //! the CubeSandbox HTTP API v1.
 //!
 //! See `README.md` for backend identity, env vars, and capability set.
-//! Real impl lands in Tasks 4–8 of the Phase 3 plan.
+//!
+//! # Capabilities
+//!
+//! Cube advertises filesystem (read + write + ext), network egress,
+//! persistence (`snapshot` / `restore`), forking, and tag (label)
+//! preservation. Hibernation is **not** supported by the upstream Cube
+//! API v1 — calls to [`HypervisorBackend::hibernate`] / `resume` fall
+//! through to the trait defaults, which return
+//! [`BackendError::NotSupported`].
+//!
+//! # Construction
+//!
+//! Three constructors are provided:
+//!
+//! - [`CubeProvider::new`] — explicit base URL + bearer token.
+//! - [`CubeProvider::from_env`] — reads `CUBE_API_URL` + `CUBE_API_TOKEN`.
+//! - [`CubeProvider::with_session`] — builder applied after construction
+//!   to bind every VM the provider creates to a session + agent. The
+//!   kernel calls this during backend registration.
+//!
+//! # Tracing
+//!
+//! Every public async method is annotated with [`macro@tracing::instrument`]
+//! carrying `backend = "cube"` plus the relevant identifier (`vm_id` /
+//! `snapshot_id`) so a single grep over Vigil traces yields the full
+//! lifecycle of a Cube-backed VM.
 //!
 //! [`HypervisorBackend`]: aios_protocol::hypervisor::HypervisorBackend
+//! [`BackendError::NotSupported`]: aios_protocol::hypervisor::BackendError::NotSupported
 
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
 mod client;
+mod convert;
 mod error;
 mod types;
 
+use aios_protocol::hypervisor::{
+    BackendCapabilitySet, BackendError, ExecRequest, ExecResult, HypervisorBackend, VmHandle,
+    VmSnapshotId, VmSpec,
+};
+use aios_protocol::ids::{AgentId, SessionId};
+use async_trait::async_trait;
+use reqwest::Method;
+use tracing::{debug, instrument};
+
 pub use error::CubeError;
+
+use client::CubeClient;
+use convert::{
+    create_vm_req_from_spec, exec_req_from, exec_result_from_resp, vm_handle_from_resp,
+};
+use types::{SnapshotResp, VmResp};
+
+/// Stable backend name used by the kernel for routing + observability.
+const BACKEND_NAME: &str = "cube";
+
+/// [`HypervisorBackend`] backed by CubeSandbox v1.
+///
+/// Construct with [`CubeProvider::new`] (explicit) or
+/// [`CubeProvider::from_env`] (reads `CUBE_API_URL` + `CUBE_API_TOKEN`).
+/// Every VM created by this provider is attributed to a session + agent;
+/// callers thread those through with [`CubeProvider::with_session`].
+#[derive(Debug, Clone)]
+pub struct CubeProvider {
+    client: CubeClient,
+    /// Session bound to every VM created by this provider — populated
+    /// via [`CubeProvider::with_session`]. Defaults to `"unbound"` so
+    /// the provider is constructable in CLI / smoke-test contexts that
+    /// do not yet have a session.
+    session_id: SessionId,
+    /// Agent attribution for every VM created by this provider — same
+    /// `"unbound"` default semantics as [`Self::session_id`].
+    agent_id: AgentId,
+}
+
+impl CubeProvider {
+    /// Construct from an explicit base URL + bearer token.
+    ///
+    /// The caller owns the configuration; no I/O happens until the first
+    /// trait method is invoked.
+    pub fn new(base_url: impl Into<String>, bearer_token: impl Into<String>) -> Self {
+        Self {
+            client: CubeClient::new(base_url, bearer_token),
+            session_id: SessionId::from_string("unbound"),
+            agent_id: AgentId::from_string("unbound"),
+        }
+    }
+
+    /// Construct from environment variables.
+    ///
+    /// | Variable | Required |
+    /// |---|---|
+    /// | `CUBE_API_URL` | yes |
+    /// | `CUBE_API_TOKEN` | yes |
+    ///
+    /// Returns [`CubeError::Unsupported`] when either variable is missing —
+    /// the kernel converts this into a `NotSupported` `BackendError` at
+    /// the registration boundary, which surfaces in startup logs as
+    /// "cube backend skipped: CUBE_API_URL must be set".
+    pub fn from_env() -> Result<Self, CubeError> {
+        let url = std::env::var("CUBE_API_URL")
+            .map_err(|_| CubeError::Unsupported("CUBE_API_URL must be set"))?;
+        let token = std::env::var("CUBE_API_TOKEN")
+            .map_err(|_| CubeError::Unsupported("CUBE_API_TOKEN must be set"))?;
+        Ok(Self::new(url, token))
+    }
+
+    /// Bind every VM this provider creates to a session + agent.
+    ///
+    /// `KernelEngine` calls this during backend registration so the
+    /// resulting [`VmHandle`] carries provenance for downstream auditing
+    /// + per-session billing.
+    #[must_use]
+    pub fn with_session(mut self, session: SessionId, agent: AgentId) -> Self {
+        self.session_id = session;
+        self.agent_id = agent;
+        self
+    }
+}
+
+#[async_trait]
+impl HypervisorBackend for CubeProvider {
+    fn name(&self) -> &'static str {
+        BACKEND_NAME
+    }
+
+    fn capabilities(&self) -> BackendCapabilitySet {
+        BackendCapabilitySet::FILESYSTEM_READ
+            | BackendCapabilitySet::FILESYSTEM_WRITE
+            | BackendCapabilitySet::FILESYSTEM_EXT
+            | BackendCapabilitySet::NETWORK_EGRESS
+            | BackendCapabilitySet::PERSISTENCE
+            | BackendCapabilitySet::FORK
+            | BackendCapabilitySet::TAGS
+    }
+
+    #[instrument(
+        skip(self, spec),
+        fields(
+            backend = BACKEND_NAME,
+            session_id = %self.session_id,
+            agent_id = %self.agent_id,
+        ),
+    )]
+    async fn create(&self, spec: VmSpec) -> Result<VmHandle, BackendError> {
+        let body = create_vm_req_from_spec(&spec);
+        debug!(
+            vcpus = body.vcpus,
+            memory_mb = body.memory_mb,
+            disk_mb = body.disk_mb,
+            "cube.create",
+        );
+        let resp: VmResp = self
+            .client
+            .request(Method::POST, "/api/v1/vms", &body)
+            .await
+            .map_err(|e| e.into_backend_error(None, None))?;
+        Ok(vm_handle_from_resp(
+            resp,
+            BACKEND_NAME,
+            &self.session_id,
+            &self.agent_id,
+        ))
+    }
+
+    #[instrument(
+        skip(self, vm, req),
+        fields(
+            backend = BACKEND_NAME,
+            vm_id = %vm.vm_id,
+            session_id = %self.session_id,
+        ),
+    )]
+    async fn exec(&self, vm: &VmHandle, req: ExecRequest) -> Result<ExecResult, BackendError> {
+        let body = exec_req_from(&req);
+        let path = format!("/api/v1/vms/{}/exec", vm.vm_id);
+        let resp = self
+            .client
+            .request(Method::POST, &path, &body)
+            .await
+            .map_err(|e| e.into_backend_error(Some(vm.vm_id.clone()), None))?;
+        exec_result_from_resp(resp).map_err(|e| e.into_backend_error(Some(vm.vm_id.clone()), None))
+    }
+
+    #[instrument(
+        skip(self, vm),
+        fields(
+            backend = BACKEND_NAME,
+            vm_id = %vm.vm_id,
+            session_id = %self.session_id,
+        ),
+    )]
+    async fn snapshot(&self, vm: &VmHandle) -> Result<VmSnapshotId, BackendError> {
+        let path = format!("/api/v1/vms/{}/snapshot", vm.vm_id);
+        let resp: SnapshotResp = self
+            .client
+            .request(Method::POST, &path, &serde_json::json!({}))
+            .await
+            .map_err(|e| e.into_backend_error(Some(vm.vm_id.clone()), None))?;
+        Ok(VmSnapshotId::from(resp.id))
+    }
+
+    #[instrument(
+        skip(self, snapshot),
+        fields(
+            backend = BACKEND_NAME,
+            snapshot_id = %snapshot,
+            session_id = %self.session_id,
+        ),
+    )]
+    async fn restore(&self, snapshot: &VmSnapshotId) -> Result<VmHandle, BackendError> {
+        let path = format!("/api/v1/snapshots/{snapshot}/restore");
+        let resp: VmResp = self
+            .client
+            .request(Method::POST, &path, &serde_json::json!({}))
+            .await
+            .map_err(|e| e.into_backend_error(None, Some(snapshot.clone())))?;
+        Ok(vm_handle_from_resp(
+            resp,
+            BACKEND_NAME,
+            &self.session_id,
+            &self.agent_id,
+        ))
+    }
+
+    #[instrument(
+        skip(self, vm),
+        fields(
+            backend = BACKEND_NAME,
+            vm_id = %vm.vm_id,
+            session_id = %self.session_id,
+        ),
+    )]
+    async fn destroy(&self, vm: &VmHandle) -> Result<(), BackendError> {
+        let path = format!("/api/v1/vms/{}", vm.vm_id);
+        match self
+            .client
+            .request_no_body::<serde_json::Value>(Method::DELETE, &path)
+            .await
+        {
+            Ok(_) => Ok(()),
+            // Destroy MUST be idempotent — the trait contract says it
+            // succeeds even when the VM is already gone.
+            Err(CubeError::NotFound(_)) => Ok(()),
+            Err(e) => Err(e.into_backend_error(Some(vm.vm_id.clone()), None)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lock the capability bit-set down so silent drift in either
+    /// direction (gaining or losing a bit) requires updating this test.
+    /// The set is tied to the wire contract — capability bits drive
+    /// kernel routing, so a regression here would silently break
+    /// `BackendSelector::Auto` matches across the whole workspace.
+    #[test]
+    fn capabilities_are_the_documented_set() {
+        let provider = CubeProvider::new("http://127.0.0.1:0", "test-token");
+        let caps = provider.capabilities();
+        let expected = BackendCapabilitySet::FILESYSTEM_READ
+            | BackendCapabilitySet::FILESYSTEM_WRITE
+            | BackendCapabilitySet::FILESYSTEM_EXT
+            | BackendCapabilitySet::NETWORK_EGRESS
+            | BackendCapabilitySet::PERSISTENCE
+            | BackendCapabilitySet::FORK
+            | BackendCapabilitySet::TAGS;
+        assert_eq!(
+            caps, expected,
+            "Cube capability set drifted; update lib.rs + README + ticket together",
+        );
+        // And spell out the negative space — Cube must NOT advertise
+        // these even by accident, because the trait routes to default
+        // `NotSupported` impls for them.
+        assert!(!caps.contains(BackendCapabilitySet::HIBERNATE));
+        assert!(!caps.contains(BackendCapabilitySet::NETWORK_INGRESS));
+        assert!(!caps.contains(BackendCapabilitySet::CUSTOM_IMAGE));
+        assert!(!caps.contains(BackendCapabilitySet::GPU));
+    }
+
+    #[test]
+    fn name_is_stable_string() {
+        let provider = CubeProvider::new("http://127.0.0.1:0", "test-token");
+        assert_eq!(provider.name(), "cube");
+        assert_eq!(provider.name(), BACKEND_NAME);
+    }
+
+    #[test]
+    fn with_session_threads_attribution_through_provider() {
+        let provider = CubeProvider::new("http://127.0.0.1:0", "test-token").with_session(
+            SessionId::from_string("sess-42"),
+            AgentId::from_string("agent-7"),
+        );
+        assert_eq!(provider.session_id.as_str(), "sess-42");
+        assert_eq!(provider.agent_id.as_str(), "agent-7");
+    }
+
+    /// Compile-time assertion that `CubeProvider` implements
+    /// [`HypervisorBackend`] — if the trait signature changes upstream,
+    /// this stops compiling first.
+    #[allow(dead_code)]
+    fn _assert_impls_hypervisor_backend() {
+        fn _accept<T: HypervisorBackend>() {}
+        _accept::<CubeProvider>();
+    }
+
+    /// Compile-time assertion that `CubeProvider` is dyn-compatible.
+    #[allow(dead_code)]
+    fn _assert_dyn_safe(_: &dyn HypervisorBackend) {}
+}


### PR DESCRIPTION
## Summary

Migration phase **M2** of the Life Runtime master spec — Tasks 6 + 7 of the [Phase 3 Cube backend plan](docs/superpowers/plans/2026-04-25-soma-phase-3-cube-backend.md).

* `CubeProvider` struct with `new`, `from_env`, `with_session` constructors
* `HypervisorBackend` impl: `create` / `exec` / `destroy` (idempotent on 404) / `snapshot` / `restore`
* Capability set: `FILESYSTEM_READ | FILESYSTEM_WRITE | FILESYSTEM_EXT | NETWORK_EGRESS | PERSISTENCE | FORK | TAGS` (no `HIBERNATE`)
* `hibernate` / `resume` at trait default (returns `BackendError::NotSupported`)
* Conversion helpers in `convert.rs`: `VmSpec → CreateVmReq`, `RuntimeHint → RuntimeKind`, `Mount → MountReq`, `aios_protocol::sandbox::NetworkPolicy → NetworkPolicyReq`
* `tracing::instrument` spans on every method with `backend="cube"` + `vm_id` + `session_id` attrs
* Capability bit-set asserted in a unit test (plan-required guard against silent drift)

Notes vs. the plan text:
* Conversion helpers live in a new `convert.rs` module (plan said "near `types.rs` or in a new `convert.rs`"). Cleaner module boundary, easier unit testing.
* Canonical `NetworkPolicy` re-export lives at `aios_protocol::sandbox::NetworkPolicy` (not in `aios_protocol::hypervisor` as the plan's import line suggested). The mapping handles `AllowAll` → wire `Open` and `AllowList { hosts }` → wire `AllowList { cidrs }` (Cube parses each entry as either a CIDR or an FQDN, so the rename is lossless).
* `RuntimeHint` is `#[non_exhaustive]`; the converter degrades unknown variants to `Shell` rather than panicking, so a future kernel adding e.g. `RuntimeHint::Bun` will not break Cube backends pinned to v0.3.

Closes BRO-915.

Tasks 8–14 ship in follow-up tickets BRO-916 (FilesystemExt + list), BRO-917 (mockito unit suite), BRO-918 (docker-compose conformance), BRO-919 (cold-start bench).

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace`: **3468 / 0 / 19** (baseline 3454 / 0 / 19 + 14 new tests in `convert.rs` + `lib.rs`)
- [x] `cargo doc -p arcan-provider-cube --no-deps` clean (every public item has rustdoc)
- [ ] CI green
- [ ] Merge with --merge

## References
- Plan: `docs/superpowers/plans/2026-04-25-soma-phase-3-cube-backend.md` (Tasks 6 + 7)
- M2 foundation: PR #1032 (BRO-859, BRO-914)
- Master spec §L11 M2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fully implemented CubeProvider for complete VM lifecycle management (creation, execution, snapshots, restoration, and deletion)
  * Added session and agent attribution support
  * Enhanced error handling and activity tracing for all operations
  * Support for environment-based configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->