### PR TITLE
feat(life-runtime): M5 Sub-phase A — lifed scaffolding + Agent + Events vs mocks (BRO-930)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,19 @@ jobs:
       - run: cargo install cargo-deny --locked
       - run: cargo deny check
 
+  # ── Gate 7b: lifed dependency rules (Spec C₂ §11) ────────────────
+  verify-deps-lifed:
+    name: Verify lifed dependency rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run scripts/verify_dependencies_lifed.sh
+        run: bash scripts/verify_dependencies_lifed.sh
+
   # ── Gate 8: Secret Scanning ───────────────────────────────────────
   secrets:
     name: Secret Scan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "anima-proxy"
+version = "0.3.0"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +701,10 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "arcan-proxy"
+version = "0.3.0"
 
 [[package]]
 name = "arcan-sandbox"
@@ -1741,6 +1749,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -3295,6 +3309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "failsafe"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b1dc7c28e66a8f5dc32b7043b735e93d9eea8ea6e7be5507dae5850ab7ac70"
+dependencies = [
+ "parking_lot",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,6 +3806,10 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "haima-proxy"
+version = "0.3.0"
 
 [[package]]
 name = "haima-wallet"
@@ -4818,6 +4846,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "lago-proxy"
+version = "0.3.0"
+
+[[package]]
 name = "lago-store"
 version = "0.3.0"
 dependencies = [
@@ -5712,6 +5744,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "life-runtime-proto"
+version = "0.3.0"
+
+[[package]]
 name = "life-vigil"
 version = "0.3.0"
 dependencies = [
@@ -5725,6 +5761,52 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "lifed"
+version = "0.3.0"
+dependencies = [
+ "aios-proto",
+ "aios-protocol",
+ "anima-proxy",
+ "anyhow",
+ "arc-swap",
+ "arcan-proxy",
+ "assert_matches",
+ "async-trait",
+ "base32",
+ "chrono",
+ "clap",
+ "dashmap",
+ "failsafe",
+ "futures",
+ "haima-proxy",
+ "http 1.4.0",
+ "hyper-util",
+ "jsonwebtoken",
+ "lago-proxy",
+ "life-kernel-proto",
+ "life-runtime-proto",
+ "life-vigil",
+ "parking_lot",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "toml",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tower 0.5.3",
+ "tower-test",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -9738,6 +9820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10005,6 +10098,20 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,6 +5746,14 @@ dependencies = [
 [[package]]
 name = "life-runtime-proto"
 version = "0.3.0"
+dependencies = [
+ "aios-proto",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
+]
 
 [[package]]
 name = "life-vigil"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5821,6 +5821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lifed-conformance"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.5",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,13 @@ members = [
     "crates/opsis/opsis-engine",
     "crates/opsis/opsis-lago",
     "crates/opsis/opsisd",
+    # M5 — life-runtime cluster (lifed facade-aggregator daemon, see Spec C₂)
+    "crates/life-runtime/lifed",
+    "crates/life-runtime/arcan-proxy",
+    "crates/life-runtime/lago-proxy",
+    "crates/life-runtime/haima-proxy",
+    "crates/life-runtime/anima-proxy",
+    "crates/life-runtime/life-runtime-proto",
 ]
 exclude = ["crates/spaces/life-spaces/spacetimedb"]
 
@@ -224,6 +231,15 @@ life-client           = { path = "crates/life-kernel/life-client",        versio
 life-kernel-facade    = { path = "crates/life-kernel/life-kernel-facade", version = "0.3.0" }
 # (life-kernel-proto already declared above with the other life-kernel-* crates)
 
+# M5 — lifed facade-aggregator daemon (Spec C₂)
+arcan-proxy        = { path = "crates/life-runtime/arcan-proxy",        version = "0.3.0" }
+lago-proxy         = { path = "crates/life-runtime/lago-proxy",         version = "0.3.0" }
+haima-proxy        = { path = "crates/life-runtime/haima-proxy",        version = "0.3.0" }
+anima-proxy        = { path = "crates/life-runtime/anima-proxy",        version = "0.3.0" }
+life-runtime-proto = { path = "crates/life-runtime/life-runtime-proto", version = "0.3.0" }
+# Workspace-level tooling for lifed (used only by the lifed crate behind a feature)
+failsafe = { version = "1", default-features = false }
+
 # ── External dependencies ──
 assert_matches = "1"
 anyhow = "1"
@@ -296,7 +312,7 @@ tonic = "0.14"
 tonic-build = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
-tower = { version = "0.5", features = ["util"] }
+tower = { version = "0.5", features = ["util", "limit", "load-shed", "timeout"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ members = [
     "crates/opsis/opsisd",
     # M5 — life-runtime cluster (lifed facade-aggregator daemon, see Spec C₂)
     "crates/life-runtime/lifed",
+    "crates/life-runtime/lifed-conformance",
     "crates/life-runtime/arcan-proxy",
     "crates/life-runtime/lago-proxy",
     "crates/life-runtime/haima-proxy",

--- a/crates/life-runtime/CLAUDE.md
+++ b/crates/life-runtime/CLAUDE.md
@@ -1,3 +1,51 @@
-# life-runtime crate cluster — see CLAUDE.md
+# life-runtime
 
-M5 introduces the `life-runtime/` crate cluster: the new `lifed` facade-aggregator daemon plus the four `*-proxy` crates (`arcan-proxy`, `lago-proxy`, `haima-proxy`, `anima-proxy`) and the generated `life-runtime-proto` types crate. See `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md` for the design and `docs/superpowers/plans/2026-04-26-m5-lifed-build.md` for the implementation plan.
+The `life-runtime` crate cluster ships the **public-facing** surface of the Life Agent OS — the boundary at which apps, browsers, CLIs, and external agents call into the framework.
+
+## Spec ground truth
+
+- **Master spec:** `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md` §L0–§L14
+- **Spec C₂ (lifed facade):** `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md`
+- **M5 implementation plan:** `docs/superpowers/plans/2026-04-26-m5-lifed-build.md`
+
+## Crates
+
+| Crate | Role |
+|---|---|
+| `lifed` (binary + lib) | Facade-aggregator daemon. Hosts `life.v1.{Agent, Events, Wallet, Identity}` and `life.admin.v1.{Runtime, Saga, RoutingCache}` over UDS. Stateless except for a routing cache rebuildable from lago. Saga-orchestrates cross-substrate writes. |
+| `arcan-proxy` | Typed tonic client for the arcan substrate. With-token builder + retry policy. (Sub-phase A: stub; sub-phase B fills in.) |
+| `lago-proxy` | Same, for lago. |
+| `haima-proxy` | Same, for haima. |
+| `anima-proxy` | Same, for anima. |
+| `life-runtime-proto` | Generated proto types for `life.v1.*` + `life.admin.v1.*`. Mirrors the `aios-proto` codegen pattern; uses `extern_path` to reuse the canonical `aios.v1.*` types instead of regenerating them. |
+| `lifed-conformance` | Substrate-token verification battery per Spec C₂ §15.5. (Sub-phase A: scaffold; sub-phase B task B17 populates the battery.) |
+
+## Phase status
+
+- **M5 sub-phase A** — Agent + Events with mock substrates: SHIPPED 2026-04-26 (BRO-930).
+- **M5 sub-phase B** — Wallet + Identity + real proxies + saga compensation: pending.
+- **M5 sub-phase C** — Admin plane: pending.
+- **M5 sub-phase D** — Connection pools + circuit breakers + backpressure + observability: pending.
+- **M5 sub-phase E** — Integration + verification + bake-in: pending.
+
+## Dependency rules
+
+Per Spec C₂ §11.2:
+
+- `lifed` MAY depend on: `aios-protocol`, `aios-proto`, `life-runtime-proto`, `life-kernel-proto` (client features only — for the SpawnChild saga's soma admin call), the four `*-proxy` crates, `life-vigil`, transport/utility crates from §10.2.
+- `lifed` MUST NOT depend on: any substrate runtime crate (`arcand`, `arcan-core`, `arcan-harness`, `arcan-aios-adapters`, `lago-runtime` family, `haima-runtime` family, `anima-runtime` family, `life-kernel-core`, `life-kernel-gate`, `life-kernel-facade`, `arcan-provider-*`).
+- The four `*-proxy` crates depend ONLY on: `aios-protocol`, `aios-proto`, the substrate's wire crate (e.g. `life-kernel-proto` for soma), `tonic`, light utility crates. They MUST NOT pull substrate runtime crates either.
+
+Enforced by `core/life/scripts/verify_dependencies_lifed.sh` and the `verify-deps-lifed` CI lane.
+
+## Sub-phase A surface
+
+* `lifed daemon` boots, binds the configured public UDS, applies mode + group, accepts a tonic client connection.
+* `tower::Layer`-mounted auth middleware runs Tier-2 validation before any handler.
+  * Sub-phase A: dev signer accepts `Bearer test-token-for-{user_id}` and synthesises minimal `CapabilityClaims`.
+  * Sub-phase B5: real ES256 + JWKS verification.
+* `Agent` service: 11 RPCs against trait-abstracted dispatch surfaces (`ArcanDispatch`, `LagoDispatch`, `HaimaDispatch`, `AnimaDispatch`). `CreateSession` does serial dispatch through all four mock substrates and seeds the routing cache. `SpawnChild` returns `Status::unimplemented` per Spec C₂ §13 (post-MVS / Spec C₇).
+* `Events` service: `Read`, `Subscribe`, `GetBlob` against a `LagoTail` trait. Sub-phase A returns canned empty streams + a single-byte blob.
+* Routing cache: `DashMap<String, Arc<RwLock<RouteEntry>>>` with `by_user` index. No eviction yet (sub-phase B8).
+* In-memory idempotency store with 24h TTL sweeper (sub-phase B7 swaps to lago).
+* No-op saga driver + 4 `CreateSession` step stubs (sub-phase B6 + B11 fill in).

--- a/crates/life-runtime/CLAUDE.md
+++ b/crates/life-runtime/CLAUDE.md
@@ -1,0 +1,3 @@
+# life-runtime crate cluster — see CLAUDE.md
+
+M5 introduces the `life-runtime/` crate cluster: the new `lifed` facade-aggregator daemon plus the four `*-proxy` crates (`arcan-proxy`, `lago-proxy`, `haima-proxy`, `anima-proxy`) and the generated `life-runtime-proto` types crate. See `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md` for the design and `docs/superpowers/plans/2026-04-26-m5-lifed-build.md` for the implementation plan.

--- a/crates/life-runtime/anima-proxy/Cargo.toml
+++ b/crates/life-runtime/anima-proxy/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anima-proxy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "M5 placeholder — typed tonic client for anima substrate. Real impl lands in M5 sub-phase B."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/life-runtime/anima-proxy/src/lib.rs
+++ b/crates/life-runtime/anima-proxy/src/lib.rs
@@ -1,0 +1,7 @@
+//! anima-proxy — typed tonic client for the anima substrate.
+//!
+//! M5 sub-phase A places this crate as a stub so the workspace resolves.
+//! Real implementation lands in Spec C₂ M5 sub-phase B (BRO-930 sub-task).
+
+#[doc(hidden)]
+pub fn _placeholder() {}

--- a/crates/life-runtime/arcan-proxy/Cargo.toml
+++ b/crates/life-runtime/arcan-proxy/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "arcan-proxy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "M5 placeholder — typed tonic client for arcan substrate. Real impl lands in M5 sub-phase B."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/life-runtime/arcan-proxy/src/lib.rs
+++ b/crates/life-runtime/arcan-proxy/src/lib.rs
@@ -1,0 +1,7 @@
+//! arcan-proxy — typed tonic client for the arcan substrate.
+//!
+//! M5 sub-phase A places this crate as a stub so the workspace resolves.
+//! Real implementation lands in Spec C₂ M5 sub-phase B (BRO-930 sub-task).
+
+#[doc(hidden)]
+pub fn _placeholder() {}

--- a/crates/life-runtime/haima-proxy/Cargo.toml
+++ b/crates/life-runtime/haima-proxy/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "haima-proxy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "M5 placeholder — typed tonic client for haima substrate. Real impl lands in M5 sub-phase B."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/life-runtime/haima-proxy/src/lib.rs
+++ b/crates/life-runtime/haima-proxy/src/lib.rs
@@ -1,0 +1,7 @@
+//! haima-proxy — typed tonic client for the haima substrate.
+//!
+//! M5 sub-phase A places this crate as a stub so the workspace resolves.
+//! Real implementation lands in Spec C₂ M5 sub-phase B (BRO-930 sub-task).
+
+#[doc(hidden)]
+pub fn _placeholder() {}

--- a/crates/life-runtime/lago-proxy/Cargo.toml
+++ b/crates/life-runtime/lago-proxy/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lago-proxy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "M5 placeholder — typed tonic client for lago substrate. Real impl lands in M5 sub-phase B."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/life-runtime/lago-proxy/src/lib.rs
+++ b/crates/life-runtime/lago-proxy/src/lib.rs
@@ -1,0 +1,7 @@
+//! lago-proxy — typed tonic client for the lago substrate.
+//!
+//! M5 sub-phase A places this crate as a stub so the workspace resolves.
+//! Real implementation lands in Spec C₂ M5 sub-phase B (BRO-930 sub-task).
+
+#[doc(hidden)]
+pub fn _placeholder() {}

--- a/crates/life-runtime/life-runtime-proto/Cargo.toml
+++ b/crates/life-runtime/life-runtime-proto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "life-runtime-proto"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "M5 placeholder — generated proto types for life.v1.* and life.admin.v1.*. Real codegen lands in A4."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/life-runtime/life-runtime-proto/Cargo.toml
+++ b/crates/life-runtime/life-runtime-proto/Cargo.toml
@@ -3,12 +3,20 @@ name = "life-runtime-proto"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "M5 placeholder — generated proto types for life.v1.* and life.admin.v1.*. Real codegen lands in A4."
+description = "Generated proto types for life.v1.* (public plane) and life.admin.v1.* (admin plane). Mirrors the aios-proto codegen pattern."
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [dependencies]
+prost = "0.14"
+prost-types = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
+aios-proto.workspace = true
+
+[build-dependencies]
+tonic-prost-build = "0.14"
 
 [lints]
 workspace = true

--- a/crates/life-runtime/life-runtime-proto/build.rs
+++ b/crates/life-runtime/life-runtime-proto/build.rs
@@ -36,6 +36,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
+        // Reuse the canonical aios.v1 types from the aios-proto crate instead
+        // of regenerating them inside this crate. This keeps a single Rust
+        // representation per wire type (Spec C₂ §10.3) and avoids duplicate
+        // symbol definitions when both crates are linked into the same binary.
+        .extern_path(".aios.v1", "::aios_proto::aios::v1")
         .compile_protos(
             &inputs.iter().map(|p| p.as_path()).collect::<Vec<_>>(),
             &[proto_root.as_path()],

--- a/crates/life-runtime/life-runtime-proto/build.rs
+++ b/crates/life-runtime/life-runtime-proto/build.rs
@@ -1,0 +1,45 @@
+//! Codegen for `life.v1.*` (public plane) + `life.admin.v1.*` (admin plane).
+//!
+//! Source proto files live under `core/life/proto/life/v1/` and
+//! `core/life/proto/life/admin/v1/`. Both subtrees import `aios.v1.*` from
+//! `core/life/proto/aios/v1/` (M3-shipped canonical vocabulary).
+
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+    // From crates/life-runtime/life-runtime-proto/, the proto root is ../../../proto/.
+    let proto_root = manifest_dir
+        .parent() // crates/life-runtime/
+        .and_then(|p| p.parent()) // crates/
+        .and_then(|p| p.parent()) // core/life/
+        .ok_or("walking up to core/life/")?
+        .join("proto");
+    let life_v1 = proto_root.join("life/v1");
+    let life_admin_v1 = proto_root.join("life/admin/v1");
+
+    let inputs: Vec<PathBuf> = vec![
+        life_v1.join("agent.proto"),
+        life_v1.join("events.proto"),
+        life_v1.join("wallet.proto"),
+        life_v1.join("identity.proto"),
+        life_admin_v1.join("runtime.proto"),
+        life_admin_v1.join("saga.proto"),
+        life_admin_v1.join("routing_cache.proto"),
+    ];
+
+    // Tell cargo to rerun on any proto change.
+    for p in &inputs {
+        println!("cargo:rerun-if-changed={}", p.display());
+    }
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(
+            &inputs.iter().map(|p| p.as_path()).collect::<Vec<_>>(),
+            &[proto_root.as_path()],
+        )?;
+
+    Ok(())
+}

--- a/crates/life-runtime/life-runtime-proto/src/lib.rs
+++ b/crates/life-runtime/life-runtime-proto/src/lib.rs
@@ -1,8 +1,26 @@
-//! life-runtime-proto — generated proto types for life.v1.* and life.admin.v1.*.
+//! Generated proto types for `life.v1.*` (public plane) and
+//! `life.admin.v1.*` (admin plane).
 //!
-//! M5 sub-phase A places this crate as a stub so the workspace resolves.
-//! Real codegen wiring lands in A4 (proto codegen scaffold) and the proto
-//! sources land in A5 (Agent + Events services).
+//! Mirrors the `aios-proto` pattern from M3 (`docs/superpowers/plans/2026-04-25-m3-proto-consolidation.md`):
+//! a thin crate that hosts `tonic::include_proto!` modules. The
+//! `core/life/proto/life/v1/*.proto` and `core/life/proto/life/admin/v1/*.proto`
+//! sources are the canonical wire surface; this crate exists to give
+//! lifed (and any future SDK builder) typed Rust bindings.
 
-#[doc(hidden)]
-pub fn _placeholder() {}
+#![deny(unsafe_code)]
+#![allow(clippy::all)]
+#![allow(missing_docs)]
+
+pub mod life {
+    pub mod v1 {
+        tonic::include_proto!("life.v1");
+    }
+    pub mod admin {
+        pub mod v1 {
+            tonic::include_proto!("life.admin.v1");
+        }
+    }
+}
+
+// Re-export aios-proto for callers that want a single import path.
+pub use aios_proto::aios as aios_v1;

--- a/crates/life-runtime/life-runtime-proto/src/lib.rs
+++ b/crates/life-runtime/life-runtime-proto/src/lib.rs
@@ -1,0 +1,8 @@
+//! life-runtime-proto — generated proto types for life.v1.* and life.admin.v1.*.
+//!
+//! M5 sub-phase A places this crate as a stub so the workspace resolves.
+//! Real codegen wiring lands in A4 (proto codegen scaffold) and the proto
+//! sources land in A5 (Agent + Events services).
+
+#[doc(hidden)]
+pub fn _placeholder() {}

--- a/crates/life-runtime/life-runtime-proto/tests/proto_codegen.rs
+++ b/crates/life-runtime/life-runtime-proto/tests/proto_codegen.rs
@@ -1,0 +1,14 @@
+//! Verifies that the generated proto types are visible at the expected
+//! module paths. If this test compiles, codegen is wired correctly.
+
+#[test]
+fn life_v1_agent_module_present() {
+    // Just check the module path resolves; the actual types are populated as
+    // services land in A5, B13, B14.
+    let _ = std::any::type_name::<life_runtime_proto::life::v1::Empty>();
+}
+
+#[test]
+fn life_admin_v1_module_present() {
+    let _ = std::any::type_name::<life_runtime_proto::life::admin::v1::Empty>();
+}

--- a/crates/life-runtime/lifed-conformance/Cargo.toml
+++ b/crates/life-runtime/lifed-conformance/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lifed-conformance"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Conformance harness for lifed's substrate-token verification (Spec C₂ §15.5)."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+thiserror.workspace = true
+tonic = "0.14"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/life-runtime/lifed-conformance/src/lib.rs
+++ b/crates/life-runtime/lifed-conformance/src/lib.rs
@@ -1,0 +1,60 @@
+//! Conformance harness for lifed's substrate-token verification.
+//!
+//! Each substrate's CI lane runs this harness as a smoke test to verify
+//! that:
+//! - lifed's published JWKS at `/run/life/lifed-jwks.json` parses cleanly.
+//! - The substrate's verifier accepts a freshly minted Tier-3 token.
+//! - The verifier REJECTS tokens with the wrong `aud`.
+//! - The verifier REJECTS expired tokens.
+//!
+//! Sub-phase A places only the trait scaffold; sub-phase B's task B17
+//! populates the test bodies.
+
+#![deny(unsafe_code)]
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConformanceError {
+    #[error("setup: {0}")]
+    Setup(String),
+    #[error("expectation '{0}' violated: {1}")]
+    Failed(&'static str, String),
+}
+
+#[async_trait]
+pub trait SubstrateUnderTest: Send + Sync {
+    /// Substrate name — `arcan`, `lago`, `haima`, `anima`, `soma`.
+    fn audience(&self) -> &'static str;
+    /// Verify a Tier-3 JWS bearer token. Returns Ok(()) on success.
+    async fn verify(&self, jws: &str) -> Result<(), tonic::Status>;
+}
+
+/// Sub-phase A no-op — B17 fills in the real conformance battery.
+pub async fn run_battery(_sut: &dyn SubstrateUnderTest) -> Result<(), ConformanceError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubSubstrate;
+
+    #[async_trait]
+    impl SubstrateUnderTest for StubSubstrate {
+        fn audience(&self) -> &'static str {
+            "stub"
+        }
+        async fn verify(&self, _jws: &str) -> Result<(), tonic::Status> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn battery_is_a_noop_in_sub_phase_a() {
+        let sut = StubSubstrate;
+        run_battery(&sut).await.expect("noop battery passes");
+    }
+}

--- a/crates/life-runtime/lifed/Cargo.toml
+++ b/crates/life-runtime/lifed/Cargo.toml
@@ -1,0 +1,87 @@
+[package]
+name = "lifed"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "lifed — Life Runtime facade-aggregator daemon (M5)."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "lifed"
+path = "src/lib.rs"
+
+[[bin]]
+name = "lifed"
+path = "src/main.rs"
+
+[features]
+default = []
+# Hand-rolled circuit breaker is the M5 default (Spec C₂ §7.2).
+# Enable `failsafe-breaker` to swap in the failsafe-rs crate as an experiment.
+failsafe-breaker = ["dep:failsafe"]
+
+[dependencies]
+# wire / ABI
+aios-protocol.workspace = true
+aios-proto.workspace = true
+life-kernel-proto = { workspace = true, features = ["client"] }
+life-runtime-proto.workspace = true
+
+# transport
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+tower = { workspace = true }
+http = "1"
+hyper-util = { version = "0.1", features = ["tokio"] }
+
+# concurrency / state
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "fs", "sync", "time"] }
+tokio-stream = { workspace = true }
+arc-swap = "1"
+dashmap = "6"
+parking_lot = "0.12"
+async-trait.workspace = true
+futures.workspace = true
+
+# robustness
+failsafe = { workspace = true, optional = true }
+
+# observability
+life-vigil.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-opentelemetry.workspace = true
+
+# auth
+jsonwebtoken.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+# utility
+anyhow.workspace = true
+thiserror.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["derive", "env"] }
+toml.workspace = true
+sha2 = "0.10"
+base32 = "0.5"
+
+# substrate proxy clients (real impls in sub-phase B; stubs in sub-phase A)
+arcan-proxy.workspace = true
+lago-proxy.workspace = true
+haima-proxy.workspace = true
+anima-proxy.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["full", "test-util"] }
+tower-test = "0.4"
+assert_matches.workspace = true
+tonic-prost = "0.14"
+
+[lints]
+workspace = true

--- a/crates/life-runtime/lifed/README.md
+++ b/crates/life-runtime/lifed/README.md
@@ -1,0 +1,25 @@
+# lifed
+
+The Life Runtime facade-aggregator daemon. Tonic-over-UDS public + admin planes; mounts `life.v1.{Agent, Events, Wallet, Identity}` and `life.admin.v1.{Runtime, Saga, RoutingCache}`. Forwards every RPC to the appropriate substrate (`arcan`, `lago`, `haima`, `anima`, `soma`). Stateless except for an in-memory routing cache rebuildable from `lago`. Hosts saga orchestration for cross-substrate writes (`Agent.CreateSession`).
+
+- **Spec:** `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md` (design ground truth)
+- **Master spec:** `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md` §L0–§L14
+- **Implementation plan:** `docs/superpowers/plans/2026-04-26-m5-lifed-build.md`
+- **Linear:** [BRO-930](https://linear.app/broomva/issue/BRO-930)
+
+## Run (after sub-phase A merges)
+
+```bash
+cargo run -p lifed -- daemon --config /etc/life/lifed.toml
+```
+
+## Operator CLI
+
+```bash
+lifed sessions ls
+lifed sessions show <sid>
+lifed routing-cache dump
+lifed saga show <saga_id>
+```
+
+All operator subcommands speak the admin-plane tonic surface on `/run/life/life-admin.sock`. Caller must be in the `life-admin` group.

--- a/crates/life-runtime/lifed/src/auth/blocklist.rs
+++ b/crates/life-runtime/lifed/src/auth/blocklist.rs
@@ -1,0 +1,32 @@
+//! Active-session blocklist. Sub-phase A in-memory only; B14 wires
+//! `revoked_sids.json` snapshot + reload.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use aios_proto::aios::v1 as aios_v1;
+
+#[derive(Default)]
+pub struct RevokedSidSet {
+    inner: Arc<RwLock<HashSet<String>>>,
+}
+
+impl RevokedSidSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, sid: &aios_v1::SessionId) {
+        self.inner.write().insert(sid.value.clone());
+    }
+
+    pub fn contains(&self, sid: &aios_v1::SessionId) -> bool {
+        self.inner.read().contains(&sid.value)
+    }
+
+    pub fn snapshot(&self) -> Vec<String> {
+        self.inner.read().iter().cloned().collect()
+    }
+}

--- a/crates/life-runtime/lifed/src/auth/capability.rs
+++ b/crates/life-runtime/lifed/src/auth/capability.rs
@@ -1,0 +1,41 @@
+//! CapabilityClaims — extracted from a Tier-2 JWS by AuthLayer middleware.
+//!
+//! The middleware attaches `CapabilityClaims` to every incoming public-plane
+//! request via `Request::extensions_mut().insert(...)`. Handlers read it via
+//! `Self::claims(&req)?`.
+
+use std::time::Instant;
+
+use aios_proto::aios::v1 as aios_v1;
+
+#[derive(Debug, Clone)]
+pub struct CapabilityClaims {
+    pub user_id: String,
+    pub project_id: String,
+    pub sid: aios_v1::SessionId,
+    pub scopes: Vec<String>,
+    pub tier: Tier,
+    pub exp: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    Free,
+    Paid,
+    Enterprise,
+}
+
+impl Default for CapabilityClaims {
+    fn default() -> Self {
+        Self {
+            user_id: String::new(),
+            project_id: String::new(),
+            sid: aios_v1::SessionId {
+                value: String::new(),
+            },
+            scopes: Vec::new(),
+            tier: Tier::Free,
+            exp: Instant::now(),
+        }
+    }
+}

--- a/crates/life-runtime/lifed/src/auth/jwks.rs
+++ b/crates/life-runtime/lifed/src/auth/jwks.rs
@@ -1,0 +1,46 @@
+//! Tier-2 token verifier.
+//!
+//! Sub-phase A ships a dev-mode verifier that accepts tokens of the form
+//! `Bearer test-token-for-{user_id}` and synthesises CapabilityClaims for
+//! the user. Sub-phase B replaces this with a real ES256 JWKS verifier
+//! (jsonwebtoken crate, gateway public key, blocklist check).
+
+use std::time::{Duration, Instant};
+
+use aios_proto::aios::v1 as aios_v1;
+
+use crate::auth::capability::{CapabilityClaims, Tier};
+use crate::error::{LifedError, LifedResult};
+
+pub struct JwksCache {
+    /// Sub-phase A: holds nothing; the dev verifier ignores it.
+    /// Sub-phase B will load + cache real gateway public keys here.
+    _placeholder: (),
+}
+
+impl JwksCache {
+    pub fn load_from_path(_path: &std::path::Path) -> LifedResult<Self> {
+        // Sub-phase A: no JWKS file required.
+        Ok(Self { _placeholder: () })
+    }
+
+    /// Validate a Tier-2 bearer token.
+    pub fn validate(&self, bearer: &str) -> LifedResult<CapabilityClaims> {
+        // Sub-phase A dev verifier: accept "test-token-for-{user_id}" and
+        // synthesise minimal claims. Sub-phase B replaces with real ES256.
+        let prefix = "test-token-for-";
+        if let Some(user_id) = bearer.strip_prefix(prefix) {
+            return Ok(CapabilityClaims {
+                user_id: user_id.to_string(),
+                project_id: "project-demo".to_string(),
+                sid: aios_v1::SessionId {
+                    value: String::new(),
+                },
+                scopes: vec!["agent:dispatch".to_string(), "events:read".to_string()],
+                tier: Tier::Free,
+                exp: Instant::now() + Duration::from_secs(900),
+            });
+        }
+        Err(LifedError::Auth("invalid bearer token".to_string()))
+    }
+}

--- a/crates/life-runtime/lifed/src/auth/middleware.rs
+++ b/crates/life-runtime/lifed/src/auth/middleware.rs
@@ -1,0 +1,76 @@
+//! Tower middleware that runs Tier-2 capability validation and attaches
+//! [`CapabilityClaims`] to the request extensions. Per master spec §L7
+//! research synthesis 3.10, this MUST be a tower Layer (NOT a tonic
+//! interceptor) so it composes with tracing + load-shed + timeout layers
+//! without ordering surprises.
+
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::Request;
+use tonic::body::Body;
+use tower::{Layer, Service};
+
+use crate::auth::jwks::JwksCache;
+
+#[derive(Clone)]
+pub struct AuthLayer {
+    jwks: Arc<JwksCache>,
+}
+
+impl AuthLayer {
+    pub fn new(jwks: Arc<JwksCache>) -> Self {
+        Self { jwks }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            jwks: Arc::clone(&self.jwks),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    jwks: Arc<JwksCache>,
+}
+
+impl<S> Service<Request<Body>> for AuthService<S>
+where
+    S: Service<Request<Body>, Response = http::Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let jwks = Arc::clone(&self.jwks);
+        Box::pin(async move {
+            // Extract authorization header.
+            let claims = req
+                .headers()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|h| h.strip_prefix("Bearer "))
+                .and_then(|tok| jwks.validate(tok).ok());
+
+            // Attach (or default) CapabilityClaims as a request extension.
+            req.extensions_mut().insert(claims.unwrap_or_default());
+            inner.call(req).await
+        })
+    }
+}

--- a/crates/life-runtime/lifed/src/auth/middleware.rs
+++ b/crates/life-runtime/lifed/src/auth/middleware.rs
@@ -69,6 +69,18 @@ where
                 .and_then(|tok| jwks.validate(tok).ok());
 
             // Attach (or default) CapabilityClaims as a request extension.
+            //
+            // SUB-PHASE A ONLY: Missing/invalid bearer falls through to a
+            // default-empty `CapabilityClaims`, which lets handlers proceed
+            // with empty `user_id`/`project_id`. This is plan-sanctioned for
+            // the dev-signer mock-substrate path (integration tests still
+            // attach valid bearers; the daemon is dev-only at this point).
+            //
+            // SUB-PHASE B5 MUST CHANGE THIS: replace `unwrap_or_default()`
+            // with an early-return `Status::unauthenticated` for the public
+            // plane. Per Spec C₂ §5.1 step 5, invalid Tier-2 capability
+            // tokens MUST be rejected before reaching any handler. Tracked
+            // as part of B5 (real ES256 + JWKS verification).
             req.extensions_mut().insert(claims.unwrap_or_default());
             inner.call(req).await
         })

--- a/crates/life-runtime/lifed/src/auth/mod.rs
+++ b/crates/life-runtime/lifed/src/auth/mod.rs
@@ -1,0 +1,14 @@
+//! Auth subsystem — Tier-2 capability validation + Tier-3 substrate-token mint.
+//!
+//! Spec C₂ §5. Sub-phase A ships a dev signer accepting
+//! `Bearer test-token-for-{user_id}`; sub-phase B replaces it with real
+//! ES256 + JWKS verification.
+
+pub mod blocklist;
+pub mod capability;
+pub mod jwks;
+pub mod middleware;
+pub mod substrate_token;
+
+pub use capability::{CapabilityClaims, Tier};
+pub use middleware::AuthLayer;

--- a/crates/life-runtime/lifed/src/auth/substrate_token.rs
+++ b/crates/life-runtime/lifed/src/auth/substrate_token.rs
@@ -1,0 +1,48 @@
+//! Tier-3 substrate-token mint.
+//!
+//! Sub-phase A ships a deterministic dev signer that returns
+//! `dev-token:{audience}:{user_id}:{sid}` strings. Mock substrates accept
+//! these directly. Sub-phase B replaces this with real ES256 JWS plus a
+//! published JWKS file (`/run/life/lifed-jwks.json`) that real substrates
+//! verify against.
+
+use std::time::{Duration, Instant};
+
+use crate::auth::capability::CapabilityClaims;
+use crate::error::{LifedError, LifedResult};
+
+#[derive(Clone, Copy)]
+pub enum Audience {
+    Arcan,
+    Lago,
+    Haima,
+    Anima,
+    Soma,
+}
+
+impl Audience {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Audience::Arcan => "arcan",
+            Audience::Lago => "lago",
+            Audience::Haima => "haima",
+            Audience::Anima => "anima",
+            Audience::Soma => "soma",
+        }
+    }
+}
+
+pub fn mint_substrate_token(claims: &CapabilityClaims, audience: Audience) -> LifedResult<String> {
+    if claims.exp < Instant::now() {
+        return Err(LifedError::Auth("Tier-2 expired".to_string()));
+    }
+    // Sub-phase A: deterministic dev token.
+    let token = format!(
+        "dev-token:{aud}:{user}:{sid}",
+        aud = audience.as_str(),
+        user = claims.user_id,
+        sid = claims.sid.value,
+    );
+    let _exp = std::cmp::min(claims.exp, Instant::now() + Duration::from_secs(30));
+    Ok(token)
+}

--- a/crates/life-runtime/lifed/src/bootstrap.rs
+++ b/crates/life-runtime/lifed/src/bootstrap.rs
@@ -1,0 +1,178 @@
+//! Bootstrap — wires config → substrate clients → router → listener.
+//!
+//! Sub-phase A entrypoints:
+//! - `run_with_mocks` (used by integration tests): mock substrates injected.
+//! - `run_daemon` (used by `lifed daemon`): mock substrates because the real
+//!   proxies don't exist yet. Sub-phase B replaces this with real-substrate
+//!   wiring (B16).
+
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::Stream;
+use tokio::sync::oneshot;
+use tonic::transport::Server;
+
+use life_runtime_proto::life::v1 as pb;
+
+use crate::auth::jwks::JwksCache;
+use crate::auth::middleware::AuthLayer;
+use crate::config::LifedConfig;
+use crate::dev_mocks::{MockAnima, MockArcan, MockHaima, MockLago, MockSubstrates};
+use crate::error::LifedResult;
+use crate::listener::public as public_listener;
+use crate::routing::cache::RoutingCache;
+use crate::services::agent::{
+    AgentService, AnimaDispatch, ArcanDispatch, HaimaDispatch, LagoDispatch,
+};
+
+/// Sub-phase A entrypoint for tests + the early daemon.
+pub async fn run_with_mocks(
+    cfg: &LifedConfig,
+    mocks: Arc<MockSubstrates>,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> LifedResult<()> {
+    let _vigil_guard = crate::observability::init(&cfg.vigil)?;
+
+    tracing::info!(
+        public_socket = %cfg.public_plane.unix_socket.display(),
+        admin_socket  = %cfg.admin_plane.unix_socket.display(),
+        "lifed starting (sub-phase A — mock substrates)",
+    );
+
+    let jwks = Arc::new(JwksCache::load_from_path(&cfg.auth.jwks_path)?);
+    let auth = AuthLayer::new(Arc::clone(&jwks));
+    let routing = Arc::new(RoutingCache::new());
+
+    let arcan: Arc<dyn ArcanDispatch> = Arc::new(MockArcanAdapter(mocks.arcan.clone()));
+    let lago_dispatch: Arc<dyn LagoDispatch> =
+        Arc::new(MockLagoDispatchAdapter(mocks.lago.clone()));
+    let haima: Arc<dyn HaimaDispatch> = Arc::new(MockHaimaAdapter(mocks.haima.clone()));
+    let anima: Arc<dyn AnimaDispatch> = Arc::new(MockAnimaAdapter(mocks.anima.clone()));
+
+    let agent = AgentService::new(arcan, lago_dispatch, haima, anima, Arc::clone(&routing));
+
+    // Mount the AuthLayer at the transport boundary so it runs once per http
+    // request, BEFORE tonic dispatches to the service. Handlers then read
+    // CapabilityClaims via Self::claims(&req); the dev signer in jwks.rs
+    // accepts the `test-token-for-{user}` bearer.
+    let router = Server::builder()
+        .layer(auth)
+        .add_service(pb::agent_server::AgentServer::new(agent));
+
+    let incoming = public_listener::bind(&cfg.public_plane).await?;
+    router
+        .serve_with_incoming_shutdown(incoming, public_listener::shutdown_signal(shutdown_rx))
+        .await
+        .map_err(|e| crate::error::LifedError::Server(format!("public-plane serve: {e}")))
+}
+
+/// Sub-phase A daemon entrypoint. Replaced in B16 with real-substrate wiring.
+pub async fn run_daemon(config_path: Option<&Path>) -> LifedResult<()> {
+    let cfg = LifedConfig::load(config_path)?;
+    let _vigil_guard = crate::observability::init(&cfg.vigil)?;
+    let shutdown_rx = crate::shutdown::install_signal_handler();
+    // Sub-phase A: synthesise mocks for the daemon entrypoint too. B16 swaps
+    // in real proxies.
+    let mocks = Arc::new(MockSubstrates::new());
+    run_with_mocks(&cfg, mocks, shutdown_rx).await
+}
+
+// ── Mock adapter glue ────────────────────────────────────────────────────────
+
+struct MockArcanAdapter(MockArcan);
+struct MockLagoDispatchAdapter(MockLago);
+struct MockHaimaAdapter(MockHaima);
+struct MockAnimaAdapter(MockAnima);
+
+#[async_trait]
+impl ArcanDispatch for MockArcanAdapter {
+    async fn create_agent(&self, sid: &str) -> Result<String, tonic::Status> {
+        self.0
+            .create_agent(sid)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+    async fn destroy_agent(&self, sid: &str) -> Result<(), tonic::Status> {
+        self.0
+            .destroy_agent(sid)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+    async fn dispatch_message(
+        &self,
+        _sid: &str,
+        _content: &str,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, tonic::Status>> + Send>>,
+        tonic::Status,
+    > {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<pb::AgentEvent, tonic::Status>>(8);
+        // Emit one canned token then finish.
+        tokio::spawn(async move {
+            let _ = tx
+                .send(Ok(pb::AgentEvent {
+                    record: None,
+                    kind: pb::AgentEventKind::Token as i32,
+                }))
+                .await;
+            let _ = tx
+                .send(Ok(pb::AgentEvent {
+                    record: None,
+                    kind: pb::AgentEventKind::Finish as i32,
+                }))
+                .await;
+        });
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+}
+
+#[async_trait]
+impl LagoDispatch for MockLagoDispatchAdapter {
+    async fn open_namespace(&self, sid: &str) -> Result<String, tonic::Status> {
+        self.0
+            .open_namespace(sid)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+    async fn close_namespace(&self, ns: &str) -> Result<(), tonic::Status> {
+        self.0
+            .close_namespace(ns)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+}
+
+#[async_trait]
+impl HaimaDispatch for MockHaimaAdapter {
+    async fn bind_wallet(&self, sid: &str, project_id: &str) -> Result<String, tonic::Status> {
+        self.0
+            .bind_wallet(sid, project_id)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+    async fn unbind_wallet(&self, wallet_id: &str) -> Result<(), tonic::Status> {
+        self.0
+            .unbind_wallet(wallet_id)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+}
+
+#[async_trait]
+impl AnimaDispatch for MockAnimaAdapter {
+    async fn register_session(&self, sid: &str, user_id: &str) -> Result<(), tonic::Status> {
+        self.0
+            .register_session(sid, user_id)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+    async fn mark_session_closed(&self, sid: &str) -> Result<(), tonic::Status> {
+        self.0
+            .mark_session_closed(sid)
+            .await
+            .map_err(tonic::Status::internal)
+    }
+}

--- a/crates/life-runtime/lifed/src/bootstrap.rs
+++ b/crates/life-runtime/lifed/src/bootstrap.rs
@@ -27,6 +27,7 @@ use crate::routing::cache::RoutingCache;
 use crate::services::agent::{
     AgentService, AnimaDispatch, ArcanDispatch, HaimaDispatch, LagoDispatch,
 };
+use crate::services::events::{EventsService, LagoTail};
 
 /// Sub-phase A entrypoint for tests + the early daemon.
 pub async fn run_with_mocks(
@@ -49,10 +50,12 @@ pub async fn run_with_mocks(
     let arcan: Arc<dyn ArcanDispatch> = Arc::new(MockArcanAdapter(mocks.arcan.clone()));
     let lago_dispatch: Arc<dyn LagoDispatch> =
         Arc::new(MockLagoDispatchAdapter(mocks.lago.clone()));
+    let lago_tail: Arc<dyn LagoTail> = Arc::new(MockLagoTailAdapter);
     let haima: Arc<dyn HaimaDispatch> = Arc::new(MockHaimaAdapter(mocks.haima.clone()));
     let anima: Arc<dyn AnimaDispatch> = Arc::new(MockAnimaAdapter(mocks.anima.clone()));
 
     let agent = AgentService::new(arcan, lago_dispatch, haima, anima, Arc::clone(&routing));
+    let events = EventsService::new(lago_tail);
 
     // Mount the AuthLayer at the transport boundary so it runs once per http
     // request, BEFORE tonic dispatches to the service. Handlers then read
@@ -60,7 +63,8 @@ pub async fn run_with_mocks(
     // accepts the `test-token-for-{user}` bearer.
     let router = Server::builder()
         .layer(auth)
-        .add_service(pb::agent_server::AgentServer::new(agent));
+        .add_service(pb::agent_server::AgentServer::new(agent))
+        .add_service(pb::events_server::EventsServer::new(events));
 
     let incoming = public_listener::bind(&cfg.public_plane).await?;
     router
@@ -84,6 +88,7 @@ pub async fn run_daemon(config_path: Option<&Path>) -> LifedResult<()> {
 
 struct MockArcanAdapter(MockArcan);
 struct MockLagoDispatchAdapter(MockLago);
+struct MockLagoTailAdapter;
 struct MockHaimaAdapter(MockHaima);
 struct MockAnimaAdapter(MockAnima);
 
@@ -142,6 +147,36 @@ impl LagoDispatch for MockLagoDispatchAdapter {
             .close_namespace(ns)
             .await
             .map_err(tonic::Status::internal)
+    }
+}
+
+#[async_trait]
+impl LagoTail for MockLagoTailAdapter {
+    async fn read(
+        &self,
+        _sid: &str,
+        _from: u64,
+        _limit: u32,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<pb::EventRecord, tonic::Status>> + Send>>,
+        tonic::Status,
+    > {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<pb::EventRecord, tonic::Status>>(1);
+        drop(tx); // empty stream
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+    async fn subscribe(
+        &self,
+        sid: &str,
+        from: u64,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<pb::EventRecord, tonic::Status>> + Send>>,
+        tonic::Status,
+    > {
+        self.read(sid, from, 0).await
+    }
+    async fn get_blob(&self, _ns: &str, _sha256: &str) -> Result<(Vec<u8>, String), tonic::Status> {
+        Ok((b"empty".to_vec(), "application/octet-stream".to_string()))
     }
 }
 

--- a/crates/life-runtime/lifed/src/cli/client.rs
+++ b/crates/life-runtime/lifed/src/cli/client.rs
@@ -1,0 +1,23 @@
+//! Shared admin-plane tonic client builder. Sub-phase A scaffolds; C5 fills in.
+
+use std::path::Path;
+
+use anyhow::Result;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+pub async fn connect(socket: &Path) -> Result<Channel> {
+    let socket = socket.to_path_buf();
+    let endpoint = Endpoint::try_from("http://[::]:0")?;
+    let channel = endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let socket = socket.clone();
+            async move {
+                let s = UnixStream::connect(socket).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(s))
+            }
+        }))
+        .await?;
+    Ok(channel)
+}

--- a/crates/life-runtime/lifed/src/cli/mod.rs
+++ b/crates/life-runtime/lifed/src/cli/mod.rs
@@ -1,0 +1,11 @@
+//! Operator CLI subcommands.
+//!
+//! All operator subcommands talk to the admin-plane UDS socket (default
+//! `/run/life/life-admin.sock`). Sub-phase A scaffolds each subcommand to
+//! print a placeholder message. Sub-phase C wires them against the real
+//! admin-plane RPCs.
+
+pub mod client;
+pub mod routing_cache;
+pub mod saga;
+pub mod sessions;

--- a/crates/life-runtime/lifed/src/cli/routing_cache.rs
+++ b/crates/life-runtime/lifed/src/cli/routing_cache.rs
@@ -1,0 +1,25 @@
+//! `lifed routing-cache dump` operator subcommand.
+//!
+//! Sub-phase A: scaffold only. Sub-phase C wires it against the admin-plane
+//! `RoutingCache` service.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct DumpArgs {
+    #[arg(
+        long,
+        env = "LIFED_ADMIN_SOCKET",
+        default_value = "/run/life/life-admin.sock"
+    )]
+    pub socket: PathBuf,
+}
+
+pub async fn run_dump(args: DumpArgs) -> Result<()> {
+    eprintln!("lifed routing-cache dump — sub-phase C wires this");
+    eprintln!("(socket: {})", args.socket.display());
+    Ok(())
+}

--- a/crates/life-runtime/lifed/src/cli/saga.rs
+++ b/crates/life-runtime/lifed/src/cli/saga.rs
@@ -1,0 +1,26 @@
+//! `lifed saga show <saga_id>` operator subcommand.
+//!
+//! Sub-phase A: scaffold only. Sub-phase C wires it against the admin-plane
+//! `Saga` service.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    #[arg(
+        long,
+        env = "LIFED_ADMIN_SOCKET",
+        default_value = "/run/life/life-admin.sock"
+    )]
+    pub socket: PathBuf,
+    pub saga_id: String,
+}
+
+pub async fn run_show(args: ShowArgs) -> Result<()> {
+    eprintln!("lifed saga show {} — sub-phase C wires this", args.saga_id);
+    eprintln!("(socket: {})", args.socket.display());
+    Ok(())
+}

--- a/crates/life-runtime/lifed/src/cli/sessions.rs
+++ b/crates/life-runtime/lifed/src/cli/sessions.rs
@@ -1,0 +1,42 @@
+//! `lifed sessions ls` / `lifed sessions show <sid>` operator subcommands.
+//!
+//! Sub-phase A: scaffold only. Sub-phase C wires them against the admin-plane
+//! `Runtime` service.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct LsArgs {
+    #[arg(
+        long,
+        env = "LIFED_ADMIN_SOCKET",
+        default_value = "/run/life/life-admin.sock"
+    )]
+    pub socket: PathBuf,
+}
+
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    #[arg(
+        long,
+        env = "LIFED_ADMIN_SOCKET",
+        default_value = "/run/life/life-admin.sock"
+    )]
+    pub socket: PathBuf,
+    pub sid: String,
+}
+
+pub async fn run_ls(args: LsArgs) -> Result<()> {
+    eprintln!("lifed sessions ls — sub-phase C wires this against the admin plane");
+    eprintln!("(socket: {})", args.socket.display());
+    Ok(())
+}
+
+pub async fn run_show(args: ShowArgs) -> Result<()> {
+    eprintln!("lifed sessions show {} — sub-phase C wires this", args.sid);
+    eprintln!("(socket: {})", args.socket.display());
+    Ok(())
+}

--- a/crates/life-runtime/lifed/src/config.rs
+++ b/crates/life-runtime/lifed/src/config.rs
@@ -1,0 +1,403 @@
+//! Parser + validator for `/etc/life/lifed.toml`.
+//!
+//! The daemon loads the config once at startup. Every field has a sensible
+//! default so an empty file (`LifedConfig::load(None)`) starts a usable
+//! daemon against the locked master-spec UDS paths.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LifedError, LifedResult};
+
+/// Top-level `/etc/life/lifed.toml` schema.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct LifedConfig {
+    /// Public plane UDS configuration.
+    #[serde(default)]
+    pub public_plane: PublicPlaneConfig,
+    /// Admin plane UDS configuration.
+    #[serde(default)]
+    pub admin_plane: AdminPlaneConfig,
+    /// Per-substrate UDS endpoints.
+    #[serde(default)]
+    pub substrates: SubstratesConfig,
+    /// Authn / authz plumbing.
+    #[serde(default)]
+    pub auth: AuthConfig,
+    /// Routing-cache parameters.
+    #[serde(default)]
+    pub routing: RoutingConfig,
+    /// Per-substrate connection-pool capacities (D1 fills these in).
+    #[serde(default)]
+    pub pools: PoolsConfig,
+    /// Idempotency-store parameters.
+    #[serde(default)]
+    pub idempotency: IdempotencyConfig,
+    /// Vigil OpenTelemetry exporter wiring.
+    #[serde(default)]
+    pub vigil: VigilConfig,
+    /// Graceful shutdown drain.
+    #[serde(default)]
+    pub shutdown: ShutdownConfig,
+}
+
+/// Public plane UDS configuration — `/run/life/life.sock`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct PublicPlaneConfig {
+    pub unix_socket: PathBuf,
+    #[serde(default)]
+    pub unix_socket_mode: Option<u32>,
+    #[serde(default)]
+    pub unix_socket_group: Option<String>,
+}
+
+impl Default for PublicPlaneConfig {
+    fn default() -> Self {
+        Self {
+            unix_socket: PathBuf::from("/run/life/life.sock"),
+            unix_socket_mode: Some(0o660),
+            unix_socket_group: Some("life-runtime".to_string()),
+        }
+    }
+}
+
+/// Admin plane UDS configuration — `/run/life/life-admin.sock`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct AdminPlaneConfig {
+    pub unix_socket: PathBuf,
+    #[serde(default)]
+    pub unix_socket_mode: Option<u32>,
+    #[serde(default)]
+    pub unix_socket_group: Option<String>,
+}
+
+impl Default for AdminPlaneConfig {
+    fn default() -> Self {
+        Self {
+            unix_socket: PathBuf::from("/run/life/life-admin.sock"),
+            unix_socket_mode: Some(0o660),
+            unix_socket_group: Some("life-admin".to_string()),
+        }
+    }
+}
+
+/// Per-substrate UDS endpoints.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct SubstratesConfig {
+    #[serde(default = "default_arcan")]
+    pub arcan: SubstrateEndpoint,
+    #[serde(default = "default_lago")]
+    pub lago: SubstrateEndpoint,
+    #[serde(default = "default_haima")]
+    pub haima: SubstrateEndpoint,
+    #[serde(default = "default_anima")]
+    pub anima: SubstrateEndpoint,
+    #[serde(default = "default_soma")]
+    pub soma: SubstrateEndpoint,
+}
+
+impl Default for SubstratesConfig {
+    fn default() -> Self {
+        Self {
+            arcan: default_arcan(),
+            lago: default_lago(),
+            haima: default_haima(),
+            anima: default_anima(),
+            soma: default_soma(),
+        }
+    }
+}
+
+fn default_arcan() -> SubstrateEndpoint {
+    SubstrateEndpoint {
+        unix_socket: PathBuf::from("/run/life/arcan.sock"),
+    }
+}
+fn default_lago() -> SubstrateEndpoint {
+    SubstrateEndpoint {
+        unix_socket: PathBuf::from("/run/life/lago.sock"),
+    }
+}
+fn default_haima() -> SubstrateEndpoint {
+    SubstrateEndpoint {
+        unix_socket: PathBuf::from("/run/life/haima.sock"),
+    }
+}
+fn default_anima() -> SubstrateEndpoint {
+    SubstrateEndpoint {
+        unix_socket: PathBuf::from("/run/life/anima.sock"),
+    }
+}
+fn default_soma() -> SubstrateEndpoint {
+    SubstrateEndpoint {
+        unix_socket: PathBuf::from("/run/life/soma-admin.sock"),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct SubstrateEndpoint {
+    pub unix_socket: PathBuf,
+}
+
+/// Authn / authz plumbing.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct AuthConfig {
+    /// Path to a JSON-encoded JWKS file used to verify Tier-2 capability tokens.
+    /// In production, this file is fetched from `lifegw`'s well-known JWKS URL.
+    /// In dev/CI this is a static bundle.
+    #[serde(default = "default_jwks_path")]
+    pub jwks_path: PathBuf,
+    /// Path to lifed's substrate-token signing key (PEM-encoded EC key).
+    /// In dev/CI a deterministic test key ships with the daemon.
+    #[serde(default = "default_signing_key_path")]
+    pub substrate_signing_key_path: PathBuf,
+    /// Path where lifed publishes its substrate-token JWKS.
+    /// Substrates poll this file for Tier-3 verification keys.
+    #[serde(default = "default_published_jwks_path")]
+    pub substrate_jwks_publish_path: PathBuf,
+    /// Path to the `revoked_sids.json` snapshot file (master spec §L4 invariant 5).
+    #[serde(default = "default_revoked_sids_path")]
+    pub revoked_sids_path: PathBuf,
+}
+
+fn default_jwks_path() -> PathBuf {
+    PathBuf::from("/etc/life/lifegw-jwks.json")
+}
+fn default_signing_key_path() -> PathBuf {
+    PathBuf::from("/etc/life/lifed-signing-key.pem")
+}
+fn default_published_jwks_path() -> PathBuf {
+    PathBuf::from("/run/life/lifed-jwks.json")
+}
+fn default_revoked_sids_path() -> PathBuf {
+    PathBuf::from("/run/life/revoked_sids.json")
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            jwks_path: default_jwks_path(),
+            substrate_signing_key_path: default_signing_key_path(),
+            substrate_jwks_publish_path: default_published_jwks_path(),
+            revoked_sids_path: default_revoked_sids_path(),
+        }
+    }
+}
+
+/// Routing-cache parameters per Spec C₂ §6.3.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct RoutingConfig {
+    /// Idle threshold for `Detached` entries before eviction.
+    #[serde(default = "default_idle_secs")]
+    pub idle_threshold_secs: u64,
+    /// Hard cap on cache size (LRU eviction over this).
+    #[serde(default = "default_hard_cap")]
+    pub hard_cap: usize,
+    /// Eviction sweep interval.
+    #[serde(default = "default_eviction_interval_secs")]
+    pub eviction_interval_secs: u64,
+}
+
+fn default_idle_secs() -> u64 {
+    3600
+}
+fn default_hard_cap() -> usize {
+    100_000
+}
+fn default_eviction_interval_secs() -> u64 {
+    300
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            idle_threshold_secs: default_idle_secs(),
+            hard_cap: default_hard_cap(),
+            eviction_interval_secs: default_eviction_interval_secs(),
+        }
+    }
+}
+
+/// Per-substrate connection-pool capacities per Spec C₂ §7.1.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct PoolsConfig {
+    #[serde(default = "default_pool_arcan")]
+    pub arcan_capacity: u32,
+    #[serde(default = "default_pool_lago")]
+    pub lago_capacity: u32,
+    #[serde(default = "default_pool_haima")]
+    pub haima_capacity: u32,
+    #[serde(default = "default_pool_anima")]
+    pub anima_capacity: u32,
+    #[serde(default = "default_pool_soma")]
+    pub soma_capacity: u32,
+}
+
+fn default_pool_arcan() -> u32 {
+    32
+}
+fn default_pool_lago() -> u32 {
+    64
+}
+fn default_pool_haima() -> u32 {
+    16
+}
+fn default_pool_anima() -> u32 {
+    16
+}
+fn default_pool_soma() -> u32 {
+    8
+}
+
+impl Default for PoolsConfig {
+    fn default() -> Self {
+        Self {
+            arcan_capacity: default_pool_arcan(),
+            lago_capacity: default_pool_lago(),
+            haima_capacity: default_pool_haima(),
+            anima_capacity: default_pool_anima(),
+            soma_capacity: default_pool_soma(),
+        }
+    }
+}
+
+/// Idempotency-store parameters per Spec C₂ §3.6.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct IdempotencyConfig {
+    /// Dedup TTL.
+    #[serde(default = "default_idem_ttl")]
+    pub ttl_secs: u64,
+    /// Whether the in-memory backend is used (sub-phase A) or lago-backed (sub-phase B).
+    #[serde(default)]
+    pub backend: IdempotencyBackend,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum IdempotencyBackend {
+    /// In-memory DashMap with TTL eviction sweeper. M5 sub-phase A default.
+    #[default]
+    InMemory,
+    /// Lago-backed durable dedup. M5 sub-phase B default.
+    Lago,
+}
+
+fn default_idem_ttl() -> u64 {
+    24 * 3600
+}
+
+impl Default for IdempotencyConfig {
+    fn default() -> Self {
+        Self {
+            ttl_secs: default_idem_ttl(),
+            backend: IdempotencyBackend::default(),
+        }
+    }
+}
+
+/// Vigil OpenTelemetry exporter wiring.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct VigilConfig {
+    /// OTLP endpoint URL. Empty = no remote exporter (stdout fallback).
+    #[serde(default)]
+    pub otlp_endpoint: Option<String>,
+    /// Trace sampler ratio (0.0–1.0). Default 0.01 = 1 % sampled, 100 % on errors.
+    #[serde(default = "default_trace_sample")]
+    pub trace_sample_ratio: f64,
+    /// Metric reader interval.
+    #[serde(default = "default_metric_interval")]
+    pub metric_interval_secs: u64,
+}
+
+fn default_trace_sample() -> f64 {
+    0.01
+}
+fn default_metric_interval() -> u64 {
+    60
+}
+
+/// Graceful shutdown drain.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct ShutdownConfig {
+    #[serde(default = "default_drain_secs")]
+    pub drain_secs: u64,
+}
+
+fn default_drain_secs() -> u64 {
+    30
+}
+
+impl Default for ShutdownConfig {
+    fn default() -> Self {
+        Self {
+            drain_secs: default_drain_secs(),
+        }
+    }
+}
+
+impl LifedConfig {
+    /// Load a config from `path` if provided, otherwise produce all-defaults.
+    pub fn load(path: Option<&Path>) -> LifedResult<Self> {
+        match path {
+            Some(p) => {
+                let text = std::fs::read_to_string(p)
+                    .map_err(|e| LifedError::Config(format!("read {}: {e}", p.display())))?;
+                let cfg: LifedConfig = toml::from_str(&text)
+                    .map_err(|e| LifedError::Config(format!("parse {}: {e}", p.display())))?;
+                cfg.validate()?;
+                Ok(cfg)
+            }
+            None => Ok(LifedConfig::default()),
+        }
+    }
+
+    /// Cross-field validation. Pure — no I/O.
+    fn validate(&self) -> LifedResult<()> {
+        if self.public_plane.unix_socket == self.admin_plane.unix_socket {
+            return Err(LifedError::Config(
+                "public_plane.unix_socket and admin_plane.unix_socket must differ".to_string(),
+            ));
+        }
+        if self.shutdown.drain_secs == 0 {
+            return Err(LifedError::Config(
+                "shutdown.drain_secs must be > 0".to_string(),
+            ));
+        }
+        if !(0.0..=1.0).contains(&self.vigil.trace_sample_ratio) {
+            return Err(LifedError::Config(
+                "vigil.trace_sample_ratio must be in [0.0, 1.0]".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Convenience: shutdown duration as a `Duration`.
+    pub fn drain_duration(&self) -> Duration {
+        Duration::from_secs(self.shutdown.drain_secs)
+    }
+}

--- a/crates/life-runtime/lifed/src/dev_mocks.rs
+++ b/crates/life-runtime/lifed/src/dev_mocks.rs
@@ -1,0 +1,129 @@
+//! Development mocks for arcan/lago/haima/anima substrates.
+//!
+//! Sub-phase A uses these as the default substrate adapters for both the
+//! daemon entrypoint and integration tests, so that lifed can be exercised
+//! end-to-end before the real `*-proxy` crates are wired in sub-phase B.
+//!
+//! Sub-phase B retires these modules (the real proxy crates take over the
+//! daemon path) but the test harness keeps them as deterministic fixtures.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+/// Mock arcan substrate. Records calls; returns canned responses.
+#[derive(Default, Clone)]
+pub struct MockArcan {
+    pub create_agent_calls: Arc<Mutex<Vec<String>>>,
+    pub destroy_agent_calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockArcan {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pretend to create an agent; returns a canned `agent_id`.
+    pub async fn create_agent(&self, sid: &str) -> Result<String, String> {
+        self.create_agent_calls.lock().push(sid.to_string());
+        Ok(format!("agent-{sid}"))
+    }
+
+    pub async fn destroy_agent(&self, sid: &str) -> Result<(), String> {
+        self.destroy_agent_calls.lock().push(sid.to_string());
+        Ok(())
+    }
+}
+
+/// Mock lago substrate.
+#[derive(Default, Clone)]
+pub struct MockLago {
+    pub open_namespace_calls: Arc<Mutex<Vec<String>>>,
+    pub close_namespace_calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockLago {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn open_namespace(&self, sid: &str) -> Result<String, String> {
+        self.open_namespace_calls.lock().push(sid.to_string());
+        Ok(format!("session/{sid}"))
+    }
+
+    pub async fn close_namespace(&self, ns: &str) -> Result<(), String> {
+        self.close_namespace_calls.lock().push(ns.to_string());
+        Ok(())
+    }
+}
+
+/// Mock haima substrate.
+#[derive(Default, Clone)]
+pub struct MockHaima {
+    pub bind_wallet_calls: Arc<Mutex<Vec<(String, String)>>>,
+    pub unbind_wallet_calls: Arc<Mutex<Vec<String>>>,
+    pub balances: Arc<Mutex<HashMap<String, u64>>>,
+}
+
+impl MockHaima {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn bind_wallet(&self, sid: &str, project_id: &str) -> Result<String, String> {
+        self.bind_wallet_calls
+            .lock()
+            .push((sid.to_string(), project_id.to_string()));
+        let wallet_id = format!("wallet-{sid}");
+        self.balances.lock().insert(wallet_id.clone(), 1_000_000);
+        Ok(wallet_id)
+    }
+
+    pub async fn unbind_wallet(&self, wallet_id: &str) -> Result<(), String> {
+        self.unbind_wallet_calls.lock().push(wallet_id.to_string());
+        Ok(())
+    }
+}
+
+/// Mock anima substrate.
+#[derive(Default, Clone)]
+pub struct MockAnima {
+    pub register_session_calls: Arc<Mutex<Vec<(String, String)>>>,
+    pub mark_closed_calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockAnima {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn register_session(&self, sid: &str, user_id: &str) -> Result<(), String> {
+        self.register_session_calls
+            .lock()
+            .push((sid.to_string(), user_id.to_string()));
+        Ok(())
+    }
+
+    pub async fn mark_session_closed(&self, sid: &str) -> Result<(), String> {
+        self.mark_closed_calls.lock().push(sid.to_string());
+        Ok(())
+    }
+}
+
+/// Bundle of all four mocks — sub-phase A test fixtures + daemon entrypoint
+/// adapter source.
+#[derive(Clone, Default)]
+pub struct MockSubstrates {
+    pub arcan: MockArcan,
+    pub lago: MockLago,
+    pub haima: MockHaima,
+    pub anima: MockAnima,
+}
+
+impl MockSubstrates {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/life-runtime/lifed/src/error.rs
+++ b/crates/life-runtime/lifed/src/error.rs
@@ -1,0 +1,67 @@
+//! Error surface for the `lifed` daemon.
+//!
+//! Every fallible subsystem result is converted into [`LifedError`] at
+//! the boundary so daemon startup failures surface with a single error
+//! type (printed to stderr and to the systemd journal).
+//!
+//! At the RPC boundary, [`LifedError`] also implements
+//! `Into<tonic::Status>` so handlers can `?`-bubble through the auth +
+//! routing layers and have errors mapped to canonical gRPC codes.
+
+use thiserror::Error;
+use tonic::Status;
+
+/// All errors surfaced by the lifed daemon.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LifedError {
+    /// Configuration loading or validation failed.
+    #[error("configuration: {0}")]
+    Config(String),
+
+    /// Auth subsystem failure (JWKS load, signature verification, blocklist).
+    #[error("auth: {0}")]
+    Auth(String),
+
+    /// Routing cache failure (cold-start replay, eviction, lookup).
+    #[error("routing: {0}")]
+    Routing(String),
+
+    /// Saga orchestration failure (forward step, compensation, deadline).
+    #[error("saga: {0}")]
+    Saga(String),
+
+    /// Substrate dispatch failure (transport, breaker open, semaphore).
+    #[error("substrate: {0}")]
+    Substrate(String),
+
+    /// Listener bind / accept / chmod failure.
+    #[error("listener: {0}")]
+    Listener(String),
+
+    /// Server-level failure (tonic Server::serve, drain).
+    #[error("server: {0}")]
+    Server(String),
+
+    /// Shutdown drain timeout or signal-handler error.
+    #[error("shutdown: {0}")]
+    Shutdown(String),
+}
+
+/// Convenience alias used throughout the daemon.
+pub type LifedResult<T> = Result<T, LifedError>;
+
+impl From<LifedError> for Status {
+    fn from(err: LifedError) -> Self {
+        match err {
+            LifedError::Auth(m) => Status::unauthenticated(m),
+            LifedError::Routing(m) => Status::not_found(m),
+            LifedError::Saga(m) => Status::aborted(m),
+            LifedError::Substrate(m) => Status::unavailable(m),
+            LifedError::Config(m)
+            | LifedError::Listener(m)
+            | LifedError::Server(m)
+            | LifedError::Shutdown(m) => Status::internal(m),
+        }
+    }
+}

--- a/crates/life-runtime/lifed/src/idempotency.rs
+++ b/crates/life-runtime/lifed/src/idempotency.rs
@@ -1,0 +1,83 @@
+//! Idempotency-key dedup store. Sub-phase A in-memory; B7 swaps to lago.
+//!
+//! Spec C₂ §3.6: dedup tuple `(user, project, key, method)` with 24 h TTL.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
+pub struct IdemKey {
+    pub user_id: String,
+    pub project_id: String,
+    pub key: String,
+    pub method: String,
+}
+
+pub struct IdempotencyStore {
+    map: DashMap<IdemKey, (Instant, Vec<u8>)>,
+    ttl: Duration,
+}
+
+impl IdempotencyStore {
+    pub fn new(ttl: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            map: DashMap::new(),
+            ttl,
+        })
+    }
+
+    pub fn lookup(&self, key: &IdemKey) -> Option<Vec<u8>> {
+        self.map.get(key).and_then(|e| {
+            let (at, bytes) = e.value();
+            if at.elapsed() > self.ttl {
+                None
+            } else {
+                Some(bytes.clone())
+            }
+        })
+    }
+
+    pub fn persist(&self, key: IdemKey, response_bytes: Vec<u8>) {
+        self.map.insert(key, (Instant::now(), response_bytes));
+    }
+
+    /// Sweep expired entries.
+    pub fn sweep(&self) {
+        let now = Instant::now();
+        let ttl = self.ttl;
+        self.map.retain(|_, (at, _)| now.duration_since(*at) <= ttl);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k(s: &str) -> IdemKey {
+        IdemKey {
+            user_id: "alice".into(),
+            project_id: "p1".into(),
+            key: s.into(),
+            method: "Wallet.Debit".into(),
+        }
+    }
+
+    #[test]
+    fn lookup_returns_persisted_value_within_ttl() {
+        let store = IdempotencyStore::new(Duration::from_secs(60));
+        store.persist(k("k1"), b"hello".to_vec());
+        assert_eq!(store.lookup(&k("k1")).as_deref(), Some(&b"hello"[..]));
+        assert_eq!(store.lookup(&k("missing")), None);
+    }
+
+    #[test]
+    fn sweep_drops_zero_ttl_entries() {
+        let store = IdempotencyStore::new(Duration::from_nanos(1));
+        store.persist(k("k1"), b"x".to_vec());
+        std::thread::sleep(Duration::from_millis(5));
+        store.sweep();
+        assert!(store.lookup(&k("k1")).is_none());
+    }
+}

--- a/crates/life-runtime/lifed/src/lib.rs
+++ b/crates/life-runtime/lifed/src/lib.rs
@@ -10,10 +10,10 @@
 
 #![deny(unsafe_code)]
 
+pub mod config;
 pub mod error;
 
-// Sub-phase A modules — populated in tasks A3–A8.
-// pub mod config;
+// Sub-phase A modules — populated in tasks A4–A8.
 // pub mod bootstrap;
 // pub mod listener;
 // pub mod auth;

--- a/crates/life-runtime/lifed/src/lib.rs
+++ b/crates/life-runtime/lifed/src/lib.rs
@@ -10,19 +10,18 @@
 
 #![deny(unsafe_code)]
 
+pub mod auth;
+pub mod bootstrap;
+pub mod cli;
 pub mod config;
+pub mod dev_mocks;
 pub mod error;
-
-// Sub-phase A modules — populated in tasks A4–A8.
-// pub mod bootstrap;
-// pub mod listener;
-// pub mod auth;
-// pub mod routing;
-// pub mod saga;
-// pub mod services;
-// pub mod observability;
-// pub mod shutdown;
-// pub mod idempotency;
-// pub mod cli;
+pub mod idempotency;
+pub mod listener;
+pub mod observability;
+pub mod routing;
+pub mod saga;
+pub mod services;
+pub mod shutdown;
 
 pub use error::{LifedError, LifedResult};

--- a/crates/life-runtime/lifed/src/lib.rs
+++ b/crates/life-runtime/lifed/src/lib.rs
@@ -1,0 +1,28 @@
+//! lifed — Life Runtime facade-aggregator daemon.
+//!
+//! See `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md` for the
+//! design and `docs/superpowers/plans/2026-04-26-m5-lifed-build.md` for
+//! the implementation plan.
+//!
+//! This crate is the binary's private library — it exists to share types
+//! between `main.rs` and the integration tests under `tests/`. No public
+//! API is exposed beyond what tests need.
+
+#![deny(unsafe_code)]
+
+pub mod error;
+
+// Sub-phase A modules — populated in tasks A3–A8.
+// pub mod config;
+// pub mod bootstrap;
+// pub mod listener;
+// pub mod auth;
+// pub mod routing;
+// pub mod saga;
+// pub mod services;
+// pub mod observability;
+// pub mod shutdown;
+// pub mod idempotency;
+// pub mod cli;
+
+pub use error::{LifedError, LifedResult};

--- a/crates/life-runtime/lifed/src/listener/mod.rs
+++ b/crates/life-runtime/lifed/src/listener/mod.rs
@@ -1,0 +1,7 @@
+//! UDS listener primitives.
+//!
+//! Sub-phase A ships only the public-plane listener. The admin-plane listener
+//! lands in C1 (Spec C₂ §5.3 — SO_PEERCRED + group membership + pidfd).
+
+pub mod public;
+// pub mod admin;     // sub-phase C (C1)

--- a/crates/life-runtime/lifed/src/listener/public.rs
+++ b/crates/life-runtime/lifed/src/listener/public.rs
@@ -48,10 +48,8 @@ pub async fn bind(cfg: &PublicPlaneConfig) -> LifedResult<UnixListenerStream> {
 }
 
 /// Build the shutdown-signal future the tonic server consumes.
-pub fn shutdown_signal(rx: oneshot::Receiver<()>) -> impl std::future::Future<Output = ()> + Send {
-    async move {
-        let _ = rx.await;
-    }
+pub async fn shutdown_signal(rx: oneshot::Receiver<()>) {
+    let _ = rx.await;
 }
 
 fn prepare_socket_path(path: &Path) -> LifedResult<()> {

--- a/crates/life-runtime/lifed/src/listener/public.rs
+++ b/crates/life-runtime/lifed/src/listener/public.rs
@@ -1,0 +1,69 @@
+//! Public-plane UDS listener.
+//!
+//! Binds `/run/life/life.sock` (configurable via `cfg.public_plane`),
+//! chmods to 0660, optionally chowns to `life-runtime`, and serves the
+//! tonic Router. Pattern lifted from soma's `listener/unix.rs`.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use tokio::net::UnixListener;
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::UnixListenerStream;
+
+use crate::config::PublicPlaneConfig;
+use crate::error::{LifedError, LifedResult};
+
+/// Bind the configured public UDS, apply mode/group settings, and return
+/// the incoming-stream + shutdown-future tuple that bootstrap can hand to
+/// `Server::builder().serve_with_incoming_shutdown(...)`.
+///
+/// We expose this as a "prepare" helper rather than wrapping the full serve
+/// call because tonic 0.14's `Router<L>` is generic over its tower layer
+/// stack and propagating those generics through this module adds a lot of
+/// trait noise for no real benefit. Bootstrap composes the router (with
+/// AuthLayer + future tracing/load-shed) and calls serve directly.
+pub async fn bind(cfg: &PublicPlaneConfig) -> LifedResult<UnixListenerStream> {
+    prepare_socket_path(&cfg.unix_socket)?;
+
+    let listener = UnixListener::bind(&cfg.unix_socket)
+        .map_err(|e| LifedError::Listener(format!("bind {}: {e}", cfg.unix_socket.display())))?;
+
+    if let Some(mode) = cfg.unix_socket_mode {
+        std::fs::set_permissions(&cfg.unix_socket, std::fs::Permissions::from_mode(mode))
+            .map_err(|e| LifedError::Listener(format!("chmod socket: {e}")))?;
+    }
+
+    if let Some(group) = cfg.unix_socket_group.as_deref() {
+        tracing::warn!(
+            target: "lifed::listener::public",
+            group,
+            path = %cfg.unix_socket.display(),
+            "unix_socket_group honored via systemd SocketGroup directive; \
+             in-process chown deferred",
+        );
+    }
+
+    Ok(UnixListenerStream::new(listener))
+}
+
+/// Build the shutdown-signal future the tonic server consumes.
+pub fn shutdown_signal(rx: oneshot::Receiver<()>) -> impl std::future::Future<Output = ()> + Send {
+    async move {
+        let _ = rx.await;
+    }
+}
+
+fn prepare_socket_path(path: &Path) -> LifedResult<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| LifedError::Listener(format!("create {}: {e}", parent.display())))?;
+    }
+    if path.exists() {
+        std::fs::remove_file(path)
+            .map_err(|e| LifedError::Listener(format!("unlink stale {}: {e}", path.display())))?;
+    }
+    Ok(())
+}

--- a/crates/life-runtime/lifed/src/main.rs
+++ b/crates/life-runtime/lifed/src/main.rs
@@ -1,0 +1,10 @@
+//! lifed — Life Runtime facade-aggregator daemon binary.
+//!
+//! M5 sub-phase A scaffold. Real entrypoint logic lands in A8.
+
+#![deny(unsafe_code)]
+
+fn main() {
+    eprintln!("lifed: M5 sub-phase A scaffold — entrypoint wired in A8 (BRO-930)");
+    std::process::exit(0);
+}

--- a/crates/life-runtime/lifed/src/main.rs
+++ b/crates/life-runtime/lifed/src/main.rs
@@ -1,10 +1,57 @@
-//! lifed — Life Runtime facade-aggregator daemon binary.
-//!
-//! M5 sub-phase A scaffold. Real entrypoint logic lands in A8.
+//! `lifed` — Life Runtime facade-aggregator daemon.
 
 #![deny(unsafe_code)]
 
-fn main() {
-    eprintln!("lifed: M5 sub-phase A scaffold — entrypoint wired in A8 (BRO-930)");
-    std::process::exit(0);
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "lifed",
+    version,
+    about = "Life Runtime facade-aggregator daemon — public + admin plane RPCs",
+    long_about = "Hosts the locked life.v1.* and life.admin.v1.* surfaces over UDS,\n\
+                  fans out to per-substrate daemons via per-substrate sockets,\n\
+                  validates Tier-2 capability tokens and mints Tier-3 substrate tokens."
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Run the daemon (default mode for systemd unit `lifed.service`).
+    Daemon {
+        #[arg(long, env = "LIFED_CONFIG")]
+        config: Option<PathBuf>,
+    },
+
+    /// Operator subcommand — list active sessions on the admin plane.
+    SessionsLs(lifed::cli::sessions::LsArgs),
+
+    /// Operator subcommand — show one session's routing entry.
+    SessionsShow(lifed::cli::sessions::ShowArgs),
+
+    /// Operator subcommand — dump the routing cache.
+    RoutingCacheDump(lifed::cli::routing_cache::DumpArgs),
+
+    /// Operator subcommand — show one saga.
+    SagaShow(lifed::cli::saga::ShowArgs),
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::Daemon { config } => {
+            lifed::bootstrap::run_daemon(config.as_deref()).await?;
+            Ok(())
+        }
+        Cmd::SessionsLs(args) => lifed::cli::sessions::run_ls(args).await,
+        Cmd::SessionsShow(args) => lifed::cli::sessions::run_show(args).await,
+        Cmd::RoutingCacheDump(args) => lifed::cli::routing_cache::run_dump(args).await,
+        Cmd::SagaShow(args) => lifed::cli::saga::run_show(args).await,
+    }
 }

--- a/crates/life-runtime/lifed/src/observability.rs
+++ b/crates/life-runtime/lifed/src/observability.rs
@@ -1,0 +1,23 @@
+//! Vigil exporter init.
+//!
+//! Sub-phase A: stdout fallback only. Real OTLP exporter wires in D5.
+
+use crate::config::VigilConfig;
+use crate::error::LifedResult;
+
+/// RAII guard returned by `init` — drops on daemon exit and flushes anything
+/// buffered. Sub-phase A is a no-op; sub-phase D (D5) wires the real OTLP
+/// flush.
+pub struct VigilGuard;
+
+pub fn init(_cfg: &VigilConfig) -> LifedResult<VigilGuard> {
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_target(true)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("lifed=info,tower=warn")),
+        )
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    Ok(VigilGuard)
+}

--- a/crates/life-runtime/lifed/src/routing/cache.rs
+++ b/crates/life-runtime/lifed/src/routing/cache.rs
@@ -1,0 +1,144 @@
+//! In-memory routing cache. Sub-phase A ships the basic shape; eviction lands
+//! in B8; cold-start replay from lago lands in D2.
+//!
+//! Per Spec C₂ §6.1, the cache maps `SessionId → RouteEntry`. Multi-tab
+//! fanout senders are stored per entry. Locking uses DashMap on the outer
+//! map and parking_lot::RwLock on entries (ergonomic; tokio::sync::RwLock
+//! would be required only when await is held across the lock).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use parking_lot::RwLock;
+
+use aios_proto::aios::v1 as aios_v1;
+
+/// Routing cache — DashMap-backed sharded outer map; parking_lot::RwLock per entry.
+pub struct RoutingCache {
+    by_sid: DashMap<String, Arc<RwLock<RouteEntry>>>,
+    by_user: DashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteEntry {
+    pub sid: aios_v1::SessionId,
+    pub user_id: String,
+    pub project_id: String,
+    pub agent_id: String,
+    pub lago_namespace: String,
+    pub haima_wallet: String,
+    pub anima_account: String,
+    pub last_touched: Instant,
+    pub status: SessionStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStatus {
+    Active,
+    Detached,
+    Hibernated,
+}
+
+impl RoutingCache {
+    pub fn new() -> Self {
+        Self {
+            by_sid: DashMap::new(),
+            by_user: DashMap::new(),
+        }
+    }
+
+    /// Sub-phase A: insert a minimal entry. B11 will replace this with the full
+    /// saga-result entry shape.
+    pub fn insert_minimal(&self, sid: &aios_v1::SessionId, user_id: &str, project_id: &str) {
+        let entry = RouteEntry {
+            sid: sid.clone(),
+            user_id: user_id.to_string(),
+            project_id: project_id.to_string(),
+            agent_id: format!("agent-{}", sid.value),
+            lago_namespace: format!("session/{}", sid.value),
+            haima_wallet: format!("wallet-{}", sid.value),
+            anima_account: format!("account-{user_id}"),
+            last_touched: Instant::now(),
+            status: SessionStatus::Active,
+        };
+        self.by_sid
+            .insert(sid.value.clone(), Arc::new(RwLock::new(entry)));
+        self.by_user
+            .entry(user_id.to_string())
+            .or_default()
+            .push(sid.value.clone());
+    }
+
+    pub fn lookup(&self, sid: &aios_v1::SessionId) -> Option<RouteEntry> {
+        self.by_sid.get(&sid.value).map(|e| e.read().clone())
+    }
+
+    pub fn evict(&self, sid: &aios_v1::SessionId) {
+        if let Some((_, entry)) = self.by_sid.remove(&sid.value) {
+            let user_id = entry.read().user_id.clone();
+            if let Some(mut sids) = self.by_user.get_mut(&user_id) {
+                sids.retain(|s| s != &sid.value);
+            }
+        }
+    }
+
+    pub fn list_for_user(&self, user_id: &str) -> Vec<aios_v1::SessionId> {
+        self.by_user
+            .get(user_id)
+            .map(|v| {
+                v.iter()
+                    .map(|s| aios_v1::SessionId { value: s.clone() })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn size(&self) -> usize {
+        self.by_sid.len()
+    }
+}
+
+impl Default for RoutingCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sid(s: &str) -> aios_v1::SessionId {
+        aios_v1::SessionId {
+            value: s.to_string(),
+        }
+    }
+
+    #[test]
+    fn insert_lookup_evict_round_trip() {
+        let cache = RoutingCache::new();
+        cache.insert_minimal(&sid("abc"), "alice", "p1");
+        let entry = cache.lookup(&sid("abc")).expect("present");
+        assert_eq!(entry.user_id, "alice");
+        assert_eq!(entry.project_id, "p1");
+        assert_eq!(cache.size(), 1);
+
+        let mine = cache.list_for_user("alice");
+        assert_eq!(mine.len(), 1);
+        assert_eq!(mine[0].value, "abc");
+
+        cache.evict(&sid("abc"));
+        assert!(cache.lookup(&sid("abc")).is_none());
+        assert_eq!(cache.size(), 0);
+        assert!(cache.list_for_user("alice").is_empty());
+    }
+
+    #[test]
+    fn multiple_sessions_for_one_user() {
+        let cache = RoutingCache::new();
+        cache.insert_minimal(&sid("a"), "alice", "p1");
+        cache.insert_minimal(&sid("b"), "alice", "p2");
+        assert_eq!(cache.list_for_user("alice").len(), 2);
+    }
+}

--- a/crates/life-runtime/lifed/src/routing/fanout.rs
+++ b/crates/life-runtime/lifed/src/routing/fanout.rs
@@ -1,0 +1,27 @@
+//! Multi-tab fan-out registry. Sub-phase A scaffolds the registry shape;
+//! B12 wires the real fanout pump.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+
+use life_runtime_proto::life::v1 as pb;
+
+#[derive(Default)]
+pub struct FanoutRegistry {
+    senders: Arc<RwLock<Vec<mpsc::Sender<Result<pb::AgentEvent, tonic::Status>>>>>,
+}
+
+impl FanoutRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Register a downstream sender. Returns the registry index.
+    pub fn register(&self, tx: mpsc::Sender<Result<pb::AgentEvent, tonic::Status>>) -> usize {
+        let mut guard = self.senders.write();
+        let i = guard.len();
+        guard.push(tx);
+        i
+    }
+}

--- a/crates/life-runtime/lifed/src/routing/fanout.rs
+++ b/crates/life-runtime/lifed/src/routing/fanout.rs
@@ -8,9 +8,14 @@ use tokio::sync::mpsc;
 
 use life_runtime_proto::life::v1 as pb;
 
+/// Type alias for the per-tab AgentEvent sender. Sub-phase A keeps the
+/// queue bounded by the receiver-side mpsc capacity (no slow-consumer
+/// policy yet — that lands in D4).
+pub type AgentEventSender = mpsc::Sender<Result<pb::AgentEvent, tonic::Status>>;
+
 #[derive(Default)]
 pub struct FanoutRegistry {
-    senders: Arc<RwLock<Vec<mpsc::Sender<Result<pb::AgentEvent, tonic::Status>>>>>,
+    senders: Arc<RwLock<Vec<AgentEventSender>>>,
 }
 
 impl FanoutRegistry {
@@ -18,7 +23,7 @@ impl FanoutRegistry {
         Self::default()
     }
     /// Register a downstream sender. Returns the registry index.
-    pub fn register(&self, tx: mpsc::Sender<Result<pb::AgentEvent, tonic::Status>>) -> usize {
+    pub fn register(&self, tx: AgentEventSender) -> usize {
         let mut guard = self.senders.write();
         let i = guard.len();
         guard.push(tx);

--- a/crates/life-runtime/lifed/src/routing/mod.rs
+++ b/crates/life-runtime/lifed/src/routing/mod.rs
@@ -1,0 +1,11 @@
+//! Routing cache + multi-tab fan-out registry.
+//!
+//! Spec C₂ §6. Sub-phase A ships an in-memory cache without eviction; sub-phase
+//! B adds eviction (B8); sub-phase D adds cold-start replay from lago (D2).
+
+pub mod cache;
+pub mod fanout;
+// pub mod pools;     // sub-phase D (D1)
+// pub mod breaker;   // sub-phase D (D1)
+
+pub use cache::{RouteEntry, RoutingCache, SessionStatus};

--- a/crates/life-runtime/lifed/src/saga/driver.rs
+++ b/crates/life-runtime/lifed/src/saga/driver.rs
@@ -1,0 +1,80 @@
+//! No-op saga driver placeholder. The real driver lands in B6.
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use aios_proto::aios::v1 as aios_v1;
+
+use crate::auth::capability::CapabilityClaims;
+
+#[derive(Debug, Error)]
+pub enum SagaError {
+    #[error("step '{name}' forward: {source}")]
+    Forward {
+        name: &'static str,
+        source: tonic::Status,
+    },
+    #[error("step '{name}' compensate: {source}")]
+    Compensate {
+        name: &'static str,
+        source: tonic::Status,
+    },
+    #[error("deadline exceeded for saga {kind}")]
+    Deadline { kind: &'static str },
+}
+
+impl SagaError {
+    pub fn into_status(self) -> tonic::Status {
+        match self {
+            SagaError::Forward { source, .. } => source,
+            SagaError::Compensate { source, .. } => source,
+            SagaError::Deadline { kind } => {
+                tonic::Status::deadline_exceeded(format!("saga {kind} timed out"))
+            }
+        }
+    }
+}
+
+pub struct SagaCtx {
+    pub saga_id: String,
+    pub user_id: String,
+    pub project_id: String,
+    pub sid: aios_v1::SessionId,
+    pub idempotency_key: Option<String>,
+    pub deadline: Instant,
+    pub trace: tracing::Span,
+    pub claims: CapabilityClaims,
+}
+
+#[async_trait]
+pub trait SagaStep: Send + Sync {
+    async fn forward(&self, ctx: &SagaCtx) -> Result<(), SagaError>;
+    async fn compensate(&self, ctx: &SagaCtx) -> Result<(), SagaError>;
+    fn name(&self) -> &'static str;
+}
+
+pub struct SagaDriver {
+    kind: &'static str,
+}
+
+impl SagaDriver {
+    pub fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+
+    /// The kind tag passed to `new`, used for deadline error labelling.
+    pub fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Sub-phase A no-op. B6 replaces with the real driver.
+    pub async fn run(
+        &self,
+        _ctx: SagaCtx,
+        _steps: Vec<Box<dyn SagaStep>>,
+    ) -> Result<(), SagaError> {
+        Ok(())
+    }
+}

--- a/crates/life-runtime/lifed/src/saga/mod.rs
+++ b/crates/life-runtime/lifed/src/saga/mod.rs
@@ -1,0 +1,6 @@
+//! Saga driver — sub-phase A ships a no-op driver. Real driver lands in B6.
+
+pub mod driver;
+pub mod steps;
+
+pub use driver::{SagaCtx, SagaDriver, SagaError, SagaStep};

--- a/crates/life-runtime/lifed/src/saga/steps.rs
+++ b/crates/life-runtime/lifed/src/saga/steps.rs
@@ -1,0 +1,62 @@
+//! Saga step types for `Agent.CreateSession`. Sub-phase A bodies are stubs.
+
+use async_trait::async_trait;
+
+use crate::saga::driver::{SagaCtx, SagaError, SagaStep};
+
+pub struct CreateAgent;
+pub struct OpenLagoNamespace;
+pub struct BindWallet;
+pub struct RegisterAnimaSession;
+
+#[async_trait]
+impl SagaStep for CreateAgent {
+    async fn forward(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    async fn compensate(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    fn name(&self) -> &'static str {
+        "create_agent"
+    }
+}
+
+#[async_trait]
+impl SagaStep for OpenLagoNamespace {
+    async fn forward(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    async fn compensate(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    fn name(&self) -> &'static str {
+        "open_lago_namespace"
+    }
+}
+
+#[async_trait]
+impl SagaStep for BindWallet {
+    async fn forward(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    async fn compensate(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    fn name(&self) -> &'static str {
+        "bind_wallet"
+    }
+}
+
+#[async_trait]
+impl SagaStep for RegisterAnimaSession {
+    async fn forward(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    async fn compensate(&self, _ctx: &SagaCtx) -> Result<(), SagaError> {
+        Ok(())
+    }
+    fn name(&self) -> &'static str {
+        "register_anima_session"
+    }
+}

--- a/crates/life-runtime/lifed/src/services/agent.rs
+++ b/crates/life-runtime/lifed/src/services/agent.rs
@@ -1,0 +1,271 @@
+//! life.v1.Agent — public-plane agent namespace.
+//!
+//! Sub-phase A wires the 11 RPCs against mock substrate clients. Sub-phase
+//! B replaces the mock dispatch with real `arcan-proxy` + saga driver.
+//!
+//! Per Spec C₂ §1 and §3.1 this implementation MUST:
+//! - Read CapabilityClaims from request extensions (set by AuthLayer middleware).
+//! - Dispatch a single substrate call OR initiate one saga.
+//! - Return.
+//!
+//! ≤20 LOC per handler is a hard constraint. Anything more is a sign that
+//! business logic is leaking into lifed.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::Utc;
+use futures::Stream;
+use sha2::{Digest, Sha256};
+use tonic::{Request, Response, Status};
+
+use aios_proto::aios::v1 as aios_v1;
+use life_runtime_proto::life::v1 as pb;
+
+use crate::auth::capability::CapabilityClaims;
+use crate::routing::cache::RoutingCache;
+
+/// Trait abstracting the dispatch surface lifed needs from arcan.
+/// Sub-phase A backs this with `MockArcan`; sub-phase B wires `ArcanProxy`.
+#[async_trait::async_trait]
+pub trait ArcanDispatch: Send + Sync + 'static {
+    async fn create_agent(&self, sid: &str) -> Result<String, Status>;
+    async fn destroy_agent(&self, sid: &str) -> Result<(), Status>;
+    async fn dispatch_message(
+        &self,
+        sid: &str,
+        content: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, Status>> + Send>>, Status>;
+}
+
+#[async_trait::async_trait]
+pub trait LagoDispatch: Send + Sync + 'static {
+    async fn open_namespace(&self, sid: &str) -> Result<String, Status>;
+    async fn close_namespace(&self, ns: &str) -> Result<(), Status>;
+}
+
+#[async_trait::async_trait]
+pub trait HaimaDispatch: Send + Sync + 'static {
+    async fn bind_wallet(&self, sid: &str, project_id: &str) -> Result<String, Status>;
+    async fn unbind_wallet(&self, wallet_id: &str) -> Result<(), Status>;
+}
+
+#[async_trait::async_trait]
+pub trait AnimaDispatch: Send + Sync + 'static {
+    async fn register_session(&self, sid: &str, user_id: &str) -> Result<(), Status>;
+    async fn mark_session_closed(&self, sid: &str) -> Result<(), Status>;
+}
+
+/// `Agent` service implementation.
+pub struct AgentService {
+    pub arcan: Arc<dyn ArcanDispatch>,
+    pub lago: Arc<dyn LagoDispatch>,
+    pub haima: Arc<dyn HaimaDispatch>,
+    pub anima: Arc<dyn AnimaDispatch>,
+    pub routing: Arc<RoutingCache>,
+}
+
+impl AgentService {
+    pub fn new(
+        arcan: Arc<dyn ArcanDispatch>,
+        lago: Arc<dyn LagoDispatch>,
+        haima: Arc<dyn HaimaDispatch>,
+        anima: Arc<dyn AnimaDispatch>,
+        routing: Arc<RoutingCache>,
+    ) -> Self {
+        Self {
+            arcan,
+            lago,
+            haima,
+            anima,
+            routing,
+        }
+    }
+
+    fn claims<T>(req: &Request<T>) -> Result<&CapabilityClaims, Status> {
+        req.extensions()
+            .get::<CapabilityClaims>()
+            .ok_or_else(|| Status::unauthenticated("missing capability claims"))
+    }
+}
+
+/// Sub-phase A: one-shot sid generator. Real saga in sub-phase B replaces this
+/// with the master-spec sid formula.
+fn mint_sid(user_id: &str, project_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(user_id.as_bytes());
+    hasher.update(project_id.as_bytes());
+    hasher.update(uuid_like::random_bytes_16());
+    hasher.update(Utc::now().timestamp_millis().to_be_bytes());
+    let digest = hasher.finalize();
+    base32::encode(base32::Alphabet::Rfc4648 { padding: false }, &digest[..16]).to_lowercase()
+}
+
+mod uuid_like {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    pub fn random_bytes_16() -> [u8; 16] {
+        // Deterministic-enough randomness for the sid mint;
+        // sub-phase B replaces with `getrandom`.
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u128;
+        nanos.to_le_bytes()
+    }
+}
+
+#[tonic::async_trait]
+impl pb::agent_server::Agent for AgentService {
+    type SendMessageStream = Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, Status>> + Send>>;
+    type StreamSessionStream = Self::SendMessageStream;
+
+    async fn create_session(
+        &self,
+        req: Request<pb::CreateSessionReq>,
+    ) -> Result<Response<pb::Session>, Status> {
+        let claims = Self::claims(&req)?.clone();
+        let body = req.into_inner();
+        let sid_value = mint_sid(&body.user_id, &body.project_id);
+        let sid = aios_v1::SessionId {
+            value: sid_value.clone(),
+        };
+
+        // Sub-phase A: serial dispatch. Sub-phase B replaces with SagaDriver.
+        let _agent_id = self.arcan.create_agent(&sid_value).await?;
+        let _ns = self.lago.open_namespace(&sid_value).await?;
+        let _wallet = self.haima.bind_wallet(&sid_value, &body.project_id).await?;
+        self.anima
+            .register_session(&sid_value, &body.user_id)
+            .await?;
+        self.routing
+            .insert_minimal(&sid, &body.user_id, &body.project_id);
+        Ok(Response::new(pb::Session {
+            sid: Some(sid),
+            agent_id: Some(aios_v1::AgentId {
+                value: format!("agent-{sid_value}"),
+            }),
+            user_id: claims.user_id,
+            project_id: body.project_id,
+            created_at: Some(prost_types::Timestamp::from(std::time::SystemTime::now())),
+        }))
+    }
+
+    async fn describe_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<pb::Session>, Status> {
+        let _claims = Self::claims(&req)?;
+        let sid = req
+            .get_ref()
+            .sid
+            .clone()
+            .ok_or_else(|| Status::invalid_argument("missing sid"))?;
+        let entry = self
+            .routing
+            .lookup(&sid)
+            .ok_or_else(|| Status::not_found("session not found"))?;
+        Ok(Response::new(pb::Session {
+            sid: Some(sid),
+            agent_id: Some(aios_v1::AgentId {
+                value: entry.agent_id.clone(),
+            }),
+            user_id: entry.user_id.clone(),
+            project_id: entry.project_id.clone(),
+            created_at: Some(prost_types::Timestamp::from(std::time::SystemTime::now())),
+        }))
+    }
+
+    async fn close_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        let _claims = Self::claims(&req)?;
+        let sid = req
+            .get_ref()
+            .sid
+            .clone()
+            .ok_or_else(|| Status::invalid_argument("missing sid"))?;
+        self.anima.mark_session_closed(&sid.value).await?;
+        self.routing.evict(&sid);
+        Ok(Response::new(pb::Empty {}))
+    }
+
+    async fn send_message(
+        &self,
+        req: Request<pb::SendMessageReq>,
+    ) -> Result<Response<Self::SendMessageStream>, Status> {
+        let _claims = Self::claims(&req)?;
+        let body = req.into_inner();
+        let sid = body
+            .sid
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing sid"))?
+            .value
+            .clone();
+        let stream = self.arcan.dispatch_message(&sid, &body.content).await?;
+        Ok(Response::new(stream))
+    }
+
+    async fn stream_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<Self::StreamSessionStream>, Status> {
+        let _claims = Self::claims(&req)?;
+        let sid = req
+            .get_ref()
+            .sid
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing sid"))?
+            .value
+            .clone();
+        // Sub-phase A: re-use SendMessage's stub stream with empty content.
+        let stream = self.arcan.dispatch_message(&sid, "").await?;
+        Ok(Response::new(stream))
+    }
+
+    async fn approve_dispatch(
+        &self,
+        _req: Request<pb::ApprovalReq>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        // Sub-phase A: ack-only stub. B12 wires the real per-sid lock.
+        Ok(Response::new(pb::Empty {}))
+    }
+
+    async fn cancel_dispatch(
+        &self,
+        _req: Request<pb::DispatchRef>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        Ok(Response::new(pb::Empty {}))
+    }
+
+    async fn list_skills(
+        &self,
+        _req: Request<pb::ListSkillsReq>,
+    ) -> Result<Response<pb::SkillCatalog>, Status> {
+        Ok(Response::new(pb::SkillCatalog { items: vec![] }))
+    }
+
+    async fn list_models(
+        &self,
+        _req: Request<pb::ListModelsReq>,
+    ) -> Result<Response<pb::ModelCatalog>, Status> {
+        Ok(Response::new(pb::ModelCatalog { items: vec![] }))
+    }
+
+    async fn list_tools(
+        &self,
+        _req: Request<pb::ListToolsReq>,
+    ) -> Result<Response<pb::ToolCatalog>, Status> {
+        Ok(Response::new(pb::ToolCatalog { items: vec![] }))
+    }
+
+    async fn spawn_child(
+        &self,
+        _req: Request<pb::SpawnChildReq>,
+    ) -> Result<Response<pb::SpawnChildResp>, Status> {
+        Err(Status::unimplemented(
+            "Agent.SpawnChild ships in Spec C₇ (recursive embedding, post-MVS). \
+             Tracking ticket: BRO-926.",
+        ))
+    }
+}

--- a/crates/life-runtime/lifed/src/services/agent.rs
+++ b/crates/life-runtime/lifed/src/services/agent.rs
@@ -109,7 +109,7 @@ mod uuid_like {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
-            .as_nanos() as u128;
+            .as_nanos();
         nanos.to_le_bytes()
     }
 }

--- a/crates/life-runtime/lifed/src/services/events.rs
+++ b/crates/life-runtime/lifed/src/services/events.rs
@@ -1,0 +1,90 @@
+//! life.v1.Events — public-plane events namespace.
+//!
+//! Sub-phase A returns canned empty streams to validate the wire shape.
+//! Sub-phase B wires real lago tail via `lago-proxy`.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::Stream;
+use tonic::{Request, Response, Status};
+
+use life_runtime_proto::life::v1 as pb;
+
+use crate::auth::capability::CapabilityClaims;
+
+#[async_trait::async_trait]
+pub trait LagoTail: Send + Sync + 'static {
+    async fn read(
+        &self,
+        sid: &str,
+        from: u64,
+        limit: u32,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<pb::EventRecord, Status>> + Send>>, Status>;
+
+    async fn subscribe(
+        &self,
+        sid: &str,
+        from: u64,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<pb::EventRecord, Status>> + Send>>, Status>;
+
+    async fn get_blob(&self, namespace: &str, sha256: &str) -> Result<(Vec<u8>, String), Status>;
+}
+
+pub struct EventsService {
+    pub lago: Arc<dyn LagoTail>,
+}
+
+impl EventsService {
+    pub fn new(lago: Arc<dyn LagoTail>) -> Self {
+        Self { lago }
+    }
+
+    fn claims<T>(req: &Request<T>) -> Result<&CapabilityClaims, Status> {
+        req.extensions()
+            .get::<CapabilityClaims>()
+            .ok_or_else(|| Status::unauthenticated("missing capability claims"))
+    }
+}
+
+#[tonic::async_trait]
+impl pb::events_server::Events for EventsService {
+    type ReadStream = Pin<Box<dyn Stream<Item = Result<pb::EventRecord, Status>> + Send>>;
+    type SubscribeStream = Self::ReadStream;
+
+    async fn read(&self, req: Request<pb::ReadReq>) -> Result<Response<Self::ReadStream>, Status> {
+        let _claims = Self::claims(&req)?;
+        let body = req.get_ref();
+        let sid = body
+            .session_id
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing session_id"))?
+            .value
+            .clone();
+        let stream = self.lago.read(&sid, body.from_sequence, body.limit).await?;
+        Ok(Response::new(stream))
+    }
+
+    async fn subscribe(
+        &self,
+        req: Request<pb::SubscribeReq>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let _claims = Self::claims(&req)?;
+        let body = req.get_ref();
+        let sid = body
+            .session_id
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing session_id"))?
+            .value
+            .clone();
+        let stream = self.lago.subscribe(&sid, body.from_sequence).await?;
+        Ok(Response::new(stream))
+    }
+
+    async fn get_blob(&self, req: Request<pb::BlobRef>) -> Result<Response<pb::Blob>, Status> {
+        let _claims = Self::claims(&req)?;
+        let body = req.get_ref();
+        let (data, content_type) = self.lago.get_blob(&body.namespace, &body.sha256).await?;
+        Ok(Response::new(pb::Blob { data, content_type }))
+    }
+}

--- a/crates/life-runtime/lifed/src/services/mod.rs
+++ b/crates/life-runtime/lifed/src/services/mod.rs
@@ -1,0 +1,16 @@
+//! gRPC service implementations.
+//!
+//! Each module hosts the tonic service trait impl for one public-plane
+//! namespace (`agent`, `events`, `wallet`, `identity`) or admin-plane
+//! namespace (under `admin/`).
+//!
+//! Per Spec C₂ §1, every public RPC handler reads the capability token,
+//! performs a single substrate route or saga dispatch, and returns. ≤20 LOC
+//! handler rule applies — anything resembling business logic happens in
+//! the substrate, never here.
+
+pub mod agent;
+// pub mod events;       // sub-phase A task A6 (lands with the events.proto service body)
+// pub mod wallet;       // sub-phase B (B13)
+// pub mod identity;     // sub-phase B (B14)
+// pub mod admin;        // sub-phase C (C2–C5)

--- a/crates/life-runtime/lifed/src/services/mod.rs
+++ b/crates/life-runtime/lifed/src/services/mod.rs
@@ -10,7 +10,7 @@
 //! the substrate, never here.
 
 pub mod agent;
-// pub mod events;       // sub-phase A task A6 (lands with the events.proto service body)
+pub mod events;
 // pub mod wallet;       // sub-phase B (B13)
 // pub mod identity;     // sub-phase B (B14)
 // pub mod admin;        // sub-phase C (C2–C5)

--- a/crates/life-runtime/lifed/src/shutdown.rs
+++ b/crates/life-runtime/lifed/src/shutdown.rs
@@ -1,0 +1,64 @@
+//! Signal-handling and graceful drain orchestrator.
+
+use std::time::Duration;
+
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::sync::oneshot;
+
+use crate::error::{LifedError, LifedResult};
+
+/// Install a SIGTERM/SIGINT handler that fires `shutdown_tx` once.
+pub fn install_signal_handler() -> oneshot::Receiver<()> {
+    let (tx, rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to install SIGTERM handler");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to install SIGINT handler");
+                return;
+            }
+        };
+
+        tokio::select! {
+            _ = sigterm.recv() => tracing::info!("SIGTERM received"),
+            _ = sigint.recv()  => tracing::info!("SIGINT received"),
+        }
+        let _ = tx.send(());
+    });
+
+    rx
+}
+
+/// Wait up to `deadline` for in-flight calls to drain. Returns the residual
+/// inflight count if the deadline elapses.
+pub async fn drain_in_flight(
+    inflight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    deadline: Duration,
+) -> Result<(), usize> {
+    let started = std::time::Instant::now();
+    while started.elapsed() < deadline {
+        let count = inflight.load(std::sync::atomic::Ordering::SeqCst);
+        if count == 0 {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Err(inflight.load(std::sync::atomic::Ordering::SeqCst))
+}
+
+pub async fn force_shutdown_after(
+    deadline: Duration,
+    inflight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) -> LifedResult<()> {
+    drain_in_flight(inflight, deadline)
+        .await
+        .map_err(|residual| LifedError::Shutdown(format!("{residual} inflight at deadline")))
+}

--- a/crates/life-runtime/lifed/tests/_support/mock_substrates.rs
+++ b/crates/life-runtime/lifed/tests/_support/mock_substrates.rs
@@ -1,0 +1,15 @@
+//! Mock arcan/lago/haima/anima daemons backed by tonic test infrastructure.
+//!
+//! Sub-phase A uses these to validate lifed's handler shape and
+//! routing/auth/observability scaffolding without depending on the real
+//! substrate dev cluster. Sub-phase B replaces these mocks with real-substrate
+//! integration via the four `*-proxy` crates.
+
+#![allow(dead_code)]
+
+// Re-export the in-crate dev mocks. The same types are used by lifed's
+// bootstrap to drive its mock-mode daemon, and by integration tests to assert
+// that the right substrate calls were made.
+pub use lifed::dev_mocks::MockSubstrates;
+#[allow(unused_imports)]
+pub use lifed::dev_mocks::{MockAnima, MockArcan, MockHaima, MockLago};

--- a/crates/life-runtime/lifed/tests/_support/mod.rs
+++ b/crates/life-runtime/lifed/tests/_support/mod.rs
@@ -1,0 +1,10 @@
+//! Shared test harness for lifed integration tests.
+//!
+//! - `mock_substrates` — tonic-test-driven fakes for arcan/lago/haima/anima.
+//! - `test_env` — `TestEnv::start_with_mocks` / `start_with_real_substrates`
+//!   which boots tempdir-rooted lifed + the right substrate set.
+
+#![allow(dead_code)]
+
+pub mod mock_substrates;
+pub mod test_env;

--- a/crates/life-runtime/lifed/tests/_support/test_env.rs
+++ b/crates/life-runtime/lifed/tests/_support/test_env.rs
@@ -1,0 +1,122 @@
+//! TestEnv — boots a tempdir-rooted lifed daemon plus the substrate set
+//! (mocks under sub-phase A; real substrates under sub-phase B).
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::sync::oneshot;
+use tonic::transport::{Endpoint, Uri};
+use tower::service_fn;
+
+use life_runtime_proto::life::v1::agent_client::AgentClient;
+use life_runtime_proto::life::v1::{CreateSessionReq, Session};
+use lifed::config::LifedConfig;
+
+use super::mock_substrates::MockSubstrates;
+
+/// Sub-phase A test environment: lifed bound to a tempdir UDS, mock substrates
+/// behind the substrate-proxy stubs, deterministic dev signing key.
+pub struct TestEnv {
+    _tempdir: TempDir,
+    public_socket: PathBuf,
+    pub mocks: Arc<MockSubstrates>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TestEnv {
+    /// Start a lifed instance backed by mock substrates.
+    pub async fn start_with_mocks() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let public_socket = tempdir.path().join("life.sock");
+        let admin_socket = tempdir.path().join("life-admin.sock");
+        let mocks = Arc::new(MockSubstrates::new());
+
+        let mut cfg = LifedConfig::default();
+        cfg.public_plane.unix_socket = public_socket.clone();
+        cfg.admin_plane.unix_socket = admin_socket;
+        cfg.public_plane.unix_socket_group = None;
+        cfg.admin_plane.unix_socket_group = None;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let mocks_clone = Arc::clone(&mocks);
+        let server_handle = tokio::spawn(async move {
+            lifed::bootstrap::run_with_mocks(&cfg, mocks_clone, shutdown_rx)
+                .await
+                .expect("lifed boots in test mode");
+        });
+
+        // Wait for the socket to appear (poll up to 2 s).
+        for _ in 0..200 {
+            if public_socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(public_socket.exists(), "public socket bound");
+
+        Self {
+            _tempdir: tempdir,
+            public_socket,
+            mocks,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+        }
+    }
+
+    /// Returns an `AgentClient` connected to the test's public socket.
+    pub async fn agent_client(&self) -> AgentClient<tonic::transport::Channel> {
+        let socket = self.public_socket.clone();
+        let endpoint = Endpoint::try_from("http://[::]:0").unwrap();
+        let channel = endpoint
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let socket = socket.clone();
+                async move {
+                    let stream = UnixStream::connect(socket).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            }))
+            .await
+            .expect("connect");
+        AgentClient::new(channel)
+    }
+
+    /// Convenience: build a `CreateSessionReq` with a dev Tier-2 token in metadata
+    /// and dispatch it.
+    pub async fn create_session_dev(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        label: &str,
+    ) -> Result<Session, tonic::Status> {
+        let mut client = self.agent_client().await;
+        let mut req = tonic::Request::new(CreateSessionReq {
+            user_id: user_id.to_string(),
+            project_id: project_id.to_string(),
+            label: label.to_string(),
+            resume_sid: None,
+            inherit_policy: None,
+        });
+        // Sub-phase A: the dev signer accepts a deterministic test token whose
+        // body is `bearer test-token-for-{user_id}`. Real ES256 lands in B5.
+        req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer test-token-for-{user_id}").parse().unwrap(),
+        );
+        client.create_session(req).await.map(|r| r.into_inner())
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.server_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+        }
+    }
+}

--- a/crates/life-runtime/lifed/tests/example_config.rs
+++ b/crates/life-runtime/lifed/tests/example_config.rs
@@ -1,0 +1,64 @@
+//! Verifies that `LifedConfig::load(None)` produces a default config that
+//! matches the expected master-spec defaults (UDS paths, drain budget, etc.).
+
+use lifed::config::LifedConfig;
+
+#[test]
+fn default_config_matches_spec_defaults() {
+    let cfg = LifedConfig::load(None).expect("default config loads");
+    assert_eq!(
+        cfg.public_plane.unix_socket.to_str(),
+        Some("/run/life/life.sock")
+    );
+    assert_eq!(cfg.public_plane.unix_socket_mode, Some(0o660));
+    assert_eq!(
+        cfg.public_plane.unix_socket_group.as_deref(),
+        Some("life-runtime")
+    );
+    assert_eq!(
+        cfg.admin_plane.unix_socket.to_str(),
+        Some("/run/life/life-admin.sock")
+    );
+    assert_eq!(cfg.admin_plane.unix_socket_mode, Some(0o660));
+    assert_eq!(
+        cfg.admin_plane.unix_socket_group.as_deref(),
+        Some("life-admin")
+    );
+    assert_eq!(cfg.shutdown.drain_secs, 30);
+    assert_eq!(cfg.routing.idle_threshold_secs, 3600);
+    assert_eq!(cfg.routing.hard_cap, 100_000);
+    assert_eq!(
+        cfg.substrates.arcan.unix_socket.to_str(),
+        Some("/run/life/arcan.sock")
+    );
+    assert_eq!(
+        cfg.substrates.lago.unix_socket.to_str(),
+        Some("/run/life/lago.sock")
+    );
+    assert_eq!(
+        cfg.substrates.haima.unix_socket.to_str(),
+        Some("/run/life/haima.sock")
+    );
+    assert_eq!(
+        cfg.substrates.anima.unix_socket.to_str(),
+        Some("/run/life/anima.sock")
+    );
+}
+
+#[test]
+fn parse_minimal_toml() {
+    let toml_text = r#"
+        [public_plane]
+        unix_socket = "/tmp/lifed-test/life.sock"
+    "#;
+    let cfg: LifedConfig = toml::from_str(toml_text).expect("parses");
+    assert_eq!(
+        cfg.public_plane.unix_socket.to_str(),
+        Some("/tmp/lifed-test/life.sock")
+    );
+    // Other fields defaulted.
+    assert_eq!(
+        cfg.admin_plane.unix_socket.to_str(),
+        Some("/run/life/life-admin.sock")
+    );
+}

--- a/crates/life-runtime/lifed/tests/integration_create_session.rs
+++ b/crates/life-runtime/lifed/tests/integration_create_session.rs
@@ -1,0 +1,26 @@
+//! M5 sub-phase A acceptance: Agent.CreateSession round-trip against the
+//! mock arcan substrate. Validates the handler shape, Tier-2 token check,
+//! Tier-3 mint, and substrate dispatch.
+
+#[path = "_support/mod.rs"]
+mod _support;
+
+use _support::test_env::TestEnv;
+
+#[tokio::test]
+async fn create_session_round_trips_against_mock_arcan() {
+    let env = TestEnv::start_with_mocks().await;
+    let session = env
+        .create_session_dev("alice", "project-demo", "test session")
+        .await
+        .expect("create_session");
+
+    assert_eq!(session.user_id, "alice");
+    assert_eq!(session.project_id, "project-demo");
+    assert!(!session.sid.expect("sid").value.is_empty());
+
+    // Sub-phase A: at least one mock arcan call recorded.
+    assert_eq!(env.mocks.arcan.create_agent_calls.lock().len(), 1);
+
+    env.shutdown().await;
+}

--- a/crates/life-runtime/lifed/tests/integration_send_message.rs
+++ b/crates/life-runtime/lifed/tests/integration_send_message.rs
@@ -1,0 +1,75 @@
+//! M5 sub-phase A acceptance: Agent.SendMessage server-stream round-trips
+//! against the mock arcan stream.
+
+#[path = "_support/mod.rs"]
+mod _support;
+
+use _support::test_env::TestEnv;
+use futures::StreamExt;
+use life_runtime_proto::life::v1::{AgentEventKind, SendMessageReq, SessionRef};
+
+#[tokio::test]
+async fn send_message_streams_at_least_one_event() {
+    let env = TestEnv::start_with_mocks().await;
+
+    // Open a session so the routing cache has an entry.
+    let session = env
+        .create_session_dev("alice", "project-demo", "stream test")
+        .await
+        .expect("create_session");
+    let sid = session.sid.expect("sid");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SendMessageReq {
+        sid: Some(sid.clone()),
+        content: "Hello, lifed".to_string(),
+        attachment_blob_ref: vec![],
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let mut stream = client
+        .send_message(req)
+        .await
+        .expect("send_message")
+        .into_inner();
+
+    let mut events = Vec::new();
+    while let Some(evt) = stream.next().await {
+        events.push(evt.expect("event ok"));
+        if events.len() >= 2 {
+            break;
+        }
+    }
+    assert!(events.len() >= 2);
+    assert_eq!(events[0].kind, AgentEventKind::Token as i32);
+    assert_eq!(events[1].kind, AgentEventKind::Finish as i32);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn stream_session_returns_canned_events() {
+    let env = TestEnv::start_with_mocks().await;
+    let session = env
+        .create_session_dev("alice", "project-demo", "stream session test")
+        .await
+        .expect("create_session");
+    let sid = session.sid.expect("sid");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SessionRef { sid: Some(sid) });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let mut stream = client
+        .stream_session(req)
+        .await
+        .expect("stream_session")
+        .into_inner();
+
+    let _ = stream.next().await; // consume at least one
+    env.shutdown().await;
+}

--- a/crates/life-runtime/lifed/tests/integration_spawn_child_stub.rs
+++ b/crates/life-runtime/lifed/tests/integration_spawn_child_stub.rs
@@ -1,0 +1,44 @@
+//! M5 sub-phase A: SpawnChild returns Status::unimplemented per Spec C₂ §13.3.
+
+#[path = "_support/mod.rs"]
+mod _support;
+
+use _support::test_env::TestEnv;
+use life_runtime_proto::life::v1::{ChildPolicy, CreateSessionReq, SpawnChildReq};
+
+#[tokio::test]
+async fn spawn_child_returns_unimplemented() {
+    let env = TestEnv::start_with_mocks().await;
+    let parent = env
+        .create_session_dev("alice", "project-demo", "spawn-child test")
+        .await
+        .expect("parent session");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SpawnChildReq {
+        parent_sid: parent.sid,
+        spec: Some(CreateSessionReq {
+            user_id: "alice".to_string(),
+            project_id: "project-demo".to_string(),
+            label: "child".to_string(),
+            resume_sid: None,
+            inherit_policy: None,
+        }),
+        budget_cap_micros: 100_000,
+        inherit_policy: Some(ChildPolicy {
+            inherit_skills: true,
+            inherit_models: true,
+            depth_cap: 5,
+            fanout_cap: 32,
+        }),
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let err = client.spawn_child(req).await.expect_err("must err");
+    assert_eq!(err.code(), tonic::Code::Unimplemented);
+    assert!(err.message().contains("Spec C") || err.message().contains("BRO-926"));
+
+    env.shutdown().await;
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -285,6 +285,31 @@ The baseline unification is active and enforced in production paths:
   = 3444 passed / 0 failed / 19 ignored.
 - Linear BRO-928. PR #TBD.
 
+### 2026-04-26 — M5 sub-phase A: lifed facade — Agent + Events vs mock substrates
+
+Spec C₂ implementation begins. Sub-phase A ships:
+
+- New `crates/life-runtime/` cluster with `lifed`, four `*-proxy` stubs,
+  `life-runtime-proto`, `lifed-conformance` scaffold.
+- Public-plane proto: `life.v1.Agent` (full surface), `life.v1.Events`
+  (full surface). `life.v1.Wallet` and `life.v1.Identity` skeletons
+  (bodies in B13/B14).
+- Admin-plane proto skeletons (bodies in C2–C5).
+- `lifed daemon` binary boots, binds the configured public UDS, mounts
+  `Agent` + `Events` services through a tower-Layer auth middleware.
+- Auth: dev signer accepting `Bearer test-token-for-{user_id}`; real
+  ES256 + JWKS in B5.
+- Routing cache: in-memory shape, by_sid + by_user indices; eviction
+  in B8; cold-start replay in D2.
+- Saga driver: no-op skeleton; real driver in B6.
+- Idempotency-store: in-memory backend; lago-backed in B7.
+- Integration tests: `integration_create_session`,
+  `integration_send_message`, `integration_spawn_child_stub` all green.
+  `Agent.SpawnChild` returns `Status::unimplemented` per Spec C₂ §13.
+- New `verify_dependencies_lifed.sh` script + CI lane enforcing
+  Spec C₂ §11 dependency rules.
+- Linear BRO-930. PR #TBD.
+
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -20,6 +20,13 @@ lint:
     - RPC_REQUEST_RESPONSE_UNIQUE  # VmHandle is reused across CreateVm + RestoreSnapshot
     - RPC_RESPONSE_STANDARD_NAME   # response types named VmHandle / Empty / etc., not <Method>Response
     - RPC_REQUEST_STANDARD_NAME    # LifecycleRequest reused for Hibernate + Resume RPCs
+    # life.v1 + life.admin.v1 service-name conventions locked by Spec C₂
+    # (docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.1–§3.5).
+    # Service names are bare nouns (Agent, Events, Wallet, Identity,
+    # Runtime, Saga, RoutingCache) — no `Service` suffix. This is an
+    # API surface decision that ships to apps + SDKs and cannot change
+    # without a major version bump.
+    - SERVICE_SUFFIX
 breaking:
   use:
     - WIRE_JSON

--- a/proto/life/admin/v1/routing_cache.proto
+++ b/proto/life/admin/v1/routing_cache.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+// Admin-plane RoutingCache dialect — full service body lands in M5 sub-phase
+// C task C4.
+
+package life.admin.v1;

--- a/proto/life/admin/v1/runtime.proto
+++ b/proto/life/admin/v1/runtime.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+// Admin-plane Runtime dialect — full service body lands in M5 sub-phase C
+// task C2.
+//
+// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.5.
+
+package life.admin.v1;
+
+message Empty {}

--- a/proto/life/admin/v1/saga.proto
+++ b/proto/life/admin/v1/saga.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+// Admin-plane Saga dialect — full service body lands in M5 sub-phase C
+// task C3.
+
+package life.admin.v1;

--- a/proto/life/v1/agent.proto
+++ b/proto/life/v1/agent.proto
@@ -4,6 +4,7 @@ package life.v1;
 
 import "google/protobuf/timestamp.proto";
 import "aios/v1/identifiers.proto";
+import "life/v1/events.proto"; // EventRecord lives in the events dialect
 
 // Public-plane Agent dialect. See Spec C₂ §3.1 for the full definition.
 //
@@ -36,16 +37,8 @@ service Agent {
   rpc SpawnChild(SpawnChildReq) returns (SpawnChildResp);
 }
 
-// EventRecord — minimal sub-phase A shape. Mirrors the master-spec
-// EventEnvelope; full parity with the aios.v1 vocabulary lands in sub-phase B
-// once aios/v1/event.proto is published.
-message EventRecord {
-  aios.v1.SessionId session_id = 1;
-  uint64 sequence = 2;
-  google.protobuf.Timestamp at = 3;
-  string kind = 4; // free-form kind tag for sub-phase A
-  bytes payload = 5;
-}
+// EventRecord lives in events.proto (same life.v1 package). Both AgentEvent
+// and the Events service stream that one canonical type.
 
 message CreateSessionReq {
   string user_id = 1;

--- a/proto/life/v1/agent.proto
+++ b/proto/life/v1/agent.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+// Public-plane Agent dialect — full service body lands in M5 sub-phase A
+// task A5. M5 sub-phase A task A4 ships only the package declaration and the
+// canonical `Empty` message used across the dialect.
+//
+// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.1 for the
+// full service definition.
+
+package life.v1;
+
+message Empty {}

--- a/proto/life/v1/agent.proto
+++ b/proto/life/v1/agent.proto
@@ -1,12 +1,145 @@
 syntax = "proto3";
 
-// Public-plane Agent dialect — full service body lands in M5 sub-phase A
-// task A5. M5 sub-phase A task A4 ships only the package declaration and the
-// canonical `Empty` message used across the dialect.
-//
-// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.1 for the
-// full service definition.
-
 package life.v1;
+
+import "google/protobuf/timestamp.proto";
+import "aios/v1/identifiers.proto";
+
+// Public-plane Agent dialect. See Spec C₂ §3.1 for the full definition.
+//
+// EventRecord / EventKind are declared locally below in the life.v1 package
+// because a canonical aios/v1/event.proto has not yet been published; sub-phase
+// B can lift these into aios.v1 if a cross-substrate event vocabulary is
+// agreed (Spec C₂ §10.3). The wire shape stays compatible because the inner
+// fields match the master-spec EventEnvelope.
+
+service Agent {
+  // Session lifecycle.
+  rpc CreateSession(CreateSessionReq) returns (Session);
+  rpc DescribeSession(SessionRef) returns (Session);
+  rpc CloseSession(SessionRef) returns (Empty);
+
+  // Message exchange — server-stream of tokens + tool events.
+  rpc SendMessage(SendMessageReq) returns (stream AgentEvent);
+  rpc StreamSession(SessionRef) returns (stream AgentEvent);
+
+  // Tool / approval surface.
+  rpc ApproveDispatch(ApprovalReq) returns (Empty);
+  rpc CancelDispatch(DispatchRef) returns (Empty);
+
+  // Catalog reads (cached client-side).
+  rpc ListSkills(ListSkillsReq) returns (SkillCatalog);
+  rpc ListModels(ListModelsReq) returns (ModelCatalog);
+  rpc ListTools(ListToolsReq) returns (ToolCatalog);
+
+  // Recursive embedding (master spec §L0.7 / Spec C₇). M5 ships a stub.
+  rpc SpawnChild(SpawnChildReq) returns (SpawnChildResp);
+}
+
+// EventRecord — minimal sub-phase A shape. Mirrors the master-spec
+// EventEnvelope; full parity with the aios.v1 vocabulary lands in sub-phase B
+// once aios/v1/event.proto is published.
+message EventRecord {
+  aios.v1.SessionId session_id = 1;
+  uint64 sequence = 2;
+  google.protobuf.Timestamp at = 3;
+  string kind = 4; // free-form kind tag for sub-phase A
+  bytes payload = 5;
+}
+
+message CreateSessionReq {
+  string user_id = 1;
+  string project_id = 2;
+  string label = 3;
+  aios.v1.SessionId resume_sid = 4;
+  ChildPolicy inherit_policy = 5;
+}
+
+message Session {
+  aios.v1.SessionId sid = 1;
+  aios.v1.AgentId agent_id = 2;
+  string user_id = 3;
+  string project_id = 4;
+  google.protobuf.Timestamp created_at = 5;
+}
+
+message SessionRef {
+  aios.v1.SessionId sid = 1;
+}
+
+message SendMessageReq {
+  aios.v1.SessionId sid = 1;
+  string content = 2;
+  bytes attachment_blob_ref = 3;
+}
+
+message AgentEvent {
+  EventRecord record = 1;
+  AgentEventKind kind = 2;
+}
+
+enum AgentEventKind {
+  AGENT_EVENT_KIND_UNSPECIFIED = 0;
+  AGENT_EVENT_KIND_TOKEN = 1;
+  AGENT_EVENT_KIND_TOOL_CALL_PENDING = 2;
+  AGENT_EVENT_KIND_TOOL_RESULT = 3;
+  AGENT_EVENT_KIND_APPROVAL_REQUIRED = 4;
+  AGENT_EVENT_KIND_FINISH = 5;
+  AGENT_EVENT_KIND_ERROR = 6;
+  AGENT_EVENT_KIND_HIBERNATE = 7;
+}
+
+message ApprovalReq {
+  aios.v1.SessionId sid = 1;
+  string dispatch_id = 2;
+}
+
+message DispatchRef {
+  aios.v1.SessionId sid = 1;
+  string dispatch_id = 2;
+}
+
+message ListSkillsReq {
+  string project_id = 1;
+}
+message ListModelsReq {
+  string project_id = 1;
+}
+message ListToolsReq {
+  string project_id = 1;
+}
+message SkillCatalog {
+  repeated CatalogEntry items = 1;
+}
+message ModelCatalog {
+  repeated CatalogEntry items = 1;
+}
+message ToolCatalog {
+  repeated CatalogEntry items = 1;
+}
+message CatalogEntry {
+  string id = 1;
+  string version = 2;
+  bytes manifest = 3;
+}
+
+message SpawnChildReq {
+  aios.v1.SessionId parent_sid = 1;
+  CreateSessionReq spec = 2;
+  uint64 budget_cap_micros = 3;
+  ChildPolicy inherit_policy = 4;
+}
+
+message SpawnChildResp {
+  aios.v1.SessionId child_sid = 1;
+  string address = 2;
+}
+
+message ChildPolicy {
+  bool inherit_skills = 1;
+  bool inherit_models = 2;
+  uint32 depth_cap = 3;
+  uint32 fanout_cap = 4;
+}
 
 message Empty {}

--- a/proto/life/v1/events.proto
+++ b/proto/life/v1/events.proto
@@ -1,8 +1,57 @@
 syntax = "proto3";
 
-// Public-plane Events dialect — full service body lands in M5 sub-phase A
-// task A6.
-//
-// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.2.
-
 package life.v1;
+
+import "aios/v1/identifiers.proto";
+import "google/protobuf/timestamp.proto";
+
+// Public-plane Events dialect. See Spec C₂ §3.2.
+//
+// Sub-phase A: returns canned empty streams to validate the wire shape.
+// Sub-phase B wires real lago tail via lago-proxy.
+
+// EventRecord — minimal sub-phase A shape. Mirrors the master-spec
+// EventEnvelope; full parity with the aios.v1 vocabulary lands in sub-phase B
+// once aios/v1/event.proto is published. Lives here (not in agent.proto) so
+// both AgentEvent and Events.{Read,Subscribe} can reference it without a
+// duplicate definition.
+message EventRecord {
+  aios.v1.SessionId session_id = 1;
+  uint64 sequence = 2;
+  google.protobuf.Timestamp at = 3;
+  string kind = 4; // free-form kind tag for sub-phase A
+  bytes payload = 5;
+}
+
+service Events {
+  // Read historical events from a session's namespace, server-streamed.
+  rpc Read(ReadReq) returns (stream EventRecord);
+  // Subscribe to live events with optional kind filter.
+  rpc Subscribe(SubscribeReq) returns (stream EventRecord);
+  // Fetch a content-addressed blob from a namespace.
+  rpc GetBlob(BlobRef) returns (Blob);
+}
+
+message ReadReq {
+  aios.v1.SessionId session_id = 1;
+  uint64 from_sequence = 2;
+  uint32 limit = 3;
+}
+
+message SubscribeReq {
+  aios.v1.SessionId session_id = 1;
+  // Sub-phase A: kind filter is a free-form string list. Sub-phase B may
+  // tighten this to an enum once an EventKind vocabulary is published.
+  repeated string kinds = 2;
+  uint64 from_sequence = 3;
+}
+
+message BlobRef {
+  string namespace = 1;
+  string sha256 = 2;
+}
+
+message Blob {
+  bytes data = 1;
+  string content_type = 2;
+}

--- a/proto/life/v1/events.proto
+++ b/proto/life/v1/events.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+// Public-plane Events dialect — full service body lands in M5 sub-phase A
+// task A6.
+//
+// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.2.
+
+package life.v1;

--- a/proto/life/v1/identity.proto
+++ b/proto/life/v1/identity.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+// Public-plane Identity dialect — full service body lands in M5 sub-phase B
+// task B14.
+//
+// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.4.
+
+package life.v1;

--- a/proto/life/v1/wallet.proto
+++ b/proto/life/v1/wallet.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+// Public-plane Wallet dialect — full service body lands in M5 sub-phase B
+// task B13.
+//
+// See docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md §3.3.
+
+package life.v1;

--- a/scripts/verify_dependencies_lifed.sh
+++ b/scripts/verify_dependencies_lifed.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Verify lifed + *-proxy + life-runtime-proto dependency rules per Spec C₂ §11.
+#
+# lifed (the facade-aggregator daemon) MAY depend on:
+#   - aios-protocol, aios-proto, life-runtime-proto
+#   - life-kernel-proto (client features only — for the SpawnChild saga's
+#     soma admin call)
+#   - the four *-proxy crates (arcan-proxy, lago-proxy, haima-proxy, anima-proxy)
+#   - life-vigil
+#   - transport / utility crates (tonic, tower, jsonwebtoken, etc.)
+#
+# lifed MUST NOT depend on any substrate runtime crate:
+#   - arcand, arcan-core, arcan-harness, arcan-aios-adapters
+#   - lago-runtime (lago-core, lago-journal, lago-store, etc.)
+#   - haima-runtime (haima-core, haima-wallet, haima-x402, etc.)
+#   - anima-runtime (anima-core, anima-identity, anima-lago, etc.)
+#   - life-kernel-core, life-kernel-gate, life-kernel-facade
+#   - arcan-provider-* (these belong to arcan, not lifed)
+#
+# The four *-proxy crates depend ONLY on:
+#   - aios-protocol, aios-proto
+#   - the substrate's wire crate (life-kernel-proto where applicable)
+#   - tonic + light utility crates (async-trait, futures, tokio-stream, etc.)
+# They MUST NOT pull substrate runtime crates either.
+#
+# Runs from the monorepo root (core/life) — uses workspace `cargo tree`.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FAIL=0
+
+# check_no_transitive_dep CRATE FORBIDDEN_REGEX
+# Fails if any crate matching FORBIDDEN_REGEX appears anywhere in the full
+# dep tree of CRATE. Silently skips if CRATE does not exist yet.
+check_no_transitive_dep() {
+    local crate="$1"
+    local forbidden_regex="$2"
+    local tree
+    tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" 2>/dev/null) || return 0
+    # Match crate names at the start of a node (after the └── / ├── prefix
+    # and version), to avoid matching docstrings or feature names.
+    if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
+        local hits
+        hits=$(echo "$tree" | grep -E "[ ]${forbidden_regex} v" | head -3)
+        echo "FAIL: $crate transitively depends on a crate matching ${forbidden_regex}:"
+        echo "$hits" | sed 's/^/    /'
+        FAIL=1
+    fi
+}
+
+echo "=== lifed + life-runtime-* dependency rules (Spec C₂ §11) ==="
+
+# lifed itself + every proxy must avoid every substrate runtime crate.
+for crate in lifed arcan-proxy lago-proxy haima-proxy anima-proxy life-runtime-proto lifed-conformance; do
+    # Skip with a quiet message if the crate hasn't landed yet (sub-phase B
+    # introduces the real proxy bodies).
+    if ! (cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1 \
+            | grep -qE "\"name\":\"${crate}\""); then
+        echo "skip: ${crate} not in workspace yet"
+        continue
+    fi
+
+    # Arcan substrate runtime crates.
+    check_no_transitive_dep "$crate" "arcand|arcan-core|arcan-harness|arcan-aios-adapters"
+    # Arcan providers — substrate-internal sandbox/launchers.
+    check_no_transitive_dep "$crate" "arcan-provider-bubblewrap|arcan-provider-local|arcan-provider-vercel|arcan-sandbox"
+    # Lago substrate runtime crates.
+    check_no_transitive_dep "$crate" "lago-core|lago-journal|lago-store|lago-fs|lago-policy|lago-knowledge|lago-auth|lago-api|lago-ingest|lago-aios-eventstore-adapter|lago-cli|lagod|lago-billing|lago-compiler|lago-lance"
+    # Haima substrate runtime crates.
+    check_no_transitive_dep "$crate" "haima-core|haima-wallet|haima-x402|haima-lago|haima-api|haimad|haima-insurance|haima-outcome"
+    # Anima substrate runtime crates.
+    check_no_transitive_dep "$crate" "anima-core|anima-identity|anima-lago"
+    # Life-kernel internals (only life-kernel-proto is allowed and only for lifed).
+    check_no_transitive_dep "$crate" "life-kernel-core|life-kernel-gate|life-kernel-facade"
+    # The proxy crates additionally must not pull life-kernel-proto.
+    if [ "$crate" != "lifed" ]; then
+        check_no_transitive_dep "$crate" "life-kernel-proto"
+    fi
+done
+
+if [ $FAIL -ne 0 ]; then
+    echo
+    echo "Dependency rules violated. See Spec C₂ §11 for the rationale."
+    exit 1
+fi
+echo "all lifed dependency rules pass"


### PR DESCRIPTION
## Summary

- Scaffolds the new `crates/life-runtime/` cluster: `lifed` (binary + lib), four `*-proxy` stubs (`arcan-proxy`, `lago-proxy`, `haima-proxy`, `anima-proxy`), `life-runtime-proto`, `lifed-conformance`.
- Implements Spec C₂ §3.1 `Agent` + §3.2 `Events` services functional against mock substrates.
- Wires tower auth middleware (Spec C₂ §5.1) — dev verifier accepts `Bearer test-token-for-{user_id}`; real ES256 + JWKS lands in B5.
- In-memory routing cache (Spec C₂ §6) and idempotency store (Spec C₂ §3.6); eviction → B8, lago backend → B7, cold-start replay → D2.
- No-op saga driver skeleton (real driver → B6).
- `Agent.SpawnChild` ships as `Status::unimplemented` per Spec C₂ §13 (post-MVS / Spec C₇).
- Integration tests `create_session`, `send_message`/`stream_session`, `spawn_child_stub` all green vs mocks.
- New `scripts/verify_dependencies_lifed.sh` + `verify-deps-lifed` CI lane enforce Spec C₂ §11.

## Refs

- Linear: BRO-930
- Spec C₂: `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md`
- M5 plan: `docs/superpowers/plans/2026-04-26-m5-lifed-build.md` (tasks A1–A14)
- Parent design ticket: BRO-921

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace`: 3492 passed / 0 failed / 19 ignored (pre-PR baseline 3479; +13 from the new lifed cluster: 4 lifed unit + 4 example_config & integration_create_session + 2 send_message + 1 spawn_child_stub + 2 proto_codegen + 1 conformance battery = 13 net new)
- [x] `cargo test -p lifed`: 7 tests green (`integration_create_session`, `integration_send_message` × 2, `integration_spawn_child_stub`, plus 4 unit tests on routing cache + idempotency)
- [x] `cargo test -p life-runtime-proto`: 2 codegen smoke tests green
- [x] `cargo test -p lifed-conformance`: 1 noop battery smoke green
- [x] `bash scripts/verify_dependencies_lifed.sh` exits 0
- [ ] CI (Format, Clippy, Test, Dependency Check, verify-deps-lifed) all green

## Decisions logged in commit bodies

- `EventRecord` is currently declared in `life.v1` (events.proto) because `aios/v1/event.proto` has not yet been published. Sub-phase B can lift this type into `aios.v1` if a cross-substrate event vocabulary is finalised (Spec C₂ §10.3 follow-up).
- `life-runtime-proto/build.rs` uses `.extern_path(\".aios.v1\", \"::aios_proto::aios::v1\")` so generated `life.v1` messages reference the canonical `aios-proto` types instead of regenerating them — keeps a single Rust representation per wire type per Spec C₂ §10.3.
- Listener module exposes `bind` + `shutdown_signal` helpers rather than a generic `serve(Router<L>, ...)` wrapper, because tonic 0.14's `Router<L>` is generic over the tower layer stack and propagating those generics through `serve` adds non-trivial trait noise without behaviour gain. Bootstrap composes the router (with AuthLayer + future tracing/load-shed) and calls `serve_with_incoming_shutdown` directly.

## Out of scope (deferred)

- Real ES256 + JWKS verification → sub-phase B5
- Real arcan/lago/haima/anima proxy bodies → sub-phase B1–B4
- `Wallet` + `Identity` service bodies → sub-phase B13/B14
- Routing-cache eviction → sub-phase B8; cold-start replay → sub-phase D2
- Idempotency-store lago backend → sub-phase B7
- Saga driver + 4 CreateSession compensation steps → sub-phase B6 + B11
- Admin plane (Runtime + Saga + RoutingCache services) → sub-phase C
- Connection pools + circuit breakers + backpressure + observability → sub-phase D
- Conformance battery body → sub-phase B17
- The full \`SpawnChild\` saga → Spec C₇ post-MVS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `lifed` daemon for managing sessions, routing, and event aggregation across substrate components.
  * Added Agent service with session creation, messaging, and streaming capabilities.
  * Added Events service for querying and subscribing to session events.
  * Added CLI subcommands for session management, routing cache inspection, and saga status queries.
  * Added authentication and capability-based authorization for all RPC operations.

* **Documentation**
  * Added comprehensive project documentation and architecture overview.
  * Updated implementation status with Sub-phase A completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->