### PR TITLE
feat(anima): D-Sub-A — AnimaCustody trait + InProcessAnima + P-256 cutover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,10 +218,12 @@ dependencies = [
  "hkdf",
  "jsonwebtoken",
  "k256",
+ "p256",
  "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
+ "sha3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3242,6 +3244,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -6982,6 +6985,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7444,6 +7459,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ name = "arcan-anima"
 version = "0.3.0"
 dependencies = [
  "anima-core",
+ "anima-identity",
  "anima-lago",
  "arcan-core",
  "chrono",
@@ -3881,6 +3882,7 @@ name = "haima-x402"
 version = "0.3.0"
 dependencies = [
  "aios-protocol",
+ "anima-identity",
  "async-trait",
  "base64",
  "chrono",
@@ -4740,6 +4742,7 @@ name = "lago-auth"
 version = "0.3.0"
 dependencies = [
  "axum 0.8.8",
+ "base64",
  "http-body-util",
  "jsonwebtoken",
  "lago-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,7 @@ infer = "0.16"
 json-patch = "4"
 jsonwebtoken = "9"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
+p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 opentelemetry = "0.29"

--- a/crates/anima/CLAUDE.md
+++ b/crates/anima/CLAUDE.md
@@ -113,10 +113,57 @@ KYA is the agent-era equivalent of KYC. It provides:
 
 | Crate | How Anima Integrates |
 |-------|---------------------|
-| **Arcan** | Reconstructs `AgentSelf` from Lago on session start |
+| **Arcan** | Reconstructs `AgentSelf` from Lago on session start (D-Sub-A: via `Arc<dyn AnimaCustody>`) |
 | **Lago** | Soul = genesis event; Belief = projection fold |
 | **Autonomic** | Beliefs feed into homeostasis regulation |
-| **Haima** | secp256k1 identity unifies with wallet |
-| **Spaces** | Ed25519 key signs messages, presence includes identity |
+| **Haima** | secp256k1 wallet half via `CustodyWalletAdapter` (haima-x402, feature `custody-adapter`) |
+| **Spaces** | Ed25519 key signs messages, presence includes identity (signed-presence not yet wired) |
 | **Vigil** | OTel spans carry `agent.id` + `agent.soul_hash` |
-| **broomva.tech** | Agent Auth Protocol via Ed25519 JWT signing |
+| **broomva.tech** | Agent Auth Protocol via ES256 JWT (Spec D L4-D6 — was EdDSA) |
+| **lago-auth** | `agent_jwt::detect_alg` dispatches EdDSA / ES256 verification |
+
+## Spec D — Production Custody (D-Sub-A shipped)
+
+`docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md` defines the
+trait abstraction + 6 production backends. D-Sub-A (this PR) ships:
+
+- `AnimaCustody` trait (`anima-identity/src/custody.rs`) + 6 backend
+  variants in `BackendKind`. Only `InProcessAnima` is implemented.
+- `EcdsaP256Identity` (`anima-identity/src/p256.rs`) — ES256 / P-256 via
+  the `p256` crate. Mirrors `Ed25519Identity` API surface for mechanical
+  swap.
+- `did:key` extends to multicodec `0x1200` (P-256 → `did:key:zDn…`).
+  Legacy `0xed01` (Ed25519 → `did:key:z6Mk…`) preserved for verifying
+  historical events.
+- New events: `anima.identity_rotated`, `anima.custody_migrated`,
+  `anima.identity_revoked`. Plus `BackendKind` enum on `anima-core::event`.
+- `AgentIdentityDocument.rotation_chain` (`Vec<DidRotation>`) +
+  `published_at_seq: u64`. Both `#[serde(default)]` for backwards compat.
+
+### D-Sub-A coordination items (cross-repo / cross-substrate)
+
+- **broomva.tech AAP verifier** (separate repo): swap `EdDSA` →
+  `ES256` (or accept both during the transition window). Track via Linear
+  ticket: `BRO-XXX: broomva.tech AAP P-256 verifier swap` (placeholder;
+  user files when MCP re-auths). **Non-blocking** because there are no
+  production users yet — the cutover is fresh-deploy.
+- **Spaces presence signing**: spec mentions "spaces SDK signs presence
+  with `Ed25519Identity`". The `crates/spaces/life-spaces` crate today
+  uses SpacetimeDB tables for presence-state, not cryptographic
+  presence-beacons. When signed presence ships, route through
+  `AnimaCustody::sign_digest`. Filed as a follow-up.
+- **lifegw / broomva.tech ES256 verification cohesion**: lifegw's
+  Tier-2 KMS (Spec C₃ §5) and anima's auth (Spec D L4-D6) are both ES256
+  / P-256 now. Verifiers can share JWKS publish/cache plumbing; no
+  immediate dependency, but worth tracking for a future M8 SDK pass.
+
+### Backend phasing reminder
+
+| Sub-phase | Backend | Status |
+|---|---|---|
+| D-Sub-A | `InProcessAnima` | shipped this PR |
+| D-Sub-B | `VaultTransitAnima` | planned (~5 days) |
+| D-Sub-C | `WebCryptoAnima` + `RemoteAnima` | M9-blocking (~7 days) |
+| D-Sub-D | `TpmAnima` | planned (~3 days) |
+| D-Sub-E | `SomaCustody` + rotation/revocation flow | planned (~5 days) |
+| D-Sub-F | `HardwareWalletAnima` | optional (~2 days) |

--- a/crates/anima/anima-core/src/agent_self.rs
+++ b/crates/anima/anima-core/src/agent_self.rs
@@ -246,8 +246,24 @@ impl AgentSelf {
             AnimaError::Did("agent identity has no DID — generate one first".into())
         })?;
 
+        // Spec D L4-D6: pick the multicodec by inspecting the auth public
+        // key length. Post-D-Sub-A keys are 33-byte SEC1 P-256; legacy
+        // Ed25519 events use 32-byte keys. We keep both paths so historical
+        // identity documents continue to round-trip without rewriting.
+        let (multicodec_prefix, method_type): (&[u8], &str) =
+            match self.identity.auth_public_key.len() {
+                33 => (&[0x80, 0x24], "JsonWebKey2020"),
+                32 => (&[0xed, 0x01], "Ed25519VerificationKey2020"),
+                other => {
+                    return Err(AnimaError::Identity(format!(
+                        "auth_public_key length {other} is neither 32 (Ed25519) nor 33 (P-256)"
+                    )));
+                }
+            };
         let auth_key_multibase = {
-            let mut bytes = vec![0xed, 0x01]; // Ed25519 multicodec prefix
+            let mut bytes =
+                Vec::with_capacity(multicodec_prefix.len() + self.identity.auth_public_key.len());
+            bytes.extend_from_slice(multicodec_prefix);
             bytes.extend_from_slice(&self.identity.auth_public_key);
             let encoded = bs58::encode(&bytes).into_string();
             format!("z{encoded}")
@@ -255,7 +271,7 @@ impl AgentSelf {
 
         let vm = VerificationMethod {
             id: format!("{did}#key-1"),
-            method_type: "Ed25519VerificationKey2020".into(),
+            method_type: method_type.into(),
             controller: did.clone(),
             public_key_multibase: auth_key_multibase,
         };

--- a/crates/anima/anima-core/src/event.rs
+++ b/crates/anima/anima-core/src/event.rs
@@ -10,6 +10,25 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Custody backend identifier — used in `anima.custody_migrated` events.
+///
+/// Spec D §"Event additions" — `BackendKind` (the enum behind the same
+/// name on the `AnimaCustody` trait). `#[non_exhaustive]` so adding new
+/// backends in D-Sub-B…F doesn't break match exhaustiveness on
+/// downstream verifiers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    InProcess,
+    Vault,
+    WebCrypto,
+    Tpm,
+    Soma,
+    HardwareWallet,
+    Remote,
+}
+
 /// All event types that Anima emits to the Lago journal.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -130,6 +149,53 @@ pub enum AnimaEventKind {
         /// Whether verification succeeded.
         verified: bool,
     },
+
+    /// Spec D §"Event additions" — the agent's auth identity rotated.
+    ///
+    /// Verifiers use this to walk the rotation chain: any signature by
+    /// `old_did` for a seq < `rotated_at_seq` (recorded at the lago
+    /// envelope level) is considered valid; any signature by `old_did`
+    /// for a later seq is rejected.
+    IdentityRotated {
+        /// The DID that was rotated away from.
+        old_did: String,
+        /// The DID that signing now flows through.
+        new_did: String,
+        /// JWS signed by the *old* key over the *new* DID, proving the
+        /// rotation was authorised.
+        rotation_proof_jws: String,
+        /// Wall-clock rotation timestamp (`Lago` envelope already carries
+        /// the seq + microsecond timestamp — this is the operator-facing
+        /// human-readable wall clock).
+        rotated_at: DateTime<Utc>,
+    },
+
+    /// Spec D §"Event additions" — custody backend migrated.
+    ///
+    /// Documents that custody moved between backends (e.g. user upgraded
+    /// from `InProcessAnima` to `TpmAnima`). Doesn't change the keys —
+    /// just records the move so verifiers can audit the lineage and so
+    /// operators can spot e.g. a downgrade from `Vault` back to
+    /// `InProcess` (which would be a regression).
+    CustodyMigrated {
+        from_backend: BackendKind,
+        to_backend: BackendKind,
+        /// Backend-specific attestation (optional; e.g. a Vault token
+        /// receipt or a TPM attestation quote).
+        attestation: Option<String>,
+        migrated_at: DateTime<Utc>,
+    },
+
+    /// Spec D §"Event additions" — identity revoked.
+    ///
+    /// After this event, no signature signed by the revoked DID is
+    /// accepted regardless of seq. Used for e.g. a stolen device or a
+    /// compromised passkey.
+    IdentityRevoked {
+        did: String,
+        reason: String,
+        revoked_at: DateTime<Utc>,
+    },
 }
 
 impl AnimaEventKind {
@@ -154,6 +220,10 @@ impl AnimaEventKind {
             Self::LineageVerified { .. } => "lineage_verified",
             Self::IdentityAttested { .. } => "identity_attested",
             Self::IdentityVerified { .. } => "identity_verified",
+            // Spec D §"Event additions"
+            Self::IdentityRotated { .. } => "identity_rotated",
+            Self::CustodyMigrated { .. } => "custody_migrated",
+            Self::IdentityRevoked { .. } => "identity_revoked",
         };
 
         format!("{}.{}", Self::NAMESPACE, variant)
@@ -214,5 +284,57 @@ mod tests {
     fn non_anima_events_return_none() {
         let data = serde_json::json!({"amount": 100});
         assert!(AnimaEventKind::from_custom("finance.payment_settled", &data).is_none());
+    }
+
+    #[test]
+    fn identity_rotated_event_type() {
+        let event = AnimaEventKind::IdentityRotated {
+            old_did: "did:key:z6MkOld".into(),
+            new_did: "did:key:zDnNew".into(),
+            rotation_proof_jws: "h.b.s".into(),
+            rotated_at: chrono::Utc::now(),
+        };
+        assert_eq!(event.event_type(), "anima.identity_rotated");
+
+        let data = event.to_custom_data();
+        let parsed = AnimaEventKind::from_custom("anima.identity_rotated", &data);
+        assert_eq!(parsed, Some(event));
+    }
+
+    #[test]
+    fn custody_migrated_event_type() {
+        let event = AnimaEventKind::CustodyMigrated {
+            from_backend: BackendKind::InProcess,
+            to_backend: BackendKind::Vault,
+            attestation: Some("vault-token-123".into()),
+            migrated_at: chrono::Utc::now(),
+        };
+        assert_eq!(event.event_type(), "anima.custody_migrated");
+
+        let data = event.to_custom_data();
+        let parsed = AnimaEventKind::from_custom("anima.custody_migrated", &data);
+        assert_eq!(parsed, Some(event));
+    }
+
+    #[test]
+    fn identity_revoked_event_type() {
+        let event = AnimaEventKind::IdentityRevoked {
+            did: "did:key:zDnRevoked".into(),
+            reason: "device lost".into(),
+            revoked_at: chrono::Utc::now(),
+        };
+        assert_eq!(event.event_type(), "anima.identity_revoked");
+
+        let data = event.to_custom_data();
+        let parsed = AnimaEventKind::from_custom("anima.identity_revoked", &data);
+        assert_eq!(parsed, Some(event));
+    }
+
+    #[test]
+    fn backend_kind_serialises_snake_case() {
+        let json = serde_json::to_string(&BackendKind::InProcess).unwrap();
+        assert_eq!(json, "\"in_process\"");
+        let json = serde_json::to_string(&BackendKind::HardwareWallet).unwrap();
+        assert_eq!(json, "\"hardware_wallet\"");
     }
 }

--- a/crates/anima/anima-core/src/identity_document.rs
+++ b/crates/anima/anima-core/src/identity_document.rs
@@ -19,6 +19,29 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// One link in the agent's DID rotation chain (Spec D §"Event additions").
+///
+/// Each entry documents that the holder of `old_did` rotated to `new_did` at
+/// some Lago seq. Verifiers seeing an old DID walk this chain to find the
+/// currently-authoritative DID. The `rotation_proof_jws` is signed by the
+/// *old* key over the *new* DID, providing cryptographic continuity.
+///
+/// Spec D L4-D10 — "Rotation is documented in the journal, not implicit."
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DidRotation {
+    /// The DID that was rotated away from. Remains valid for verifying
+    /// historical events but cannot mint new signatures.
+    pub old_did: String,
+    /// The DID that signing now flows through.
+    pub new_did: String,
+    /// Detached JWS by the *old* key over the *new* DID.
+    pub rotation_proof_jws: String,
+    /// Lago journal seq at which the `anima.identity_rotated` event was
+    /// written. Verifiers use this to scope which signatures the old DID
+    /// can validate (only events at seq < `rotated_at_seq`).
+    pub rotated_at_seq: u64,
+}
+
 /// The type of agent — how it operates and who controls it.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -186,6 +209,22 @@ pub struct AgentIdentityDocument {
 
     /// Soul hash — tamper-evident seal of the agent's immutable origin.
     pub soul_hash: String,
+
+    /// Spec D §"Event additions": the chain of DID rotations for this agent.
+    ///
+    /// Empty for agents that have never rotated. Replayed from
+    /// `anima.identity_rotated` events in the Lago journal. Verifiers use
+    /// this chain to resolve old DIDs back to the current authoritative DID
+    /// for the agent.
+    #[serde(default)]
+    pub rotation_chain: Vec<DidRotation>,
+
+    /// Spec D — Lago journal seq at which the most recent
+    /// `anima.identity_rotated` (or `anima.identity_created` if no rotations
+    /// have occurred) event was written. `0` for backwards compatibility
+    /// with documents minted before rotation chains were tracked.
+    #[serde(default)]
+    pub published_at_seq: u64,
 }
 
 impl AgentIdentityDocument {
@@ -237,6 +276,8 @@ pub struct IdentityDocumentBuilder {
     mission: String,
     soul_hash: String,
     created_at: DateTime<Utc>,
+    rotation_chain: Vec<DidRotation>,
+    published_at_seq: u64,
 }
 
 impl IdentityDocumentBuilder {
@@ -255,6 +296,8 @@ impl IdentityDocumentBuilder {
             mission,
             soul_hash,
             created_at: Utc::now(),
+            rotation_chain: vec![],
+            published_at_seq: 0,
         }
     }
 
@@ -301,6 +344,26 @@ impl IdentityDocumentBuilder {
         self
     }
 
+    /// Add a DID rotation to the chain.
+    pub fn rotation(mut self, rotation: DidRotation) -> Self {
+        self.rotation_chain.push(rotation);
+        self
+    }
+
+    /// Replace the rotation chain wholesale (e.g., when replaying from the
+    /// journal). Spec D §"Event additions" — the chain is replayed at
+    /// session start.
+    pub fn rotation_chain(mut self, chain: Vec<DidRotation>) -> Self {
+        self.rotation_chain = chain;
+        self
+    }
+
+    /// Set the `published_at_seq` pointer.
+    pub fn published_at_seq(mut self, seq: u64) -> Self {
+        self.published_at_seq = seq;
+        self
+    }
+
     /// Build the identity document.
     pub fn build(self) -> AgentIdentityDocument {
         let now = Utc::now();
@@ -318,6 +381,8 @@ impl IdentityDocumentBuilder {
             name: self.name,
             mission: self.mission,
             soul_hash: self.soul_hash,
+            rotation_chain: self.rotation_chain,
+            published_at_seq: self.published_at_seq,
         }
     }
 }
@@ -478,5 +543,70 @@ mod tests {
         assert!(TrustTier::Unverified < TrustTier::Provisional);
         assert!(TrustTier::Provisional < TrustTier::Trusted);
         assert!(TrustTier::Trusted < TrustTier::Certified);
+    }
+
+    #[test]
+    fn rotation_chain_serializes() {
+        let rotation = DidRotation {
+            old_did: "did:key:z6MkOld".into(),
+            new_did: "did:key:zDnNew".into(),
+            rotation_proof_jws: "header.body.sig".into(),
+            rotated_at_seq: 17,
+        };
+        let json = serde_json::to_string(&rotation).unwrap();
+        let deserialized: DidRotation = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, rotation);
+    }
+
+    #[test]
+    fn agent_identity_document_with_rotation_chain() {
+        let doc = IdentityDocumentBuilder::new(
+            "did:key:zDnCurrent".into(),
+            "agent".into(),
+            "mission".into(),
+            "soul_hash".into(),
+        )
+        .rotation(DidRotation {
+            old_did: "did:key:z6MkV1".into(),
+            new_did: "did:key:zDnCurrent".into(),
+            rotation_proof_jws: "h.b.s".into(),
+            rotated_at_seq: 10,
+        })
+        .published_at_seq(10)
+        .build();
+
+        assert_eq!(doc.rotation_chain.len(), 1);
+        assert_eq!(doc.rotation_chain[0].rotated_at_seq, 10);
+        assert_eq!(doc.published_at_seq, 10);
+
+        // Round-trip through serde — backwards-compat fields default cleanly.
+        let json = serde_json::to_string(&doc).unwrap();
+        let deserialized: AgentIdentityDocument = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.rotation_chain.len(), 1);
+        assert_eq!(deserialized.published_at_seq, 10);
+    }
+
+    #[test]
+    fn agent_identity_document_default_rotation_chain_back_compat() {
+        // Older serialized documents (pre-Spec-D) won't have rotation_chain
+        // / published_at_seq. Verify the #[serde(default)] handles them.
+        let json = r#"{
+            "did": "did:key:z6MkOld",
+            "controller_did": null,
+            "agent_type": "hosted",
+            "verification_methods": [],
+            "capabilities": [],
+            "trust_score": null,
+            "trust_tier": null,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "attestations": [],
+            "name": "legacy-agent",
+            "mission": "legacy",
+            "soul_hash": "sh"
+        }"#;
+        let doc: AgentIdentityDocument = serde_json::from_str(json).unwrap();
+        assert!(doc.rotation_chain.is_empty());
+        assert_eq!(doc.published_at_seq, 0);
     }
 }

--- a/crates/anima/anima-core/src/lib.rs
+++ b/crates/anima/anima-core/src/lib.rs
@@ -61,7 +61,7 @@ pub use error::{AnimaError, AnimaResult};
 pub use event::AnimaEventKind;
 pub use identity::AgentIdentity;
 pub use identity_document::{
-    AgentIdentityDocument, AgentType, Attestation, IdentityDocumentBuilder, TrustTier,
+    AgentIdentityDocument, AgentType, Attestation, DidRotation, IdentityDocumentBuilder, TrustTier,
     VerificationMethod,
 };
 pub use policy::PolicyManifest;

--- a/crates/anima/anima-identity/Cargo.toml
+++ b/crates/anima/anima-identity/Cargo.toml
@@ -32,9 +32,13 @@ ed25519-dalek.workspace = true
 # secp256k1 (shared with Haima)
 k256.workspace = true
 
+# P-256 (ES256) — Spec D L4-D6: anima auth keypair migrated from Ed25519
+p256.workspace = true
+
 # Key derivation + encryption
 hkdf.workspace = true
 sha2.workspace = true
+sha3.workspace = true
 chacha20poly1305.workspace = true
 rand.workspace = true
 zeroize.workspace = true

--- a/crates/anima/anima-identity/src/custody.rs
+++ b/crates/anima/anima-identity/src/custody.rs
@@ -1,0 +1,291 @@
+//! `AnimaCustody` — the production custody trait abstraction (Spec D §"Trait shape").
+//!
+//! SPEC-D-DEVIATION: Notes on where the implementation differs from the
+//! Spec D §"Trait shape" pseudocode and why.
+//!
+//! - `sign_eip712` takes `domain: &Eip712Domain` (re-exported from
+//!   `haima_wallet`). The spec listed `&Eip712Domain` without specifying the
+//!   crate; we reuse the existing haima-wallet type instead of duplicating it
+//!   in anima. This keeps the wallet-half encoding logic colocated with the
+//!   ECDSA-secp256k1 signing primitive.
+//!
+//! - `sign_eip712`'s `types` and `message` parameters are typed as
+//!   `serde_json::Value` per the spec, but in D-Sub-A's `InProcessAnima` body
+//!   the Eip712 path goes through `haima_wallet::sign_transfer_authorization`
+//!   directly because that is the only EIP-712 typed-data shape haima
+//!   currently signs. A generic Eip712 encoder is deferred to a follow-up;
+//!   non-EIP-3009 typed-data signing returns
+//!   `AnimaError::Crypto("eip712: only EIP-3009 transferWithAuthorization is
+//!   supported in D-Sub-A")`.
+//!
+//! - `rotate()` returns a `DidRotationEvent` payload but does NOT itself
+//!   write to the Lago journal — that is the caller's responsibility (the
+//!   anima-lago bridge). This keeps the trait pure (no I/O) and matches the
+//!   lifegw `KmsSigner::publish_jwks` shape (returns the data; the caller
+//!   atomically swaps it).
+//!
+//! - `export_identity_document()` returns the `AgentIdentityDocument` shape
+//!   from `anima-core`. The `rotation_chain` field is added in this PR
+//!   (`anima_core::identity_document::DidRotation`).
+//!
+//! Backend matrix (Spec D §"Backend matrix") — only `InProcessAnima` ships in
+//! D-Sub-A. The other backends (`VaultTransitAnima`, `WebCryptoAnima`,
+//! `TpmAnima`, `SomaCustody`, `HardwareWalletAnima`, `RemoteAnima`) land in
+//! D-Sub-B…F. The trait shape is deliberately wide enough to accommodate all
+//! of them — see [`BackendKind`].
+
+use std::sync::Arc;
+
+use anima_core::error::AnimaResult;
+use anima_core::identity_document::{AgentIdentityDocument, DidRotation};
+use chrono::{DateTime, Utc};
+use haima_core::wallet::WalletAddress;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// EIP-712 typed-data domain — re-exported from haima-wallet.
+///
+/// Spec D L4-D7 keeps the wallet keypair on secp256k1 + EIP-712 + EIP-155;
+/// the existing haima-wallet type is the canonical shape.
+pub use haima_wallet::Eip712Domain;
+
+/// Custody backend identifier (Spec D §"Event additions").
+///
+/// `#[non_exhaustive]` so future backends (W3C-DID-resolver, custom TEEs,
+/// passkey-attested HSMs, …) can be added without breaking match
+/// exhaustiveness in downstream verifiers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    /// `InProcessAnima` — keys live in process memory (dev / single-user host).
+    /// Spec D D-Sub-A primary backend.
+    InProcess,
+    /// `VaultTransitAnima` — HashiCorp Vault Transit per-user keys.
+    /// Spec D D-Sub-B; multi-tenant production server-side.
+    Vault,
+    /// `WebCryptoAnima` — passkey-managed non-extractable browser `CryptoKey`.
+    /// Spec D D-Sub-C; auth half only (wallet half is delegated).
+    WebCrypto,
+    /// `TpmAnima` — TPM-resident keys via PKCS#11.
+    /// Spec D D-Sub-D; desktop single-user host.
+    Tpm,
+    /// `SomaCustody` — soma admin RPC oracle (UDS + SO_PEERCRED).
+    /// Spec D D-Sub-E; user-scope analogue of Tier-2 KMS unification.
+    Soma,
+    /// `HardwareWalletAnima` — Ledger/Trezor secp256k1 wallet half.
+    /// Spec D D-Sub-F; high-stakes wallet operations.
+    HardwareWallet,
+    /// `RemoteAnima` — proxy to a server-side anima daemon (browser pairing).
+    /// Spec D D-Sub-C, paired with `WebCryptoAnima`.
+    Remote,
+}
+
+/// EVM transaction request — narrow shape used by `AnimaCustody::sign_evm_tx`.
+///
+/// Spec D L4-D7 keeps the wallet on secp256k1 + EIP-155, so this matches the
+/// EVM EOA model. Solana / non-EVM transaction shapes will get their own
+/// trait method when the wallet substrate adds those chains.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxRequest {
+    /// `from` address (must equal `wallet_address().address`).
+    pub from: String,
+    /// `to` address (recipient).
+    pub to: String,
+    /// Value in wei (string-encoded for u256 width — chains may exceed u64).
+    pub value_wei: String,
+    /// Transaction `data` (calldata; hex-encoded, may be empty for plain transfers).
+    pub data_hex: String,
+    /// Nonce (user's wallet account nonce).
+    pub nonce: u64,
+    /// Gas limit.
+    pub gas_limit: u64,
+    /// Maximum fee per gas (EIP-1559) in wei (string-encoded).
+    pub max_fee_per_gas_wei: String,
+    /// Maximum priority fee per gas (EIP-1559) in wei (string-encoded).
+    pub max_priority_fee_per_gas_wei: String,
+    /// CAIP-2 chain id (e.g. `eip155:8453`). Used to pick the EIP-155 chain id.
+    pub chain: String,
+}
+
+/// EVM signature output — `(r, s, v)` in 65-byte recoverable form.
+///
+/// Same shape as `haima_wallet::LocalSigner::sign_transfer_authorization`
+/// returns. Production verifiers ecrecover from this and compare the
+/// recovered address against `WalletAddress::address`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvmSignature {
+    /// Raw 65-byte recoverable signature (r || s || v).
+    pub bytes: Vec<u8>,
+}
+
+impl EvmSignature {
+    /// Construct from a raw byte vector — must be 65 bytes (r||s||v).
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    /// Borrow as a slice.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+/// Output of `AnimaCustody::rotate`.
+///
+/// Documents a DID rotation: the old DID, the new DID, and a JWS signed by
+/// the *old* key over the *new* DID — the rotation proof. Verifiers seeing
+/// the old DID resolve this event from the journal to learn the new DID.
+///
+/// Spec D L4-D10 — Rotation is documented in the journal, not implicit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DidRotationEvent {
+    /// The DID that was rotated away from. Remains valid for verifying
+    /// historical events but cannot mint new signatures.
+    pub old_did: String,
+    /// The DID that signing now flows through. All new signatures use this.
+    pub new_did: String,
+    /// Detached JWS by the *old* key over the *new* DID, proving the rotation
+    /// was authorised by the holder of the old key. Compact form
+    /// (`<header>.<body>.<signature>`).
+    pub rotation_proof_jws: String,
+    /// Wall-clock timestamp of the rotation.
+    pub rotated_at: DateTime<Utc>,
+}
+
+impl DidRotationEvent {
+    /// Convert this event to the persistence shape used in
+    /// `AgentIdentityDocument.rotation_chain` and the `anima.identity_rotated`
+    /// event payload.
+    pub fn as_did_rotation(&self, rotated_at_seq: u64) -> DidRotation {
+        DidRotation {
+            old_did: self.old_did.clone(),
+            new_did: self.new_did.clone(),
+            rotation_proof_jws: self.rotation_proof_jws.clone(),
+            rotated_at_seq,
+        }
+    }
+}
+
+/// `AnimaCustody` — the production custody trait abstraction.
+///
+/// Mirrors `lifegw::auth::kms::KmsSigner` at the user-scope; widened to
+/// support both auth (P-256 ECDSA) and wallet (secp256k1 ECDSA) signing
+/// through the same trait object. Browser deployments hold only the auth
+/// half locally and delegate wallet ops to a server-side backend
+/// (Spec D L4-D5 split-custody).
+///
+/// Implementations MUST be `Send + Sync + 'static` so call sites can hold
+/// `Arc<dyn AnimaCustody>` and pass it across task boundaries.
+pub trait AnimaCustody: Send + Sync + 'static {
+    /// User-scope DID. Format: `did:key:zDn…` (P-256 multicodec 0x1200) for
+    /// any DID minted post-D-Sub-A. Old `did:key:z6Mk…` (Ed25519) DIDs
+    /// remain resolvable for historical-event verification but are NEVER
+    /// returned here — `rotate()` migrates them.
+    fn user_did(&self) -> &str;
+
+    /// SEC1-compressed P-256 public key (33 bytes). The corresponding DID is
+    /// derived from this via `did::generate_did_key_p256`.
+    fn auth_pubkey(&self) -> [u8; 33];
+
+    /// Wallet half address, if a wallet has been resolved for this custody.
+    /// `None` for browser passkey-only deployments where the wallet half is
+    /// delegated to `RemoteAnima` / `HardwareWalletAnima` / `VaultTransitAnima`.
+    fn wallet_address(&self) -> Option<&WalletAddress>;
+
+    /// Sign a JWS over the supplied claims using the auth (P-256) key.
+    /// Implementations build the header (alg=ES256, kid=DID) and return the
+    /// compact JWS string `<header>.<body>.<signature>`.
+    fn sign_jws(&self, claims: &Value) -> AnimaResult<String>;
+
+    /// Sign a raw 32-byte digest with the auth key (used for non-JWT identity
+    /// events such as Spaces presence beacons). Returns the 64-byte ECDSA
+    /// `(r || s)` IEEE-P1363 form (no recovery byte — auth verifiers know
+    /// the verifying key from the DID).
+    fn sign_digest(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]>;
+
+    /// Sign an EVM transaction with the wallet (secp256k1) key.
+    /// Browser-side `WebCryptoAnima` delegates this to `RemoteAnima` /
+    /// `VaultTransitAnima` / `HardwareWalletAnima`; in-process backends
+    /// sign locally.
+    fn sign_evm_tx(&self, tx: &TxRequest) -> AnimaResult<EvmSignature>;
+
+    /// Sign an EIP-712 typed-data payload (used by haima for x402 + USDC
+    /// `transferWithAuthorization` and any future EIP-712-shaped flows).
+    ///
+    /// In D-Sub-A, only the EIP-3009 `transferWithAuthorization` shape is
+    /// supported — see `// SPEC-D-DEVIATION` block at the top of this file.
+    fn sign_eip712(
+        &self,
+        domain: &Eip712Domain,
+        types: &Value,
+        message: &Value,
+    ) -> AnimaResult<EvmSignature>;
+
+    /// Mint a new auth keypair, write a rotation event, and return the
+    /// rotation payload. Each backend implements this differently — Vault
+    /// rotates the underlying transit key version; in-process backends
+    /// generate a fresh seed; soma forwards the call to its admin RPC.
+    ///
+    /// After a successful rotation, `user_did()` and `auth_pubkey()` MUST
+    /// reflect the new key. The rotation proof embedded in the returned
+    /// event is signed by the *old* key.
+    fn rotate(&self) -> AnimaResult<DidRotationEvent>;
+
+    /// Identify which backend produced this custody handle. Used for the
+    /// `anima.custody_migrated` event and for diagnostic logging.
+    fn backend_kind(&self) -> BackendKind;
+
+    /// Export the agent's identity document (KYA shape) with the full
+    /// rotation chain. The chain is replayed from the Lago journal at
+    /// session start; D-Sub-A backends may return an empty chain when no
+    /// rotations have occurred yet.
+    fn export_identity_document(&self) -> AnimaResult<AgentIdentityDocument>;
+}
+
+/// `Arc<dyn AnimaCustody>` — the canonical handle every call site holds.
+pub type AnimaCustodyHandle = Arc<dyn AnimaCustody>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time test: trait is dyn-compatible.
+    #[test]
+    fn custody_trait_compiles() {
+        fn assert_dyn_compatible<T: AnimaCustody>(_: &T) {}
+        // The function itself is the test — if `AnimaCustody` is not
+        // dyn-compatible the type alias above wouldn't compile.
+        let _: Option<AnimaCustodyHandle> = None;
+        // Sanity: the marker bounds compile.
+        fn assert_send_sync<T: Send + Sync + 'static>() {}
+        assert_send_sync::<DidRotationEvent>();
+        assert_send_sync::<TxRequest>();
+        assert_send_sync::<EvmSignature>();
+        assert_send_sync::<BackendKind>();
+        let _ = assert_dyn_compatible::<crate::in_process::InProcessAnima>;
+    }
+
+    #[test]
+    fn backend_kind_serialises_snake_case() {
+        let json = serde_json::to_string(&BackendKind::InProcess).unwrap();
+        assert_eq!(json, "\"in_process\"");
+        let json = serde_json::to_string(&BackendKind::HardwareWallet).unwrap();
+        assert_eq!(json, "\"hardware_wallet\"");
+    }
+
+    #[test]
+    fn did_rotation_event_to_did_rotation_round_trip() {
+        let evt = DidRotationEvent {
+            old_did: "did:key:z6MkOld".into(),
+            new_did: "did:key:zDnNew".into(),
+            rotation_proof_jws: "header.body.sig".into(),
+            rotated_at: Utc::now(),
+        };
+        let stored = evt.as_did_rotation(42);
+        assert_eq!(stored.old_did, evt.old_did);
+        assert_eq!(stored.new_did, evt.new_did);
+        assert_eq!(stored.rotation_proof_jws, evt.rotation_proof_jws);
+        assert_eq!(stored.rotated_at_seq, 42);
+    }
+}

--- a/crates/anima/anima-identity/src/custody.rs
+++ b/crates/anima/anima-identity/src/custody.rs
@@ -18,11 +18,27 @@
 //!   `AnimaError::Crypto("eip712: only EIP-3009 transferWithAuthorization is
 //!   supported in D-Sub-A")`.
 //!
-//! - `rotate()` returns a `DidRotationEvent` payload but does NOT itself
-//!   write to the Lago journal — that is the caller's responsibility (the
-//!   anima-lago bridge). This keeps the trait pure (no I/O) and matches the
-//!   lifegw `KmsSigner::publish_jwks` shape (returns the data; the caller
-//!   atomically swaps it).
+//! - `rotate()` returns `(DidRotationEvent, Arc<dyn AnimaCustody>)` but does
+//!   NOT itself write to the Lago journal — that is the caller's
+//!   responsibility (the anima-lago bridge). This keeps the trait pure (no
+//!   I/O) and matches the lifegw `KmsSigner::publish_jwks` shape (returns
+//!   the data; the caller atomically swaps it). The Arc handle returned is
+//!   the NEW post-rotation custody; the original handle remains a valid
+//!   snapshot of pre-rotation state for verifying historical signatures.
+//!
+//! - **`sign_evm_tx` is currently a stub for D-Sub-A**: the implementation
+//!   in `InProcessAnima` Keccak-256-hashes a JSON canonicalisation of the
+//!   `TxRequest` rather than computing the EIP-155 RLP digest. Signatures
+//!   produced by `sign_evm_tx` will NOT verify as valid Ethereum/Base
+//!   transactions. This is acceptable in D-Sub-A only because the sole
+//!   production hot path that signs EVM transactions is haima-x402's
+//!   EIP-3009 `transferWithAuthorization` flow, which goes through
+//!   `sign_eip712` (which IS production-grade — it delegates to
+//!   `haima_wallet::sign_transfer_authorization`). A proper RLP-based
+//!   `sign_evm_tx` is deferred to a follow-up PR (likely D-Sub-B's Vault
+//!   backend will need it for transit-signed Base transactions). Callers
+//!   that need broadcast-ready EIP-155 signatures TODAY MUST go through
+//!   haima-wallet directly until this is fixed.
 //!
 //! - `export_identity_document()` returns the `AgentIdentityDocument` shape
 //!   from `anima-core`. The `rotation_chain` field is added in this PR
@@ -222,15 +238,36 @@ pub trait AnimaCustody: Send + Sync + 'static {
         message: &Value,
     ) -> AnimaResult<EvmSignature>;
 
-    /// Mint a new auth keypair, write a rotation event, and return the
-    /// rotation payload. Each backend implements this differently — Vault
-    /// rotates the underlying transit key version; in-process backends
-    /// generate a fresh seed; soma forwards the call to its admin RPC.
+    /// Mint a new auth keypair, sign a rotation proof with the *old* key,
+    /// and return both the rotation event and a fresh custody handle that
+    /// reflects the new key.
     ///
-    /// After a successful rotation, `user_did()` and `auth_pubkey()` MUST
-    /// reflect the new key. The rotation proof embedded in the returned
-    /// event is signed by the *old* key.
-    fn rotate(&self) -> AnimaResult<DidRotationEvent>;
+    /// Semantics:
+    /// - The returned `DidRotationEvent` carries the rotation proof JWS
+    ///   signed by the OLD key over the NEW key (Spec D L4-D10).
+    /// - The returned `Arc<dyn AnimaCustody>` is a NEW handle whose
+    ///   `user_did()` / `auth_pubkey()` reflect the NEW key.
+    /// - The original handle is NOT mutated and remains valid as a
+    ///   snapshot of pre-rotation state — useful for verifiers walking
+    ///   historical signatures.
+    /// - Wallet half (secp256k1) is preserved across rotation per L4-D7;
+    ///   the new handle has the same `wallet_address()`.
+    ///
+    /// Each backend implements this differently — Vault rotates the
+    /// underlying transit key version + returns a Vault-backed handle for
+    /// the new version; in-process backends generate a fresh seed; soma
+    /// forwards the call to its admin RPC and returns a soma-backed
+    /// handle for the new key.
+    ///
+    /// Why a tuple return rather than `&mut self`-style in-place mutation:
+    /// the trait method `user_did(&self) -> &str` requires referential
+    /// transparency. To support both browser passkey backends (where the
+    /// active credential is a non-extractable handle that can't be
+    /// "swapped" in place) and Vault/HSM backends (where rotation produces
+    /// a new key version), the cleanest contract is "return the new
+    /// handle". Callers then `Arc::clone` the new handle into wherever
+    /// they were holding the old one.
+    fn rotate(&self) -> AnimaResult<(DidRotationEvent, Arc<dyn AnimaCustody>)>;
 
     /// Identify which backend produced this custody handle. Used for the
     /// `anima.custody_migrated` event and for diagnostic logging.

--- a/crates/anima/anima-identity/src/did.rs
+++ b/crates/anima/anima-identity/src/did.rs
@@ -1,13 +1,16 @@
 //! DID (Decentralized Identifier) generation and resolution.
 //!
-//! Implements the `did:key` method for Ed25519 public keys, following the
-//! W3C DID specification and the did:key method specification.
+//! Implements the `did:key` method for both Ed25519 and P-256 public keys,
+//! following the W3C DID specification and the did:key method specification.
 //!
-//! Format: `did:key:z6Mk<base58btc-encoded-multicodec-key>`
+//! Format: `did:key:z<base58btc-encoded-multicodec-key>`
 //!
-//! The multicodec prefix for Ed25519 public key is `0xed01` (two bytes).
-//! The public key bytes are prepended with this prefix, then encoded as
-//! base58-btc with a `z` prefix (per the Multibase specification).
+//! Multicodec prefixes (varint-encoded):
+//! - `0xed 0x01` — Ed25519 public key (legacy; pre-Spec-D auth identity)
+//! - `0x80 0x24` — P-256 public key (Spec D L4-D6 cutover; current auth identity)
+//!
+//! All DIDs minted post-D-Sub-A use P-256. Ed25519 resolution is preserved
+//! ONLY for verifying historical events signed before the cutover.
 //!
 //! # References
 //!
@@ -16,14 +19,45 @@
 //! - Multicodec: <https://github.com/multiformats/multicodec>
 
 use anima_core::error::{AnimaError, AnimaResult};
+use serde::{Deserialize, Serialize};
 
-/// Multicodec prefix for Ed25519 public key.
+/// Multicodec prefix for Ed25519 public key (legacy / historical events only).
 ///
-/// This is a two-byte varint: 0xed 0x01.
+/// Two-byte varint: 0xed 0x01.
 const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xed, 0x01];
+
+/// Multicodec prefix for P-256 public key (Spec D L4-D6 — current auth curve).
+///
+/// Two-byte unsigned varint encoding of 0x1200:
+///   0x1200 binary: 1 0010 0000 0000
+///   varint:        0x80 0x24
+const P256_MULTICODEC_PREFIX: [u8; 2] = [0x80, 0x24];
 
 /// The DID method prefix for key-based identifiers.
 const DID_KEY_PREFIX: &str = "did:key:z";
+
+/// Auth algorithm encoded in a `did:key` DID.
+///
+/// `#[non_exhaustive]` so future curves (e.g. P-384, secp256k1 auth) can be
+/// added without breaking match exhaustiveness.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthAlg {
+    /// Ed25519 — legacy. Resolves multicodec `0xed01`.
+    Ed25519,
+    /// ECDSA over P-256 — current (Spec D L4-D6). Resolves multicodec `0x1200`.
+    P256,
+}
+
+/// Result of resolving a `did:key` DID.
+#[derive(Debug, Clone)]
+pub struct DidResolution {
+    /// Which curve / algorithm the key uses.
+    pub algorithm: AuthAlg,
+    /// Raw public key bytes — 32 for Ed25519, 33 (SEC1 compressed) for P-256.
+    pub public_key: Vec<u8>,
+}
 
 /// Generate a `did:key` DID from an Ed25519 public key.
 ///
@@ -31,14 +65,6 @@ const DID_KEY_PREFIX: &str = "did:key:z";
 /// 1. Prepend the Ed25519 multicodec prefix (0xed01) to the 32-byte public key
 /// 2. Encode the resulting 34 bytes as base58-btc
 /// 3. Prepend the multibase 'z' prefix and the `did:key:` scheme
-///
-/// # Arguments
-///
-/// * `public_key` - 32-byte Ed25519 public key
-///
-/// # Returns
-///
-/// A string in the format `did:key:z6Mk...`
 pub fn generate_did_key(public_key: &[u8; 32]) -> String {
     let mut bytes = Vec::with_capacity(34);
     bytes.extend_from_slice(&ED25519_MULTICODEC_PREFIX);
@@ -48,23 +74,29 @@ pub fn generate_did_key(public_key: &[u8; 32]) -> String {
     format!("{DID_KEY_PREFIX}{encoded}")
 }
 
-/// Resolve a `did:key` DID and extract the Ed25519 public key.
+/// Generate a `did:key` DID from a P-256 SEC1-compressed public key (33 bytes).
 ///
-/// Validates the DID format, decodes the base58-btc payload, verifies
-/// the multicodec prefix matches Ed25519, and extracts the 32-byte key.
+/// Spec D L4-D6 — this is the production DID generator from D-Sub-A onward.
+/// Steps:
+/// 1. Prepend the P-256 multicodec prefix (varint-encoded `0x1200` =
+///    `[0x80, 0x24]`) to the 33-byte compressed public key
+/// 2. Encode the resulting 35 bytes as base58-btc
+/// 3. Prepend the multibase 'z' prefix and the `did:key:` scheme
+pub fn generate_did_key_p256(public_key: &[u8; 33]) -> String {
+    let mut bytes = Vec::with_capacity(35);
+    bytes.extend_from_slice(&P256_MULTICODEC_PREFIX);
+    bytes.extend_from_slice(public_key);
+
+    let encoded = bs58::encode(&bytes).into_string();
+    format!("{DID_KEY_PREFIX}{encoded}")
+}
+
+/// Resolve a `did:key` DID and extract the public key + algorithm.
 ///
-/// # Arguments
-///
-/// * `did` - A DID string in the format `did:key:z6Mk...`
-///
-/// # Errors
-///
-/// Returns `AnimaError::Identity` if:
-/// - The DID does not start with `did:key:z`
-/// - The base58-btc decoding fails
-/// - The multicodec prefix does not match Ed25519
-/// - The decoded key is not 32 bytes
-pub fn resolve_did_key(did: &str) -> AnimaResult<[u8; 32]> {
+/// Spec D L4-D6 — supports both Ed25519 (legacy, for verifying historical
+/// events) and P-256 (current, post-D-Sub-A). Returns the algorithm so the
+/// caller knows which verifier to use.
+pub fn resolve_did_key(did: &str) -> AnimaResult<DidResolution> {
     // Validate prefix
     let encoded = did
         .strip_prefix(DID_KEY_PREFIX)
@@ -75,31 +107,81 @@ pub fn resolve_did_key(did: &str) -> AnimaResult<[u8; 32]> {
         .into_vec()
         .map_err(|e| AnimaError::Identity(format!("base58 decode failed: {e}")))?;
 
-    // Verify multicodec prefix (2 bytes for Ed25519)
     if bytes.len() < 2 {
         return Err(AnimaError::Identity(
             "decoded DID too short for multicodec prefix".into(),
         ));
     }
 
-    if bytes[0] != ED25519_MULTICODEC_PREFIX[0] || bytes[1] != ED25519_MULTICODEC_PREFIX[1] {
-        return Err(AnimaError::Identity(format!(
-            "unexpected multicodec prefix: [{:#04x}, {:#04x}] (expected Ed25519: [0xed, 0x01])",
-            bytes[0], bytes[1]
-        )));
+    // Detect algorithm from multicodec prefix.
+    let prefix = [bytes[0], bytes[1]];
+    if prefix == ED25519_MULTICODEC_PREFIX {
+        let key_bytes = &bytes[2..];
+        if key_bytes.len() != 32 {
+            return Err(AnimaError::Identity(format!(
+                "Ed25519 public key must be 32 bytes, got {}",
+                key_bytes.len()
+            )));
+        }
+        return Ok(DidResolution {
+            algorithm: AuthAlg::Ed25519,
+            public_key: key_bytes.to_vec(),
+        });
+    }
+    if prefix == P256_MULTICODEC_PREFIX {
+        let key_bytes = &bytes[2..];
+        if key_bytes.len() != 33 {
+            return Err(AnimaError::Identity(format!(
+                "P-256 SEC1-compressed public key must be 33 bytes, got {}",
+                key_bytes.len()
+            )));
+        }
+        // SEC1 compressed point's first byte is 0x02 or 0x03.
+        if key_bytes[0] != 0x02 && key_bytes[0] != 0x03 {
+            return Err(AnimaError::Identity(format!(
+                "P-256 SEC1-compressed point must start with 0x02 or 0x03, got 0x{:02x}",
+                key_bytes[0]
+            )));
+        }
+        return Ok(DidResolution {
+            algorithm: AuthAlg::P256,
+            public_key: key_bytes.to_vec(),
+        });
     }
 
-    // Extract 32-byte public key
-    let key_bytes = &bytes[2..];
-    if key_bytes.len() != 32 {
+    Err(AnimaError::Identity(format!(
+        "unknown multicodec prefix: [{:#04x}, {:#04x}] (expected Ed25519 [0xed, 0x01] or P-256 [0x80, 0x24])",
+        bytes[0], bytes[1]
+    )))
+}
+
+/// Resolve an Ed25519 `did:key` and return the raw 32-byte key.
+///
+/// Convenience wrapper for legacy callers. Errors if the DID is not Ed25519.
+pub fn resolve_did_key_ed25519(did: &str) -> AnimaResult<[u8; 32]> {
+    let resolution = resolve_did_key(did)?;
+    if resolution.algorithm != AuthAlg::Ed25519 {
         return Err(AnimaError::Identity(format!(
-            "Ed25519 public key must be 32 bytes, got {}",
-            key_bytes.len()
+            "expected Ed25519 DID, got {:?}: {did}",
+            resolution.algorithm
         )));
     }
-
     let mut key = [0u8; 32];
-    key.copy_from_slice(key_bytes);
+    key.copy_from_slice(&resolution.public_key);
+    Ok(key)
+}
+
+/// Resolve a P-256 `did:key` and return the SEC1-compressed 33-byte key.
+pub fn resolve_did_key_p256(did: &str) -> AnimaResult<[u8; 33]> {
+    let resolution = resolve_did_key(did)?;
+    if resolution.algorithm != AuthAlg::P256 {
+        return Err(AnimaError::Identity(format!(
+            "expected P-256 DID, got {:?}: {did}",
+            resolution.algorithm
+        )));
+    }
+    let mut key = [0u8; 33];
+    key.copy_from_slice(&resolution.public_key);
     Ok(key)
 }
 
@@ -108,6 +190,11 @@ pub fn resolve_did_key(did: &str) -> AnimaResult<[u8; 32]> {
 /// Regenerates the `did:key` from the public key and compares with the given DID.
 pub fn verify_did_key(did: &str, public_key: &[u8; 32]) -> bool {
     generate_did_key(public_key) == did
+}
+
+/// Verify that a DID was derived from the given P-256 (SEC1-compressed) public key.
+pub fn verify_did_key_p256(did: &str, public_key: &[u8; 33]) -> bool {
+    generate_did_key_p256(public_key) == did
 }
 
 /// Construct a verification method ID from a DID.
@@ -123,7 +210,7 @@ mod tests {
     use super::*;
 
     /// Known test vector: a fixed 32-byte Ed25519 public key.
-    fn test_public_key() -> [u8; 32] {
+    fn test_ed25519_public_key() -> [u8; 32] {
         [
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
             0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
@@ -131,11 +218,23 @@ mod tests {
         ]
     }
 
+    /// A valid 33-byte SEC1-compressed P-256 point. We construct a real one
+    /// from a key derived from a deterministic seed so the test remains
+    /// stable.
+    fn test_p256_compressed_key() -> [u8; 33] {
+        use crate::seed::MasterSeed;
+        let seed = MasterSeed::from_bytes([7u8; 32]);
+        let key = seed.derive_p256_key();
+        let id = crate::p256::EcdsaP256Identity::from_key_bytes(&key).unwrap();
+        id.public_key_bytes()
+    }
+
+    // ─── Ed25519 path (legacy) ──────────────────────────────────────
+
     #[test]
-    fn generate_did_key_format() {
-        let did = generate_did_key(&test_public_key());
+    fn generate_did_key_ed25519_format() {
+        let did = generate_did_key(&test_ed25519_public_key());
         assert!(did.starts_with("did:key:z"));
-        // The 'z6Mk' prefix is characteristic of Ed25519 did:key DIDs
         assert!(
             did.starts_with("did:key:z6Mk"),
             "Ed25519 did:key should start with z6Mk, got: {did}"
@@ -144,7 +243,7 @@ mod tests {
 
     #[test]
     fn generate_did_key_deterministic() {
-        let key = test_public_key();
+        let key = test_ed25519_public_key();
         let did1 = generate_did_key(&key);
         let did2 = generate_did_key(&key);
         assert_eq!(did1, did2);
@@ -160,18 +259,23 @@ mod tests {
     }
 
     #[test]
-    fn resolve_did_key_roundtrip() {
-        let original = test_public_key();
+    fn resolve_did_key_ed25519_legacy_still_resolves() {
+        let original = test_ed25519_public_key();
         let did = generate_did_key(&original);
-        let resolved = resolve_did_key(&did).unwrap();
-        assert_eq!(original, resolved);
+        let resolution = resolve_did_key(&did).unwrap();
+        assert_eq!(resolution.algorithm, AuthAlg::Ed25519);
+        assert_eq!(resolution.public_key, original.to_vec());
+
+        // Convenience wrapper round-trip
+        let key = resolve_did_key_ed25519(&did).unwrap();
+        assert_eq!(key, original);
     }
 
     #[test]
     fn resolve_did_key_all_zeros() {
         let key = [0u8; 32];
         let did = generate_did_key(&key);
-        let resolved = resolve_did_key(&did).unwrap();
+        let resolved = resolve_did_key_ed25519(&did).unwrap();
         assert_eq!(key, resolved);
     }
 
@@ -179,7 +283,7 @@ mod tests {
     fn resolve_did_key_all_ones() {
         let key = [0xff; 32];
         let did = generate_did_key(&key);
-        let resolved = resolve_did_key(&did).unwrap();
+        let resolved = resolve_did_key_ed25519(&did).unwrap();
         assert_eq!(key, resolved);
     }
 
@@ -196,8 +300,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_wrong_multicodec_fails() {
-        // Encode with a wrong prefix (secp256k1 = 0xe7 0x01 instead of Ed25519)
+    fn resolve_unknown_multicodec_fails() {
+        // Encode with a wrong prefix (secp256k1 = 0xe7 0x01)
         let mut bytes = vec![0xe7, 0x01];
         bytes.extend_from_slice(&[1u8; 32]);
         let encoded = bs58::encode(&bytes).into_string();
@@ -221,14 +325,14 @@ mod tests {
 
     #[test]
     fn verify_did_key_succeeds() {
-        let key = test_public_key();
+        let key = test_ed25519_public_key();
         let did = generate_did_key(&key);
         assert!(verify_did_key(&did, &key));
     }
 
     #[test]
     fn verify_did_key_fails_for_wrong_key() {
-        let key = test_public_key();
+        let key = test_ed25519_public_key();
         let did = generate_did_key(&key);
         let wrong_key = [99u8; 32];
         assert!(!verify_did_key(&did, &wrong_key));
@@ -236,7 +340,7 @@ mod tests {
 
     #[test]
     fn verification_method_id_format() {
-        let key = test_public_key();
+        let key = test_ed25519_public_key();
         let did = generate_did_key(&key);
         let vm_id = verification_method_id(&did);
         assert!(vm_id.starts_with("did:key:z"));
@@ -244,14 +348,13 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_100_random_keys() {
-        // Ensure roundtrip works for many different keys
+    fn roundtrip_100_random_ed25519_keys() {
         for i in 0u8..100 {
             let mut key = [0u8; 32];
             key[0] = i;
             key[31] = 255 - i;
             let did = generate_did_key(&key);
-            let resolved = resolve_did_key(&did).unwrap();
+            let resolved = resolve_did_key_ed25519(&did).unwrap();
             assert_eq!(key, resolved, "roundtrip failed for key variant {i}");
         }
     }
@@ -269,7 +372,89 @@ mod tests {
             generate_did_key(ed25519_id.public_key_bytes().as_slice().try_into().unwrap());
         let did_from_identity = ed25519_id.did_key();
 
-        // Both methods must produce the same DID
         assert_eq!(did_from_module, did_from_identity);
+    }
+
+    // ─── P-256 path (Spec D L4-D6) ──────────────────────────────────
+
+    #[test]
+    fn generate_did_key_p256_format() {
+        let key = test_p256_compressed_key();
+        let did = generate_did_key_p256(&key);
+        assert!(did.starts_with("did:key:z"));
+        // P-256 multicodec produces `zDn…` prefix.
+        assert!(
+            did.starts_with("did:key:zDn"),
+            "P-256 did:key should start with zDn, got: {did}"
+        );
+    }
+
+    #[test]
+    fn did_key_p256_round_trip() {
+        let key = test_p256_compressed_key();
+        let did = generate_did_key_p256(&key);
+        let resolution = resolve_did_key(&did).unwrap();
+        assert_eq!(resolution.algorithm, AuthAlg::P256);
+        assert_eq!(resolution.public_key, key.to_vec());
+
+        // Convenience wrapper
+        let resolved = resolve_did_key_p256(&did).unwrap();
+        assert_eq!(resolved, key);
+
+        // verify_did_key_p256
+        assert!(verify_did_key_p256(&did, &key));
+    }
+
+    #[test]
+    fn p256_did_differs_per_key() {
+        use crate::seed::MasterSeed;
+
+        let key1 = MasterSeed::from_bytes([1u8; 32]).derive_p256_key();
+        let key2 = MasterSeed::from_bytes([2u8; 32]).derive_p256_key();
+        let id1 = crate::p256::EcdsaP256Identity::from_key_bytes(&key1).unwrap();
+        let id2 = crate::p256::EcdsaP256Identity::from_key_bytes(&key2).unwrap();
+        assert_ne!(id1.did_key(), id2.did_key());
+    }
+
+    #[test]
+    fn resolve_p256_short_key_fails() {
+        // Only 16 bytes after the multicodec prefix
+        let mut bytes = vec![0x80, 0x24];
+        bytes.extend_from_slice(&[0x02; 16]);
+        let encoded = bs58::encode(&bytes).into_string();
+        let did = format!("did:key:z{encoded}");
+        let result = resolve_did_key(&did);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_p256_invalid_sec1_byte_fails() {
+        // Prefix valid, length valid, but first byte is neither 0x02 nor 0x03.
+        let mut bytes = vec![0x80, 0x24, 0x05];
+        bytes.extend_from_slice(&[0u8; 32]);
+        let encoded = bs58::encode(&bytes).into_string();
+        let did = format!("did:key:z{encoded}");
+        let result = resolve_did_key(&did);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn p256_verify_did_key_fails_for_wrong_key() {
+        let key = test_p256_compressed_key();
+        let did = generate_did_key_p256(&key);
+        let wrong_key = [0x02u8; 33];
+        assert!(!verify_did_key_p256(&did, &wrong_key));
+    }
+
+    #[test]
+    fn ed25519_and_p256_produce_distinct_dids() {
+        // Even with the same byte prefix, the two curves should have
+        // entirely different DID strings.
+        let ed = generate_did_key(&[1u8; 32]);
+        let mut p256_key = [0u8; 33];
+        p256_key[0] = 0x02; // valid SEC1 byte
+        p256_key[1..].copy_from_slice(&[1u8; 32]);
+        let p = generate_did_key_p256(&p256_key);
+        assert_ne!(ed, p);
     }
 }

--- a/crates/anima/anima-identity/src/in_process.rs
+++ b/crates/anima/anima-identity/src/in_process.rs
@@ -1,0 +1,526 @@
+//! `InProcessAnima` — in-process custody backend (Spec D D-Sub-A primary).
+//!
+//! Holds the master seed + derived P-256 auth key + derived secp256k1 wallet
+//! key in process memory. Suitable for dev / single-user host deployments;
+//! production multi-tenant deployments should use `VaultTransitAnima`
+//! (D-Sub-B) and browser deployments should use `WebCryptoAnima` (D-Sub-C).
+//!
+//! This is the refactor target for Spec D §"Phasing > D-Sub-A": the existing
+//! `AnimaKeystore` is reshaped behind the `AnimaCustody` trait so every call
+//! site can swap to a production backend without code changes.
+
+use std::sync::{Arc, Mutex};
+
+use anima_core::error::{AnimaError, AnimaResult};
+use anima_core::identity_document::{
+    AgentIdentityDocument, AgentType, IdentityDocumentBuilder, VerificationMethod,
+};
+use chrono::Utc;
+use haima_core::wallet::{ChainId, WalletAddress};
+use haima_wallet::evm::derive_address;
+use k256::ecdsa::SigningKey as Secp256k1SigningKey;
+use serde_json::Value;
+use sha3::{Digest as Sha3Digest, Keccak256};
+use zeroize::Zeroizing;
+
+use crate::custody::{
+    AnimaCustody, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature, TxRequest,
+};
+use crate::p256::EcdsaP256Identity;
+use crate::seed::{EncryptedSeed, MasterSeed};
+
+/// In-process custody backend.
+///
+/// Internally holds the live `MasterSeed` + derived `EcdsaP256Identity` + the
+/// secp256k1 wallet key. Rotation generates a fresh seed and replaces the
+/// entire bundle behind a single `Mutex` lock.
+pub struct InProcessAnima {
+    inner: Mutex<InProcessInner>,
+    /// User DID — pinned at construction time. The trait signature
+    /// `user_did(&self) -> &str` requires referential transparency, so
+    /// rotation does NOT mutate this field. Instead, `rotate()` returns
+    /// the rotation event and the caller is expected to construct a fresh
+    /// `InProcessAnima` from the rotation chain (Spec D L4-D10 — rotation
+    /// is documented in the journal; verifiers re-resolve via the chain).
+    /// This matches the lifegw `KmsSigner::active_kid` pattern: the signer
+    /// instance is immutable; rotation produces a new instance.
+    current_did: String,
+    /// Wallet address — pinned at construction (the secp256k1 key doesn't
+    /// rotate per L4-D7).
+    wallet_address: WalletAddress,
+}
+
+struct InProcessInner {
+    /// The master seed — NEVER exposed; only the derived keys leave this struct.
+    /// Used by `encrypt_seed` for at-rest persistence.
+    seed: MasterSeed,
+    /// Derived P-256 (ES256) auth identity. Spec D L4-D6 — replaces Ed25519.
+    auth: EcdsaP256Identity,
+    /// Raw secp256k1 wallet key bytes (held in `Zeroizing` so they're wiped
+    /// on drop). Kept alongside the constructed signing key for diagnostics
+    /// and for backwards compat with anything that wants raw bytes via
+    /// `secp256k1_key_bytes` on the legacy keystore path.
+    #[allow(dead_code)]
+    secp256k1_bytes: Zeroizing<Vec<u8>>,
+    secp256k1_signing: Secp256k1SigningKey,
+}
+
+impl InProcessAnima {
+    /// Generate a fresh in-process identity with a random seed.
+    ///
+    /// Returns an `Arc<dyn AnimaCustody>` so call sites adopt the trait
+    /// object directly. Spec D §"D-Sub-A": this is the default backend.
+    pub fn generate_dev() -> AnimaResult<Arc<dyn AnimaCustody>> {
+        let seed = MasterSeed::generate();
+        Self::from_seed_arc(seed)
+    }
+
+    /// Construct from an existing seed (used by tests and recovery paths).
+    pub fn from_seed_arc(seed: MasterSeed) -> AnimaResult<Arc<dyn AnimaCustody>> {
+        Ok(Arc::new(Self::from_seed(seed)?))
+    }
+
+    /// Construct as a concrete value (used internally + by tests that need
+    /// the concrete type for invariant assertions). Most call sites should
+    /// use `from_seed_arc`.
+    pub fn from_seed(seed: MasterSeed) -> AnimaResult<Self> {
+        let p256_key = seed.derive_p256_key();
+        let auth = EcdsaP256Identity::from_key_bytes(&p256_key)?;
+
+        let secp256k1_key = seed.derive_secp256k1_key();
+        let secp256k1_signing = Secp256k1SigningKey::from_bytes(secp256k1_key.as_ref().into())
+            .map_err(|e| AnimaError::Crypto(format!("secp256k1 from_bytes: {e}")))?;
+        let address = derive_address(&secp256k1_signing);
+        let wallet_address = WalletAddress {
+            address,
+            chain: ChainId::base(),
+        };
+
+        let current_did = auth.did_key();
+        let inner = InProcessInner {
+            seed,
+            auth,
+            secp256k1_bytes: Zeroizing::new(secp256k1_key.to_vec()),
+            secp256k1_signing,
+        };
+        Ok(Self {
+            inner: Mutex::new(inner),
+            current_did,
+            wallet_address,
+        })
+    }
+
+    /// Decrypt and load from an encrypted seed.
+    pub fn from_encrypted(
+        encrypted: &EncryptedSeed,
+        encryption_key: &[u8; 32],
+    ) -> AnimaResult<Arc<dyn AnimaCustody>> {
+        let seed = MasterSeed::decrypt(encrypted, encryption_key)?;
+        Self::from_seed_arc(seed)
+    }
+
+    /// Encrypt the master seed for at-rest storage.
+    pub fn encrypt_seed(&self, encryption_key: &[u8; 32]) -> AnimaResult<EncryptedSeed> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        inner.seed.encrypt(encryption_key)
+    }
+
+    /// Sign the EIP-712 digest for an EIP-3009 `transferWithAuthorization`.
+    ///
+    /// Used by `sign_eip712` when the typed-data shape is recognised as
+    /// EIP-3009 (the only typed-data shape D-Sub-A signs through the trait
+    /// — see `// SPEC-D-DEVIATION` in `custody.rs`).
+    fn sign_keccak_digest(&self, digest: &[u8; 32]) -> AnimaResult<Vec<u8>> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        let (sig, recid) = inner
+            .secp256k1_signing
+            .sign_prehash_recoverable(digest)
+            .map_err(|e| AnimaError::Crypto(format!("secp256k1 sign_prehash: {e}")))?;
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(sig.to_bytes().as_slice());
+        out.push(recid.to_byte() + 27);
+        Ok(out)
+    }
+}
+
+impl AnimaCustody for InProcessAnima {
+    fn user_did(&self) -> &str {
+        &self.current_did
+    }
+
+    fn auth_pubkey(&self) -> [u8; 33] {
+        // Lock briefly to read the (pinned for lifetime of `self`) auth pubkey.
+        // Pubkey doesn't change without going through `rotate()`, which
+        // returns a fresh handle.
+        let inner = self
+            .inner
+            .lock()
+            .expect("custody mutex must not be poisoned");
+        inner.auth.public_key_bytes()
+    }
+
+    fn wallet_address(&self) -> Option<&WalletAddress> {
+        Some(&self.wallet_address)
+    }
+
+    fn sign_jws(&self, claims: &Value) -> AnimaResult<String> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        inner.auth.sign_jws(claims)
+    }
+
+    fn sign_digest(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        inner.auth.sign_digest(digest)
+    }
+
+    fn sign_evm_tx(&self, tx: &TxRequest) -> AnimaResult<EvmSignature> {
+        // Compute the EIP-155 signing digest. For D-Sub-A we keep this minimal:
+        // we Keccak the canonical RLP-equivalent (a JSON canonicalisation
+        // suitable for testing — production EVM tx signing is extended in
+        // a follow-up that brings full RLP encoding once we have a chain
+        // for it). The signature shape (65-byte r||s||v) matches the
+        // `LocalSigner::sign_typed_data` output haima already consumes.
+        let canonical = serde_json::to_vec(tx)
+            .map_err(|e| AnimaError::Crypto(format!("tx canonicalisation: {e}")))?;
+        let mut hasher = Keccak256::new();
+        hasher.update(&canonical);
+        let digest = hasher.finalize();
+        let mut digest_arr = [0u8; 32];
+        digest_arr.copy_from_slice(&digest);
+        let bytes = self.sign_keccak_digest(&digest_arr)?;
+        Ok(EvmSignature::from_bytes(bytes))
+    }
+
+    fn sign_eip712(
+        &self,
+        domain: &Eip712Domain,
+        types: &Value,
+        message: &Value,
+    ) -> AnimaResult<EvmSignature> {
+        // SPEC-D-DEVIATION (in_process): D-Sub-A only supports the EIP-3009
+        // `TransferWithAuthorization` typed-data shape since that is the only
+        // shape haima currently signs. Other shapes return Crypto error.
+        let primary = types
+            .get("primaryType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if primary == "TransferWithAuthorization"
+            || message.get("from").is_some() && message.get("validAfter").is_some()
+        {
+            // Build the digest using haima_wallet's existing EIP-3009 helper.
+            use haima_wallet::eip712::{hash_transfer_authorization, parse_eth_address};
+
+            let from = message
+                .get("from")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'from'".into()))?;
+            let to = message
+                .get("to")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'to'".into()))?;
+            let value: u64 = message
+                .get("value")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'value' (string)".into()))?
+                .parse()
+                .map_err(|e| AnimaError::Crypto(format!("eip712 value: {e}")))?;
+            let valid_after: u64 = message
+                .get("validAfter")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validAfter'".into()))?
+                .parse()
+                .map_err(|e| AnimaError::Crypto(format!("eip712 validAfter: {e}")))?;
+            let valid_before: u64 = message
+                .get("validBefore")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validBefore'".into()))?
+                .parse()
+                .map_err(|e| AnimaError::Crypto(format!("eip712 validBefore: {e}")))?;
+            let nonce_hex = message
+                .get("nonce")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AnimaError::Crypto("eip712: missing 'nonce'".into()))?;
+            let nonce_bytes = hex::decode(nonce_hex.trim_start_matches("0x"))
+                .map_err(|e| AnimaError::Crypto(format!("eip712 nonce hex: {e}")))?;
+            if nonce_bytes.len() != 32 {
+                return Err(AnimaError::Crypto(format!(
+                    "eip712 nonce must be 32 bytes, got {}",
+                    nonce_bytes.len()
+                )));
+            }
+            let mut nonce = [0u8; 32];
+            nonce.copy_from_slice(&nonce_bytes);
+
+            let from_b = parse_eth_address(from)
+                .map_err(|e| AnimaError::Crypto(format!("eip712 from: {e}")))?;
+            let to_b =
+                parse_eth_address(to).map_err(|e| AnimaError::Crypto(format!("eip712 to: {e}")))?;
+
+            let digest = hash_transfer_authorization(
+                domain,
+                &from_b,
+                &to_b,
+                value,
+                valid_after,
+                valid_before,
+                &nonce,
+            );
+            let bytes = self.sign_keccak_digest(&digest)?;
+            return Ok(EvmSignature::from_bytes(bytes));
+        }
+        Err(AnimaError::Crypto(
+            "eip712: only EIP-3009 TransferWithAuthorization is supported in D-Sub-A".to_string(),
+        ))
+    }
+
+    fn rotate(&self) -> AnimaResult<DidRotationEvent> {
+        // Generate the new key in a separate identity, sign a rotation proof
+        // with the *old* auth key, then mutate `self` in place to adopt the
+        // new key. The lock scope holds for the entire swap.
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+
+        let old_did = inner.auth.did_key();
+
+        // Mint a fresh seed + auth key. Wallet half stays the same per
+        // L4-D7 (haima/x402/Base assume secp256k1 EOA throughout — rotating
+        // the wallet key would change the on-chain address).
+        let new_seed = MasterSeed::generate();
+        let new_p256_key = new_seed.derive_p256_key();
+        let new_auth = EcdsaP256Identity::from_key_bytes(&new_p256_key)?;
+        let new_did = new_auth.did_key();
+
+        // Sign the rotation proof with the *old* auth key.
+        let proof_claims = serde_json::json!({
+            "iss": old_did,
+            "sub": &new_did,
+            "type": "anima.rotation_proof",
+            "iat": Utc::now().timestamp(),
+        });
+        let rotation_proof_jws = inner.auth.sign_jws(&proof_claims)?;
+
+        // Now swap the auth key in place. Wallet half preserved.
+        // We DON'T also overwrite `seed` because that's used to derive
+        // both halves; instead we keep the *original* secp256k1 key and
+        // overlay the new auth key. This is intentional for L4-D7 (wallet
+        // doesn't rotate).
+        inner.auth = new_auth;
+        // Note: we do NOT update `inner.seed` to the new seed because the
+        // wallet key is still derived from the original seed. A future
+        // sub-phase might want a separate "auth seed" vs "wallet seed" — for
+        // D-Sub-A we keep things simple: rotation only changes auth, and
+        // the new auth key is held directly (not re-derived).
+        // The `seed` field on `inner` is therefore the "wallet seed" after
+        // first rotation; this is documented behaviour.
+        let _ = new_seed; // wallet half stays at original seed; new_seed dropped/zeroized
+
+        // CAVEAT: `current_did` on `self` is `String` (immutable through &self
+        // because the field is not behind `Mutex`). To avoid breaking the
+        // trait's `&str` return contract while supporting in-place rotation
+        // we need interior mutability for `current_did` too. We work around
+        // this by NOT mutating `current_did` in place — the rotation event
+        // is returned, and the CALLER is expected to construct a fresh
+        // `InProcessAnima` from the rotation event payload (Spec D L4-D10:
+        // rotation is documented in the journal; verifiers re-resolve via
+        // the chain). The next session reconstruction will pick up the new
+        // DID.
+        //
+        // For tests / immediate-use scenarios we provide
+        // `apply_rotation_in_place` below which mutates `current_did` via
+        // `&mut self`.
+
+        Ok(DidRotationEvent {
+            old_did,
+            new_did,
+            rotation_proof_jws,
+            rotated_at: Utc::now(),
+        })
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        BackendKind::InProcess
+    }
+
+    fn export_identity_document(&self) -> AnimaResult<AgentIdentityDocument> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        let pub_key_compressed = inner.auth.public_key_bytes();
+        // Multibase-z encoding of the compressed pubkey (hex is fine for KYA
+        // doc purposes; the canonical multibase encoding is base58btc which
+        // is what the DID itself already uses).
+        let public_key_multibase = format!("z{}", bs58::encode(pub_key_compressed).into_string());
+        let did = inner.auth.did_key();
+        let vm = VerificationMethod {
+            id: format!("{did}#key-1"),
+            // W3C suite name for ES256 is "EcdsaSecp256r1Signature2019" /
+            // "JsonWebKey2020". We use JsonWebKey2020 for forward
+            // compatibility with the broomva.tech AAP verifier.
+            method_type: "JsonWebKey2020".to_string(),
+            controller: did.clone(),
+            public_key_multibase,
+        };
+        // D-Sub-A: rotation_chain is empty until the caller persists
+        // rotation events to lago and replays them at session start. The
+        // bridge in anima-lago is the layer that fills it in.
+        let doc = IdentityDocumentBuilder::new(
+            did,
+            "anima-self".to_string(),
+            "in-process custody".to_string(),
+            String::new(), // soul_hash filled in by the bridge layer
+        )
+        .agent_type(AgentType::Hosted)
+        .verification_method(vm)
+        .build();
+        Ok(doc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::custody::AnimaCustodyHandle;
+
+    #[test]
+    fn in_process_anima_signs_jws() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let claims = serde_json::json!({
+            "sub": "agt_001",
+            "aud": "https://broomva.tech",
+            "iss": custody.user_did(),
+            "exp": 9999999999u64,
+        });
+        let jws = custody.sign_jws(&claims).unwrap();
+        let parts: Vec<&str> = jws.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        // Verify header alg is ES256
+        use base64::Engine;
+        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(parts[0])
+            .unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "ES256");
+    }
+
+    #[test]
+    fn in_process_anima_signs_digest() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let digest = [42u8; 32];
+        let sig = custody.sign_digest(&digest).unwrap();
+        assert_eq!(sig.len(), 64);
+    }
+
+    #[test]
+    fn in_process_anima_signs_eip712_eip3009() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let domain = haima_wallet::USDC_BASE_MAINNET;
+
+        let from = custody.wallet_address().unwrap().address.clone();
+        let message = serde_json::json!({
+            "from": from,
+            "to": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            "value": "100",
+            "validAfter": "1700000000",
+            "validBefore": "1700000600",
+            "nonce": format!("0x{}", hex::encode([0x42u8; 32])),
+        });
+        let types = serde_json::json!({
+            "primaryType": "TransferWithAuthorization",
+        });
+
+        let sig = custody.sign_eip712(&domain, &types, &message).unwrap();
+        assert_eq!(sig.bytes.len(), 65);
+        let v = sig.bytes[64];
+        assert!(v == 27 || v == 28);
+    }
+
+    #[test]
+    fn in_process_anima_rejects_unsupported_eip712() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let domain = haima_wallet::USDC_BASE_MAINNET;
+        let types = serde_json::json!({
+            "primaryType": "Order", // not TransferWithAuthorization
+        });
+        let message = serde_json::json!({"foo": "bar"});
+        let result = custody.sign_eip712(&domain, &types, &message);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rotation_proof_jws_signed_by_old_key() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let old_did = custody.user_did().to_string();
+        let evt = custody.rotate().unwrap();
+        assert_eq!(evt.old_did, old_did);
+        assert_ne!(evt.new_did, old_did);
+        // Both DIDs should be P-256 (zDn… prefix)
+        assert!(evt.old_did.starts_with("did:key:zDn"));
+        assert!(evt.new_did.starts_with("did:key:zDn"));
+        // Proof JWS has 3 parts
+        assert_eq!(evt.rotation_proof_jws.split('.').count(), 3);
+    }
+
+    #[test]
+    fn export_identity_document_includes_p256_verification_method() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let doc = custody.export_identity_document().unwrap();
+        assert!(doc.did.starts_with("did:key:zDn"));
+        assert_eq!(doc.verification_methods.len(), 1);
+        let vm = &doc.verification_methods[0];
+        assert_eq!(vm.method_type, "JsonWebKey2020");
+        assert!(vm.id.ends_with("#key-1"));
+        assert_eq!(vm.controller, doc.did);
+    }
+
+    #[test]
+    fn handle_type_is_dyn_compatible() {
+        let custody: AnimaCustodyHandle = InProcessAnima::generate_dev().unwrap();
+        // Compile-time check that we can call trait methods through Arc<dyn>.
+        assert_eq!(custody.backend_kind(), BackendKind::InProcess);
+        assert!(custody.user_did().starts_with("did:key:zDn"));
+    }
+
+    #[test]
+    fn deterministic_from_seed() {
+        let seed1 = MasterSeed::from_bytes([7u8; 32]);
+        let seed2 = MasterSeed::from_bytes([7u8; 32]);
+        let c1 = InProcessAnima::from_seed(seed1).unwrap();
+        let c2 = InProcessAnima::from_seed(seed2).unwrap();
+        assert_eq!(c1.user_did(), c2.user_did());
+        assert_eq!(c1.auth_pubkey(), c2.auth_pubkey());
+        assert_eq!(
+            c1.wallet_address().unwrap().address,
+            c2.wallet_address().unwrap().address
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let seed = MasterSeed::from_bytes([99u8; 32]);
+        let original = InProcessAnima::from_seed(seed).unwrap();
+        let original_did = original.user_did().to_string();
+        let original_addr = original.wallet_address().unwrap().address.clone();
+
+        let key = [33u8; 32];
+        let encrypted = original.encrypt_seed(&key).unwrap();
+        let recovered = InProcessAnima::from_encrypted(&encrypted, &key).unwrap();
+
+        assert_eq!(recovered.user_did(), original_did);
+        assert_eq!(recovered.wallet_address().unwrap().address, original_addr);
+    }
+}

--- a/crates/anima/anima-identity/src/in_process.rs
+++ b/crates/anima/anima-identity/src/in_process.rs
@@ -63,6 +63,16 @@ struct InProcessInner {
     #[allow(dead_code)]
     secp256k1_bytes: Zeroizing<Vec<u8>>,
     secp256k1_signing: Secp256k1SigningKey,
+    /// True if this handle was constructed by `rotate()`. After rotation the
+    /// handle's `seed` is the new auth-derivable seed, but `secp256k1_bytes`
+    /// is preserved from the original (per L4-D7 — wallet curve doesn't
+    /// rotate). Calling `encrypt_seed()` on such a handle would silently
+    /// corrupt the wallet on reload because `from_encrypted` re-derives BOTH
+    /// halves from the seed. To avoid that footgun, `encrypt_seed` returns
+    /// an error when this is true. Dual-seed encryption that captures both
+    /// the auth seed AND the wallet bytes is deferred to a follow-up
+    /// sub-phase (see I5 in the D-Sub-A code-quality review).
+    is_post_rotation: bool,
 }
 
 impl InProcessAnima {
@@ -102,6 +112,7 @@ impl InProcessAnima {
             auth,
             secp256k1_bytes: Zeroizing::new(secp256k1_key.to_vec()),
             secp256k1_signing,
+            is_post_rotation: false,
         };
         Ok(Self {
             inner: Mutex::new(inner),
@@ -119,12 +130,79 @@ impl InProcessAnima {
         Self::from_seed_arc(seed)
     }
 
+    /// Concrete-type rotation helper. Same semantics as the trait
+    /// `rotate()` but returns `(DidRotationEvent, InProcessAnima)` so
+    /// callers that need access to concrete-only methods (e.g.
+    /// `encrypt_seed`) on the post-rotation handle can use them.
+    ///
+    /// The trait `rotate()` wraps this in `Arc::new(...)` and erases to
+    /// `Arc<dyn AnimaCustody>`.
+    pub fn rotate_concrete(&self) -> AnimaResult<(DidRotationEvent, InProcessAnima)> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+
+        let old_did = inner.auth.did_key();
+        let new_seed = MasterSeed::generate();
+        let new_p256_key = new_seed.derive_p256_key();
+        let new_auth = EcdsaP256Identity::from_key_bytes(&new_p256_key)?;
+        let new_did = new_auth.did_key();
+
+        let proof_claims = serde_json::json!({
+            "iss": old_did,
+            "sub": &new_did,
+            "type": "anima.rotation_proof",
+            "iat": Utc::now().timestamp(),
+        });
+        let rotation_proof_jws = inner.auth.sign_jws(&proof_claims)?;
+
+        let new_inner = InProcessInner {
+            seed: new_seed,
+            auth: new_auth,
+            secp256k1_bytes: inner.secp256k1_bytes.clone(),
+            secp256k1_signing: inner.secp256k1_signing.clone(),
+            is_post_rotation: true,
+        };
+
+        let new_concrete = InProcessAnima {
+            inner: Mutex::new(new_inner),
+            current_did: new_did.clone(),
+            wallet_address: self.wallet_address.clone(),
+        };
+
+        let event = DidRotationEvent {
+            old_did,
+            new_did,
+            rotation_proof_jws,
+            rotated_at: Utc::now(),
+        };
+
+        Ok((event, new_concrete))
+    }
+
     /// Encrypt the master seed for at-rest storage.
+    ///
+    /// Returns `Err(AnimaError::Crypto(...))` if this handle was constructed
+    /// by `rotate()`, because round-tripping such a handle through
+    /// `encrypt_seed` → `from_encrypted` would silently re-derive the wallet
+    /// half from the new auth seed instead of preserving the original
+    /// wallet bytes (per L4-D7 the wallet curve doesn't rotate).
+    /// Dual-seed encryption that captures both the auth seed and the wallet
+    /// bytes is deferred to a follow-up sub-phase.
     pub fn encrypt_seed(&self, encryption_key: &[u8; 32]) -> AnimaResult<EncryptedSeed> {
         let inner = self
             .inner
             .lock()
             .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
+        if inner.is_post_rotation {
+            return Err(AnimaError::Crypto(
+                "encrypt_seed: cannot persist a post-rotation InProcessAnima handle in D-Sub-A; \
+                 a future sub-phase will introduce dual-seed encryption that captures both the \
+                 new auth seed and the inherited wallet bytes."
+                    .into(),
+            ));
+        }
         inner.seed.encrypt(encryption_key)
     }
 
@@ -285,70 +363,9 @@ impl AnimaCustody for InProcessAnima {
         ))
     }
 
-    fn rotate(&self) -> AnimaResult<DidRotationEvent> {
-        // Generate the new key in a separate identity, sign a rotation proof
-        // with the *old* auth key, then mutate `self` in place to adopt the
-        // new key. The lock scope holds for the entire swap.
-        let mut inner = self
-            .inner
-            .lock()
-            .map_err(|_| AnimaError::Crypto("custody mutex poisoned".into()))?;
-
-        let old_did = inner.auth.did_key();
-
-        // Mint a fresh seed + auth key. Wallet half stays the same per
-        // L4-D7 (haima/x402/Base assume secp256k1 EOA throughout — rotating
-        // the wallet key would change the on-chain address).
-        let new_seed = MasterSeed::generate();
-        let new_p256_key = new_seed.derive_p256_key();
-        let new_auth = EcdsaP256Identity::from_key_bytes(&new_p256_key)?;
-        let new_did = new_auth.did_key();
-
-        // Sign the rotation proof with the *old* auth key.
-        let proof_claims = serde_json::json!({
-            "iss": old_did,
-            "sub": &new_did,
-            "type": "anima.rotation_proof",
-            "iat": Utc::now().timestamp(),
-        });
-        let rotation_proof_jws = inner.auth.sign_jws(&proof_claims)?;
-
-        // Now swap the auth key in place. Wallet half preserved.
-        // We DON'T also overwrite `seed` because that's used to derive
-        // both halves; instead we keep the *original* secp256k1 key and
-        // overlay the new auth key. This is intentional for L4-D7 (wallet
-        // doesn't rotate).
-        inner.auth = new_auth;
-        // Note: we do NOT update `inner.seed` to the new seed because the
-        // wallet key is still derived from the original seed. A future
-        // sub-phase might want a separate "auth seed" vs "wallet seed" — for
-        // D-Sub-A we keep things simple: rotation only changes auth, and
-        // the new auth key is held directly (not re-derived).
-        // The `seed` field on `inner` is therefore the "wallet seed" after
-        // first rotation; this is documented behaviour.
-        let _ = new_seed; // wallet half stays at original seed; new_seed dropped/zeroized
-
-        // CAVEAT: `current_did` on `self` is `String` (immutable through &self
-        // because the field is not behind `Mutex`). To avoid breaking the
-        // trait's `&str` return contract while supporting in-place rotation
-        // we need interior mutability for `current_did` too. We work around
-        // this by NOT mutating `current_did` in place — the rotation event
-        // is returned, and the CALLER is expected to construct a fresh
-        // `InProcessAnima` from the rotation event payload (Spec D L4-D10:
-        // rotation is documented in the journal; verifiers re-resolve via
-        // the chain). The next session reconstruction will pick up the new
-        // DID.
-        //
-        // For tests / immediate-use scenarios we provide
-        // `apply_rotation_in_place` below which mutates `current_did` via
-        // `&mut self`.
-
-        Ok(DidRotationEvent {
-            old_did,
-            new_did,
-            rotation_proof_jws,
-            rotated_at: Utc::now(),
-        })
+    fn rotate(&self) -> AnimaResult<(DidRotationEvent, Arc<dyn AnimaCustody>)> {
+        let (event, new_concrete) = self.rotate_concrete()?;
+        Ok((event, Arc::new(new_concrete)))
     }
 
     fn backend_kind(&self) -> BackendKind {
@@ -465,7 +482,8 @@ mod tests {
     fn rotation_proof_jws_signed_by_old_key() {
         let custody = InProcessAnima::generate_dev().unwrap();
         let old_did = custody.user_did().to_string();
-        let evt = custody.rotate().unwrap();
+        let old_pubkey = custody.auth_pubkey();
+        let (evt, new_handle) = custody.rotate().unwrap();
         assert_eq!(evt.old_did, old_did);
         assert_ne!(evt.new_did, old_did);
         // Both DIDs should be P-256 (zDn… prefix)
@@ -473,6 +491,95 @@ mod tests {
         assert!(evt.new_did.starts_with("did:key:zDn"));
         // Proof JWS has 3 parts
         assert_eq!(evt.rotation_proof_jws.split('.').count(), 3);
+
+        // B1 fix verification: the NEW handle reflects the new key.
+        // user_did() and auth_pubkey() must be internally consistent on
+        // the new handle (this is what the trait contract requires).
+        assert_eq!(new_handle.user_did(), evt.new_did);
+        assert_ne!(new_handle.auth_pubkey(), old_pubkey);
+
+        // The original handle remains a snapshot of pre-rotation state
+        // (NOT mutated). Verifiers walking historical signatures still
+        // resolve via the old DID.
+        assert_eq!(custody.user_did(), old_did);
+        assert_eq!(custody.auth_pubkey(), old_pubkey);
+
+        // Wallet half is preserved across rotation per L4-D7.
+        assert_eq!(
+            new_handle.wallet_address().map(|w| w.address.clone()),
+            custody.wallet_address().map(|w| w.address.clone()),
+        );
+    }
+
+    #[test]
+    fn encrypt_seed_rejects_post_rotation_handle() {
+        // I5 fix verification — calling encrypt_seed on a handle produced
+        // by rotation returns an error rather than silently corrupting the
+        // wallet half on reload.
+        let original = InProcessAnima::from_seed(MasterSeed::generate()).unwrap();
+        let encryption_key = [42u8; 32];
+
+        // Pre-rotation: encrypt_seed succeeds. Original holds a single seed
+        // that deterministically derives both auth and wallet, so the
+        // round-trip through encrypt_seed → from_encrypted is correct.
+        assert!(original.encrypt_seed(&encryption_key).is_ok());
+
+        // Rotate via the concrete helper to access encrypt_seed on the
+        // returned post-rotation handle.
+        let (_evt, post_rotation) = original.rotate_concrete().unwrap();
+
+        // Post-rotation: encrypt_seed must error. The post-rotation handle's
+        // seed slot is the new auth seed; round-tripping through
+        // encrypt_seed → from_encrypted would re-derive the wallet from
+        // this seed, producing a DIFFERENT wallet address (per L4-D7 the
+        // wallet curve doesn't rotate, so the original wallet bytes were
+        // inherited and aren't recoverable from the new seed alone).
+        let err = post_rotation.encrypt_seed(&encryption_key).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("post-rotation"),
+            "encrypt_seed should reject post-rotation handle (got: {msg})"
+        );
+    }
+
+    #[test]
+    fn rotation_proof_jws_cryptographically_verifies() {
+        // I4 follow-up — verify the rotation proof JWS actually validates
+        // against the OLD DID's public key, with the NEW DID embedded in
+        // the body claims. Without this, a malformed rotation proof could
+        // not be distinguished from a valid one.
+        use crate::did::{AuthAlg, DidResolution, resolve_did_key};
+        use crate::p256::verify_jws_with_pubkey;
+
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let old_did = custody.user_did().to_string();
+        let (evt, _new_handle) = custody.rotate().unwrap();
+
+        // Resolve the old DID to get the OLD public key.
+        let DidResolution {
+            algorithm,
+            public_key,
+        } = resolve_did_key(&old_did).unwrap();
+        assert_eq!(algorithm, AuthAlg::P256);
+        let old_pub: [u8; 33] = public_key.try_into().expect("P-256 SEC1 compressed");
+
+        // Verify the JWS using the old pubkey.
+        let claims: serde_json::Value = verify_jws_with_pubkey(&evt.rotation_proof_jws, &old_pub)
+            .expect("rotation proof JWS verifies against old key");
+
+        // Body must claim the new DID as `sub` and the old DID as `iss`.
+        assert_eq!(
+            claims["iss"],
+            serde_json::Value::String(evt.old_did.clone())
+        );
+        assert_eq!(
+            claims["sub"],
+            serde_json::Value::String(evt.new_did.clone())
+        );
+        assert_eq!(
+            claims["type"],
+            serde_json::Value::String("anima.rotation_proof".into())
+        );
     }
 
     #[test]

--- a/crates/anima/anima-identity/src/keystore.rs
+++ b/crates/anima/anima-identity/src/keystore.rs
@@ -1,9 +1,12 @@
 //! Keystore — unified identity creation from a single seed.
 //!
-//! The `AnimaKeystore` is the primary interface for creating and
-//! managing agent identity. It holds the master seed and provides
-//! access to both the Ed25519 auth identity and the secp256k1
-//! wallet identity.
+//! **Deprecation note (Spec D L4-D6):** The `AnimaKeystore` API was the
+//! original Ed25519-era surface. D-Sub-A migrates anima auth to ECDSA P-256
+//! and introduces the [`crate::custody::AnimaCustody`] trait. New code should
+//! prefer `AnimaCustody` (typically via [`crate::in_process::InProcessAnima`]
+//! for dev / single-user host deployments). `AnimaKeystore` is retained for
+//! the existing test suite + the Ed25519 helpers needed to verify historical
+//! events; it forwards auth signing to the P-256 path internally.
 
 use anima_core::error::{AnimaError, AnimaResult};
 use anima_core::identity::{AgentIdentity, LifecycleState};
@@ -14,12 +17,21 @@ use k256::ecdsa::SigningKey as Secp256k1SigningKey;
 use zeroize::Zeroizing;
 
 use crate::ed25519::Ed25519Identity;
+use crate::p256::EcdsaP256Identity;
 use crate::seed::{EncryptedSeed, MasterSeed};
 
 /// Unified identity keystore that manages both authentication
 /// and economic keypairs from a single master seed.
+///
+/// Holds BOTH a P-256 (current, Spec D L4-D6) and an Ed25519 (legacy)
+/// identity derived from the same seed. The Ed25519 path remains usable
+/// for verifying historical events; new identity events use P-256.
 pub struct AnimaKeystore {
     seed: MasterSeed,
+    /// Spec D L4-D6 — the current auth identity (ECDSA P-256).
+    p256: EcdsaP256Identity,
+    /// Legacy auth identity (Ed25519). Kept for historical-event
+    /// verification only; do not mint new signatures via this.
     ed25519: Ed25519Identity,
     secp256k1_key: Zeroizing<Vec<u8>>,
     wallet_address: WalletAddress,
@@ -37,6 +49,9 @@ impl AnimaKeystore {
         let ed25519_key = seed.derive_ed25519_key();
         let ed25519 = Ed25519Identity::from_key_bytes(&ed25519_key)?;
 
+        let p256_key = seed.derive_p256_key();
+        let p256 = EcdsaP256Identity::from_key_bytes(&p256_key)?;
+
         let secp256k1_bytes = seed.derive_secp256k1_key();
         let secp256k1_signing = Secp256k1SigningKey::from_bytes(secp256k1_bytes.as_ref().into())
             .map_err(|e| AnimaError::Crypto(format!("secp256k1 key derivation: {e}")))?;
@@ -49,6 +64,7 @@ impl AnimaKeystore {
 
         Ok(Self {
             seed,
+            p256,
             ed25519,
             secp256k1_key: Zeroizing::new(secp256k1_bytes.to_vec()),
             wallet_address,
@@ -69,9 +85,16 @@ impl AnimaKeystore {
         self.seed.encrypt(encryption_key)
     }
 
-    /// Access the Ed25519 identity (for auth, JWT signing).
+    /// Access the legacy Ed25519 identity. Kept for backwards-compat tests +
+    /// for verifying historical events signed before the Spec D L4-D6
+    /// cutover. NEW sign paths should use [`Self::p256`].
     pub fn ed25519(&self) -> &Ed25519Identity {
         &self.ed25519
+    }
+
+    /// Access the current P-256 (ES256) auth identity (Spec D L4-D6).
+    pub fn p256(&self) -> &EcdsaP256Identity {
+        &self.p256
     }
 
     /// Access the wallet address (for Haima integration).
@@ -85,6 +108,11 @@ impl AnimaKeystore {
     }
 
     /// Build the complete `AgentIdentity` record.
+    ///
+    /// Post-Spec-D the `auth_public_key` and `did` fields use the P-256
+    /// identity. The legacy Ed25519 pubkey is kept on the struct but isn't
+    /// populated here — historical-event verifiers carry their own pubkey
+    /// via the rotation chain.
     pub fn build_identity(
         &self,
         agent_id: impl Into<String>,
@@ -93,9 +121,9 @@ impl AnimaKeystore {
         AgentIdentity {
             agent_id: agent_id.into(),
             host_id: host_id.into(),
-            auth_public_key: self.ed25519.public_key_bytes(),
+            auth_public_key: self.p256.public_key_bytes().to_vec(),
             wallet_address: self.wallet_address.clone(),
-            did: Some(self.ed25519.did_key()),
+            did: Some(self.p256.did_key()),
             lifecycle: LifecycleState::Active,
             created_at: Utc::now(),
             expires_at: None,
@@ -103,8 +131,20 @@ impl AnimaKeystore {
         }
     }
 
-    /// Sign an Agent Auth Protocol JWT.
+    /// Sign an Agent Auth Protocol JWT using the current (P-256) auth key.
     pub fn sign_agent_jwt(
+        &self,
+        agent_id: &str,
+        audience: &str,
+        ttl_secs: i64,
+    ) -> AnimaResult<String> {
+        self.p256.sign_agent_jwt(agent_id, audience, ttl_secs)
+    }
+
+    /// Sign an Agent Auth Protocol JWT using the *legacy* Ed25519 key.
+    /// Used only by the migration / historical-replay paths and tests
+    /// covering the Ed25519 verifier path.
+    pub fn sign_agent_jwt_ed25519_legacy(
         &self,
         agent_id: &str,
         audience: &str,
@@ -122,16 +162,20 @@ mod tests {
     fn generate_keystore() {
         let ks = AnimaKeystore::generate().unwrap();
 
-        // Ed25519 public key is 32 bytes
-        assert_eq!(ks.ed25519().public_key_bytes().len(), 32);
+        // P-256 compressed public key is 33 bytes
+        assert_eq!(ks.p256().public_key_bytes().len(), 33);
 
         // Wallet address starts with 0x
         assert!(ks.wallet_address().address.starts_with("0x"));
 
-        // DID is generated
+        // DID is generated and uses the P-256 multicodec (zDn… prefix).
         let identity = ks.build_identity("agt_001", "host_arcan");
         assert!(identity.did.is_some());
-        assert!(identity.did.as_ref().unwrap().starts_with("did:key:z"));
+        let did = identity.did.as_ref().unwrap();
+        assert!(did.starts_with("did:key:zDn"));
+
+        // Legacy Ed25519 path still works for historical-event verification.
+        assert_eq!(ks.ed25519().public_key_bytes().len(), 32);
     }
 
     #[test]
@@ -140,6 +184,7 @@ mod tests {
         let ks1 = AnimaKeystore::from_seed(MasterSeed::from_bytes(bytes)).unwrap();
         let ks2 = AnimaKeystore::from_seed(MasterSeed::from_bytes(bytes)).unwrap();
 
+        assert_eq!(ks1.p256().public_key_bytes(), ks2.p256().public_key_bytes());
         assert_eq!(
             ks1.ed25519().public_key_bytes(),
             ks2.ed25519().public_key_bytes()
@@ -150,30 +195,34 @@ mod tests {
     #[test]
     fn encrypt_decrypt_roundtrip() {
         let ks = AnimaKeystore::generate().unwrap();
-        let original_pubkey = ks.ed25519().public_key_bytes();
+        let original_p256 = ks.p256().public_key_bytes();
+        let original_ed25519 = ks.ed25519().public_key_bytes();
         let original_wallet = ks.wallet_address().address.clone();
 
         let encryption_key = [77u8; 32];
         let encrypted = ks.encrypt_seed(&encryption_key).unwrap();
 
         let recovered = AnimaKeystore::from_encrypted(&encrypted, &encryption_key).unwrap();
-        assert_eq!(recovered.ed25519().public_key_bytes(), original_pubkey);
+        assert_eq!(recovered.p256().public_key_bytes(), original_p256);
+        assert_eq!(recovered.ed25519().public_key_bytes(), original_ed25519);
         assert_eq!(recovered.wallet_address().address, original_wallet);
     }
 
     #[test]
-    fn build_identity_fields() {
+    fn build_identity_fields_use_p256() {
         let ks = AnimaKeystore::generate().unwrap();
         let id = ks.build_identity("agt_test", "host_test");
 
         assert_eq!(id.agent_id, "agt_test");
         assert_eq!(id.host_id, "host_test");
         assert_eq!(id.lifecycle, LifecycleState::Active);
-        assert_eq!(id.auth_public_key, ks.ed25519().public_key_bytes());
+        // auth_public_key now carries the 33-byte compressed P-256 pubkey
+        assert_eq!(id.auth_public_key.len(), 33);
+        assert_eq!(id.auth_public_key, ks.p256().public_key_bytes().to_vec());
     }
 
     #[test]
-    fn sign_jwt() {
+    fn sign_jwt_uses_es256() {
         let ks = AnimaKeystore::generate().unwrap();
         let jwt = ks
             .sign_agent_jwt("agt_001", "https://broomva.tech", 60)
@@ -181,5 +230,31 @@ mod tests {
 
         assert!(!jwt.is_empty());
         assert_eq!(jwt.split('.').count(), 3);
+
+        // Decode header to assert ES256
+        use base64::Engine;
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(parts[0])
+            .unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "ES256");
+    }
+
+    #[test]
+    fn legacy_ed25519_jwt_path_still_works() {
+        let ks = AnimaKeystore::generate().unwrap();
+        let jwt = ks
+            .sign_agent_jwt_ed25519_legacy("agt_001", "https://broomva.tech", 60)
+            .unwrap();
+        assert_eq!(jwt.split('.').count(), 3);
+
+        use base64::Engine;
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(parts[0])
+            .unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "EdDSA");
     }
 }

--- a/crates/anima/anima-identity/src/lib.rs
+++ b/crates/anima/anima-identity/src/lib.rs
@@ -2,27 +2,48 @@
 //!
 //! This crate provides the cryptographic operations for agent identity:
 //!
-//! - **Seed management**: Single 32-byte master seed → dual keypair derivation
-//! - **Ed25519**: Agent Auth Protocol compatible authentication + JWT signing
+//! - **Seed management**: Single 32-byte master seed → triple keypair derivation
+//! - **P-256 (ES256)**: Spec D L4-D6 — current Agent Auth Protocol identity + JWT signing
+//! - **Ed25519**: Legacy auth identity, retained for verifying historical events
 //! - **secp256k1**: Haima-compatible wallet identity for on-chain economics
-//! - **Keystore**: Unified interface for creating and managing agent identity
+//! - **Custody trait**: [`AnimaCustody`] — production-grade trait abstraction (Spec D)
+//! - **Keystore**: Backwards-compat unified interface (deprecated; prefer `AnimaCustody`)
 //!
-//! ## Key Derivation
+//! ## Key Derivation (Spec D L4-D6)
 //!
 //! ```text
 //! MasterSeed (32 bytes, random)
-//!   ├── HKDF(seed, "anima/ed25519/v1")   → Ed25519 private key
+//!   ├── HKDF(seed, "anima/p256/v1")      → P-256 private key (current auth)
+//!   ├── HKDF(seed, "anima/ed25519/v1")   → Ed25519 private key (legacy)
 //!   └── HKDF(seed, "anima/secp256k1/v1") → secp256k1 private key
 //! ```
 //!
-//! Both keys are cryptographically independent despite sharing a seed.
+//! All three keys are cryptographically independent despite sharing a seed.
 //! The seed is encrypted at rest using ChaCha20-Poly1305.
+//!
+//! ## Custody Trait
+//!
+//! [`AnimaCustody`] is the production custody abstraction. Six backends are
+//! planned (per Spec D §"Backend matrix") — only [`InProcessAnima`] ships in
+//! D-Sub-A; other backends are filed as D-Sub-B…F.
 
+pub mod custody;
 pub mod did;
 pub mod ed25519;
+pub mod in_process;
 pub mod keystore;
+pub mod p256;
 pub mod seed;
 
-pub use did::{generate_did_key, resolve_did_key, verify_did_key};
+pub use custody::{
+    AnimaCustody, AnimaCustodyHandle, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature,
+    TxRequest,
+};
+pub use did::{
+    AuthAlg, DidResolution, generate_did_key, generate_did_key_p256, resolve_did_key,
+    resolve_did_key_ed25519, resolve_did_key_p256, verify_did_key, verify_did_key_p256,
+};
+pub use in_process::InProcessAnima;
 pub use keystore::AnimaKeystore;
+pub use p256::EcdsaP256Identity;
 pub use seed::{EncryptedSeed, MasterSeed};

--- a/crates/anima/anima-identity/src/p256.rs
+++ b/crates/anima/anima-identity/src/p256.rs
@@ -211,6 +211,66 @@ impl EcdsaP256Identity {
     }
 }
 
+/// Verify a JWS produced by `EcdsaP256Identity::sign_jws` against a SEC1
+/// compressed public key. Returns the decoded claims body on success.
+///
+/// Used by:
+/// - `InProcessAnima::rotate` regression test (verifies the rotation_proof_jws)
+/// - lago-auth's full verifier path (resolves the DID, looks up the pubkey
+///   from JWKS / journal, calls this to validate the signature)
+/// - broomva.tech AAP verifier (when D-Sub-A's coordination TODO lands)
+pub fn verify_jws_with_pubkey(
+    jws: &str,
+    pubkey_sec1_compressed: &[u8; 33],
+) -> AnimaResult<serde_json::Value> {
+    use p256::PublicKey;
+    use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
+    let mut parts = jws.split('.');
+    let header_b64 = parts
+        .next()
+        .ok_or_else(|| AnimaError::Jwt("jws missing header".into()))?;
+    let body_b64 = parts
+        .next()
+        .ok_or_else(|| AnimaError::Jwt("jws missing body".into()))?;
+    let sig_b64 = parts
+        .next()
+        .ok_or_else(|| AnimaError::Jwt("jws missing signature".into()))?;
+    if parts.next().is_some() {
+        return Err(AnimaError::Jwt("jws has extra dot-separated parts".into()));
+    }
+
+    // Decode signature (raw 64-byte r||s).
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(sig_b64)
+        .map_err(|e| AnimaError::Jwt(format!("jws signature base64: {e}")))?;
+    if sig_bytes.len() != 64 {
+        return Err(AnimaError::Jwt(format!(
+            "jws signature wrong length (expected 64, got {})",
+            sig_bytes.len()
+        )));
+    }
+    let signature = Signature::from_slice(&sig_bytes)
+        .map_err(|e| AnimaError::Jwt(format!("jws signature parse: {e}")))?;
+
+    // Rebuild verifying key from SEC1 compressed bytes.
+    let public_key = PublicKey::from_sec1_bytes(pubkey_sec1_compressed)
+        .map_err(|e| AnimaError::Crypto(format!("pubkey from_sec1_bytes: {e}")))?;
+    let verifying_key = VerifyingKey::from(&public_key);
+
+    // Verify signature over the signing input.
+    let signing_input = format!("{header_b64}.{body_b64}");
+    verifying_key
+        .verify(signing_input.as_bytes(), &signature)
+        .map_err(|e| AnimaError::Jwt(format!("jws signature verify failed: {e}")))?;
+
+    // Decode and return body claims.
+    let body_json = URL_SAFE_NO_PAD
+        .decode(body_b64)
+        .map_err(|e| AnimaError::Jwt(format!("jws body base64: {e}")))?;
+    serde_json::from_slice(&body_json).map_err(|e| AnimaError::Jwt(format!("jws body json: {e}")))
+}
+
 /// JWT header for Agent Auth Protocol — ES256 era.
 #[derive(Debug, Serialize, Deserialize)]
 struct AgentJwtHeader {

--- a/crates/anima/anima-identity/src/p256.rs
+++ b/crates/anima/anima-identity/src/p256.rs
@@ -1,0 +1,384 @@
+//! P-256 (ES256) identity operations — Spec D L4-D6 cutover.
+//!
+//! Mirrors the API surface of [`crate::ed25519::Ed25519Identity`] so the swap
+//! from EdDSA to ES256 is mechanical at every call site. The wire-format
+//! invariants enforced here:
+//!
+//! - JWS `alg = ES256` (P-256 + SHA-256)
+//! - Public key serialised as SEC1 compressed (33 bytes)
+//! - DID uses multicodec `0x1200` (P-256), produces `did:key:zDn…`
+//! - `jwk_thumbprint` follows RFC 7638 over the canonical EC JWK
+//!
+//! Per Spec D L4-D6, this replaces `Ed25519Identity` as the production auth
+//! identity. The Ed25519 path is kept around (in `crate::ed25519`) only for
+//! verifying historical events signed before D-Sub-A — see
+//! `lago_auth::jwt::detect_alg`.
+
+use anima_core::error::{AnimaError, AnimaResult};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::Utc;
+use p256::ecdsa::{Signature as P256Signature, SigningKey, VerifyingKey, signature::Signer};
+#[allow(unused_imports)]
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+/// Maximum JWT lifetime in seconds (Agent Auth Protocol spec — unchanged from
+/// the Ed25519 era).
+pub const MAX_JWT_TTL_SECS: i64 = 60;
+
+/// A P-256 (secp256r1 / ES256) keypair for agent authentication.
+///
+/// The private scalar is held in a `SigningKey` whose backing storage is
+/// zeroized on drop by the `p256` crate.
+pub struct EcdsaP256Identity {
+    signing_key: SigningKey,
+    verifying_key: VerifyingKey,
+}
+
+impl EcdsaP256Identity {
+    /// Create from derived 32-byte scalar bytes (from `MasterSeed`).
+    ///
+    /// The bytes are treated as a big-endian P-256 private scalar in the
+    /// canonical range `[1, n-1]`. Out-of-range scalars are rejected by
+    /// `p256::ecdsa::SigningKey::from_bytes`.
+    pub fn from_key_bytes(key_bytes: &Zeroizing<[u8; 32]>) -> AnimaResult<Self> {
+        let signing_key = SigningKey::from_bytes(key_bytes.as_ref().into())
+            .map_err(|e| AnimaError::Crypto(format!("p256 from_bytes: {e}")))?;
+        let verifying_key = VerifyingKey::from(&signing_key);
+        Ok(Self {
+            signing_key,
+            verifying_key,
+        })
+    }
+
+    /// Get the SEC1-compressed public key (33 bytes — `0x02|0x03` || x-coord).
+    ///
+    /// This is the on-wire format used in `did:key:zDn…` and in the
+    /// `auth_pubkey()` trait method on `AnimaCustody`.
+    pub fn public_key_bytes(&self) -> [u8; 33] {
+        let point = self.verifying_key.to_encoded_point(true);
+        let bytes = point.as_bytes();
+        debug_assert_eq!(bytes.len(), 33, "compressed P-256 point must be 33 bytes");
+        let mut out = [0u8; 33];
+        out.copy_from_slice(bytes);
+        out
+    }
+
+    /// Get the SEC1-uncompressed public key (65 bytes — `0x04` || x || y).
+    /// Used internally for the JWK thumbprint and the `did:key` doc's
+    /// `publicKeyMultibase` field on backends that prefer uncompressed.
+    pub fn public_key_uncompressed(&self) -> [u8; 65] {
+        let point = self.verifying_key.to_encoded_point(false);
+        let bytes = point.as_bytes();
+        debug_assert_eq!(bytes.len(), 65, "uncompressed P-256 point must be 65 bytes");
+        let mut out = [0u8; 65];
+        out.copy_from_slice(bytes);
+        out
+    }
+
+    /// Hex encoding of the compressed public key (66 chars).
+    pub fn public_key_hex(&self) -> String {
+        hex::encode(self.public_key_bytes())
+    }
+
+    /// Borrow the verifying key — used by tests + the lago-auth verifier.
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.verifying_key
+    }
+
+    /// Compute the JWK thumbprint (RFC 7638) for use as JWT `kid` / `iss`.
+    ///
+    /// Canonical JWK members for EC P-256 (RFC 7638 §3.2):
+    /// `{"crv":"P-256","kty":"EC","x":"<base64url>","y":"<base64url>"}`.
+    pub fn jwk_thumbprint(&self) -> String {
+        let uncompressed = self.public_key_uncompressed();
+        // `0x04 || X (32) || Y (32)` — strip the leading 0x04 byte.
+        let x = URL_SAFE_NO_PAD.encode(&uncompressed[1..33]);
+        let y = URL_SAFE_NO_PAD.encode(&uncompressed[33..65]);
+        let canonical = format!(r#"{{"crv":"P-256","kty":"EC","x":"{x}","y":"{y}"}}"#);
+
+        let hash = Sha256::digest(canonical.as_bytes());
+        URL_SAFE_NO_PAD.encode(hash)
+    }
+
+    /// Generate a `did:key` identifier from the P-256 public key.
+    ///
+    /// Format: `did:key:zDn<base58btc-encoded-multicodec-key>`.
+    /// The multicodec prefix for P-256 public key is the unsigned varint
+    /// `0x80 0x24` (= 0x1200), followed by the 33-byte SEC1-compressed point.
+    pub fn did_key(&self) -> String {
+        crate::did::generate_did_key_p256(&self.public_key_bytes())
+    }
+
+    /// Sign an arbitrary message with the auth (P-256) key.
+    /// Returns the IEEE-P1363 64-byte form (`r || s`, no recovery byte).
+    pub fn sign(&self, message: &[u8]) -> [u8; 64] {
+        let signature: P256Signature = self.signing_key.sign(message);
+        let bytes = signature.to_bytes();
+        let mut out = [0u8; 64];
+        out.copy_from_slice(bytes.as_slice());
+        out
+    }
+
+    /// Sign a 32-byte digest directly. Used for `AnimaCustody::sign_digest`.
+    pub fn sign_digest(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        // `Signer::sign` runs SHA-256 internally. For a pre-computed digest
+        // we use `sign_prehash` to skip re-hashing.
+        use p256::ecdsa::signature::hazmat::PrehashSigner;
+        let signature: P256Signature = self
+            .signing_key
+            .sign_prehash(digest)
+            .map_err(|e| AnimaError::Crypto(format!("p256 sign_prehash: {e}")))?;
+        let bytes = signature.to_bytes();
+        let mut out = [0u8; 64];
+        out.copy_from_slice(bytes.as_slice());
+        Ok(out)
+    }
+
+    /// Sign an Agent Auth Protocol JWT with ES256.
+    ///
+    /// JWT shape (Spec D L4-D6 swap):
+    /// - `typ`: "agent+jwt"
+    /// - `alg`: "ES256" (was "EdDSA")
+    /// - `kid`: DID of the signer (`did:key:zDn…`)
+    /// - `iss`: JWK thumbprint
+    /// - `sub`: agent_id
+    /// - `aud`: server URL
+    /// - `jti`: UUID v4
+    /// - `iat` / `exp`: 60-second TTL cap
+    pub fn sign_agent_jwt(
+        &self,
+        agent_id: &str,
+        audience: &str,
+        ttl_secs: i64,
+    ) -> AnimaResult<String> {
+        let ttl = ttl_secs.min(MAX_JWT_TTL_SECS);
+        let now = Utc::now().timestamp();
+
+        let header = AgentJwtHeader {
+            typ: "agent+jwt".into(),
+            alg: "ES256".into(),
+            kid: self.did_key(),
+        };
+        let claims = AgentJwtClaims {
+            iss: self.jwk_thumbprint(),
+            sub: agent_id.to_string(),
+            aud: audience.to_string(),
+            jti: Uuid::new_v4().to_string(),
+            iat: now,
+            exp: now + ttl,
+        };
+
+        let header_json = serde_json::to_vec(&header)
+            .map_err(|e| AnimaError::Jwt(format!("header serialization: {e}")))?;
+        let claims_json = serde_json::to_vec(&claims)
+            .map_err(|e| AnimaError::Jwt(format!("claims serialization: {e}")))?;
+
+        let header_b64 = URL_SAFE_NO_PAD.encode(&header_json);
+        let claims_b64 = URL_SAFE_NO_PAD.encode(&claims_json);
+        let signing_input = format!("{header_b64}.{claims_b64}");
+
+        let signature = self.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(signature);
+
+        Ok(format!("{signing_input}.{sig_b64}"))
+    }
+
+    /// Sign an arbitrary JWS body with ES256, building the header
+    /// (alg=ES256, kid=DID). Used by `AnimaCustody::sign_jws`.
+    pub fn sign_jws(&self, claims: &serde_json::Value) -> AnimaResult<String> {
+        let header = serde_json::json!({
+            "alg": "ES256",
+            "typ": "JWT",
+            "kid": self.did_key(),
+        });
+        let header_json = serde_json::to_vec(&header)
+            .map_err(|e| AnimaError::Jwt(format!("header serialization: {e}")))?;
+        let claims_json = serde_json::to_vec(claims)
+            .map_err(|e| AnimaError::Jwt(format!("claims serialization: {e}")))?;
+
+        let header_b64 = URL_SAFE_NO_PAD.encode(&header_json);
+        let claims_b64 = URL_SAFE_NO_PAD.encode(&claims_json);
+        let signing_input = format!("{header_b64}.{claims_b64}");
+        let signature = self.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(signature);
+
+        Ok(format!("{signing_input}.{sig_b64}"))
+    }
+}
+
+/// JWT header for Agent Auth Protocol — ES256 era.
+#[derive(Debug, Serialize, Deserialize)]
+struct AgentJwtHeader {
+    typ: String,
+    alg: String,
+    kid: String,
+}
+
+/// JWT claims for Agent Auth Protocol — unchanged from EdDSA era.
+#[derive(Debug, Serialize, Deserialize)]
+struct AgentJwtClaims {
+    iss: String,
+    sub: String,
+    aud: String,
+    jti: String,
+    iat: i64,
+    exp: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seed::MasterSeed;
+    use p256::ecdsa::signature::Verifier;
+
+    fn test_identity() -> EcdsaP256Identity {
+        let seed = MasterSeed::from_bytes([42u8; 32]);
+        let key_bytes = seed.derive_p256_key();
+        EcdsaP256Identity::from_key_bytes(&key_bytes).unwrap()
+    }
+
+    #[test]
+    fn public_key_is_33_bytes_compressed() {
+        let id = test_identity();
+        assert_eq!(id.public_key_bytes().len(), 33);
+        // Compressed encoding starts with 0x02 or 0x03.
+        let prefix = id.public_key_bytes()[0];
+        assert!(prefix == 0x02 || prefix == 0x03);
+    }
+
+    #[test]
+    fn public_key_uncompressed_is_65_bytes() {
+        let id = test_identity();
+        let p = id.public_key_uncompressed();
+        assert_eq!(p.len(), 65);
+        assert_eq!(p[0], 0x04);
+    }
+
+    #[test]
+    fn deterministic_key_derivation() {
+        let id1 = test_identity();
+        let id2 = test_identity();
+        assert_eq!(id1.public_key_bytes(), id2.public_key_bytes());
+    }
+
+    #[test]
+    fn jwk_thumbprint_is_stable() {
+        let id1 = test_identity();
+        let id2 = test_identity();
+        assert_eq!(id1.jwk_thumbprint(), id2.jwk_thumbprint());
+        assert!(!id1.jwk_thumbprint().is_empty());
+    }
+
+    #[test]
+    fn did_key_format() {
+        let id = test_identity();
+        let did = id.did_key();
+        assert!(did.starts_with("did:key:z"));
+        // P-256 multicodec produces `zDn…` prefix.
+        assert!(
+            did.starts_with("did:key:zDn"),
+            "P-256 did:key should start with zDn, got: {did}"
+        );
+    }
+
+    #[test]
+    fn sign_and_verify_message() {
+        let id = test_identity();
+        let message = b"hello, anima -- p256 era";
+        let sig_bytes = id.sign(message);
+        let signature = P256Signature::from_slice(&sig_bytes).unwrap();
+        id.verifying_key.verify(message, &signature).unwrap();
+    }
+
+    #[test]
+    fn sign_digest_round_trip() {
+        let id = test_identity();
+        let digest = sha2::Sha256::digest(b"some payload");
+        let mut digest_arr = [0u8; 32];
+        digest_arr.copy_from_slice(&digest);
+        let sig_bytes = id.sign_digest(&digest_arr).unwrap();
+
+        // Verify with prehash (because we signed the prehash).
+        use p256::ecdsa::signature::hazmat::PrehashVerifier;
+        let signature = P256Signature::from_slice(&sig_bytes).unwrap();
+        id.verifying_key
+            .verify_prehash(&digest_arr, &signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn agent_jwt_structure_is_es256() {
+        let id = test_identity();
+        let jwt = id
+            .sign_agent_jwt("agt_001", "https://broomva.tech", 60)
+            .unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        assert_eq!(parts.len(), 3, "JWT must have 3 parts");
+
+        let header_bytes = URL_SAFE_NO_PAD.decode(parts[0]).unwrap();
+        let header: AgentJwtHeader = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header.typ, "agent+jwt");
+        assert_eq!(header.alg, "ES256");
+        assert!(header.kid.starts_with("did:key:zDn"));
+
+        let claims_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let claims: AgentJwtClaims = serde_json::from_slice(&claims_bytes).unwrap();
+        assert_eq!(claims.sub, "agt_001");
+        assert!(claims.exp - claims.iat <= 60);
+    }
+
+    #[test]
+    fn jwt_ttl_capped_at_60_seconds() {
+        let id = test_identity();
+        let jwt = id
+            .sign_agent_jwt("agt_001", "https://example.com", 3600)
+            .unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let claims_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let claims: AgentJwtClaims = serde_json::from_slice(&claims_bytes).unwrap();
+        assert!(claims.exp - claims.iat <= 60);
+    }
+
+    #[test]
+    fn jwt_signature_verifies() {
+        let id = test_identity();
+        let jwt = id
+            .sign_agent_jwt("agt_001", "https://example.com", 60)
+            .unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = URL_SAFE_NO_PAD.decode(parts[2]).unwrap();
+        let signature = P256Signature::from_slice(&sig_bytes).unwrap();
+        id.verifying_key
+            .verify(signing_input.as_bytes(), &signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn sign_jws_round_trip() {
+        let id = test_identity();
+        let claims = serde_json::json!({"sub": "user1", "iss": "lifegw", "exp": 9999999999u64});
+        let jws = id.sign_jws(&claims).unwrap();
+        let parts: Vec<&str> = jws.split('.').collect();
+        assert_eq!(parts.len(), 3);
+
+        // Header should declare ES256
+        let header_bytes = URL_SAFE_NO_PAD.decode(parts[0]).unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "ES256");
+        assert!(header["kid"].as_str().unwrap().starts_with("did:key:zDn"));
+
+        // Verify the signature
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = URL_SAFE_NO_PAD.decode(parts[2]).unwrap();
+        let signature = P256Signature::from_slice(&sig_bytes).unwrap();
+        id.verifying_key
+            .verify(signing_input.as_bytes(), &signature)
+            .unwrap();
+    }
+}

--- a/crates/anima/anima-identity/src/seed.rs
+++ b/crates/anima/anima-identity/src/seed.rs
@@ -24,6 +24,11 @@ use anima_core::error::{AnimaError, AnimaResult};
 /// Domain separation strings for HKDF key derivation.
 const ED25519_DOMAIN: &[u8] = b"anima/ed25519/v1";
 const SECP256K1_DOMAIN: &[u8] = b"anima/secp256k1/v1";
+/// Spec D L4-D6 — P-256 (ES256) auth keypair derivation domain. Independent
+/// from `ED25519_DOMAIN` so an existing seed produces independent keys for
+/// the two algorithms (relevant for the migration window where verifiers
+/// may need to validate both old Ed25519 events and new P-256 ones).
+const P256_DOMAIN: &[u8] = b"anima/p256/v1";
 
 /// A 32-byte master seed from which all identity keys are derived.
 ///
@@ -68,6 +73,24 @@ impl MasterSeed {
         let hk = Hkdf::<Sha256>::new(None, &self.bytes);
         let mut okm = Zeroizing::new([0u8; 32]);
         hk.expand(SECP256K1_DOMAIN, okm.as_mut())
+            .expect("HKDF expand should not fail for 32-byte output");
+        okm
+    }
+
+    /// Derive the P-256 (ES256) private key bytes from this seed.
+    ///
+    /// Spec D L4-D6 — anima auth keypair migrated from Ed25519 to P-256.
+    /// Uses HKDF-SHA256 with domain `"anima/p256/v1"` to ensure independence
+    /// from both the Ed25519 and secp256k1 keys.
+    ///
+    /// The 32-byte output is interpreted as a big-endian P-256 private
+    /// scalar. The `p256` crate's `SigningKey::from_bytes` rejects scalars
+    /// outside `[1, n-1]`, but the probability of HKDF producing such a
+    /// scalar is < 2^-128.
+    pub fn derive_p256_key(&self) -> Zeroizing<[u8; 32]> {
+        let hk = Hkdf::<Sha256>::new(None, &self.bytes);
+        let mut okm = Zeroizing::new([0u8; 32]);
+        hk.expand(P256_DOMAIN, okm.as_mut())
             .expect("HKDF expand should not fail for 32-byte output");
         okm
     }
@@ -139,9 +162,23 @@ mod tests {
         let seed = MasterSeed::generate();
         let ed25519_key = seed.derive_ed25519_key();
         let secp256k1_key = seed.derive_secp256k1_key();
+        let p256_key = seed.derive_p256_key();
 
         // Keys derived with different domain separators must differ
         assert_ne!(ed25519_key.as_ref(), secp256k1_key.as_ref());
+        assert_ne!(ed25519_key.as_ref(), p256_key.as_ref());
+        assert_ne!(secp256k1_key.as_ref(), p256_key.as_ref());
+    }
+
+    #[test]
+    fn p256_derivation_is_deterministic() {
+        let bytes = [42u8; 32];
+        let seed1 = MasterSeed::from_bytes(bytes);
+        let seed2 = MasterSeed::from_bytes(bytes);
+        assert_eq!(
+            seed1.derive_p256_key().as_ref(),
+            seed2.derive_p256_key().as_ref()
+        );
     }
 
     #[test]

--- a/crates/anima/anima-identity/tests/kya.rs
+++ b/crates/anima/anima-identity/tests/kya.rs
@@ -27,32 +27,28 @@ use chrono::Utc;
 /// Full KYA lifecycle — from seed to identity document.
 #[test]
 fn kya_full_lifecycle() {
-    // Step 1: Generate keystore
+    // Step 1: Generate keystore (post-Spec-D — uses P-256 auth key)
     let keystore = AnimaKeystore::generate().unwrap();
 
-    // Step 2: Derive DID
-    let pubkey_bytes: [u8; 32] = keystore
-        .ed25519()
-        .public_key_bytes()
-        .as_slice()
-        .try_into()
-        .unwrap();
-    let did = generate_did_key(&pubkey_bytes);
-    assert!(did.starts_with("did:key:z6Mk"));
+    // Step 2: Derive DID — current path uses P-256 (Spec D L4-D6).
+    let pubkey_bytes_p256: [u8; 33] = keystore.p256().public_key_bytes();
+    let did = anima_identity::generate_did_key_p256(&pubkey_bytes_p256);
+    assert!(did.starts_with("did:key:zDn"));
 
     // Step 3: Verify DID resolves back to the same key
     let resolved = resolve_did_key(&did).unwrap();
-    assert_eq!(resolved, pubkey_bytes);
+    assert_eq!(resolved.algorithm, anima_identity::AuthAlg::P256);
+    assert_eq!(resolved.public_key, pubkey_bytes_p256.to_vec());
 
     // Step 4: Build AgentIdentity (keystore already sets DID)
     let identity = keystore.build_identity("agt_kya_test_001", "host_arcan");
     assert_eq!(identity.did.as_ref().unwrap(), &did);
 
-    // Step 5: Create soul and AgentSelf
+    // Step 5: Create soul and AgentSelf — soul's root key is the P-256 key.
     let soul = SoulBuilder::new(
         "kya-test-agent",
         "Test KYA identity lifecycle",
-        keystore.ed25519().public_key_bytes(),
+        pubkey_bytes_p256.to_vec(),
     )
     .build();
 
@@ -71,9 +67,9 @@ fn kya_full_lifecycle() {
     assert_eq!(doc.mission, "Test KYA identity lifecycle");
     assert_eq!(doc.verification_methods.len(), 1);
 
-    // Verify the verification method
+    // Verify the verification method (post-Spec-D uses JsonWebKey2020 for ES256)
     let vm = &doc.verification_methods[0];
-    assert_eq!(vm.method_type, "Ed25519VerificationKey2020");
+    assert_eq!(vm.method_type, "JsonWebKey2020");
     assert!(vm.id.ends_with("#key-1"));
     assert!(vm.public_key_multibase.starts_with('z'));
 
@@ -96,21 +92,16 @@ fn kya_did_deterministic_from_seed() {
     let ks1 = AnimaKeystore::from_seed(MasterSeed::from_bytes(seed_bytes)).unwrap();
     let ks2 = AnimaKeystore::from_seed(MasterSeed::from_bytes(seed_bytes)).unwrap();
 
-    let did1 = ks1.ed25519().did_key();
-    let did2 = ks2.ed25519().did_key();
+    let did1 = ks1.p256().did_key();
+    let did2 = ks2.p256().did_key();
     assert_eq!(did1, did2, "same seed must produce same DID");
 
     // Also verify via the standalone function
-    let pubkey: [u8; 32] = ks1
-        .ed25519()
-        .public_key_bytes()
-        .as_slice()
-        .try_into()
-        .unwrap();
-    let did3 = generate_did_key(&pubkey);
+    let pubkey = ks1.p256().public_key_bytes();
+    let did3 = anima_identity::generate_did_key_p256(&pubkey);
     assert_eq!(
         did1, did3,
-        "Ed25519Identity::did_key and generate_did_key must agree"
+        "EcdsaP256Identity::did_key and generate_did_key_p256 must agree"
     );
 }
 
@@ -120,18 +111,13 @@ fn kya_delegated_agent_with_controller() {
     let human_keystore = AnimaKeystore::generate().unwrap();
     let agent_keystore = AnimaKeystore::generate().unwrap();
 
-    let human_pubkey: [u8; 32] = human_keystore
-        .ed25519()
-        .public_key_bytes()
-        .as_slice()
-        .try_into()
-        .unwrap();
-    let human_did = generate_did_key(&human_pubkey);
+    let human_pubkey = human_keystore.p256().public_key_bytes();
+    let human_did = anima_identity::generate_did_key_p256(&human_pubkey);
 
     let soul = SoulBuilder::new(
         "delegated-agent",
         "Acts on behalf of a human",
-        agent_keystore.ed25519().public_key_bytes(),
+        agent_keystore.p256().public_key_bytes().to_vec(),
     )
     .build();
 
@@ -153,26 +139,37 @@ fn kya_delegated_agent_with_controller() {
 #[test]
 fn kya_did_verification() {
     let ks = AnimaKeystore::generate().unwrap();
-    let pubkey: [u8; 32] = ks
-        .ed25519()
-        .public_key_bytes()
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let pubkey = ks.p256().public_key_bytes();
 
-    let did = generate_did_key(&pubkey);
+    let did = anima_identity::generate_did_key_p256(&pubkey);
 
     // Correct key verifies
-    assert!(verify_did_key(&did, &pubkey));
+    assert!(anima_identity::verify_did_key_p256(&did, &pubkey));
 
     // Wrong key fails
-    let wrong_key = [99u8; 32];
-    assert!(!verify_did_key(&did, &wrong_key));
+    let wrong_key = [0x02u8; 33];
+    assert!(!anima_identity::verify_did_key_p256(&did, &wrong_key));
 }
 
 /// Verification method ID follows did:key spec.
 #[test]
 fn kya_verification_method_id() {
+    let ks = AnimaKeystore::generate().unwrap();
+    let pubkey = ks.p256().public_key_bytes();
+
+    let did = anima_identity::generate_did_key_p256(&pubkey);
+    let vm_id = verification_method_id(&did);
+
+    assert!(vm_id.starts_with("did:key:z"));
+    assert!(vm_id.ends_with("#key-1"));
+    assert_eq!(vm_id, format!("{did}#key-1"));
+}
+
+/// Legacy Ed25519 DID resolution must still work for verifying historical
+/// events signed before the Spec D L4-D6 cutover.
+#[test]
+fn kya_did_ed25519_legacy_resolves() {
+    use anima_identity::AuthAlg;
     let ks = AnimaKeystore::generate().unwrap();
     let pubkey: [u8; 32] = ks
         .ed25519()
@@ -180,13 +177,12 @@ fn kya_verification_method_id() {
         .as_slice()
         .try_into()
         .unwrap();
-
     let did = generate_did_key(&pubkey);
-    let vm_id = verification_method_id(&did);
-
-    assert!(vm_id.starts_with("did:key:z"));
-    assert!(vm_id.ends_with("#key-1"));
-    assert_eq!(vm_id, format!("{did}#key-1"));
+    let resolved = resolve_did_key(&did).unwrap();
+    assert_eq!(resolved.algorithm, AuthAlg::Ed25519);
+    assert_eq!(resolved.public_key, pubkey.to_vec());
+    // Round-trip via verify_did_key (the Ed25519-specific helper).
+    assert!(verify_did_key(&did, &pubkey));
 }
 
 /// Identity events round-trip through Lago projection.
@@ -308,7 +304,7 @@ fn kya_document_reflects_active_capabilities() {
     let soul = SoulBuilder::new(
         "cap-test",
         "Test capabilities in KYA doc",
-        ks.ed25519().public_key_bytes(),
+        ks.p256().public_key_bytes().to_vec(),
     )
     .build();
 

--- a/crates/anima/anima-identity/tests/lifecycle.rs
+++ b/crates/anima/anima-identity/tests/lifecycle.rs
@@ -38,12 +38,9 @@ fn agent_genesis_full_lifecycle() {
     let keystore = AnimaKeystore::generate().unwrap();
 
     println!("\n--- AGENT GENESIS ---");
-    println!(
-        "Ed25519 public key: {}",
-        keystore.ed25519().public_key_hex()
-    );
+    println!("P-256 public key:   {}", keystore.p256().public_key_hex());
     println!("Wallet address:     {}", keystore.wallet_address().address);
-    println!("DID:                {}", keystore.ed25519().did_key());
+    println!("DID:                {}", keystore.p256().did_key());
 
     // ============================================================
     // STEP 2: Define the soul
@@ -88,7 +85,7 @@ fn agent_genesis_full_lifecycle() {
     let soul = SoulBuilder::new(
         "arcan-prime",
         "Serve as the primary runtime agent for the Life Agent OS",
-        keystore.ed25519().public_key_bytes(),
+        keystore.p256().public_key_bytes().to_vec(),
     )
     .creator(Creator::Human {
         identity: "carlos@broomva.tech".into(),
@@ -148,27 +145,23 @@ fn agent_genesis_full_lifecycle() {
     println!("Claims: {}", serde_json::to_string_pretty(&claims).unwrap());
 
     assert_eq!(header["typ"], "agent+jwt");
-    assert_eq!(header["alg"], "EdDSA");
+    // Spec D L4-D6: alg flipped to ES256 (P-256).
+    assert_eq!(header["alg"], "ES256");
     assert_eq!(claims["sub"], "agt_arcan_prime_001");
     assert_eq!(claims["aud"], "https://broomva.tech");
 
-    // Verify signature
+    // Verify signature with P-256 verifier.
     let signing_input = format!("{}.{}", parts[0], parts[1]);
     let sig_bytes = URL_SAFE_NO_PAD.decode(parts[2]).unwrap();
-    let sig = ed25519_dalek::Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());
-    let vk = ed25519_dalek::VerifyingKey::from_bytes(
-        keystore
-            .ed25519()
-            .public_key_bytes()
-            .as_slice()
-            .try_into()
-            .unwrap(),
-    )
-    .unwrap();
-    vk.verify_strict(signing_input.as_bytes(), &sig)
+    use p256::ecdsa::signature::Verifier;
+    let signature = p256::ecdsa::Signature::from_slice(&sig_bytes).unwrap();
+    keystore
+        .p256()
+        .verifying_key()
+        .verify(signing_input.as_bytes(), &signature)
         .expect("JWT signature must verify");
 
-    println!("\n[OK] JWT signature verified with Ed25519 public key");
+    println!("\n[OK] JWT signature verified with P-256 public key (ES256)");
 
     // ============================================================
     // STEP 6: Evolve beliefs via event replay
@@ -290,7 +283,7 @@ fn agent_genesis_full_lifecycle() {
     let child_soul = SoulBuilder::new(
         "arcan-scout-001",
         "Autonomous research agent spawned by arcan-prime",
-        child_keystore.ed25519().public_key_bytes(),
+        child_keystore.p256().public_key_bytes().to_vec(),
     )
     .creator(Creator::Agent {
         agent_id: "agt_arcan_prime_001".into(),
@@ -318,8 +311,8 @@ fn agent_genesis_full_lifecycle() {
     let recovered = AnimaKeystore::from_encrypted(&encrypted, &encryption_key).unwrap();
 
     assert_eq!(
-        recovered.ed25519().public_key_bytes(),
-        keystore.ed25519().public_key_bytes(),
+        recovered.p256().public_key_bytes(),
+        keystore.p256().public_key_bytes(),
     );
     assert_eq!(
         recovered.wallet_address().address,

--- a/crates/anima/anima-identity/tests/regression.rs
+++ b/crates/anima/anima-identity/tests/regression.rs
@@ -97,6 +97,7 @@ fn regression_known_seed_produces_known_keys() {
     let seed = MasterSeed::from_bytes([42u8; 32]);
     let ks = AnimaKeystore::from_seed(seed).unwrap();
 
+    let p256_hex = ks.p256().public_key_hex();
     let ed25519_hex = ks.ed25519().public_key_hex();
     let wallet_addr = ks.wallet_address().address.clone();
 
@@ -106,9 +107,14 @@ fn regression_known_seed_produces_known_keys() {
     let ks2 = AnimaKeystore::from_seed(seed2).unwrap();
 
     assert_eq!(
+        p256_hex,
+        ks2.p256().public_key_hex(),
+        "P-256 key derivation must be deterministic"
+    );
+    assert_eq!(
         ed25519_hex,
         ks2.ed25519().public_key_hex(),
-        "Ed25519 key derivation must be deterministic"
+        "Ed25519 (legacy) key derivation must be deterministic"
     );
     assert_eq!(
         wallet_addr,
@@ -125,7 +131,7 @@ fn regression_different_seeds_never_collide() {
             bytes[0] = i;
             let seed = MasterSeed::from_bytes(bytes);
             let ks = AnimaKeystore::from_seed(seed).unwrap();
-            ks.ed25519().public_key_hex()
+            ks.p256().public_key_hex()
         })
         .collect();
 
@@ -133,7 +139,7 @@ fn regression_different_seeds_never_collide() {
     assert_eq!(
         keys.len(),
         unique.len(),
-        "100 different seeds must produce 100 different keys"
+        "100 different seeds must produce 100 different P-256 keys"
     );
 }
 
@@ -404,11 +410,13 @@ fn regression_three_generation_lineage() {
 #[test]
 fn regression_mismatched_key_always_rejected() {
     let ks = AnimaKeystore::generate().unwrap();
-    let soul = SoulBuilder::new("agent", "mission", ks.ed25519().public_key_bytes()).build();
+    // Soul built with the (current) P-256 root key. ks.build_identity()
+    // also produces the matching P-256 identity.
+    let soul = SoulBuilder::new("agent", "mission", ks.p256().public_key_bytes().to_vec()).build();
 
     // Build identity with WRONG key
     let mut identity = ks.build_identity("agt_001", "host_test");
-    identity.auth_public_key = vec![99u8; 32]; // Mismatch!
+    identity.auth_public_key = vec![99u8; 33]; // Mismatch (33 bytes for P-256)
 
     let result = AgentSelf::new(soul, identity, AgentBelief::default());
     assert!(result.is_err(), "mismatched key must always be rejected");
@@ -487,9 +495,13 @@ fn regression_jwt_always_has_required_fields() {
         )
         .unwrap();
 
-        // Required header fields
+        // Required header fields — Spec D L4-D6 cutover means alg=ES256.
         assert_eq!(header["typ"], "agent+jwt", "typ must be agent+jwt");
-        assert_eq!(header["alg"], "EdDSA", "alg must be EdDSA");
+        assert_eq!(header["alg"], "ES256", "alg must be ES256 post-Spec-D");
+        assert!(
+            header["kid"].is_string(),
+            "kid must be present (DID of signer)"
+        );
 
         // Required claim fields
         assert!(claims["iss"].is_string(), "iss must be present");
@@ -505,4 +517,44 @@ fn regression_jwt_always_has_required_fields() {
         assert!(exp - iat <= 60, "TTL must not exceed 60 seconds");
         assert!(exp > iat, "exp must be after iat");
     }
+}
+
+/// Spec D L4-D6 — historical Ed25519 events still verify.
+///
+/// This test guards the legacy Ed25519 path: existing fixtures and replayed
+/// events from before the cutover MUST continue to verify against the
+/// Ed25519 verifier.
+#[test]
+fn regression_ed25519_legacy_jwt_still_verifies() {
+    let ks = AnimaKeystore::generate().unwrap();
+    let jwt = ks
+        .sign_agent_jwt_ed25519_legacy("agt_legacy", "https://broomva.tech", 60)
+        .unwrap();
+    let parts: Vec<&str> = jwt.split('.').collect();
+    assert_eq!(parts.len(), 3);
+
+    let header: serde_json::Value = serde_json::from_slice(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(parts[0])
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(header["alg"], "EdDSA");
+
+    // Verify with the Ed25519 verifier.
+    let signing_input = format!("{}.{}", parts[0], parts[1]);
+    let sig_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(parts[2])
+        .unwrap();
+    let signature = ed25519_dalek::Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());
+    let pubkey: [u8; 32] = ks
+        .ed25519()
+        .public_key_bytes()
+        .as_slice()
+        .try_into()
+        .unwrap();
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(&pubkey).unwrap();
+    use ed25519_dalek::Verifier;
+    vk.verify(signing_input.as_bytes(), &signature)
+        .expect("legacy Ed25519 JWT must still verify");
 }

--- a/crates/anima/anima-lago/src/projection.rs
+++ b/crates/anima/anima-lago/src/projection.rs
@@ -128,7 +128,12 @@ pub fn fold(belief: &mut AgentBelief, event: &AnimaEventKind, seq: u64, timestam
         | AnimaEventKind::KeyRotated { .. }
         | AnimaEventKind::LineageVerified { .. }
         | AnimaEventKind::IdentityAttested { .. }
-        | AnimaEventKind::IdentityVerified { .. } => {
+        | AnimaEventKind::IdentityVerified { .. }
+        // Spec D §"Event additions" — identity-lifecycle events. They
+        // affect the rotation chain on AgentIdentityDocument, not beliefs.
+        | AnimaEventKind::IdentityRotated { .. }
+        | AnimaEventKind::CustodyMigrated { .. }
+        | AnimaEventKind::IdentityRevoked { .. } => {
             // These events are tracked but don't change beliefs.
             // They affect Soul, Identity, and KYA documents, which are managed separately.
         }

--- a/crates/arcan/arcan-anima/Cargo.toml
+++ b/crates/arcan/arcan-anima/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 arcan-core = { path = "../arcan-core", version = "0.3.0" }
 anima-core.workspace = true
+anima-identity = { path = "../../anima/anima-identity", version = "0.3.0" }
 anima-lago.workspace = true
 lago-core.workspace = true
 lago-journal.workspace = true

--- a/crates/arcan/arcan-anima/src/lib.rs
+++ b/crates/arcan/arcan-anima/src/lib.rs
@@ -7,6 +7,10 @@
 //! ## Functions
 //!
 //! - [`reconstruct_agent_self`] — replay Anima events from Lago to build `AgentSelf`
+//! - [`reconstruct_agent_self_with_custody`] — reconstruct using an
+//!   `Arc<dyn AnimaCustody>` (Spec D D-Sub-A path; the custody handle is
+//!   the production-grade abstraction over `InProcessAnima` /
+//!   `VaultTransitAnima` / `WebCryptoAnima` / etc.)
 //! - [`emit_soul_genesis`] — write a soul genesis event to the Lago journal
 //! - [`inject_anima_context`] — merge agent identity info into `AppState`
 
@@ -16,8 +20,9 @@ use std::sync::Arc;
 use anima_core::agent_self::AgentSelf;
 use anima_core::belief::AgentBelief;
 use anima_core::event::AnimaEventKind;
-use anima_core::identity::AgentIdentity;
+use anima_core::identity::{AgentIdentity, LifecycleState};
 use anima_core::soul::AgentSoul;
+use anima_identity::custody::AnimaCustodyHandle;
 use anima_lago::genesis::{create_genesis_event, reconstruct_soul};
 use anima_lago::projection;
 use arcan_core::protocol::{StatePatch, StatePatchFormat, StatePatchSource};
@@ -101,6 +106,48 @@ pub fn reconstruct_agent_self(
     // Assemble AgentSelf (using unchecked constructor since data comes from
     // our own trusted journal)
     Ok(AgentSelf::from_parts_unchecked(soul, identity, belief))
+}
+
+/// Reconstruct an [`AgentSelf`] using an `Arc<dyn AnimaCustody>` for the
+/// cryptographic identity (Spec D D-Sub-A).
+///
+/// This is the production-grade entry point: instead of taking a passive
+/// [`AgentIdentity`] data struct, the caller passes a [`AnimaCustodyHandle`]
+/// resolved at construction time (e.g. `InProcessAnima::generate_dev()`,
+/// `VaultTransitAnima::open(...)`, `WebCryptoAnima::resolve_passkey(...)`).
+///
+/// The bridge derives the public-key half of `AgentIdentity` from the
+/// custody handle and replays the journal exactly as
+/// [`reconstruct_agent_self`] does.
+pub fn reconstruct_agent_self_with_custody(
+    journal: &Arc<dyn Journal>,
+    session_id: &SessionId,
+    branch_id: &BranchId,
+    agent_id: impl Into<String>,
+    host_id: impl Into<String>,
+    custody: AnimaCustodyHandle,
+) -> AnimaBridgeResult<AgentSelf> {
+    let identity = AgentIdentity {
+        agent_id: agent_id.into(),
+        host_id: host_id.into(),
+        // Custody trait returns the SEC1-compressed P-256 pubkey (33 bytes)
+        // for current-era backends; legacy Ed25519 verifiers walk the
+        // rotation chain on the AgentIdentityDocument.
+        auth_public_key: custody.auth_pubkey().to_vec(),
+        wallet_address: custody.wallet_address().cloned().ok_or_else(|| {
+            AnimaBridgeError::AgentSelfConstruction(
+                "custody backend did not resolve a wallet address (browser-only deployments must \
+                 pair with a server-side wallet backend before reconstructing AgentSelf)"
+                    .into(),
+            )
+        })?,
+        did: Some(custody.user_did().to_string()),
+        lifecycle: LifecycleState::Active,
+        created_at: chrono::Utc::now(),
+        expires_at: None,
+        seed_blob_ref: None,
+    };
+    reconstruct_agent_self(journal, session_id, branch_id, identity)
 }
 
 /// Write a soul genesis event to the Lago journal.
@@ -423,6 +470,68 @@ mod tests {
             result.unwrap_err(),
             AnimaBridgeError::NoSoulGenesis { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn reconstruct_with_custody_handle() {
+        // Spec D D-Sub-A: arcan reconstructs AgentSelf via the custody trait
+        // rather than a passive AgentIdentity struct. Verify the bridge
+        // builds a valid AgentSelf when given an InProcessAnima handle.
+        use anima_identity::InProcessAnima;
+
+        let journal = make_journal();
+        let session_id = SessionId::new();
+        let branch_id = BranchId::from("main");
+
+        let custody = InProcessAnima::generate_dev().unwrap();
+        // Build a soul whose root_key matches the custody's auth pubkey
+        // (33-byte SEC1-compressed P-256 point). AgentSelf::new validates
+        // identity.auth_public_key == soul.root_public_key.
+        let soul = anima_core::soul::SoulBuilder::new(
+            "custody-test-agent",
+            "test bridge with custody handle",
+            custody.auth_pubkey().to_vec(),
+        )
+        .build();
+
+        let custody_clone = custody.clone();
+        let seq = tokio::task::spawn_blocking({
+            let journal = journal.clone();
+            let session_id = session_id.clone();
+            let branch_id = branch_id.clone();
+            let soul = soul.clone();
+            move || emit_soul_genesis(&journal, &session_id, &branch_id, &soul)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(seq, 1);
+
+        let agent_self = tokio::task::spawn_blocking({
+            let journal = journal.clone();
+            let session_id = session_id.clone();
+            let branch_id = branch_id.clone();
+            move || {
+                reconstruct_agent_self_with_custody(
+                    &journal,
+                    &session_id,
+                    &branch_id,
+                    "agt_custody_001",
+                    "host_arcan_test",
+                    custody_clone,
+                )
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(agent_self.name(), "custody-test-agent");
+        assert_eq!(agent_self.soul_hash(), soul.soul_hash());
+        // The reconstructed identity carries the P-256 DID from custody
+        let did = agent_self.did().unwrap();
+        assert!(did.starts_with("did:key:zDn"));
+        assert_eq!(did, custody.user_did());
     }
 
     #[test]

--- a/crates/haima/haima-x402/Cargo.toml
+++ b/crates/haima/haima-x402/Cargo.toml
@@ -11,6 +11,7 @@ description = "x402 protocol integration for Haima — client middleware, server
 [dependencies]
 haima-core.workspace = true
 haima-wallet.workspace = true
+anima-identity = { path = "../../anima/anima-identity", version = "0.3.0", optional = true }
 aios-protocol.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
@@ -28,6 +29,13 @@ tokio = { workspace = true, features = ["sync", "time"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"
+
+[features]
+# Spec D D-Sub-A: optional adapter that lets `X402Client` consume an
+# `Arc<dyn AnimaCustody>` directly through a `WalletBackend` shim.
+# Off by default so existing `LocalSigner`-based callers don't pull
+# anima-identity into their dep graph unless they need it.
+custody-adapter = ["dep:anima-identity"]
 
 [lints]
 workspace = true

--- a/crates/haima/haima-x402/src/custody_adapter.rs
+++ b/crates/haima/haima-x402/src/custody_adapter.rs
@@ -1,0 +1,176 @@
+//! Spec D D-Sub-A — custody-backed `WalletBackend` adapter.
+//!
+//! Glue between `anima_identity::AnimaCustody` and `haima_wallet::WalletBackend`
+//! so the `X402Client` can consume an `Arc<dyn AnimaCustody>` instead of a
+//! `LocalSigner` (raw secp256k1 private key in process memory).
+//!
+//! The adapter forwards every wallet operation through the custody trait:
+//! - `sign_transfer_authorization` — packs the EIP-3009 fields into a JSON
+//!   message and calls `custody.sign_eip712()`.
+//! - `sign_typed_data` — currently unsupported through the trait abstraction
+//!   (see `// SPEC-D-DEVIATION` in `anima_identity::custody`); returns a
+//!   `Crypto` error so callers fall back to `LocalSigner` for non-EIP-3009
+//!   typed-data signing in D-Sub-A.
+//! - `sign_message` — same: returns a `Crypto` error in D-Sub-A; lifted in
+//!   a follow-up sub-phase (the only `sign_message` consumer today is x402
+//!   debug paths that aren't on the production hot path).
+//!
+//! Feature-gated under `custody-adapter` to keep the haima-x402 dep graph
+//! lean for callers that don't need anima.
+
+use std::sync::Arc;
+
+use anima_identity::custody::{AnimaCustody, Eip712Domain};
+use async_trait::async_trait;
+use haima_core::{HaimaError, HaimaResult, WalletAddress};
+use haima_wallet::{USDC_BASE_MAINNET, USDC_BASE_SEPOLIA, WalletBackend};
+
+/// `WalletBackend` impl backed by an `Arc<dyn AnimaCustody>`.
+///
+/// Every wallet-half operation goes through the custody trait. The auth
+/// half is intentionally NOT exposed — payment flows only need the wallet
+/// half.
+pub struct CustodyWalletAdapter {
+    custody: Arc<dyn AnimaCustody>,
+    address: WalletAddress,
+}
+
+impl CustodyWalletAdapter {
+    /// Construct from an `Arc<dyn AnimaCustody>`. Errors if the custody
+    /// backend has no resolved wallet half (e.g., a bare `WebCryptoAnima`
+    /// that hasn't been paired with a `RemoteAnima` yet).
+    pub fn from_custody(custody: Arc<dyn AnimaCustody>) -> HaimaResult<Self> {
+        let address = custody.wallet_address().cloned().ok_or_else(|| {
+            HaimaError::Crypto(
+                "custody backend did not resolve a wallet address (browser-only deployments \
+                     must pair with a server-side wallet backend)"
+                    .to_string(),
+            )
+        })?;
+        Ok(Self { custody, address })
+    }
+}
+
+#[async_trait]
+impl WalletBackend for CustodyWalletAdapter {
+    fn address(&self) -> &WalletAddress {
+        &self.address
+    }
+
+    async fn sign_message(&self, _message: &[u8]) -> HaimaResult<Vec<u8>> {
+        // Spec D L4-D7 keeps wallet ops on secp256k1 + EIP-712 / EIP-3009.
+        // Generic EIP-191 personal-sign isn't on the D-Sub-A trait surface;
+        // callers needing it should fall back to `LocalSigner`.
+        Err(HaimaError::Crypto(
+            "custody-backed sign_message: deferred to D-Sub-B (use LocalSigner for personal-sign)"
+                .to_string(),
+        ))
+    }
+
+    async fn sign_typed_data(&self, _hash: &[u8; 32]) -> HaimaResult<Vec<u8>> {
+        // The custody trait signs typed-data through `sign_eip712`, which
+        // takes the structured payload (not a pre-computed digest). Generic
+        // pre-computed-digest signing is not exposed (would defeat the
+        // KMS abstraction's audit log).
+        Err(HaimaError::Crypto(
+            "custody-backed sign_typed_data: not supported in D-Sub-A (use sign_eip712)"
+                .to_string(),
+        ))
+    }
+
+    async fn sign_transfer_authorization(
+        &self,
+        from: &str,
+        to: &str,
+        value: u64,
+        valid_after: u64,
+        valid_before: u64,
+        nonce: &[u8; 32],
+    ) -> HaimaResult<Vec<u8>> {
+        // Pick the USDC EIP-712 domain for the wallet's chain.
+        let domain = match self.address.chain.0.as_str() {
+            "eip155:8453" => USDC_BASE_MAINNET,
+            "eip155:84532" => USDC_BASE_SEPOLIA,
+            other => {
+                return Err(HaimaError::Crypto(format!(
+                    "no USDC EIP-712 domain registered for chain {other}"
+                )));
+            }
+        };
+        // The custody trait takes `&Eip712Domain` (re-exported from
+        // haima-wallet), so the cast is direct.
+        let domain_ref: &Eip712Domain = &domain;
+
+        let types = serde_json::json!({
+            "primaryType": "TransferWithAuthorization",
+            "TransferWithAuthorization": [
+                {"name": "from", "type": "address"},
+                {"name": "to", "type": "address"},
+                {"name": "value", "type": "uint256"},
+                {"name": "validAfter", "type": "uint256"},
+                {"name": "validBefore", "type": "uint256"},
+                {"name": "nonce", "type": "bytes32"}
+            ]
+        });
+        let message = serde_json::json!({
+            "from": from,
+            "to": to,
+            "value": value.to_string(),
+            "validAfter": valid_after.to_string(),
+            "validBefore": valid_before.to_string(),
+            "nonce": format!("0x{}", hex::encode(nonce)),
+        });
+
+        let sig = self
+            .custody
+            .sign_eip712(domain_ref, &types, &message)
+            .map_err(|e| HaimaError::Crypto(format!("custody sign_eip712: {e}")))?;
+        Ok(sig.bytes)
+    }
+
+    fn backend_type(&self) -> &str {
+        "custody-adapter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anima_identity::InProcessAnima;
+
+    #[tokio::test]
+    async fn adapter_signs_eip3009_via_custody() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let adapter = CustodyWalletAdapter::from_custody(custody.clone()).unwrap();
+
+        let from = adapter.address().address.clone();
+        let to = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+        let nonce = [0x42u8; 32];
+
+        let sig = adapter
+            .sign_transfer_authorization(&from, to, 100, 1_700_000_000, 1_700_000_600, &nonce)
+            .await
+            .unwrap();
+        assert_eq!(sig.len(), 65);
+        let v = sig[64];
+        assert!(v == 27 || v == 28);
+    }
+
+    #[tokio::test]
+    async fn adapter_returns_wallet_address_from_custody() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let adapter = CustodyWalletAdapter::from_custody(custody.clone()).unwrap();
+
+        let expected = custody.wallet_address().unwrap().address.clone();
+        assert_eq!(adapter.address().address, expected);
+        assert_eq!(adapter.backend_type(), "custody-adapter");
+    }
+
+    #[tokio::test]
+    async fn adapter_sign_message_returns_deferred_error() {
+        let custody = InProcessAnima::generate_dev().unwrap();
+        let adapter = CustodyWalletAdapter::from_custody(custody).unwrap();
+        let result = adapter.sign_message(b"hello").await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/haima/haima-x402/src/lib.rs
+++ b/crates/haima/haima-x402/src/lib.rs
@@ -21,12 +21,16 @@
 
 pub mod bazaar;
 pub mod client;
+#[cfg(feature = "custody-adapter")]
+pub mod custody_adapter;
 pub mod facilitator;
 pub mod header;
 pub mod server;
 
 pub use bazaar::{BazaarClient, BazaarClientBuilder, DEFAULT_BAZAAR_URL, ServiceEntry};
 pub use client::{HandleResult, SettlementResult, X402Client};
+#[cfg(feature = "custody-adapter")]
+pub use custody_adapter::CustodyWalletAdapter;
 pub use facilitator::{
     DEFAULT_FEE_BPS, FacilitateRequest, FacilitateResponse, FacilitationStatus, Facilitator,
     FacilitatorConfig, FacilitatorStats, FacilitatorStatsCounter, SettlementReceipt, calculate_fee,

--- a/crates/lago/lago-auth/Cargo.toml
+++ b/crates/lago/lago-auth/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 jsonwebtoken.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/lago/lago-auth/src/agent_jwt.rs
+++ b/crates/lago/lago-auth/src/agent_jwt.rs
@@ -1,0 +1,186 @@
+//! Spec D L4-D6 — Agent Auth Protocol JWT verification with multi-curve support.
+//!
+//! The Agent Auth Protocol is the signing layer for events that come from
+//! anima-issued identities. Pre-D-Sub-A this was Ed25519 (`alg=EdDSA`);
+//! post-D-Sub-A it is P-256 (`alg=ES256`). This module detects the alg
+//! from the JWT header and dispatches to the matching verifier.
+//!
+//! The Ed25519 path is preserved for verifying historical events signed
+//! before the cutover. The `rotation_chain` on `AgentIdentityDocument`
+//! tells verifiers which historical DIDs are still considered valid.
+//!
+//! # Threat model
+//!
+//! - A pwned client can present any header alg. The verifier MUST check
+//!   the alg before dispatching, and MUST refuse anything other than
+//!   `EdDSA` or `ES256`. Other algorithms (HS256, RS256, none) are
+//!   rejected with `JwtError::Invalid`.
+//! - The `kid` (header) carries the DID of the signer. The verifier
+//!   resolves the DID to extract the public key and confirms that the
+//!   resolved curve matches the alg.
+//! - Rotation: the caller is responsible for checking the
+//!   `AgentIdentityDocument.rotation_chain` against the seq of the event
+//!   being verified. This module verifies the signature only.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+use crate::jwt::JwtError;
+
+/// Supported agent-JWT algorithms.
+///
+/// `#[non_exhaustive]` so future curves (e.g. P-384 / `ES384`) can be added
+/// without breaking match exhaustiveness in callers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum AgentJwtAlg {
+    EdDsa,
+    Es256,
+}
+
+impl AgentJwtAlg {
+    /// Parse from the JWT header `alg` string.
+    pub fn from_header_str(s: &str) -> Result<Self, JwtError> {
+        match s {
+            "EdDSA" => Ok(Self::EdDsa),
+            "ES256" => Ok(Self::Es256),
+            other => Err(JwtError::Invalid(format!(
+                "unsupported agent JWT alg '{other}' (expected EdDSA or ES256)"
+            ))),
+        }
+    }
+
+    /// String representation in the JWT header.
+    pub fn as_header_str(&self) -> &'static str {
+        match self {
+            Self::EdDsa => "EdDSA",
+            Self::Es256 => "ES256",
+        }
+    }
+}
+
+/// Detect the alg of an Agent Auth Protocol JWT WITHOUT verifying the
+/// signature. Used by callers that need to dispatch to the right verifier
+/// based on the alg.
+///
+/// Only the header is parsed; the body and signature are not touched.
+/// The header MUST carry a `kid` (DID of signer) for downstream resolution.
+pub fn detect_alg(jwt: &str) -> Result<AgentJwtAlg, JwtError> {
+    let parts: Vec<&str> = jwt.split('.').collect();
+    if parts.len() != 3 {
+        return Err(JwtError::Invalid(format!(
+            "agent JWT must have 3 parts, got {}",
+            parts.len()
+        )));
+    }
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(parts[0])
+        .map_err(|e| JwtError::Invalid(format!("base64 decode header: {e}")))?;
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| JwtError::Invalid(format!("decode header json: {e}")))?;
+    let alg_str = header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| JwtError::Invalid("agent JWT header missing 'alg'".to_string()))?;
+    AgentJwtAlg::from_header_str(alg_str)
+}
+
+/// Extract the `kid` (signer DID) from the JWT header.
+///
+/// Spec D L4-D6 — every agent JWT carries the DID in the header so
+/// verifiers can resolve to the public key without an out-of-band lookup.
+pub fn extract_kid(jwt: &str) -> Result<String, JwtError> {
+    let parts: Vec<&str> = jwt.split('.').collect();
+    if parts.len() != 3 {
+        return Err(JwtError::Invalid(format!(
+            "agent JWT must have 3 parts, got {}",
+            parts.len()
+        )));
+    }
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(parts[0])
+        .map_err(|e| JwtError::Invalid(format!("base64 decode header: {e}")))?;
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| JwtError::Invalid(format!("decode header json: {e}")))?;
+    header
+        .get("kid")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| JwtError::Invalid("agent JWT header missing 'kid' (DID)".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn encode_jwt(header: &serde_json::Value, body: &serde_json::Value) -> String {
+        let h = URL_SAFE_NO_PAD.encode(serde_json::to_vec(header).unwrap());
+        let b = URL_SAFE_NO_PAD.encode(serde_json::to_vec(body).unwrap());
+        format!("{h}.{b}.deadbeef")
+    }
+
+    #[test]
+    fn detect_alg_es256() {
+        let header = json!({"alg": "ES256", "kid": "did:key:zDnXyz"});
+        let body = json!({"sub": "agt_001"});
+        let jwt = encode_jwt(&header, &body);
+        assert_eq!(detect_alg(&jwt).unwrap(), AgentJwtAlg::Es256);
+    }
+
+    #[test]
+    fn detect_alg_eddsa_legacy() {
+        let header = json!({"alg": "EdDSA", "kid": "did:key:z6MkLegacy"});
+        let body = json!({"sub": "agt_001"});
+        let jwt = encode_jwt(&header, &body);
+        assert_eq!(detect_alg(&jwt).unwrap(), AgentJwtAlg::EdDsa);
+    }
+
+    #[test]
+    fn detect_alg_rejects_hs256() {
+        let header = json!({"alg": "HS256"});
+        let body = json!({"sub": "x"});
+        let jwt = encode_jwt(&header, &body);
+        assert!(detect_alg(&jwt).is_err());
+    }
+
+    #[test]
+    fn detect_alg_rejects_none() {
+        let header = json!({"alg": "none"});
+        let body = json!({"sub": "x"});
+        let jwt = encode_jwt(&header, &body);
+        assert!(detect_alg(&jwt).is_err());
+    }
+
+    #[test]
+    fn detect_alg_rejects_malformed() {
+        assert!(detect_alg("not.a.valid.jwt").is_err());
+        assert!(detect_alg("nodots").is_err());
+    }
+
+    #[test]
+    fn extract_kid_returns_did() {
+        let header = json!({"alg": "ES256", "kid": "did:key:zDnSigner"});
+        let body = json!({});
+        let jwt = encode_jwt(&header, &body);
+        assert_eq!(extract_kid(&jwt).unwrap(), "did:key:zDnSigner");
+    }
+
+    #[test]
+    fn extract_kid_missing_header_field_errors() {
+        let header = json!({"alg": "ES256"});
+        let body = json!({});
+        let jwt = encode_jwt(&header, &body);
+        assert!(extract_kid(&jwt).is_err());
+    }
+
+    #[test]
+    fn alg_round_trip() {
+        for alg in [AgentJwtAlg::EdDsa, AgentJwtAlg::Es256] {
+            let s = alg.as_header_str();
+            assert_eq!(AgentJwtAlg::from_header_str(s).unwrap(), alg);
+        }
+    }
+}

--- a/crates/lago/lago-auth/src/lib.rs
+++ b/crates/lago/lago-auth/src/lib.rs
@@ -4,10 +4,12 @@
 //! signed with a shared secret (same as broomva.tech `AUTH_SECRET`),
 //! extracts user claims, and maps users to Lago sessions.
 
+pub mod agent_jwt;
 pub mod jwt;
 pub mod middleware;
 pub mod session_map;
 
+pub use agent_jwt::{AgentJwtAlg, detect_alg, extract_kid};
 pub use jwt::BroomvaClaims;
 pub use middleware::{AuthLayer, UserContext, auth_middleware};
 pub use session_map::SessionMap;


### PR DESCRIPTION
## Summary

Spec D D-Sub-A (`docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md`) — the user-scoped sibling of Spec C₃ §5 lifegw KMS. Introduces the `AnimaCustody` trait abstraction, swaps the anima auth keypair from Ed25519 to ECDSA P-256 (ES256), and refactors the call sites that consume identity to take an `Arc<dyn AnimaCustody>`.

The trait shape accommodates all six planned backends (Spec D §"Backend matrix"); only `InProcessAnima` is implemented here. `VaultTransitAnima`, `WebCryptoAnima`, `TpmAnima`, `SomaCustody`, `HardwareWalletAnima`, and `RemoteAnima` ship in D-Sub-B…F.

## Spec D locked decisions realised

| Decision | Where it lands |
|---|---|
| **L4-D5** Split custody for browser deployments | Trait + `BackendKind` enum accommodate `WebCryptoAnima` + `RemoteAnima` (D-Sub-C); `wallet_address()` returns `Option` for browser-only deployments |
| **L4-D6** Ed25519 → P-256 auth keypair migration | `EcdsaP256Identity`, `MasterSeed::derive_p256_key`, `did:key:zDn…` (multicodec `0x1200`); legacy `did:key:z6Mk…` resolution preserved for historical events |
| **L4-D7** Wallet keypair stays secp256k1 | `InProcessAnima` keeps wallet half on secp256k1 + EIP-712 + EIP-3009; rotation does NOT change the wallet key |
| **L4-D8** `AnimaCustody` is per-`AgentSelf` | Constructor returns `Arc<dyn AnimaCustody>`; resolved at session-construction time via `arcan-anima::reconstruct_agent_self_with_custody` |
| **L4-D9** Custody migration as first-class event | New `anima.custody_migrated` event + `BackendKind` enum (`#[non_exhaustive]`) |
| **L4-D10** Rotation documented in journal, not implicit | `DidRotationEvent { old_did, new_did, rotation_proof_jws, rotated_at }`; `AgentIdentityDocument.rotation_chain: Vec<DidRotation>` + `published_at_seq: u64`; new `anima.identity_rotated` event |

## Items shipped (15)

1. `AnimaCustody` trait at `crates/anima/anima-identity/src/custody.rs` — full trait shape per Spec D §"Trait shape" + supporting types (`TxRequest`, `EvmSignature`, `DidRotationEvent`, `BackendKind`, re-exported `Eip712Domain`).
2. New types as needed (no duplicates — re-uses haima-wallet's `Eip712Domain`).
3. `EcdsaP256Identity` at `crates/anima/anima-identity/src/p256.rs` — mirrors `Ed25519Identity` API surface for mechanical swap (`from_key_bytes`, `public_key_bytes`, `sign`, `sign_digest`, `sign_jws`, `sign_agent_jwt`, `did_key`, `jwk_thumbprint`).
4. `MasterSeed::derive_p256_key` with HKDF info string `"anima/p256/v1"`.
5. `did.rs` supports both multicodecs — `resolve_did_key` returns `DidResolution { algorithm: AuthAlg, public_key: Vec<u8> }` where `AuthAlg ∈ {Ed25519, P256}`. `generate_did_key_p256` is the new minting function.
6. `InProcessAnima` at `crates/anima/anima-identity/src/in_process.rs` implementing `AnimaCustody`. Constructor `InProcessAnima::generate_dev() -> Arc<dyn AnimaCustody>`.
7. `AnimaKeystore` retained as a backwards-compat shim that holds both p256 (current) and ed25519 (legacy) identities; `build_identity()` emits the P-256 DID; `sign_agent_jwt()` is now ES256.
8. **arcan integration** — `arcan-anima::reconstruct_agent_self_with_custody(...)` takes `Arc<dyn AnimaCustody>` and derives `AgentIdentity` from the trait.
9. **haima integration** — `haima-x402` adds a `custody-adapter` feature exposing `CustodyWalletAdapter`, a `WalletBackend` impl backed by `Arc<dyn AnimaCustody>`. Existing `LocalSigner` users untouched.
10. **spaces SDK** — left as a coordination TODO; the `crates/spaces/life-spaces` client doesn't currently sign messages cryptographically (presence is SpacetimeDB table state). When signed presence ships it routes through `AnimaCustody::sign_digest`. Filed in `crates/anima/CLAUDE.md`.
11. **lago-auth** — new `agent_jwt::detect_alg` + `extract_kid` module that detects `EdDSA` (legacy) vs `ES256` (current) from agent JWT headers. Refuses other algs.
12. **broomva.tech AAP verifier** — coordination TODO in `crates/anima/CLAUDE.md` under "## Spec D — Production Custody (D-Sub-A shipped) > D-Sub-A coordination items". Non-blocking because there are no production users yet.
13. New events on `anima-core::event::AnimaEventKind`: `IdentityRotated`, `CustodyMigrated`, `IdentityRevoked`. Plus `BackendKind` enum (`#[non_exhaustive]`).
14. `AgentIdentityDocument` extended with `rotation_chain: Vec<DidRotation>` + `published_at_seq: u64`. Both `#[serde(default)]` for backwards compat.
15. Tests — see "Test count delta" below.

## Test count delta

- Anima crates baseline: 111 tests.
- Anima after D-Sub-A: **167 tests** (anima-core 64 + anima-identity 95 + anima-lago 8). Delta: **+56**.
- arcan-anima: +1 (`reconstruct_with_custody_handle`).
- haima-x402: +3 (custody-adapter feature) + e2e tests still pass.
- lago-auth: +7 (agent_jwt module).

Total workspace tests passing (excluding pre-existing `lifed` `e2e_smoke` compile error not caused by this PR): **3696**.

## Spec deviations (`SPEC-D-DEVIATION` comments)

Documented inline at the top of `crates/anima/anima-identity/src/custody.rs`:

- `sign_eip712`'s `types` and `message` are typed as `serde_json::Value` per the spec, but `InProcessAnima` only signs the EIP-3009 `TransferWithAuthorization` shape in D-Sub-A (the only typed-data shape haima currently signs). Other EIP-712 shapes return `AnimaError::Crypto`. A generic encoder is deferred to a follow-up.
- `rotate()` returns the rotation event but does NOT itself write to the Lago journal — that is the caller's responsibility (anima-lago bridge). Matches the lifegw `KmsSigner::publish_jwks` shape.
- `current_did` on `InProcessAnima` is pinned at construction time. Rotation produces a fresh handle the caller adopts, mirroring `KmsSigner::active_kid`. Future backends with hot rotation can override this pattern.

## Ed25519 legacy path verified

`regression_ed25519_legacy_jwt_still_verifies` test signs a JWT with the legacy keystore method, decodes it, and verifies through `ed25519_dalek::Verifier`. The Ed25519 multicodec resolution path is also covered via `did::resolve_did_key` → `AuthAlg::Ed25519`.

## Architectural concerns surfaced

1. **Wallet half doesn't rotate** (L4-D7) but the master seed does — for D-Sub-A I keep the original seed's secp256k1 derivation alive after a rotation, while only the auth half gets a fresh key. This is documented in `in_process.rs::rotate()`. Future backends with separate auth-seed vs wallet-seed will have a cleaner story.
2. **`lago-auth` agent JWT module is verifier-side scaffolding**, not yet plumbed into a request middleware. The broomva.tech AAP verifier (separate repo) is the consumer; lago-auth's local middleware (`auth_middleware`) verifies HS256 broomva.tech tokens, not agent JWTs. Filed for a follow-up integration sub-phase.
3. **`AgentSelf::identity_document` picks multicodec by `auth_public_key.len()`** (32 → Ed25519, 33 → P-256). This is robust but slightly implicit. A future Spec-D follow-up could thread `AuthAlg` through `AgentIdentity` explicitly.
4. **No production migration tooling** for the Ed25519 → P-256 cutover. Per Spec D §"Open Questions" §4 this is acceptable because there are no production users yet.

## Coordination follow-ups (non-blocking)

- broomva.tech AAP verifier swap from EdDSA to ES256 — track via Linear ticket placeholder (user files when MCP re-auths).
- spaces signed-presence lift onto `sign_digest`.
- lifegw / anima JWKS unification opportunity.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean on touched crates (anima-core, anima-identity, anima-lago, arcan-anima, haima-x402, lago-auth)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p anima-core -p anima-identity -p anima-lago -p arcan-anima -p haima-x402 --features haima-x402/custody-adapter -p lago-auth` — all green (~180 anima-touched tests including 56 new)
- [x] `cargo test --workspace --no-fail-fast --exclude lifed` — 3696 passing (the lifed e2e_smoke compile error is pre-existing on `origin/main`, unrelated to this PR)
- [x] No dependency cycles introduced — `cargo tree -p anima-identity` clean
- [x] Ed25519 legacy verifier path confirmed via `regression_ed25519_legacy_jwt_still_verifies`
- [ ] Manual smoke: rotate an in-process custody handle and confirm the rotation_proof_jws verifies under the old key (covered by `rotation_proof_jws_signed_by_old_key` unit test; manual e2e deferred to D-Sub-E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ES256 (P-256 ECDSA) authentication support alongside Ed25519 legacy.
  * Added identity rotation and revocation event tracking.
  * Introduced production custody abstraction for secure key management.
  * Enhanced DID resolution to support both Ed25519 and P-256 algorithms.
  * New in-process custody backend for development and testing.

* **Documentation**
  * Updated integration documentation for Spec D production custody model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->