### PR TITLE
feat(lifegw): M7 Sub-phase A — scaffolding + TLS bind + tonic-web proxy + dev JWT (BRO-935)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,19 @@ jobs:
       - name: Run scripts/verify_dependencies_lifed.sh
         run: bash scripts/verify_dependencies_lifed.sh
 
+  # ── Gate 7c: lifegw dependency rules (Spec C₃ §11) ────────────────
+  verify-deps-lifegw:
+    name: Verify lifegw dependency rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run scripts/verify_dependencies_lifegw.sh
+        run: bash scripts/verify_dependencies_lifegw.sh
+
   # ── Gate 8: Secret Scanning ───────────────────────────────────────
   secrets:
     name: Secret Scan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,7 @@ dependencies = [
  "socket2 0.6.3",
  "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
  "windows-registry",
@@ -5898,6 +5899,52 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.5",
+]
+
+[[package]]
+name = "lifegw"
+version = "0.3.0"
+dependencies = [
+ "aios-proto",
+ "aios-protocol",
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "clap",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonwebtoken",
+ "life-runtime-proto",
+ "life-vigil",
+ "lifed",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "toml",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-web",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -8012,6 +8059,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10109,6 +10169,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29453d84de05f4f1b573db22e6f9f6c95c189a6089a440c9a098aa9dea009299"
+dependencies = [
+ "base64",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "pin-project",
+ "tokio-stream",
+ "tonic 0.14.5",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11419,6 +11497,15 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,8 @@ members = [
     "crates/life-runtime/haima-proxy",
     "crates/life-runtime/anima-proxy",
     "crates/life-runtime/life-runtime-proto",
+    # M7 — lifegw edge gateway (see Spec C₃ at docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md)
+    "crates/life-runtime/lifegw",
 ]
 exclude = ["crates/spaces/life-spaces/spacetimedb"]
 

--- a/crates/life-runtime/lifegw/Cargo.toml
+++ b/crates/life-runtime/lifegw/Cargo.toml
@@ -1,0 +1,99 @@
+[package]
+name = "lifegw"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "lifegw — Life Runtime edge gateway daemon (M7). The only daemon with a public TCP socket: terminates TLS, verifies Tier-1 JWTs, mints Tier-2 capability tokens, forwards life.v1.* RPCs to lifed via UDS."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "lifegw"
+path = "src/lib.rs"
+
+[[bin]]
+name = "lifegw"
+path = "src/main.rs"
+
+[features]
+default = []
+# Production KMS providers (deferred to Sub-phase E).
+kms-aws = []
+kms-gcp = []
+# In-process dev signing key — gates the dev-token Bearer shortcut. Off in production.
+dev-mode = []
+
+[dependencies]
+# wire / ABI — Spec C₃ §11.3: the only proto crate lifegw depends on.
+aios-protocol.workspace = true
+aios-proto.workspace = true
+life-runtime-proto.workspace = true
+
+# transport — tonic 0.14 + tonic-web for browser-compatible Connect protocol.
+tonic = "0.14"
+tonic-web = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+tower = { workspace = true }
+tower-http = { workspace = true }
+http = "1"
+http-body-util = "0.1"
+bytes = { workspace = true }
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
+
+# TLS + (future) WS
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pemfile = "2"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+
+# JWT mint + verify
+jsonwebtoken.workspace = true
+ring = "0.17"
+
+# concurrency / state
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "fs", "sync", "time", "io-util"] }
+tokio-stream = { workspace = true }
+arc-swap = "1"
+async-trait.workspace = true
+futures.workspace = true
+
+# observability
+life-vigil.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+# utility
+anyhow.workspace = true
+thiserror.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["derive", "env"] }
+toml.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid = { workspace = true }
+base64 = { workspace = true }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["full", "test-util"] }
+rcgen = "0.13"
+tonic-prost = "0.14"
+async-trait.workspace = true
+# Sub-phase A integration test stands up a real lifed instance with mock
+# substrates and proxies through lifegw. Allowed as a *dev*-dep only; the
+# production crate graph never pulls lifed (Spec C₃ §11.2 dependency rules
+# apply to the production graph, not test rigs — verify_dependencies_lifegw.sh
+# checks `cargo tree`, which excludes dev-deps).
+lifed = { path = "../lifed" }
+http-body-util = "0.1"
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pemfile = "2"
+
+[lints]
+workspace = true

--- a/crates/life-runtime/lifegw/README.md
+++ b/crates/life-runtime/lifegw/README.md
@@ -1,0 +1,62 @@
+# lifegw — Life Runtime Edge Gateway (M7)
+
+`lifegw` is the **stateless, internet-facing edge gateway** of the Life Runtime —
+the only daemon with a public TCP socket. Spec C₃ at
+[`docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md`](../../../docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md)
+is the canonical implementation reference; this README is a navigation aid.
+
+## Sub-phase status
+
+- **Sub-phase A** (BRO-935, this PR): scaffolding + TLS bind + dev-mode JWT
+  acceptance + Tier-2 mint via static dev keystore + `tonic-web` unary proxy
+  passthrough to lifed UDS + `/healthz`.
+- **Sub-phase B** (BRO-936, planned): real Vercel JWKS + ES256 + KMS-backed
+  Tier-2 mint + scope intersection table.
+- **Sub-phase C** (BRO-937, planned): WebSocket upgrade + bidi pump + reconnect.
+- **Sub-phase D** (BRO-938, planned): per-user / per-IP token-bucket rate limit
+  + bounded backpressure + admin-plane UDS + cert-watch.
+- **Sub-phase E** (BRO-939, planned): production KMS swap-in + chaos tests.
+
+## What ships in Sub-phase A
+
+| Subsystem | State |
+|---|---|
+| TLS bind via rustls (TLS 1.2/1.3 default) | shipped |
+| Dev-mode JWT acceptance (`Bearer dev-token-for-{user_id}`) | shipped |
+| Tier-2 capability token mint via in-process P-256 keystore | shipped |
+| `tonic-web` Connect protocol layer | shipped |
+| `life.v1.{Agent, Events, Wallet, Identity}` unary proxy passthrough | shipped |
+| `/healthz` upstream-readiness check | shipped |
+| Real ES256 + Vercel JWKS | deferred to Sub-phase B |
+| WS upgrade + reconnect | deferred to Sub-phase C |
+| Rate limiting + bounded buffers | deferred to Sub-phase D |
+
+## Quick start
+
+```bash
+# Build the daemon.
+cargo build -p lifegw --bin lifegw
+
+# Run with a dev config (binds [::]:8443 with a self-signed cert).
+LIFEGW_CONFIG=crates/life-runtime/lifegw/lifegw.example.toml \
+  cargo run -p lifegw -- daemon
+```
+
+## Dependency rules
+
+Per Spec C₃ §11, lifegw MUST NOT depend on:
+
+- substrate runtime crates (`arcand`, `arcan-core`, `lago-runtime` family,
+  `haima-runtime` family, `anima-runtime` family, `life-kernel-*`)
+- substrate proxy crates (`arcan-proxy`, `lago-proxy`, `haima-proxy`,
+  `anima-proxy`)
+- the `lifed` runtime crate
+
+`scripts/verify_dependencies_lifegw.sh` enforces these rules in CI.
+
+## Tests
+
+```bash
+cargo test -p lifegw                   # unit tests + integration tests
+bash scripts/verify_dependencies_lifegw.sh
+```

--- a/crates/life-runtime/lifegw/lifegw.example.toml
+++ b/crates/life-runtime/lifegw/lifegw.example.toml
@@ -1,0 +1,51 @@
+# lifegw example configuration — Sub-phase A.
+#
+# Production deployments load `/etc/lifegw/config.toml`; the systemd unit at
+# `deploy/systemd/lifegw.service` sets `Environment=LIFEGW_CONFIG=/etc/lifegw/config.toml`.
+# This file lives in the repo as a documented dev fallback.
+
+[tls]
+# Self-signed cert acceptable for local dev. Production cert lives in
+# /etc/lifegw/tls/{fullchain,privkey}.pem and is rotated by certbot/cert-manager.
+cert_path = "./crates/life-runtime/lifegw/dev-tls/cert.pem"
+key_path = "./crates/life-runtime/lifegw/dev-tls/key.pem"
+acme_enabled = false
+
+[listen]
+# Dev listener — production uses systemd socket activation on 80+443.
+https_addr = "127.0.0.1:8443"
+http_redirect_addr = "127.0.0.1:8080"
+
+[upstream]
+# lifed public-plane UDS (Spec C₂ §3).
+lifed_uds_path = "/run/life/life.sock"
+
+[auth]
+# Vercel JWKS endpoint — used in Sub-phase B; ignored in Sub-phase A while
+# the dev signer is the only accepted bearer.
+jwks_url = "https://broomva.tech/api/auth/jwks.json"
+
+# Production: "aws" / "gcp" / "vault" (Sub-phase E).
+kms_provider = "dev"
+
+# Dev only — accepts Bearer dev-token-for-{user_id} as a Tier-1 substitute.
+# MUST be `false` in production.
+dev_signer_enabled = true
+
+# Spec C₃ §5.4 — Tier-2 capability tokens.
+tier2_audience = "lifed"
+tier2_issuer = "lifegw"
+tier2_ttl = "900s"  # 15 min cap (master spec §L4 invariant 4)
+
+[rate_limit]
+# Sub-phase D wires these. Defaults match master spec §L12 #10.
+per_user_capacity = 60
+per_user_refill_per_sec = 60
+per_ip_capacity = 60
+per_ip_refill_per_min = 60
+concurrent_ws_per_user = 10
+
+[observability]
+# Empty / null = stdout fallback.
+trace_sample_ratio = 0.05
+metric_interval = "60s"

--- a/crates/life-runtime/lifegw/src/auth/dev_signer.rs
+++ b/crates/life-runtime/lifegw/src/auth/dev_signer.rs
@@ -1,0 +1,60 @@
+//! Dev-mode JWT acceptance — `Bearer dev-token-for-{user_id}`.
+//!
+//! Sub-phase A only. Gated by `cfg.auth.dev_signer_enabled`. When enabled,
+//! the middleware accepts the magic Bearer string and synthesises a
+//! [`Tier1Claims`] body. Sub-phase B replaces this with a real ES256+JWKS
+//! verifier; the magic-Bearer path is removed once production cuts over.
+
+use crate::auth::tier1::Tier1Claims;
+use crate::error::{LifegwError, LifegwResult};
+
+const DEV_BEARER_PREFIX: &str = "dev-token-for-";
+
+/// Verify a dev-mode bearer token. Returns synthesised Tier-1 claims on
+/// success; `LifegwError::Auth` otherwise.
+pub fn verify(bearer: &str) -> LifegwResult<Tier1Claims> {
+    if let Some(user_id) = bearer.strip_prefix(DEV_BEARER_PREFIX) {
+        if user_id.is_empty() {
+            return Err(LifegwError::Auth("empty dev user_id".to_string()));
+        }
+        Ok(Tier1Claims {
+            user_id: user_id.to_string(),
+            project_id: "default-project".to_string(),
+            scopes: vec!["agent:dispatch".to_string()],
+        })
+    } else {
+        Err(LifegwError::Auth(
+            "dev signer rejects non-dev bearer (expected dev-token-for-{user_id})".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_signer_accepts_well_formed_bearer() {
+        let claims = verify("dev-token-for-user-1").expect("accept dev token");
+        assert_eq!(claims.user_id, "user-1");
+        assert_eq!(claims.project_id, "default-project");
+        assert_eq!(claims.scopes, vec!["agent:dispatch".to_string()]);
+    }
+
+    #[test]
+    fn dev_signer_rejects_non_dev_bearer() {
+        assert!(matches!(
+            verify("eyJhbGciOiJFUzI1NiJ9..."),
+            Err(LifegwError::Auth(_))
+        ));
+        assert!(matches!(verify(""), Err(LifegwError::Auth(_))));
+    }
+
+    #[test]
+    fn dev_signer_rejects_empty_user_id() {
+        assert!(matches!(
+            verify("dev-token-for-"),
+            Err(LifegwError::Auth(_))
+        ));
+    }
+}

--- a/crates/life-runtime/lifegw/src/auth/keystore.rs
+++ b/crates/life-runtime/lifegw/src/auth/keystore.rs
@@ -1,0 +1,232 @@
+//! Tier-2 capability-token signing keystore.
+//!
+//! Sub-phase A: an in-process P-256 (ES256) keypair generated at daemon
+//! startup. The same `Keystore` is held by both the Tier-2 minter (signs
+//! outbound tokens) and the test harness (verifies them). Production KMS
+//! providers (AWS, GCP, Vault) replace this in Sub-phase E, gated behind
+//! Cargo features.
+//!
+//! Per Spec C₃ §5.4 LOCKED L4-D2: Tier-2 tokens are ES256 over P-256. The
+//! daemon publishes the public key as a JWKS at `/.well-known/jwks.json` so
+//! lifed can verify (Sub-phase D wires the publish path; A keeps the
+//! keystore in-memory only and exposes it to integration tests via the
+//! crate-private API).
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use jsonwebtoken::{DecodingKey, EncodingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LifegwError, LifegwResult};
+
+/// EC keypair (P-256) plus a key id used to sign Tier-2 capability tokens.
+///
+/// Cloning is cheap (the underlying jsonwebtoken types are `Arc`-backed).
+#[derive(Clone)]
+pub struct Keystore {
+    pub kid: String,
+    pub encoding: EncodingKey,
+    pub decoding: DecodingKey,
+    pub public_pem: String,
+}
+
+impl Keystore {
+    /// Generate a new dev-only P-256 keypair. NOT suitable for production —
+    /// production deployments use a KMS-backed signer (Sub-phase E).
+    ///
+    /// Uses `rcgen` under the hood (already a dev-dependency for the TLS
+    /// integration test). To keep the runtime crate free of `rcgen`, we
+    /// embed an alternative pure-`ring` flow: generate a P-256 keypair and
+    /// emit it as PKCS#8 PEM via `ring`'s built-in serialiser.
+    pub fn generate_dev() -> LifegwResult<Self> {
+        // ring's deterministic-RNG-free ECDSA P-256 keygen.
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            &rng,
+        )
+        .map_err(|e| LifegwError::Auth(format!("generate ec keypair: {e}")))?;
+        let pkcs8_bytes = pkcs8.as_ref();
+
+        // Wrap the DER blob into a PEM string for jsonwebtoken's PEM loader.
+        let priv_pem = der_to_pem("PRIVATE KEY", pkcs8_bytes);
+        let encoding = EncodingKey::from_ec_pem(priv_pem.as_bytes())
+            .map_err(|e| LifegwError::Auth(format!("encode priv pem: {e}")))?;
+
+        // Extract the SubjectPublicKeyInfo from the PKCS#8 blob to give
+        // verifiers a separate public-key handle.
+        let kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            pkcs8_bytes,
+            &rng,
+        )
+        .map_err(|e| LifegwError::Auth(format!("parse pkcs8: {e}")))?;
+        // ring's `public_key()` returns the uncompressed SEC1 representation
+        // (0x04 || X || Y, 65 bytes). Wrap it in a SubjectPublicKeyInfo so
+        // jsonwebtoken accepts it as a P-256 PEM.
+        let raw_pub = ring::signature::KeyPair::public_key(&kp).as_ref().to_vec();
+        let spki_der = sec1_uncompressed_to_spki(&raw_pub);
+        let pub_pem = der_to_pem("PUBLIC KEY", &spki_der);
+        let decoding = DecodingKey::from_ec_pem(pub_pem.as_bytes())
+            .map_err(|e| LifegwError::Auth(format!("decode pub pem: {e}")))?;
+
+        // 64-bit random kid so dev rotations show up distinct in logs.
+        let mut kid_bytes = [0u8; 8];
+        ring::rand::SecureRandom::fill(&rng, &mut kid_bytes)
+            .map_err(|e| LifegwError::Auth(format!("rand kid: {e}")))?;
+        let kid = format!("dev-{}", URL_SAFE_NO_PAD.encode(kid_bytes));
+
+        Ok(Self {
+            kid,
+            encoding,
+            decoding,
+            public_pem: pub_pem,
+        })
+    }
+
+    /// Public key in PEM form. Sub-phase D writes this to disk so lifed (the
+    /// downstream verifier) can read it from a known path.
+    pub fn public_key_pem(&self) -> String {
+        self.public_pem.clone()
+    }
+
+    /// JWKS metadata published at `/.well-known/jwks.json` (Sub-phase D).
+    pub fn publish_jwks(&self) -> Jwks {
+        Jwks {
+            keys: vec![JwksKey {
+                kid: self.kid.clone(),
+                kty: "EC".to_string(),
+                crv: "P-256".to_string(),
+                alg: "ES256".to_string(),
+                use_: "sig".to_string(),
+                pem: Some(self.public_pem.clone()),
+            }],
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Jwks {
+    pub keys: Vec<JwksKey>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct JwksKey {
+    pub kid: String,
+    pub kty: String,
+    pub crv: String,
+    pub alg: String,
+    #[serde(rename = "use")]
+    pub use_: String,
+    /// Optional PEM-encoded public key. Sub-phase A writes this so consumers
+    /// (lifed) can decode the key without parsing JWK x/y components.
+    /// Sub-phase D will additionally publish x/y for browser-side verifiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pem: Option<String>,
+}
+
+fn der_to_pem(label: &str, der: &[u8]) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(der);
+    let mut pem = format!("-----BEGIN {label}-----\n");
+    // `b64` is pure ASCII (base64 standard alphabet), so 64-byte chunks of
+    // the underlying `&str` are always valid UTF-8 sub-slices. `from_utf8`
+    // returns `Ok` for every chunk; we still surface a fallback rather than
+    // `.expect()` so the production path has no `panic!`-equivalent calls.
+    for chunk in b64.as_bytes().chunks(64) {
+        match std::str::from_utf8(chunk) {
+            Ok(line) => {
+                pem.push_str(line);
+                pem.push('\n');
+            }
+            // Mathematically unreachable; included only to keep production
+            // free of `expect`/`unwrap`-style panics.
+            Err(_) => {
+                let lossy = String::from_utf8_lossy(chunk);
+                pem.push_str(&lossy);
+                pem.push('\n');
+            }
+        }
+    }
+    pem.push_str(&format!("-----END {label}-----\n"));
+    pem
+}
+
+/// Wrap a raw SEC1-uncompressed P-256 public key (65 bytes: 0x04 || X || Y)
+/// in a SubjectPublicKeyInfo DER structure compatible with PEM
+/// `-----BEGIN PUBLIC KEY-----` blocks. Hand-rolled because the workspace
+/// dependency budget can't justify a full ASN.1 crate for this one shape.
+fn sec1_uncompressed_to_spki(pubkey: &[u8]) -> Vec<u8> {
+    // SubjectPublicKeyInfo for an EC P-256 key — the prefix is fixed and
+    // exactly 26 bytes (handles AlgorithmIdentifier + BIT STRING wrapper).
+    // The trailing 65 bytes are the SEC1 uncompressed point.
+    debug_assert_eq!(pubkey.len(), 65, "sec1 uncompressed must be 65 bytes");
+    const SPKI_PREFIX: &[u8] = &[
+        0x30, 0x59, // SEQUENCE, length 89
+        0x30, 0x13, // SEQUENCE, length 19 (AlgorithmIdentifier)
+        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02,
+        0x01, // OID 1.2.840.10045.2.1 (id-ecPublicKey)
+        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01,
+        0x07, // OID 1.2.840.10045.3.1.7 (P-256)
+        0x03, 0x42, // BIT STRING, length 66
+        0x00, // unused-bits prefix
+    ];
+    let mut spki = Vec::with_capacity(SPKI_PREFIX.len() + pubkey.len());
+    spki.extend_from_slice(SPKI_PREFIX);
+    spki.extend_from_slice(pubkey);
+    spki
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, decode_header, encode};
+
+    #[test]
+    fn keystore_generate_dev_round_trip() {
+        let ks = Keystore::generate_dev().expect("generate dev keystore");
+        assert!(!ks.kid.is_empty());
+        assert!(ks.public_pem.contains("BEGIN PUBLIC KEY"));
+
+        // Smoke test: sign a JWS, decode the header, verify with the same keystore.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Probe {
+            sub: String,
+            aud: String,
+            iss: String,
+            exp: u64,
+        }
+        let claims = Probe {
+            sub: "user-1".to_string(),
+            aud: "lifed".to_string(),
+            iss: "lifegw".to_string(),
+            exp: (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs())
+                + 60,
+        };
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(ks.kid.clone());
+        let token = encode(&header, &claims, &ks.encoding).expect("encode");
+
+        let parsed_header = decode_header(&token).expect("decode_header");
+        assert_eq!(parsed_header.alg, Algorithm::ES256);
+        assert_eq!(parsed_header.kid.as_deref(), Some(ks.kid.as_str()));
+
+        let mut v = Validation::new(Algorithm::ES256);
+        v.set_audience(&["lifed"]);
+        v.set_issuer(&["lifegw"]);
+        let decoded = decode::<Probe>(&token, &ks.decoding, &v).expect("verify");
+        assert_eq!(decoded.claims.sub, "user-1");
+    }
+
+    #[test]
+    fn publish_jwks_includes_pem() {
+        let ks = Keystore::generate_dev().expect("generate dev keystore");
+        let jwks = ks.publish_jwks();
+        assert_eq!(jwks.keys.len(), 1);
+        assert_eq!(jwks.keys[0].alg, "ES256");
+        assert_eq!(jwks.keys[0].crv, "P-256");
+        assert!(jwks.keys[0].pem.is_some());
+    }
+}

--- a/crates/life-runtime/lifegw/src/auth/middleware.rs
+++ b/crates/life-runtime/lifegw/src/auth/middleware.rs
@@ -1,0 +1,172 @@
+//! Tower middleware that runs Tier-1 verify (in) → Tier-2 mint (out).
+//!
+//! Per Spec C₃ §5.1, every public-plane request:
+//!
+//! 1. Reads the `authorization` header → strips `Bearer `.
+//! 2. Validates the bearer via the dev signer (Sub-phase A) or the real
+//!    Vercel JWKS verifier (Sub-phase B).
+//! 3. Mints a Tier-2 capability JWS via the in-process keystore (A) or KMS
+//!    (E). Audience `lifed`, issuer `lifegw`, lifetime ≤ 15 min.
+//! 4. Replaces the inbound `authorization` header with the Tier-2 JWS.
+//! 5. Forwards to the proxy service.
+//!
+//! Health endpoints (`/healthz`, `/readyz`, `/version`, `/metrics`) bypass
+//! this layer per Spec C₃ §3.5 LOCKED L4-D7. Sub-phase A handles `/healthz`
+//! inline here so the gateway can answer health checks without standing up a
+//! second listener.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::Request;
+use tonic::body::Body;
+use tower::{Layer, Service};
+
+use crate::auth::dev_signer;
+use crate::auth::tier2::Tier2Minter;
+use crate::services::health;
+
+/// Tower Layer wrapping a service with Tier-1 verify + Tier-2 mint and a
+/// `/healthz` bypass path.
+#[derive(Clone)]
+pub struct AuthLayer {
+    minter: Arc<Tier2Minter>,
+    dev_signer_enabled: bool,
+    upstream_path: Arc<PathBuf>,
+}
+
+impl AuthLayer {
+    pub fn new(
+        minter: Arc<Tier2Minter>,
+        dev_signer_enabled: bool,
+        upstream_path: Arc<PathBuf>,
+    ) -> Self {
+        Self {
+            minter,
+            dev_signer_enabled,
+            upstream_path,
+        }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            minter: Arc::clone(&self.minter),
+            dev_signer_enabled: self.dev_signer_enabled,
+            upstream_path: Arc::clone(&self.upstream_path),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    minter: Arc<Tier2Minter>,
+    dev_signer_enabled: bool,
+    upstream_path: Arc<PathBuf>,
+}
+
+impl<S> Service<Request<Body>> for AuthService<S>
+where
+    S: Service<Request<Body>, Response = http::Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let minter = Arc::clone(&self.minter);
+        let dev_signer_enabled = self.dev_signer_enabled;
+        let upstream_path = Arc::clone(&self.upstream_path);
+
+        Box::pin(async move {
+            // Spec C₃ §3.5 LOCKED L4-D7: health endpoints bypass auth.
+            if req.uri().path() == "/healthz" {
+                return Ok(health::handle(upstream_path).await);
+            }
+
+            let bearer = req
+                .headers()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|h| h.strip_prefix("Bearer "))
+                .map(|t| t.to_string());
+
+            let tier1 = match bearer {
+                Some(tok) if dev_signer_enabled => match dev_signer::verify(&tok) {
+                    Ok(c) => c,
+                    Err(_) => return Ok(unauth_response("invalid Tier-1 bearer (dev signer)")),
+                },
+                Some(_) => {
+                    // Sub-phase B wires the real ES256 + JWKS verifier here.
+                    return Ok(unauth_response(
+                        "real Tier-1 verification not enabled in Sub-phase A; \
+                         set auth.dev_signer_enabled = true",
+                    ));
+                }
+                None => return Ok(unauth_response("missing Tier-1 bearer token")),
+            };
+
+            let tier2 = match minter.mint(&tier1) {
+                Ok(t) => t,
+                Err(e) => return Ok(internal_response(&format!("tier-2 mint: {e}"))),
+            };
+
+            // Replace the inbound bearer with the Tier-2 JWS so the upstream
+            // lifed verifier receives a token signed by lifegw.
+            let new_value = match http::HeaderValue::from_str(&format!("Bearer {tier2}")) {
+                Ok(v) => v,
+                Err(e) => return Ok(internal_response(&format!("tier-2 header: {e}"))),
+            };
+            req.headers_mut().insert("authorization", new_value);
+
+            inner.call(req).await
+        })
+    }
+}
+
+/// Build a `Status::unauthenticated`-shaped HTTP response that tonic clients
+/// surface as a `tonic::Status` of code `Unauthenticated`. Same trick lifed
+/// uses (`crates/life-runtime/lifed/src/auth/middleware.rs::unauth_response`).
+fn unauth_response(msg: &str) -> http::Response<Body> {
+    let status = tonic::Status::unauthenticated(msg.to_string());
+    grpc_status_response(status)
+}
+
+fn internal_response(msg: &str) -> http::Response<Body> {
+    let status = tonic::Status::internal(msg.to_string());
+    grpc_status_response(status)
+}
+
+fn grpc_status_response(status: tonic::Status) -> http::Response<Body> {
+    let mut resp = http::Response::new(Body::empty());
+    *resp.status_mut() = http::StatusCode::OK;
+    let headers = resp.headers_mut();
+    headers.insert(
+        "content-type",
+        http::HeaderValue::from_static("application/grpc"),
+    );
+    headers.insert(
+        "grpc-status",
+        http::HeaderValue::from_str(&(status.code() as i32).to_string())
+            .unwrap_or_else(|_| http::HeaderValue::from_static("13")),
+    );
+    if let Ok(v) = http::HeaderValue::from_str(status.message()) {
+        headers.insert("grpc-message", v);
+    }
+    resp
+}

--- a/crates/life-runtime/lifegw/src/auth/mod.rs
+++ b/crates/life-runtime/lifegw/src/auth/mod.rs
@@ -1,0 +1,25 @@
+//! Auth subsystem — Tier-1 verify (in) → Tier-2 mint (out).
+//!
+//! Sub-phase A scope (Spec C₃ §12.A):
+//! - `keystore` — in-process P-256 ES256 dev signing key.
+//! - `dev_signer` — accepts `Bearer dev-token-for-{user_id}` and synthesises
+//!   minimal Tier-1 claims.
+//! - `middleware` — tower Layer that validates inbound bearer, swaps it for
+//!   a freshly-minted Tier-2 capability JWS, and forwards to the proxy.
+//! - `tier1` — Tier-1 claim shape (used by both dev signer and Sub-phase B
+//!   real verifier).
+//! - `tier2` — Tier-2 capability claim shape + mint helper.
+//!
+//! Real ES256 + Vercel JWKS replaces `dev_signer` in Sub-phase B; the
+//! middleware shape stays.
+
+pub mod dev_signer;
+pub mod keystore;
+pub mod middleware;
+pub mod tier1;
+pub mod tier2;
+
+pub use keystore::Keystore;
+pub use middleware::AuthLayer;
+pub use tier1::Tier1Claims;
+pub use tier2::Tier2Claims;

--- a/crates/life-runtime/lifegw/src/auth/tier1.rs
+++ b/crates/life-runtime/lifegw/src/auth/tier1.rs
@@ -1,0 +1,27 @@
+//! Tier-1 identity-token claim shape (Spec C₃ §5.2).
+//!
+//! Sub-phase A's `dev_signer` synthesises these claims from a magic Bearer
+//! string. Sub-phase B's real ES256+JWKS verifier produces the same shape so
+//! the rest of the gateway is unchanged.
+
+use serde::{Deserialize, Serialize};
+
+/// Subset of Tier-1 claims the gateway propagates downstream into Tier-2.
+///
+/// Required claims per Spec C₃ §5.2: `iss`, `aud`, `sub`, `exp`.
+/// Sub-phase B will additionally validate `kid` (header), `nbf`, and `alg`.
+/// Sub-phase A only carries the fields the Tier-2 minter needs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Tier1Claims {
+    /// Subject — canonical user_id.
+    pub user_id: String,
+    /// Active project id. Falls back to `default-project` when the dev
+    /// signer is in use; Sub-phase B reads from the `project_id` claim or
+    /// the `X-Life-Project-Id` header.
+    pub project_id: String,
+    /// Identity-scoped permissions intersected with the route's required
+    /// scope (Sub-phase B). Sub-phase A returns a single broad `agent:dispatch`
+    /// scope so the proxy can ship something usable.
+    pub scopes: Vec<String>,
+}

--- a/crates/life-runtime/lifegw/src/auth/tier2.rs
+++ b/crates/life-runtime/lifegw/src/auth/tier2.rs
@@ -1,0 +1,153 @@
+//! Tier-2 capability-token mint (Spec C₃ §5.4).
+//!
+//! Tier-2 tokens are ES256-signed JWS with `aud=lifed`, `iss=lifegw`,
+//! lifetime ≤ 15 min. Sub-phase A signs with the in-process [`Keystore`];
+//! Sub-phase E swaps in the KMS-backed signer.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{Algorithm, Header, encode};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::auth::keystore::Keystore;
+use crate::auth::tier1::Tier1Claims;
+use crate::config::AuthConfig;
+use crate::error::{LifegwError, LifegwResult};
+
+/// Tier-2 claim shape — subset of the spec body relevant to Sub-phase A.
+/// Spec C₃ §5.4 lists the full claim set; the fields below are sufficient
+/// for lifed (Spec C₂ §5.1) to verify and route.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tier2Claims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: String,
+    pub exp: u64,
+    pub iat: u64,
+    /// 128-bit random unique JWT id — observability + replay-attack tagging.
+    pub jti: String,
+    /// Session id when the route is session-scoped. For session-creating
+    /// routes (`Agent.CreateSession`) the gateway emits the empty string.
+    pub sid: String,
+    /// Project id propagated from Tier-1.
+    pub project_id: String,
+    /// Capability scopes (intersection of Tier-1 claim scopes with the
+    /// route's required scope per Spec C₃ §5.4).
+    pub scopes: Vec<String>,
+    /// Optional tier name (`free` / `paid` / `enterprise` / `anon`). Sub-phase
+    /// A always emits `free`; Sub-phase B copies it from the Tier-1 `tier`
+    /// claim.
+    pub tier: String,
+}
+
+/// Tier-2 minter — a thin wrapper around the keystore + AuthConfig.
+#[derive(Clone)]
+pub struct Tier2Minter {
+    keystore: Keystore,
+    audience: String,
+    issuer: String,
+    ttl: Duration,
+}
+
+impl Tier2Minter {
+    pub fn new(keystore: Keystore, cfg: &AuthConfig) -> Self {
+        Self {
+            keystore,
+            audience: cfg.tier2_audience.clone(),
+            issuer: cfg.tier2_issuer.clone(),
+            ttl: cfg.tier2_ttl,
+        }
+    }
+
+    /// Mint a Tier-2 capability JWS from a Tier-1 claim set. Returns the
+    /// compact-form JWS string the gateway places in the upstream
+    /// `authorization` metadata header.
+    pub fn mint(&self, t1: &Tier1Claims) -> LifegwResult<String> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| LifegwError::Auth(format!("clock: {e}")))?
+            .as_secs();
+        let claims = Tier2Claims {
+            iss: self.issuer.clone(),
+            sub: t1.user_id.clone(),
+            aud: self.audience.clone(),
+            iat: now,
+            exp: now + self.ttl.as_secs(),
+            jti: Uuid::new_v4().to_string(),
+            sid: String::new(),
+            project_id: t1.project_id.clone(),
+            scopes: t1.scopes.clone(),
+            tier: "free".to_string(),
+        };
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(self.keystore.kid.clone());
+        encode(&header, &claims, &self.keystore.encoding)
+            .map_err(|e| LifegwError::Auth(format!("encode tier-2: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{Validation, decode, decode_header};
+
+    fn dev_minter() -> Tier2Minter {
+        let ks = Keystore::generate_dev().expect("dev keystore");
+        let cfg = AuthConfig {
+            tier2_audience: "lifed".to_string(),
+            tier2_issuer: "lifegw".to_string(),
+            tier2_ttl: Duration::from_secs(900),
+            ..AuthConfig::default()
+        };
+        Tier2Minter::new(ks, &cfg)
+    }
+
+    #[test]
+    fn mint_round_trip() {
+        let minter = dev_minter();
+        let t1 = Tier1Claims {
+            user_id: "user-1".to_string(),
+            project_id: "demo".to_string(),
+            scopes: vec!["agent:dispatch".to_string()],
+        };
+        let jws = minter.mint(&t1).expect("mint");
+        let header = decode_header(&jws).expect("decode_header");
+        assert_eq!(header.alg, Algorithm::ES256);
+        assert_eq!(header.kid.as_deref(), Some(minter.keystore.kid.as_str()));
+
+        let mut v = Validation::new(Algorithm::ES256);
+        v.set_audience(&["lifed"]);
+        v.set_issuer(&["lifegw"]);
+        let body = decode::<Tier2Claims>(&jws, &minter.keystore.decoding, &v).expect("verify");
+        assert_eq!(body.claims.sub, "user-1");
+        assert_eq!(body.claims.project_id, "demo");
+        assert_eq!(body.claims.aud, "lifed");
+        assert_eq!(body.claims.iss, "lifegw");
+        assert!(body.claims.exp > body.claims.iat);
+        assert!(!body.claims.jti.is_empty());
+    }
+
+    #[test]
+    fn mint_uses_configured_lifetime() {
+        let ks = Keystore::generate_dev().expect("ks");
+        let cfg = AuthConfig {
+            tier2_audience: "lifed".to_string(),
+            tier2_issuer: "lifegw".to_string(),
+            tier2_ttl: Duration::from_secs(60),
+            ..AuthConfig::default()
+        };
+        let m = Tier2Minter::new(ks, &cfg);
+        let t1 = Tier1Claims {
+            user_id: "u".to_string(),
+            project_id: "p".to_string(),
+            scopes: vec![],
+        };
+        let jws = m.mint(&t1).expect("mint");
+        let mut v = Validation::new(Algorithm::ES256);
+        v.set_audience(&["lifed"]);
+        v.set_issuer(&["lifegw"]);
+        let body = decode::<Tier2Claims>(&jws, &m.keystore.decoding, &v).expect("verify");
+        assert_eq!(body.claims.exp - body.claims.iat, 60);
+    }
+}

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -1,0 +1,159 @@
+//! Bootstrap — wires config → TLS bind → upstream lifed channel → router.
+//!
+//! Sub-phase A scope (Spec C₃ §12.A): the gateway terminates TLS, runs the
+//! auth middleware (dev-signer Tier-1 → Tier-2 mint), forwards the four
+//! `life.v1.*` services to lifed via UDS, and answers `/healthz` without
+//! auth. WS upgrade is C; rate-limit is D; production KMS is E.
+//!
+//! Two entrypoints:
+//! - `run_daemon` — production path (binds the configured TCP address).
+//! - `serve_with_listener` — used by integration tests to pre-bind on
+//!   `127.0.0.1:0`, extract the resolved port, and start serving.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use futures::Stream;
+use futures::stream::unfold;
+use tokio::sync::oneshot;
+use tonic::transport::Server;
+use tonic_web::GrpcWebLayer;
+
+use life_runtime_proto::life::v1 as pb;
+
+use crate::auth::keystore::Keystore;
+use crate::auth::middleware::AuthLayer;
+use crate::auth::tier2::Tier2Minter;
+use crate::config::LifegwConfig;
+use crate::error::{LifegwError, LifegwResult};
+use crate::listener::{self, LifegwTlsStream, TlsBind};
+use crate::proxy::{
+    AgentForwarder, EventsForwarder, IdentityForwarder, WalletForwarder, connect_uds,
+};
+
+/// Production daemon entrypoint. Reads the config (or defaults), installs
+/// the signal handler, binds TLS, dials upstream, and serves until SIGTERM.
+pub async fn run_daemon(config_path: Option<&Path>) -> LifegwResult<()> {
+    let cfg = LifegwConfig::load(config_path)?;
+    let _vigil_guard = crate::observability::init(&cfg.observability)?;
+    install_default_crypto_provider();
+
+    tracing::info!(
+        https_addr = %cfg.listen.https_addr,
+        upstream = %cfg.upstream.lifed_uds_path.display(),
+        dev_signer = cfg.auth.dev_signer_enabled,
+        "lifegw starting (Sub-phase A)",
+    );
+
+    let shutdown_rx = crate::shutdown::install_signal_handler();
+    let bind = listener::bind(&cfg.tls, &cfg.listen).await?;
+    serve_with_listener(cfg, bind, shutdown_rx).await
+}
+
+/// Serve atop an already-bound `TlsBind`. Useful for integration tests that
+/// pre-bind a listener so they can extract the local port before launching
+/// the server. Generates a fresh dev keystore at startup; tests that need
+/// to share the keystore with lifed (so the downstream Tier-2 verifier
+/// trusts the minted tokens) call [`serve_with_listener_and_keystore`].
+pub async fn serve_with_listener(
+    cfg: LifegwConfig,
+    bind: TlsBind,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> LifegwResult<()> {
+    let keystore = Keystore::generate_dev()?;
+    serve_with_listener_and_keystore(cfg, bind, keystore, shutdown_rx).await
+}
+
+/// Test helper — same as [`serve_with_listener`] but accepts a pre-generated
+/// keystore so callers can publish its JWKS to a path lifed reads.
+pub async fn serve_with_listener_and_keystore(
+    cfg: LifegwConfig,
+    bind: TlsBind,
+    keystore: Keystore,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> LifegwResult<()> {
+    install_default_crypto_provider();
+
+    let upstream_path = Arc::new(cfg.upstream.lifed_uds_path.clone());
+    let upstream_channel = connect_uds(&cfg.upstream.lifed_uds_path).await?;
+
+    let minter = Arc::new(Tier2Minter::new(keystore, &cfg.auth));
+    let auth_layer = AuthLayer::new(
+        minter,
+        cfg.auth.dev_signer_enabled,
+        Arc::clone(&upstream_path),
+    );
+
+    let agent = AgentForwarder::new(upstream_channel.clone());
+    let events = EventsForwarder::new(upstream_channel.clone());
+    let wallet = WalletForwarder::new(upstream_channel.clone());
+    let identity = IdentityForwarder::new(upstream_channel.clone());
+
+    // tonic-web `GrpcWebLayer` translates browser fetch (Connect / grpc-web)
+    // calls into native gRPC for the underlying tonic services. With
+    // `accept_http1(true)` the same listener handles both HTTP/2 (native
+    // gRPC) and HTTP/1.1 (browser fetch) connections multiplexed via ALPN.
+    let router = Server::builder()
+        .accept_http1(true)
+        .layer(auth_layer)
+        .layer(GrpcWebLayer::new())
+        .add_service(pb::agent_server::AgentServer::new(agent))
+        .add_service(pb::events_server::EventsServer::new(events))
+        .add_service(pb::wallet_server::WalletServer::new(wallet))
+        .add_service(pb::identity_server::IdentityServer::new(identity));
+
+    let TlsBind {
+        acceptor,
+        listener,
+        local_addr,
+    } = bind;
+
+    tracing::info!(addr = %local_addr, "lifegw listening");
+
+    let incoming = tls_incoming_stream(listener, acceptor);
+    router
+        .serve_with_incoming_shutdown(incoming, async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .map_err(|e| LifegwError::Server(format!("serve_with_incoming_shutdown: {e}")))
+}
+
+/// Convert a TCP listener + TLS acceptor into a `Stream` of accepted TLS
+/// connections that tonic's `serve_with_incoming_shutdown` can consume.
+///
+/// Each yielded item is a `LifegwTlsStream` so tonic 0.14's `Connected`
+/// trait bound is satisfied. Errors during TCP accept or TLS handshake are
+/// logged and skipped — a single misbehaving client never tears down the
+/// listener.
+fn tls_incoming_stream(
+    listener: tokio::net::TcpListener,
+    acceptor: tokio_rustls::TlsAcceptor,
+) -> impl Stream<Item = Result<LifegwTlsStream, std::io::Error>> {
+    unfold((listener, acceptor), |(listener, acceptor)| async move {
+        loop {
+            match listener.accept().await {
+                Ok((sock, _peer)) => match acceptor.accept(sock).await {
+                    Ok(tls) => {
+                        return Some((Ok(LifegwTlsStream::new(tls)), (listener, acceptor)));
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = %e, "tls handshake failed");
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(error = %e, "tcp accept failed");
+                    return Some((Err(e), (listener, acceptor)));
+                }
+            }
+        }
+    })
+}
+
+/// Install the rustls default crypto provider exactly once. rustls 0.23
+/// requires this dance before any TLS handshake. Multiple calls are
+/// harmless — only the first installation has effect.
+pub(crate) fn install_default_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}

--- a/crates/life-runtime/lifegw/src/cli.rs
+++ b/crates/life-runtime/lifegw/src/cli.rs
@@ -1,0 +1,7 @@
+//! CLI subcommands.
+//!
+//! Sub-phase A only ships the `daemon` subcommand (handled inline in `main.rs`).
+//! Sub-phase D adds `lifegwctl admin reload-certs`, `lifegwctl admin stats`,
+//! and `lifegwctl admin override-rate-limit` per Spec C₃ §4.3 + §7.5.
+
+// Intentionally empty for Sub-phase A.

--- a/crates/life-runtime/lifegw/src/config.rs
+++ b/crates/life-runtime/lifegw/src/config.rs
@@ -1,0 +1,481 @@
+//! Parser + validator for `/etc/lifegw/config.toml`.
+//!
+//! The daemon loads the config once at startup. Every field has a sensible
+//! default so an empty file (`LifegwConfig::load(None)`) starts a usable
+//! daemon against the locked Spec C₃ paths.
+//!
+//! Sub-phase A scope (Spec C₃ §12.A):
+//! - `[tls]` cert + key paths (rustls bind).
+//! - `[listen]` listener address (default `[::]:443`).
+//! - `[upstream]` `lifed_uds_path` (default `/run/life/life.sock`).
+//! - `[auth]` Tier-2 mint settings + dev-signer toggle.
+//! - `[rate_limit]`, `[observability]` — fields present, unused in A.
+//!
+//! Real Vercel JWKS, KMS provider, and OTLP exporter wiring live in B/D/E.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LifegwError, LifegwResult};
+
+/// Top-level `/etc/lifegw/config.toml` schema.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct LifegwConfig {
+    /// TLS termination configuration.
+    #[serde(default)]
+    pub tls: TlsConfig,
+    /// Listener configuration (TCP bind addresses).
+    #[serde(default)]
+    pub listen: ListenConfig,
+    /// Upstream lifed dial path.
+    #[serde(default)]
+    pub upstream: UpstreamConfig,
+    /// Authn / authz plumbing.
+    #[serde(default)]
+    pub auth: AuthConfig,
+    /// Rate-limit defaults (Sub-phase D fills this in).
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
+    /// Vigil OTLP exporter wiring (Sub-phase D fills this in).
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
+}
+
+/// TLS termination configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct TlsConfig {
+    /// Path to the PEM-encoded full-chain certificate.
+    #[serde(default = "default_cert_path")]
+    pub cert_path: PathBuf,
+    /// Path to the PEM-encoded private key.
+    #[serde(default = "default_key_path")]
+    pub key_path: PathBuf,
+    /// Whether ACME-based cert issuance is enabled. Sub-phase E feature; field
+    /// present here so config-file consumers don't fail validation when they
+    /// pre-declare it. Default `false`.
+    #[serde(default)]
+    pub acme_enabled: bool,
+}
+
+fn default_cert_path() -> PathBuf {
+    PathBuf::from("/etc/lifegw/tls/fullchain.pem")
+}
+
+fn default_key_path() -> PathBuf {
+    PathBuf::from("/etc/lifegw/tls/privkey.pem")
+}
+
+impl Default for TlsConfig {
+    fn default() -> Self {
+        Self {
+            cert_path: default_cert_path(),
+            key_path: default_key_path(),
+            acme_enabled: false,
+        }
+    }
+}
+
+/// Listener configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct ListenConfig {
+    /// HTTPS bind address (default `[::]:443`). Production uses systemd
+    /// socket activation which inherits the bound fd; the dev fallback
+    /// reads this field directly.
+    #[serde(default = "default_https_addr")]
+    pub https_addr: String,
+    /// Optional HTTP→HTTPS redirect bind. `None` disables the redirect
+    /// listener (the redirect is a hint, not a hard requirement).
+    #[serde(default = "default_http_redirect_addr")]
+    pub http_redirect_addr: Option<String>,
+}
+
+fn default_https_addr() -> String {
+    "[::]:443".to_string()
+}
+
+fn default_http_redirect_addr() -> Option<String> {
+    Some("[::]:80".to_string())
+}
+
+impl Default for ListenConfig {
+    fn default() -> Self {
+        Self {
+            https_addr: default_https_addr(),
+            http_redirect_addr: default_http_redirect_addr(),
+        }
+    }
+}
+
+/// Upstream lifed dial path.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct UpstreamConfig {
+    /// Path to the lifed public-plane UDS (Spec C₂ §3 — default
+    /// `/run/life/life.sock`).
+    #[serde(default = "default_lifed_uds_path")]
+    pub lifed_uds_path: PathBuf,
+}
+
+fn default_lifed_uds_path() -> PathBuf {
+    PathBuf::from("/run/life/life.sock")
+}
+
+impl Default for UpstreamConfig {
+    fn default() -> Self {
+        Self {
+            lifed_uds_path: default_lifed_uds_path(),
+        }
+    }
+}
+
+/// Authn / authz plumbing.
+///
+/// Sub-phase A uses the dev-signer path: `Bearer dev-token-for-{user_id}` is
+/// accepted and a Tier-2 capability token is minted via a static in-process
+/// P-256 keystore. Real ES256 + Vercel JWKS lands in Sub-phase B.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct AuthConfig {
+    /// Vercel JWKS endpoint URL. Field present in Sub-phase A but unused —
+    /// the dev signer bypasses JWKS verification. Wired in Sub-phase B.
+    #[serde(default = "default_jwks_url")]
+    pub jwks_url: String,
+    /// KMS provider. Sub-phase E feature; in Sub-phase A only the in-process
+    /// dev signer is used.
+    #[serde(default)]
+    pub kms_provider: KmsProvider,
+    /// Whether the `Bearer dev-token-for-{user_id}` shortcut is accepted.
+    /// MUST be `false` in production; set `true` only in dev / CI.
+    ///
+    /// Field name matches lifed's `JwksCache::dev_signer_enabled` so when
+    /// production goes live, both daemons gate dev paths the same way.
+    #[serde(default)]
+    pub dev_signer_enabled: bool,
+    /// Tier-2 audience (Spec C₃ §5.4). Default `lifed`.
+    #[serde(default = "default_tier2_audience")]
+    pub tier2_audience: String,
+    /// Tier-2 issuer (Spec C₃ §5.4). Default `lifegw`.
+    #[serde(default = "default_tier2_issuer")]
+    pub tier2_issuer: String,
+    /// Tier-2 capability lifetime cap (Spec C₃ §5.4 — ≤ 15 min).
+    #[serde(default = "default_tier2_ttl", with = "humantime_serde")]
+    pub tier2_ttl: Duration,
+}
+
+fn default_jwks_url() -> String {
+    "https://broomva.tech/api/auth/jwks.json".to_string()
+}
+
+fn default_tier2_audience() -> String {
+    "lifed".to_string()
+}
+
+fn default_tier2_issuer() -> String {
+    "lifegw".to_string()
+}
+
+fn default_tier2_ttl() -> Duration {
+    Duration::from_secs(15 * 60)
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum KmsProvider {
+    /// In-process dev signer. Sub-phase A default.
+    #[default]
+    Dev,
+    /// AWS KMS (Sub-phase E, behind feature flag `kms-aws`).
+    Aws,
+    /// GCP Cloud KMS (Sub-phase E, behind feature flag `kms-gcp`).
+    Gcp,
+    /// HashiCorp Vault Transit (Sub-phase E recommendation).
+    Vault,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            jwks_url: default_jwks_url(),
+            kms_provider: KmsProvider::default(),
+            dev_signer_enabled: false,
+            tier2_audience: default_tier2_audience(),
+            tier2_issuer: default_tier2_issuer(),
+            tier2_ttl: default_tier2_ttl(),
+        }
+    }
+}
+
+/// Rate-limit configuration. Spec C₃ §7 — fields present, unused in
+/// Sub-phase A. Defaults match master spec §L12 #10.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct RateLimitConfig {
+    /// Per-user token-bucket capacity (default 60 req).
+    #[serde(default = "default_per_user_capacity")]
+    pub per_user_capacity: u32,
+    /// Per-user refill rate (default 60 req/sec).
+    #[serde(default = "default_per_user_refill_per_sec")]
+    pub per_user_refill_per_sec: u32,
+    /// Per-IP token-bucket capacity for pre-auth requests (default 60 req).
+    #[serde(default = "default_per_ip_capacity")]
+    pub per_ip_capacity: u32,
+    /// Per-IP refill rate (default 60 req/min).
+    #[serde(default = "default_per_ip_refill_per_min")]
+    pub per_ip_refill_per_min: u32,
+    /// Concurrent WS connection cap per user (default 10 — `free` tier).
+    #[serde(default = "default_concurrent_ws_per_user")]
+    pub concurrent_ws_per_user: u32,
+}
+
+fn default_per_user_capacity() -> u32 {
+    60
+}
+fn default_per_user_refill_per_sec() -> u32 {
+    60
+}
+fn default_per_ip_capacity() -> u32 {
+    60
+}
+fn default_per_ip_refill_per_min() -> u32 {
+    60
+}
+fn default_concurrent_ws_per_user() -> u32 {
+    10
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            per_user_capacity: default_per_user_capacity(),
+            per_user_refill_per_sec: default_per_user_refill_per_sec(),
+            per_ip_capacity: default_per_ip_capacity(),
+            per_ip_refill_per_min: default_per_ip_refill_per_min(),
+            concurrent_ws_per_user: default_concurrent_ws_per_user(),
+        }
+    }
+}
+
+/// Vigil OTLP exporter configuration. Sub-phase D wires the real exporter.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct ObservabilityConfig {
+    /// OTLP endpoint URL. Empty / `None` = no remote exporter (stdout fallback).
+    #[serde(default)]
+    pub otlp_endpoint: Option<String>,
+    /// Trace sampler ratio (0.0–1.0). Default 0.05 — Spec C₃ §9.4.
+    #[serde(default = "default_trace_sample_ratio")]
+    pub trace_sample_ratio: f64,
+    /// Metric reader interval (default 60s).
+    #[serde(default = "default_metric_interval", with = "humantime_serde")]
+    pub metric_interval: Duration,
+}
+
+fn default_trace_sample_ratio() -> f64 {
+    0.05
+}
+
+fn default_metric_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+impl LifegwConfig {
+    /// Load a config from `path` if provided, otherwise produce all-defaults.
+    pub fn load(path: Option<&Path>) -> LifegwResult<Self> {
+        match path {
+            Some(p) => {
+                let text = std::fs::read_to_string(p)
+                    .map_err(|e| LifegwError::Config(format!("read {}: {e}", p.display())))?;
+                let cfg: LifegwConfig = toml::from_str(&text)
+                    .map_err(|e| LifegwError::Config(format!("parse {}: {e}", p.display())))?;
+                cfg.validate()?;
+                Ok(cfg)
+            }
+            None => {
+                let cfg = LifegwConfig::default();
+                cfg.validate()?;
+                Ok(cfg)
+            }
+        }
+    }
+
+    /// Cross-field validation. Pure — no I/O.
+    pub fn validate(&self) -> LifegwResult<()> {
+        if self.listen.https_addr.is_empty() {
+            return Err(LifegwError::Config(
+                "listen.https_addr must not be empty".to_string(),
+            ));
+        }
+        if self.auth.tier2_audience.is_empty() {
+            return Err(LifegwError::Config(
+                "auth.tier2_audience must not be empty".to_string(),
+            ));
+        }
+        if self.auth.tier2_issuer.is_empty() {
+            return Err(LifegwError::Config(
+                "auth.tier2_issuer must not be empty".to_string(),
+            ));
+        }
+        // Spec C₃ §5.4 LOCKED L4-D2: Tier-2 lifetime ≤ 15 minutes.
+        if self.auth.tier2_ttl > Duration::from_secs(15 * 60) {
+            return Err(LifegwError::Config(format!(
+                "auth.tier2_ttl ({}s) exceeds Spec C₃ §5.4 cap of 15 minutes",
+                self.auth.tier2_ttl.as_secs()
+            )));
+        }
+        if self.auth.tier2_ttl.is_zero() {
+            return Err(LifegwError::Config(
+                "auth.tier2_ttl must be > 0".to_string(),
+            ));
+        }
+        if !(0.0..=1.0).contains(&self.observability.trace_sample_ratio) {
+            return Err(LifegwError::Config(
+                "observability.trace_sample_ratio must be in [0.0, 1.0]".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// Inline serde helper for `Duration` round-tripping via `humantime`.
+mod humantime_serde {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
+
+    pub fn serialize<S>(d: &Duration, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}s", d.as_secs());
+        s.serialize(ser)
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+        // Accept either "<n>s" (lifed-style) or a bare number-of-seconds string.
+        if let Some(stripped) = s.strip_suffix('s') {
+            let n: u64 = stripped
+                .parse()
+                .map_err(|e| D::Error::custom(format!("parse seconds: {e}")))?;
+            return Ok(Duration::from_secs(n));
+        }
+        let n: u64 = s
+            .parse()
+            .map_err(|e| D::Error::custom(format!("parse duration: {e}")))?;
+        Ok(Duration::from_secs(n))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_validates() {
+        let cfg = LifegwConfig::default();
+        cfg.validate().expect("default config validates");
+        assert_eq!(cfg.listen.https_addr, "[::]:443");
+        assert_eq!(cfg.auth.tier2_audience, "lifed");
+        assert_eq!(cfg.auth.tier2_issuer, "lifegw");
+        assert_eq!(cfg.auth.tier2_ttl, Duration::from_secs(15 * 60));
+        assert!(!cfg.auth.dev_signer_enabled);
+        assert_eq!(
+            cfg.upstream.lifed_uds_path.to_string_lossy(),
+            "/run/life/life.sock"
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        // Minimal config: every field defaults.
+        let cfg = LifegwConfig::default();
+        let toml_text = toml::to_string(&cfg).expect("serialize default");
+        let parsed: LifegwConfig = toml::from_str(&toml_text).expect("re-parse default");
+        parsed.validate().expect("re-parsed default validates");
+
+        // Overridden config exercises every section + the `humantime_serde` helper.
+        let overridden_toml = r#"
+[tls]
+cert_path = "/tmp/cert.pem"
+key_path = "/tmp/key.pem"
+acme_enabled = true
+
+[listen]
+https_addr = "127.0.0.1:8443"
+http_redirect_addr = "127.0.0.1:8080"
+
+[upstream]
+lifed_uds_path = "/tmp/life.sock"
+
+[auth]
+jwks_url = "https://example.test/jwks"
+kms_provider = "vault"
+dev_signer_enabled = true
+tier2_audience = "lifed"
+tier2_issuer = "lifegw"
+tier2_ttl = "600s"
+
+[rate_limit]
+per_user_capacity = 100
+per_user_refill_per_sec = 100
+per_ip_capacity = 30
+per_ip_refill_per_min = 30
+concurrent_ws_per_user = 5
+
+[observability]
+otlp_endpoint = "http://otlp.test:4317"
+trace_sample_ratio = 0.1
+metric_interval = "30s"
+"#;
+        let cfg: LifegwConfig = toml::from_str(overridden_toml).expect("parse overrides");
+        cfg.validate().expect("overridden config validates");
+        assert!(cfg.tls.acme_enabled);
+        assert_eq!(cfg.listen.https_addr, "127.0.0.1:8443");
+        assert!(matches!(cfg.auth.kms_provider, KmsProvider::Vault));
+        assert!(cfg.auth.dev_signer_enabled);
+        assert_eq!(cfg.auth.tier2_ttl, Duration::from_secs(600));
+        assert_eq!(cfg.rate_limit.per_user_capacity, 100);
+        assert_eq!(cfg.observability.metric_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn validate_rejects_oversized_tier2_ttl() {
+        let mut cfg = LifegwConfig::default();
+        cfg.auth.tier2_ttl = Duration::from_secs(20 * 60);
+        let err = cfg.validate().expect_err("must reject > 15min");
+        match err {
+            LifegwError::Config(m) => assert!(m.contains("15 minutes"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_zero_tier2_ttl() {
+        let mut cfg = LifegwConfig::default();
+        cfg.auth.tier2_ttl = Duration::from_secs(0);
+        assert!(matches!(cfg.validate(), Err(LifegwError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_oob_sample_ratio() {
+        let mut cfg = LifegwConfig::default();
+        cfg.observability.trace_sample_ratio = 1.5;
+        assert!(matches!(cfg.validate(), Err(LifegwError::Config(_))));
+    }
+}

--- a/crates/life-runtime/lifegw/src/error.rs
+++ b/crates/life-runtime/lifegw/src/error.rs
@@ -1,0 +1,66 @@
+//! Error surface for the `lifegw` daemon.
+//!
+//! Every fallible subsystem result is converted into [`LifegwError`] at
+//! the boundary so daemon startup failures surface with a single error
+//! type (printed to stderr and to the systemd journal).
+//!
+//! At the RPC boundary, [`LifegwError`] also implements `Into<tonic::Status>`
+//! so handlers can `?`-bubble through the proxy layer and have errors mapped
+//! to canonical gRPC codes.
+
+use thiserror::Error;
+use tonic::Status;
+
+/// All errors surfaced by the lifegw daemon.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LifegwError {
+    /// Configuration loading or validation failed.
+    #[error("configuration: {0}")]
+    Config(String),
+
+    /// Auth subsystem failure (JWT verification, Tier-2 mint).
+    #[error("auth: {0}")]
+    Auth(String),
+
+    /// TLS subsystem failure (cert load, key load, ServerConfig build).
+    #[error("tls: {0}")]
+    Tls(String),
+
+    /// Listener bind / accept failure.
+    #[error("listener: {0}")]
+    Listener(String),
+
+    /// Upstream lifed dial failure.
+    #[error("upstream: {0}")]
+    Upstream(String),
+
+    /// Proxy forwarding failure.
+    #[error("proxy: {0}")]
+    Proxy(String),
+
+    /// Server-level failure (tonic Server::serve, drain).
+    #[error("server: {0}")]
+    Server(String),
+
+    /// Shutdown drain timeout or signal-handler error.
+    #[error("shutdown: {0}")]
+    Shutdown(String),
+}
+
+/// Convenience alias used throughout the daemon.
+pub type LifegwResult<T> = Result<T, LifegwError>;
+
+impl From<LifegwError> for Status {
+    fn from(err: LifegwError) -> Self {
+        match err {
+            LifegwError::Auth(m) => Status::unauthenticated(m),
+            LifegwError::Upstream(m) | LifegwError::Proxy(m) => Status::unavailable(m),
+            LifegwError::Config(m)
+            | LifegwError::Tls(m)
+            | LifegwError::Listener(m)
+            | LifegwError::Server(m)
+            | LifegwError::Shutdown(m) => Status::internal(m),
+        }
+    }
+}

--- a/crates/life-runtime/lifegw/src/lib.rs
+++ b/crates/life-runtime/lifegw/src/lib.rs
@@ -1,0 +1,39 @@
+//! lifegw — Life Runtime edge gateway daemon.
+//!
+//! The unprivileged stateless internet-facing daemon that terminates TLS,
+//! verifies Tier-1 identity JWTs, mints Tier-2 capability tokens, and forwards
+//! `life.v1.*` unary RPCs to lifed via UDS.
+//!
+//! See `docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md` for the
+//! detailed design. This crate is the binary's private library — it exists to
+//! share types between `main.rs` and the integration tests under `tests/`. No
+//! public API is exposed beyond what tests need.
+//!
+//! # Sub-phase A scope
+//!
+//! Per Spec C₃ §12.A:
+//!
+//! - TLS bind via rustls.
+//! - Dev-mode JWT acceptance (`Bearer dev-token-for-{user_id}`).
+//! - Tier-2 capability token mint via a static in-process P-256 keystore.
+//! - `tonic-web` Connect protocol layer fronting a transparent proxy to
+//!   `/run/life/life.sock` (lifed).
+//! - `/healthz` endpoint that probes upstream lifed reachability.
+//!
+//! Real ES256 + Vercel JWKS land in Sub-phase B; WS in C; rate-limit in D;
+//! production hardening in E.
+
+#![deny(unsafe_code)]
+
+pub mod auth;
+pub mod bootstrap;
+pub mod cli;
+pub mod config;
+pub mod error;
+pub mod listener;
+pub mod observability;
+pub mod proxy;
+pub mod services;
+pub mod shutdown;
+
+pub use error::{LifegwError, LifegwResult};

--- a/crates/life-runtime/lifegw/src/listener.rs
+++ b/crates/life-runtime/lifegw/src/listener.rs
@@ -1,0 +1,265 @@
+//! Listener primitives (TLS + TCP bind).
+//!
+//! Sub-phase A: rustls-backed TLS bind on a configured TCP address.
+//! Sub-phase D wires systemd socket activation (`LISTEN_FDS`) so the daemon
+//! never calls `bind(2)` in production.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::server::TlsStream;
+use tonic::transport::server::{Connected, TcpConnectInfo};
+
+use crate::config::{ListenConfig, TlsConfig};
+use crate::error::{LifegwError, LifegwResult};
+
+/// Result of a successful TLS + TCP bind: the rustls acceptor and the bound
+/// listener. Bootstrap glues these together with the tonic Server's
+/// `serve_with_incoming_shutdown`.
+pub struct TlsBind {
+    pub acceptor: TlsAcceptor,
+    pub listener: TcpListener,
+    pub local_addr: std::net::SocketAddr,
+}
+
+/// Bind a TCP listener at `cfg_listen.https_addr` and load TLS material from
+/// `cfg_tls.cert_path` + `cfg_tls.key_path`. Returns the rustls acceptor + the
+/// bound listener.
+///
+/// Used by both production bootstrap and the integration test rig.
+pub async fn bind(cfg_tls: &TlsConfig, cfg_listen: &ListenConfig) -> LifegwResult<TlsBind> {
+    let acceptor = build_acceptor(&cfg_tls.cert_path, &cfg_tls.key_path)?;
+    let listener = TcpListener::bind(&cfg_listen.https_addr)
+        .await
+        .map_err(|e| LifegwError::Listener(format!("bind {}: {e}", cfg_listen.https_addr)))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| LifegwError::Listener(format!("local_addr: {e}")))?;
+    Ok(TlsBind {
+        acceptor,
+        listener,
+        local_addr,
+    })
+}
+
+/// Build a rustls `TlsAcceptor` from PEM-encoded cert + key files.
+pub fn build_acceptor(cert_path: &Path, key_path: &Path) -> LifegwResult<TlsAcceptor> {
+    let certs = load_certs(cert_path)?;
+    let key = load_private_key(key_path)?;
+    let server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| LifegwError::Tls(format!("server config: {e}")))?;
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
+
+/// Newtype wrapping `tokio_rustls::server::TlsStream<TcpStream>` so we can
+/// impl tonic's `Connected` trait. tonic 0.14 requires the IO type to expose
+/// `connect_info` for request extensions; the inner `TcpStream` carries the
+/// addresses, so we derive from there.
+#[derive(Debug)]
+pub struct LifegwTlsStream {
+    inner: TlsStream<TcpStream>,
+    local_addr: Option<SocketAddr>,
+    remote_addr: Option<SocketAddr>,
+}
+
+impl LifegwTlsStream {
+    pub fn new(inner: TlsStream<TcpStream>) -> Self {
+        let (tcp, _) = inner.get_ref();
+        let local_addr = tcp.local_addr().ok();
+        let remote_addr = tcp.peer_addr().ok();
+        Self {
+            inner,
+            local_addr,
+            remote_addr,
+        }
+    }
+}
+
+impl Connected for LifegwTlsStream {
+    type ConnectInfo = TcpConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        // tonic 0.14's TcpConnectInfo uses public fields; mirror them.
+        TcpConnectInfo {
+            local_addr: self.local_addr,
+            remote_addr: self.remote_addr,
+        }
+    }
+}
+
+impl AsyncRead for LifegwTlsStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for LifegwTlsStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+fn load_certs(path: &Path) -> LifegwResult<Vec<CertificateDer<'static>>> {
+    let pem = std::fs::read(path)
+        .map_err(|e| LifegwError::Tls(format!("read cert {}: {e}", path.display())))?;
+    let mut reader = std::io::BufReader::new(&pem[..]);
+    let certs: Vec<_> = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<_, _>>()
+        .map_err(|e| LifegwError::Tls(format!("parse cert: {e}")))?;
+    if certs.is_empty() {
+        return Err(LifegwError::Tls(format!("no certs in {}", path.display())));
+    }
+    Ok(certs)
+}
+
+fn load_private_key(path: &Path) -> LifegwResult<PrivateKeyDer<'static>> {
+    let pem = std::fs::read(path)
+        .map_err(|e| LifegwError::Tls(format!("read key {}: {e}", path.display())))?;
+    let mut reader = std::io::BufReader::new(&pem[..]);
+    let key = rustls_pemfile::private_key(&mut reader)
+        .map_err(|e| LifegwError::Tls(format!("parse key: {e}")))?
+        .ok_or_else(|| LifegwError::Tls(format!("no private key in {}", path.display())))?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Generate a self-signed cert via `rcgen`, write cert + key PEMs to
+    /// `dir/{cert,key}.pem`, return their paths.
+    pub(crate) fn generate_self_signed(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        let cert_kp =
+            rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+                .expect("rcgen self-signed");
+        let cert_pem = cert_kp.cert.pem();
+        let key_pem = cert_kp.key_pair.serialize_pem();
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        std::fs::write(&cert_path, cert_pem).expect("write cert pem");
+        std::fs::write(&key_path, key_pem).expect("write key pem");
+        (cert_path, key_path)
+    }
+
+    #[test]
+    fn build_acceptor_round_trip() {
+        // rustls in tests requires the default crypto provider be installed once.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let dir = TempDir::new().expect("tempdir");
+        let (cert_path, key_path) = generate_self_signed(dir.path());
+
+        let acceptor = build_acceptor(&cert_path, &key_path).expect("build acceptor");
+        // Confirm the returned acceptor is usable — `Arc::strong_count` >= 1.
+        let _config = acceptor.config().clone();
+    }
+
+    #[test]
+    fn missing_cert_returns_tls_error() {
+        let dir = TempDir::new().expect("tempdir");
+        let cert_path = dir.path().join("missing-cert.pem");
+        let key_path = dir.path().join("missing-key.pem");
+        match build_acceptor(&cert_path, &key_path) {
+            Ok(_) => panic!("missing cert path must fail"),
+            Err(LifegwError::Tls(_)) => {}
+            Err(other) => panic!("expected Tls error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tls_bind_completes_handshake() {
+        use std::sync::Arc;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let dir = TempDir::new().expect("tempdir");
+        let (cert_path, key_path) = generate_self_signed(dir.path());
+        let cert_pem = std::fs::read(&cert_path).expect("read cert pem");
+
+        let cfg_tls = TlsConfig {
+            cert_path: cert_path.clone(),
+            key_path: key_path.clone(),
+            acme_enabled: false,
+        };
+        let cfg_listen = ListenConfig {
+            https_addr: "127.0.0.1:0".to_string(),
+            http_redirect_addr: None,
+        };
+
+        let bind_result = bind(&cfg_tls, &cfg_listen).await.expect("bind");
+        let local = bind_result.local_addr;
+        let acceptor = bind_result.acceptor;
+        let listener = bind_result.listener;
+
+        // Server: accept one TLS connection, echo a bytes-string.
+        let server = tokio::spawn(async move {
+            let (sock, _) = listener.accept().await.expect("accept");
+            let mut tls = acceptor.accept(sock).await.expect("tls accept");
+            tls.write_all(b"OK").await.expect("write");
+            let mut buf = [0u8; 4];
+            let n = tls.read(&mut buf).await.expect("read");
+            buf[..n].to_vec()
+        });
+
+        // Client: build a rustls config that trusts the self-signed cert.
+        let mut roots = rustls::RootCertStore::empty();
+        let mut reader = std::io::BufReader::new(&cert_pem[..]);
+        for cert in rustls_pemfile::certs(&mut reader) {
+            let cert = cert.expect("parse cert");
+            roots.add(cert).expect("add to root store");
+        }
+        let client_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+
+        let stream = TcpStream::connect(&local).await.expect("tcp connect");
+        let domain = rustls::pki_types::ServerName::try_from("localhost").expect("name");
+        let mut tls = connector.connect(domain, stream).await.expect("client tls");
+
+        let mut response = [0u8; 8];
+        let n = tls.read(&mut response).await.expect("client read");
+        assert_eq!(&response[..n], b"OK");
+        tls.write_all(b"PONG").await.expect("client write");
+        let received = server.await.expect("server task");
+        assert_eq!(&received, b"PONG");
+    }
+}

--- a/crates/life-runtime/lifegw/src/main.rs
+++ b/crates/life-runtime/lifegw/src/main.rs
@@ -1,0 +1,41 @@
+//! `lifegw` — Life Runtime edge gateway daemon.
+
+#![deny(unsafe_code)]
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "lifegw",
+    version,
+    about = "Life Runtime edge gateway daemon — TLS termination + Tier-2 mint + tonic-web proxy",
+    long_about = "Terminates TLS, verifies Tier-1 identity JWTs, mints Tier-2 capability\n\
+                  tokens, and forwards life.v1.* RPCs to lifed via /run/life/life.sock.\n\
+                  Real ES256 + Vercel JWKS lands in Sub-phase B; WS in C; rate-limit in D."
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Run the daemon (default mode for systemd unit `lifegw.service`).
+    Daemon {
+        #[arg(long, env = "LIFEGW_CONFIG")]
+        config: Option<PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::Daemon { config } => {
+            lifegw::bootstrap::run_daemon(config.as_deref()).await?;
+            Ok(())
+        }
+    }
+}

--- a/crates/life-runtime/lifegw/src/observability.rs
+++ b/crates/life-runtime/lifegw/src/observability.rs
@@ -1,0 +1,23 @@
+//! Vigil exporter init.
+//!
+//! Sub-phase A: stdout fallback only. Real OTLP exporter wires in
+//! Sub-phase D (Spec C₃ §9.4).
+
+use crate::config::ObservabilityConfig;
+use crate::error::LifegwResult;
+
+/// RAII guard returned by `init` — drops on daemon exit and flushes anything
+/// buffered. Sub-phase A is a no-op; Sub-phase D wires the real OTLP flush.
+pub struct VigilGuard;
+
+pub fn init(_cfg: &ObservabilityConfig) -> LifegwResult<VigilGuard> {
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_target(true)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("lifegw=info,tower=warn")),
+        )
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    Ok(VigilGuard)
+}

--- a/crates/life-runtime/lifegw/src/proxy.rs
+++ b/crates/life-runtime/lifegw/src/proxy.rs
@@ -1,0 +1,388 @@
+//! Transparent forwarding proxies for `life.v1.{Agent, Events, Wallet, Identity}`.
+//!
+//! Sub-phase A scope (Spec C₃ §12.A): every public-plane unary RPC the
+//! gateway accepts is forwarded verbatim to lifed via the upstream UDS
+//! channel. Server-streaming RPCs (`Agent.SendMessage`, `Agent.StreamSession`,
+//! `Events.Read`, `Events.Subscribe`, `Wallet.Statement`) are passed through
+//! using tonic's native `Streaming<T>`. The handlers do **not** perform any
+//! business logic — they are pure transport translators.
+//!
+//! Per Spec C₃ §3.2: if a method is not implemented by lifed the gateway
+//! returns the substrate's error verbatim — `Status::unimplemented` is not
+//! rewritten.
+
+use std::pin::Pin;
+
+use futures::stream::Stream;
+use tonic::transport::Channel;
+use tonic::{Request, Response, Status};
+
+use life_runtime_proto::life::v1 as pb;
+
+/// Forwarder for `life.v1.Agent`. Holds an upstream tonic channel to lifed.
+#[derive(Clone)]
+pub struct AgentForwarder {
+    channel: Channel,
+}
+
+impl AgentForwarder {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    fn client(&self) -> pb::agent_client::AgentClient<Channel> {
+        pb::agent_client::AgentClient::new(self.channel.clone())
+    }
+}
+
+type AgentEventStream =
+    Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, Status>> + Send + 'static>>;
+
+#[tonic::async_trait]
+impl pb::agent_server::Agent for AgentForwarder {
+    async fn create_session(
+        &self,
+        req: Request<pb::CreateSessionReq>,
+    ) -> Result<Response<pb::Session>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .create_session(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn describe_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<pb::Session>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .describe_session(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn close_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .close_session(forwarded.into_request_with(body))
+            .await
+    }
+
+    type SendMessageStream = AgentEventStream;
+    async fn send_message(
+        &self,
+        req: Request<pb::SendMessageReq>,
+    ) -> Result<Response<Self::SendMessageStream>, Status> {
+        let (forwarded, body) = forward_request(req);
+        let resp = self
+            .client()
+            .send_message(forwarded.into_request_with(body))
+            .await?;
+        let (meta, stream, ext) = resp.into_parts();
+        let pinned: AgentEventStream = Box::pin(stream);
+        Ok(Response::from_parts(meta, pinned, ext))
+    }
+
+    type StreamSessionStream = AgentEventStream;
+    async fn stream_session(
+        &self,
+        req: Request<pb::SessionRef>,
+    ) -> Result<Response<Self::StreamSessionStream>, Status> {
+        let (forwarded, body) = forward_request(req);
+        let resp = self
+            .client()
+            .stream_session(forwarded.into_request_with(body))
+            .await?;
+        let (meta, stream, ext) = resp.into_parts();
+        let pinned: AgentEventStream = Box::pin(stream);
+        Ok(Response::from_parts(meta, pinned, ext))
+    }
+
+    async fn approve_dispatch(
+        &self,
+        req: Request<pb::ApprovalReq>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .approve_dispatch(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn cancel_dispatch(
+        &self,
+        req: Request<pb::DispatchRef>,
+    ) -> Result<Response<pb::Empty>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .cancel_dispatch(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn list_skills(
+        &self,
+        req: Request<pb::ListSkillsReq>,
+    ) -> Result<Response<pb::SkillCatalog>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .list_skills(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn list_models(
+        &self,
+        req: Request<pb::ListModelsReq>,
+    ) -> Result<Response<pb::ModelCatalog>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .list_models(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn list_tools(
+        &self,
+        req: Request<pb::ListToolsReq>,
+    ) -> Result<Response<pb::ToolCatalog>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .list_tools(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn spawn_child(
+        &self,
+        req: Request<pb::SpawnChildReq>,
+    ) -> Result<Response<pb::SpawnChildResp>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .spawn_child(forwarded.into_request_with(body))
+            .await
+    }
+}
+
+/// Forwarder for `life.v1.Events`.
+#[derive(Clone)]
+pub struct EventsForwarder {
+    channel: Channel,
+}
+
+impl EventsForwarder {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    fn client(&self) -> pb::events_client::EventsClient<Channel> {
+        pb::events_client::EventsClient::new(self.channel.clone())
+    }
+}
+
+type EventRecordStream =
+    Pin<Box<dyn Stream<Item = Result<pb::EventRecord, Status>> + Send + 'static>>;
+
+#[tonic::async_trait]
+impl pb::events_server::Events for EventsForwarder {
+    type ReadStream = EventRecordStream;
+    async fn read(&self, req: Request<pb::ReadReq>) -> Result<Response<Self::ReadStream>, Status> {
+        let (forwarded, body) = forward_request(req);
+        let resp = self
+            .client()
+            .read(forwarded.into_request_with(body))
+            .await?;
+        let (meta, stream, ext) = resp.into_parts();
+        let pinned: EventRecordStream = Box::pin(stream);
+        Ok(Response::from_parts(meta, pinned, ext))
+    }
+
+    type SubscribeStream = EventRecordStream;
+    async fn subscribe(
+        &self,
+        req: Request<pb::SubscribeReq>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let (forwarded, body) = forward_request(req);
+        let resp = self
+            .client()
+            .subscribe(forwarded.into_request_with(body))
+            .await?;
+        let (meta, stream, ext) = resp.into_parts();
+        let pinned: EventRecordStream = Box::pin(stream);
+        Ok(Response::from_parts(meta, pinned, ext))
+    }
+
+    async fn get_blob(&self, req: Request<pb::BlobRef>) -> Result<Response<pb::Blob>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .get_blob(forwarded.into_request_with(body))
+            .await
+    }
+}
+
+/// Forwarder for `life.v1.Wallet`.
+#[derive(Clone)]
+pub struct WalletForwarder {
+    channel: Channel,
+}
+
+impl WalletForwarder {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    fn client(&self) -> pb::wallet_client::WalletClient<Channel> {
+        pb::wallet_client::WalletClient::new(self.channel.clone())
+    }
+}
+
+type LedgerEntryStream =
+    Pin<Box<dyn Stream<Item = Result<pb::LedgerEntry, Status>> + Send + 'static>>;
+
+#[tonic::async_trait]
+impl pb::wallet_server::Wallet for WalletForwarder {
+    async fn get_balance(
+        &self,
+        req: Request<pb::WalletRef>,
+    ) -> Result<Response<pb::Balance>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .get_balance(forwarded.into_request_with(body))
+            .await
+    }
+
+    type StatementStream = LedgerEntryStream;
+    async fn statement(
+        &self,
+        req: Request<pb::StatementReq>,
+    ) -> Result<Response<Self::StatementStream>, Status> {
+        let (forwarded, body) = forward_request(req);
+        let resp = self
+            .client()
+            .statement(forwarded.into_request_with(body))
+            .await?;
+        let (meta, stream, ext) = resp.into_parts();
+        let pinned: LedgerEntryStream = Box::pin(stream);
+        Ok(Response::from_parts(meta, pinned, ext))
+    }
+
+    async fn debit(
+        &self,
+        req: Request<pb::DebitReq>,
+    ) -> Result<Response<pb::DebitReceipt>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client().debit(forwarded.into_request_with(body)).await
+    }
+
+    async fn transfer(
+        &self,
+        req: Request<pb::TransferReq>,
+    ) -> Result<Response<pb::TransferReceipt>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .transfer(forwarded.into_request_with(body))
+            .await
+    }
+}
+
+/// Forwarder for `life.v1.Identity`.
+#[derive(Clone)]
+pub struct IdentityForwarder {
+    channel: Channel,
+}
+
+impl IdentityForwarder {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    fn client(&self) -> pb::identity_client::IdentityClient<Channel> {
+        pb::identity_client::IdentityClient::new(self.channel.clone())
+    }
+}
+
+#[tonic::async_trait]
+impl pb::identity_server::Identity for IdentityForwarder {
+    async fn me(&self, req: Request<pb::IdentityEmpty>) -> Result<Response<pb::Account>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client().me(forwarded.into_request_with(body)).await
+    }
+
+    async fn update_profile(
+        &self,
+        req: Request<pb::UpdateProfileReq>,
+    ) -> Result<Response<pb::Account>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .update_profile(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn list_sessions(
+        &self,
+        req: Request<pb::ListSessionsReq>,
+    ) -> Result<Response<pb::SessionList>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .list_sessions(forwarded.into_request_with(body))
+            .await
+    }
+
+    async fn revoke_session(
+        &self,
+        req: Request<pb::IdentitySessionRef>,
+    ) -> Result<Response<pb::IdentityEmpty>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .revoke_session(forwarded.into_request_with(body))
+            .await
+    }
+}
+
+// ── Forwarding helpers ──────────────────────────────────────────────────
+
+/// A request whose metadata + extensions have been peeled off the inbound
+/// request, ready to be re-attached to the outbound upstream call.
+struct ForwardedHeaders {
+    meta: tonic::metadata::MetadataMap,
+    ext: tonic::Extensions,
+}
+
+impl ForwardedHeaders {
+    /// Re-attach the captured metadata + extensions to a freshly-constructed
+    /// `Request` carrying the forwarded body.
+    fn into_request_with<T>(self, body: T) -> Request<T> {
+        let mut req = Request::new(body);
+        *req.metadata_mut() = self.meta;
+        *req.extensions_mut() = self.ext;
+        req
+    }
+}
+
+/// Split an inbound `Request<T>` into its metadata + extensions and the body
+/// payload. The metadata MUST be carried through verbatim so that the
+/// auth-middleware-rewritten `authorization` header reaches lifed and tonic's
+/// trace-context propagation continues working.
+fn forward_request<T>(req: Request<T>) -> (ForwardedHeaders, T) {
+    let (meta, ext, body) = req.into_parts();
+    (ForwardedHeaders { meta, ext }, body)
+}
+
+/// Dial a tonic Channel over a Unix Domain Socket. The same pattern lifed
+/// uses for its admin client (Spec C₂ §12 admin plane).
+pub async fn connect_uds(path: &std::path::Path) -> crate::error::LifegwResult<Channel> {
+    use tokio::net::UnixStream;
+    use tonic::transport::{Endpoint, Uri};
+    use tower::service_fn;
+
+    let socket = path.to_path_buf();
+    let endpoint = Endpoint::try_from("http://[::]:0")
+        .map_err(|e| crate::error::LifegwError::Upstream(format!("endpoint scheme: {e}")))?;
+    endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let socket = socket.clone();
+            async move {
+                let s = UnixStream::connect(socket).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(s))
+            }
+        }))
+        .await
+        .map_err(|e| crate::error::LifegwError::Upstream(format!("dial uds: {e}")))
+}

--- a/crates/life-runtime/lifegw/src/services/health.rs
+++ b/crates/life-runtime/lifegw/src/services/health.rs
@@ -1,0 +1,63 @@
+//! `/healthz` — liveness probe.
+//!
+//! Spec C₃ §3.5: returns 200 when the upstream lifed UDS is reachable, 503
+//! otherwise. Bypasses auth per LOCKED L4-D7. Sub-phase D adds `/readyz`,
+//! `/version`, and `/metrics`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use http::{HeaderValue, Response, StatusCode};
+use tonic::body::Body;
+
+/// Probe the upstream lifed UDS by attempting to `connect(2)`. Returns true
+/// when the socket accepts a connection (regardless of what handshake the
+/// peer chooses to perform — readiness here is "the kernel accepted").
+async fn upstream_reachable(path: &PathBuf) -> bool {
+    tokio::net::UnixStream::connect(path).await.is_ok()
+}
+
+/// Build a `Response` for `/healthz`. Returns 200 + "OK" when reachable,
+/// 503 + "lifed unreachable" otherwise.
+pub async fn handle(upstream: Arc<PathBuf>) -> Response<Body> {
+    if upstream_reachable(upstream.as_ref()).await {
+        plain_response(StatusCode::OK, "OK")
+    } else {
+        plain_response(StatusCode::SERVICE_UNAVAILABLE, "lifed unreachable")
+    }
+}
+
+fn plain_response(status: StatusCode, body: &'static str) -> Response<Body> {
+    let mut resp = Response::new(Body::new(http_body_util::Full::new(
+        bytes::Bytes::from_static(body.as_bytes()),
+    )));
+    *resp.status_mut() = status;
+    let h = resp.headers_mut();
+    h.insert("content-type", HeaderValue::from_static("text/plain"));
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+
+    #[tokio::test]
+    async fn healthz_returns_200_when_upstream_listening() {
+        let dir = TempDir::new().expect("tempdir");
+        let socket = dir.path().join("life.sock");
+        let _listener = UnixListener::bind(&socket).expect("bind upstream");
+        let resp = handle(Arc::new(socket)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_503_when_upstream_missing() {
+        let dir = TempDir::new().expect("tempdir");
+        let socket = dir.path().join("missing.sock");
+        // No listener bound on this path.
+        let resp = handle(Arc::new(socket)).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/crates/life-runtime/lifegw/src/services/mod.rs
+++ b/crates/life-runtime/lifegw/src/services/mod.rs
@@ -1,0 +1,6 @@
+//! Auxiliary services mounted alongside the public-plane proxy.
+//!
+//! Sub-phase A ships only `/healthz`. Sub-phase D adds `/readyz`,
+//! `/version`, `/metrics`, and the admin-plane UDS listener.
+
+pub mod health;

--- a/crates/life-runtime/lifegw/src/shutdown.rs
+++ b/crates/life-runtime/lifegw/src/shutdown.rs
@@ -1,0 +1,44 @@
+//! Signal-handling and graceful drain orchestrator.
+//!
+//! Mirrors the lifed pattern: a SIGTERM/SIGINT handler that fires a
+//! `oneshot::Receiver<()>` once. Sub-phase D wires the WS-drain semantics
+//! (close existing WS with code 1001 going-away). Sub-phase A simply waits
+//! for in-flight unary requests to drain via tonic's `serve_with_incoming_shutdown`.
+
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::sync::oneshot;
+
+/// Install a SIGTERM/SIGINT handler that fires `shutdown_tx` once.
+pub fn install_signal_handler() -> oneshot::Receiver<()> {
+    let (tx, rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to install SIGTERM handler");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to install SIGINT handler");
+                return;
+            }
+        };
+
+        tokio::select! {
+            _ = sigterm.recv() => tracing::info!("SIGTERM received"),
+            _ = sigint.recv()  => tracing::info!("SIGINT received"),
+        }
+        let _ = tx.send(());
+    });
+
+    rx
+}
+
+/// Build the shutdown-signal future the tonic server consumes.
+pub async fn shutdown_signal(rx: oneshot::Receiver<()>) {
+    let _ = rx.await;
+}

--- a/crates/life-runtime/lifegw/tests/integration_proxy_passthrough.rs
+++ b/crates/life-runtime/lifegw/tests/integration_proxy_passthrough.rs
@@ -1,0 +1,366 @@
+//! Integration test — Sub-phase A acceptance criterion #6.
+//!
+//! Brings up:
+//! 1. A `lifed` instance bound to a tempdir UDS, fronted by mock substrates.
+//! 2. A `lifegw` instance bound to `127.0.0.1:0` with a self-signed TLS cert,
+//!    pointing at lifed's UDS.
+//!
+//! Then dials lifegw with a tonic client over rustls trusting the dev cert,
+//! and asserts:
+//! - `/healthz` returns HTTP 200 (browser-style probe).
+//! - `Agent.CreateSession` round-trips → lifed's mock arcan observes one
+//!   `create_agent` call.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http::StatusCode;
+use http_body_util::BodyExt;
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use tempfile::TempDir;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+use life_runtime_proto::life::v1::CreateSessionReq;
+use life_runtime_proto::life::v1::agent_client::AgentClient;
+
+#[tokio::test]
+async fn proxy_forwards_create_session() {
+    let env = TestEnv::start().await;
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(CreateSessionReq {
+        user_id: "user-pass-thru".to_string(),
+        project_id: "demo".to_string(),
+        label: "lifegw-roundtrip".to_string(),
+        resume_sid: None,
+        inherit_policy: None,
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer dev-token-for-user-pass-thru".parse().expect("hv"),
+    );
+
+    let session = client
+        .create_session(req)
+        .await
+        .expect("create_session round-trips through lifegw → lifed → mock-arcan")
+        .into_inner();
+
+    assert_eq!(session.user_id, "user-pass-thru");
+    {
+        let arcan_calls = env.mocks.arcan.create_agent_calls.lock();
+        assert_eq!(
+            arcan_calls.len(),
+            1,
+            "mock arcan saw exactly one create_agent: {:?}",
+            *arcan_calls
+        );
+    }
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn health_endpoint_responds_200() {
+    let env = TestEnv::start().await;
+
+    let resp = env.healthz().await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.body, "OK");
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn missing_bearer_returns_unauthenticated() {
+    let env = TestEnv::start().await;
+
+    let mut client = env.agent_client().await;
+    let req = tonic::Request::new(CreateSessionReq {
+        user_id: "u".to_string(),
+        project_id: "p".to_string(),
+        label: "no-auth".to_string(),
+        resume_sid: None,
+        inherit_policy: None,
+    });
+    let err = client
+        .create_session(req)
+        .await
+        .expect_err("must fail without bearer");
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+    env.shutdown().await;
+}
+
+// ─── Test rig ───────────────────────────────────────────────────────────
+
+struct TestEnv {
+    _tempdir: TempDir,
+    cert_pem: Vec<u8>,
+    lifegw_addr: std::net::SocketAddr,
+    mocks: Arc<lifed::dev_mocks::MockSubstrates>,
+    lifegw_shutdown_tx: Option<oneshot::Sender<()>>,
+    lifed_shutdown_tx: Option<oneshot::Sender<()>>,
+    lifegw_handle: Option<tokio::task::JoinHandle<()>>,
+    lifed_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TestEnv {
+    async fn start() -> Self {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tempdir = TempDir::new().expect("tempdir");
+        let lifed_socket = tempdir.path().join("life.sock");
+        let jwks_path = tempdir.path().join("lifegw-jwks.json");
+
+        // Pre-generate the lifegw Tier-2 signing keystore + write its JWKS
+        // to a path that lifed reads at startup. This makes the downstream
+        // Tier-2 verifier trust the tokens lifegw mints during the test —
+        // without this, lifed falls back to its own dev keystore (whose
+        // public key is unrelated to lifegw's) and rejects every request
+        // with `Unauthenticated`.
+        let lifegw_keystore =
+            lifegw::auth::keystore::Keystore::generate_dev().expect("dev keystore");
+        let jwks_json =
+            serde_json::to_string_pretty(&lifegw_keystore.publish_jwks()).expect("jwks json");
+        std::fs::write(&jwks_path, jwks_json).expect("write jwks");
+
+        // Boot lifed against the tempdir UDS with mocks.
+        let mocks = Arc::new(lifed::dev_mocks::MockSubstrates::new());
+        let mut lifed_cfg = lifed::config::LifedConfig::default();
+        lifed_cfg.public_plane.unix_socket = lifed_socket.clone();
+        lifed_cfg.public_plane.unix_socket_group = None;
+        lifed_cfg.admin_plane.unix_socket = tempdir.path().join("life-admin.sock");
+        lifed_cfg.admin_plane.unix_socket_group = None;
+        // Tell lifed to load lifegw's published JWKS so Tier-2 verification
+        // recognises the keys lifegw mints with.
+        lifed_cfg.auth.jwks_path = jwks_path.clone();
+        let (lifed_shutdown_tx, lifed_shutdown_rx) = oneshot::channel();
+        let mocks_for_lifed = Arc::clone(&mocks);
+        let lifed_handle = tokio::spawn(async move {
+            lifed::bootstrap::run_with_mocks(&lifed_cfg, mocks_for_lifed, lifed_shutdown_rx)
+                .await
+                .expect("lifed boots");
+        });
+        // Wait for lifed's UDS to appear.
+        for _ in 0..200 {
+            if lifed_socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(lifed_socket.exists(), "lifed bound its UDS");
+
+        // Generate a self-signed cert for lifegw.
+        let cert_kp = rcgen::generate_simple_self_signed(vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+        ])
+        .expect("rcgen");
+        let cert_pem = cert_kp.cert.pem().into_bytes();
+        let key_pem = cert_kp.key_pair.serialize_pem().into_bytes();
+        let cert_path = tempdir.path().join("lifegw-cert.pem");
+        let key_path = tempdir.path().join("lifegw-key.pem");
+        std::fs::write(&cert_path, &cert_pem).expect("write cert");
+        std::fs::write(&key_path, &key_pem).expect("write key");
+
+        // Boot lifegw on a free port. The config structs are
+        // `#[non_exhaustive]`, so we mutate a `default()` instead of
+        // struct-literal construction (which is forbidden across crates).
+        let mut lifegw_cfg = lifegw::config::LifegwConfig::default();
+        lifegw_cfg.tls.cert_path = cert_path.clone();
+        lifegw_cfg.tls.key_path = key_path.clone();
+        lifegw_cfg.listen.https_addr = "127.0.0.1:0".to_string();
+        lifegw_cfg.listen.http_redirect_addr = None;
+        lifegw_cfg.upstream.lifed_uds_path = lifed_socket.clone();
+        lifegw_cfg.auth.dev_signer_enabled = true;
+        // Pre-bind so we can extract the resolved port.
+        let bind = lifegw::listener::bind(&lifegw_cfg.tls, &lifegw_cfg.listen)
+            .await
+            .expect("bind");
+        let lifegw_addr = bind.local_addr;
+        let (lifegw_shutdown_tx, lifegw_shutdown_rx) = oneshot::channel();
+        let lifegw_handle = tokio::spawn(async move {
+            lifegw::bootstrap::serve_with_listener_and_keystore(
+                lifegw_cfg,
+                bind,
+                lifegw_keystore,
+                lifegw_shutdown_rx,
+            )
+            .await
+            .expect("lifegw boots");
+        });
+
+        // Briefly poll the gateway for readiness — TLS handshake needs the
+        // crypto provider to be installed and the bound listener to be in
+        // accept(). 50 attempts × 20 ms = 1 s.
+        for _ in 0..50 {
+            if TcpStream::connect(&lifegw_addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        Self {
+            _tempdir: tempdir,
+            cert_pem,
+            lifegw_addr,
+            mocks,
+            lifegw_shutdown_tx: Some(lifegw_shutdown_tx),
+            lifed_shutdown_tx: Some(lifed_shutdown_tx),
+            lifegw_handle: Some(lifegw_handle),
+            lifed_handle: Some(lifed_handle),
+        }
+    }
+
+    async fn agent_client(&self) -> AgentClient<Channel> {
+        AgentClient::new(self.dial_lifegw().await)
+    }
+
+    /// Dial the gateway via a rustls-wrapped TcpStream that trusts the
+    /// self-signed cert. Returns a tonic Channel ready for clients.
+    async fn dial_lifegw(&self) -> Channel {
+        let cert_pem = self.cert_pem.clone();
+        let addr = self.lifegw_addr;
+        let endpoint = Endpoint::try_from("https://localhost").expect("endpoint");
+        endpoint
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let cert_pem = cert_pem.clone();
+                async move {
+                    let tls = tls_dial(addr, &cert_pem).await?;
+                    Ok::<_, std::io::Error>(TokioIo::new(BoxedAsyncIo(Box::new(tls))))
+                }
+            }))
+            .await
+            .expect("connect lifegw")
+    }
+
+    async fn healthz(&self) -> HealthzResponse {
+        let tls = tls_dial(self.lifegw_addr, &self.cert_pem)
+            .await
+            .expect("tls dial");
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(tls))
+            .await
+            .expect("h1 handshake");
+        let conn_handle = tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                tracing::debug!(error = %e, "h1 conn done");
+            }
+        });
+        let req = Request::builder()
+            .method("GET")
+            .uri("/healthz")
+            .header("host", "localhost")
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .expect("build req");
+        let resp = sender.send_request(req).await.expect("send /healthz");
+        let status = resp.status();
+        let body_bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes();
+        let body = String::from_utf8_lossy(&body_bytes).into_owned();
+        drop(sender);
+        let _ = tokio::time::timeout(Duration::from_secs(1), conn_handle).await;
+        HealthzResponse { status, body }
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(tx) = self.lifegw_shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(tx) = self.lifed_shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.lifegw_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+        }
+        if let Some(h) = self.lifed_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+        }
+    }
+}
+
+struct HealthzResponse {
+    status: StatusCode,
+    body: String,
+}
+
+async fn tls_dial(
+    addr: std::net::SocketAddr,
+    cert_pem: &[u8],
+) -> std::io::Result<tokio_rustls::client::TlsStream<TcpStream>> {
+    let mut roots = rustls::RootCertStore::empty();
+    let mut reader = std::io::BufReader::new(cert_pem);
+    for cert in rustls_pemfile::certs(&mut reader) {
+        let cert = cert.map_err(|e| std::io::Error::other(format!("parse cert: {e}")))?;
+        roots
+            .add(cert)
+            .map_err(|e| std::io::Error::other(format!("root: {e}")))?;
+    }
+    let mut client_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    // Sub-phase A's tonic-web layer expects HTTP/1.1 for browser fetch and
+    // HTTP/2 for native gRPC — for the gRPC client below we negotiate
+    // `h2` via ALPN.
+    client_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+    let stream = TcpStream::connect(addr).await?;
+    let domain = rustls::pki_types::ServerName::try_from("localhost")
+        .map_err(|e| std::io::Error::other(format!("name: {e}")))?;
+    let tls = connector.connect(domain, stream).await?;
+    Ok(tls)
+}
+
+/// Box the `AsyncRead+AsyncWrite` so a trait-object-using `service_fn` can
+/// return a uniform connector across both gRPC and HTTP/1.1 dials.
+struct BoxedAsyncIo(Box<dyn DynAsyncIo + Send + Unpin>);
+
+impl AsyncRead for BoxedAsyncIo {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut *self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for BoxedAsyncIo {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut *self.0).poll_write(cx, buf)
+    }
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut *self.0).poll_flush(cx)
+    }
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut *self.0).poll_shutdown(cx)
+    }
+}
+
+trait DynAsyncIo: AsyncRead + AsyncWrite {}
+impl<T: AsyncRead + AsyncWrite + ?Sized> DynAsyncIo for T {}
+
+// Suppress warnings about the `_support` mod placeholder.
+#[allow(dead_code)]
+fn _force_path_unused(_: PathBuf) {}

--- a/deploy/systemd/lifegw.service
+++ b/deploy/systemd/lifegw.service
@@ -1,0 +1,72 @@
+[Unit]
+Description=Life Agent OS edge gateway (lifegw)
+Documentation=https://github.com/broomva/life/tree/main/crates/life-runtime/lifegw
+After=network-online.target lifed.service
+Wants=network-online.target lifed.service
+Requires=lifegw.socket
+
+[Service]
+Type=notify
+NotifyAccess=main
+ExecStart=/usr/local/bin/lifegw daemon
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+
+# ── Environment ─────────────────────────────────────────────────────────────
+Environment=LIFEGW_CONFIG=/etc/lifegw/config.toml
+Environment=RUST_LOG=info,lifegw=debug
+
+# ── Security hardening (Spec C₃ §4.1 / §4.2) ────────────────────────────────
+User=life-runtime-gw
+Group=life-runtime-gw
+SupplementaryGroups=life-runtime
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+# Public + IPv4/IPv6 + UDS; the daemon does NOT need raw sockets, netlink,
+# or BPF.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
+# Inherit pre-bound TCP sockets from lifegw.socket — no CAP_NET_BIND_SERVICE
+# needed even though the listener is on :443.
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# ── Runtime / state / log directories (auto-created by systemd) ─────────────
+RuntimeDirectory=life
+RuntimeDirectoryMode=0750
+StateDirectory=lifegw
+StateDirectoryMode=0750
+LogsDirectory=lifegw
+LogsDirectoryMode=0750
+ConfigurationDirectory=lifegw
+ConfigurationDirectoryMode=0750
+
+# ── File descriptor limits ──────────────────────────────────────────────────
+LimitNOFILE=65536
+
+# ── Restart limits ──────────────────────────────────────────────────────────
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# Allow up to 30 s for graceful drain on SIGTERM / SIGHUP. Sub-phase D's
+# WS-drain semantics (close existing WS with 1001) consume most of this
+# budget; Sub-phase A drains in-flight unary requests via tonic's native
+# `serve_with_incoming_shutdown`.
+TimeoutStopSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/lifegw.socket
+++ b/deploy/systemd/lifegw.socket
@@ -1,0 +1,20 @@
+[Unit]
+Description=Life Agent OS edge gateway listener
+Documentation=https://github.com/broomva/life/tree/main/crates/life-runtime/lifegw
+
+[Socket]
+# Spec C₃ §4.4: systemd binds 80+443 and passes fds via LISTEN_FDS so the
+# daemon never needs CAP_NET_BIND_SERVICE.
+ListenStream=0.0.0.0:443
+ListenStream=[::]:443
+ListenStream=0.0.0.0:80
+ListenStream=[::]:80
+ReusePort=yes
+NoDelay=yes
+KeepAlive=yes
+SocketUser=life-runtime-gw
+SocketGroup=life-runtime-gw
+SocketMode=0640
+
+[Install]
+WantedBy=sockets.target

--- a/scripts/verify_dependencies_lifegw.sh
+++ b/scripts/verify_dependencies_lifegw.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Verify lifegw dependency rules per Spec C₃ §11.
+#
+# lifegw (the unprivileged stateless edge gateway daemon) MAY depend on:
+#   - aios-protocol, aios-proto, life-runtime-proto (Spec C₂ public-plane proto types)
+#   - life-vigil (observability)
+#   - transport / TLS / WS / JWT crates (tonic, tonic-web, rustls, jsonwebtoken, etc.)
+#   - standard utility crates (anyhow, thiserror, clap, toml, tower, tower-http, etc.)
+#
+# lifegw MUST NOT depend on (Spec C₃ §11.2 LOCKED L4-D13):
+#   - substrate runtime crates: arcand, arcan-core, arcan-harness, arcan-aios-adapters,
+#     arcan-provider-* (substrate-internal sandbox/launchers),
+#     lago-runtime family (lago-core, lago-journal, lago-store, etc.),
+#     haima-runtime family (haima-core, haima-wallet, haima-x402, etc.),
+#     anima-runtime family (anima-core, anima-identity, anima-lago, etc.),
+#     life-kernel-* (life-kernel-core, life-kernel-gate, life-kernel-facade,
+#     life-kernel-proto)
+#   - substrate proxy crates: arcan-proxy, lago-proxy, haima-proxy, anima-proxy
+#     (these are lifed's south-side; the gateway never reaches a substrate directly)
+#   - lifed itself (the gateway dials via life-runtime-proto's tonic client; it
+#     must not link against lifed's saga, routing-cache, or auth code)
+#
+# A substrate panic must never reach the gateway. Bypassing lifed would skip
+# the Tier-2 → Tier-3 derivation. Both are non-negotiable trust-boundary rules.
+#
+# Runs from the monorepo root (core/life) — uses workspace `cargo tree`.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FAIL=0
+
+# check_no_transitive_dep CRATE FORBIDDEN_REGEX
+# Fails if any crate matching FORBIDDEN_REGEX appears anywhere in the full
+# dep tree of CRATE. Silently skips if CRATE does not exist yet.
+check_no_transitive_dep() {
+    local crate="$1"
+    local forbidden_regex="$2"
+    local tree
+    # `--edges normal` excludes dev-dependencies and build-dependencies so the
+    # check inspects only the *production* dep graph. Spec C₃ §11.2 forbids
+    # production deps on substrate runtimes / proxies / lifed; integration
+    # tests are allowed to pull lifed as a dev-dep to stand up an end-to-end
+    # rig (see crates/life-runtime/lifegw/tests/integration_proxy_passthrough.rs).
+    tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" --edges normal 2>/dev/null) || return 0
+    # Match crate names at the start of a node (after the └── / ├── prefix
+    # and version), to avoid matching docstrings or feature names.
+    if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
+        local hits
+        hits=$(echo "$tree" | grep -E "[ ]${forbidden_regex} v" | head -3)
+        echo "FAIL: $crate transitively depends on a crate matching ${forbidden_regex}:"
+        echo "$hits" | sed 's/^/    /'
+        FAIL=1
+    fi
+}
+
+echo "=== lifegw (edge gateway) dependency rules (Spec C₃ §11) ==="
+
+# Skip with a quiet message if the crate hasn't landed yet.
+if ! (cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1 \
+        | grep -qE "\"name\":\"lifegw\""); then
+    echo "skip: lifegw not in workspace yet"
+    exit 0
+fi
+
+# Arcan substrate runtime crates.
+check_no_transitive_dep "lifegw" "arcand|arcan-core|arcan-harness|arcan-aios-adapters"
+# Arcan providers — substrate-internal sandbox/launchers.
+check_no_transitive_dep "lifegw" "arcan-provider-bubblewrap|arcan-provider-local|arcan-provider-vercel|arcan-sandbox"
+# Lago substrate runtime crates.
+check_no_transitive_dep "lifegw" "lago-core|lago-journal|lago-store|lago-fs|lago-policy|lago-knowledge|lago-auth|lago-api|lago-ingest|lago-aios-eventstore-adapter|lago-cli|lagod|lago-billing|lago-compiler|lago-lance"
+# Haima substrate runtime crates.
+check_no_transitive_dep "lifegw" "haima-core|haima-wallet|haima-x402|haima-lago|haima-api|haimad|haima-insurance|haima-outcome"
+# Anima substrate runtime crates.
+check_no_transitive_dep "lifegw" "anima-core|anima-identity|anima-lago"
+# Life-kernel internals — lifegw must NOT pull any of these (unlike lifed
+# which is allowed life-kernel-proto for the SpawnChild saga).
+check_no_transitive_dep "lifegw" "life-kernel-core|life-kernel-gate|life-kernel-facade|life-kernel-proto"
+# Substrate proxy crates — owned by lifed's south side; lifegw must not reach
+# substrates directly (master spec §L13 anti-pattern #10).
+check_no_transitive_dep "lifegw" "arcan-proxy|lago-proxy|haima-proxy|anima-proxy"
+# Lifed runtime crate — the gateway dials via life-runtime-proto's tonic
+# client and must never link against lifed's saga / routing / auth code.
+check_no_transitive_dep "lifegw" "lifed"
+
+if [ $FAIL -ne 0 ]; then
+    echo
+    echo "Dependency rules violated. See Spec C₃ §11 for the rationale:"
+    echo "  docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md"
+    exit 1
+fi
+echo "all lifegw dependency rules pass"


### PR DESCRIPTION
## Summary
- New `crates/life-runtime/lifegw/` cluster: binary + lib that terminates TLS, accepts dev-mode JWTs, mints static-key Tier-2 capability tokens, and forwards `life.v1.*` unary RPCs to lifed via UDS.
- `LifegwConfig` schema with serde defaults + validation; `lifegw.example.toml` ships a working dev config.
- TLS bind via rustls (self-signed cert test included).
- Dev-mode auth: `Bearer dev-token-for-{user_id}` accepted; production ES256 + Vercel JWKS lands in Sub-phase B.
- `tonic-web` `GrpcWebLayer` for browser-compatible unary RPCs; WS upgrade comes in Sub-phase C.
- `/healthz` endpoint reports upstream lifed reachability.
- New `scripts/verify_dependencies_lifegw.sh` + CI lane enforcing Spec C₃ §11 dependency rules (lifegw must NOT depend on lifed, the four `*-proxy` crates, or any substrate runtime crate).
- Systemd unit + socket activation per Spec C₃ §4.

## Refs
- Linear: BRO-935 (parent: BRO-932)
- Spec C₃: `docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md`
- Master spec: `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md` §L4 + §L5

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` — Sub-phase B baseline 3516 preserved + 20 new lifegw tests (3536 total)
- [x] `cargo test -p lifegw` — 17 unit + 3 integration tests green
- [x] Integration: lifegw forwards `Agent.CreateSession` to lifed (mock-arcan sees the call)
- [x] `bash scripts/verify_dependencies_lifegw.sh` exits 0
- [ ] CI all green (Format, Lint, MSRV, Test Linux, Test macOS, Security Audit, Dependency Check, Verify lifed dependency rules, **Verify lifegw dependency rules** ← new, Build Release, buf lint, buf breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)