### PR TITLE
feat(sdk): M8 — public TypeScript SDK over lifegw (Connect-ES + WS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,26 @@ jobs:
           echo "$PR_TITLE" | grep -qE '^(feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)(\(.+\))?(!)?: .+' \
             || { echo "::error::PR title must follow conventional commits: <type>(<scope>): <subject>"; exit 1; }
 
+  # ── Gate 9b: Life TypeScript SDK ──────────────────────────────────
+  sdk-life-ts:
+    name: SDK life-ts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/life-sdk-ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: TypeScript strict-mode check
+        run: bun run typecheck
+      - name: Unit tests
+        run: bun run test
+      - name: Production build
+        run: bun run build
+
   # ── Gate 10: Console Frontend ─────────────────────────────────────
   console:
     name: Console Frontend

--- a/sdks/CLAUDE.md
+++ b/sdks/CLAUDE.md
@@ -1,14 +1,28 @@
-# BRO-42: Multi-framework Haima SDK
+# Life Agent OS — Language SDKs
 
 ## Overview
 
-Multi-framework SDKs for x402 payments through the Haima facilitator.
-The Stripe Connect play: become the payment layer for AI agent platforms.
+Public-facing client libraries for the Life Agent OS Rust monorepo.
+Two product areas live here:
+
+1. **`life-sdk-ts`** — public TypeScript SDK over `lifegw` (M8). Browsers,
+   Node apps, and CLIs talk to the Life Agent OS through this client.
+   Wraps the four user-facing services from `life.v1.*` (Agent, Events,
+   Wallet, Identity) plus the WebSocket transport for `Agent.StreamSession`.
+2. **`haima-py` + `haima-ts`** (BRO-42) — multi-framework SDKs for x402
+   payments through the Haima facilitator. The Stripe Connect play.
 
 ## Structure
 
 ```
-BRO-42/
+sdks/
+├── life-sdk-ts/       # Public Life Agent OS SDK (npm: @broomva/life-sdk) — M8
+│   ├── src/           # client, transport, ws, errors
+│   │   ├── proto/     # Hand-curated TS mirror of proto/life/v1/*
+│   │   └── services/  # AgentClient, EventsClient, WalletClient, IdentityClient
+│   ├── examples/      # quickstart, streaming
+│   └── tests/         # vitest — 49 tests across 6 files
+│
 ├── haima-py/          # Python SDK (PyPI: haima)
 │   ├── src/haima/     # Core: client, wallet, types, x402
 │   │   └── integrations/  # LangChain, CrewAI

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -4,5 +4,6 @@ Multi-language SDK wrappers for the Life Agent OS Rust crates.
 
 ## Packages
 
+- **life-sdk-ts** (`@broomva/life-sdk`) — Public TypeScript SDK over `lifegw`. Implements the four user-facing services (`life.v1.{Agent, Events, Wallet, Identity}`) over `grpc-web` + WebSocket. Browsers, Node, and CLIs talk to the Life Agent OS through this client.
 - **haima-py** — Python SDK for x402 payments, wallet management, and framework integrations (LangChain, CrewAI)
 - **haima-ts** — TypeScript SDK for x402 payments with ElizaOS and OpenAI integrations

--- a/sdks/life-sdk-ts/.gitignore
+++ b/sdks/life-sdk-ts/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.vitest-cache/
+.turbo/

--- a/sdks/life-sdk-ts/.gitignore
+++ b/sdks/life-sdk-ts/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 .vitest-cache/
 .turbo/
+pnpm-lock.yaml

--- a/sdks/life-sdk-ts/KNOWN_LIMITATIONS.md
+++ b/sdks/life-sdk-ts/KNOWN_LIMITATIONS.md
@@ -1,0 +1,99 @@
+# Known Limitations — `@broomva/life-sdk` v0.1.0-pre
+
+This SDK ships as **v0.1.0-pre** — the structural foundation (services,
+typed errors, WS state machine, proto type mirrors, codec helpers, 50
+unit tests) is solid and reusable. Two wire-protocol limitations are
+documented here as known follow-ups before v0.2.0 / GA:
+
+## B1 — SDK speaks Connect-protocol JSON; lifegw runs `tonic-web` (gRPC-Web binary)
+
+**Status:** Known limitation. v0.1.0-pre will NOT successfully complete
+unary or server-streaming calls against a real lifegw deployment. Tests
+pass against the in-tree `FakeGateway` test helper because it accepts
+both content-types.
+
+### What's wrong
+
+- The SDK's `Transport` sends `Content-Type: application/json` (unary)
+  and `Content-Type: application/connect+json` (server-streaming) —
+  the Connect protocol JSON wire format
+  ([connectrpc.com/docs/protocol](https://connectrpc.com/docs/protocol)).
+- The lifegw gateway mounts `tonic_web::GrpcWebLayer` (per
+  `crates/life-runtime/lifegw/src/bootstrap.rs`) which accepts ONLY
+  `application/grpc-web`, `application/grpc-web+proto`,
+  `application/grpc-web-text`, `application/grpc-web-text+proto`. The
+  inner tonic stack expects binary-framed protobuf. There is no
+  Connect-protocol layer in the lifegw stack.
+- Result: every call from this SDK to a real lifegw returns
+  `415 Unsupported Media Type` or similar.
+
+### Resolution paths (for v0.2.0)
+
+- **Option A (preferred):** Switch SDK transport to gRPC-Web binary
+  framing with `@bufbuild/protobuf` codec. Connect-ES already supports
+  `grpc-web` mode — the public API surface stays the same; only
+  `Transport`'s internal framing changes. Adds one runtime dep.
+- **Option B:** Add a Connect-protocol translation layer to lifegw.
+  Connect-rs is young; this is the bigger lift but doesn't require an
+  SDK rebuild.
+- **Option C:** Add a lightweight JSON-to-grpc-web translation proxy
+  service that the SDK calls instead of lifegw directly. Adds a hop.
+
+Option A is the canonical path for SDKs targeting tonic-backed
+gateways. Tracked under follow-up ticket "M8.1 — SDK transport rework
+to gRPC-Web binary framing".
+
+## B2 — Browser WebSocket auth uses subprotocol; gateway reads only `Authorization` header
+
+**Status:** Browser path of `Agent.StreamSession` will fail Tier-1 auth
+on production lifegw without a gateway-side change. Node hosts can pass
+a `webSocketFactory` that sets the `Authorization` header on the
+underlying `ws` package.
+
+### What's wrong
+
+- Browsers cannot set arbitrary headers on the WS upgrade request — the
+  Fetch API doesn't expose `Authorization` for the WS path.
+- The SDK forwards the Tier-1 bearer token via the
+  `Sec-WebSocket-Protocol: bearer.<token>` subprotocol header, which
+  IS settable from the browser.
+- The lifegw gateway's `services::ws::parse_upgrade_request` reads ONLY
+  the `Authorization` header. The subprotocol is silently ignored.
+- The `auth/middleware.rs::AuthLayer` runs BEFORE `WsLayer` and rejects
+  upgrade requests without a `Bearer` token in `Authorization` — the
+  upgrade response is never sent.
+
+### Resolution paths (for v0.2.0)
+
+- **Option A (preferred):** Add `Sec-WebSocket-Protocol: bearer.*`
+  parsing to lifegw's `parse_upgrade_request` + `AuthLayer`. Mirrors
+  the SDK's existing approach. Gateway-side change only.
+- **Option B:** Use cookie-based auth for WS. The gateway sets an
+  HttpOnly cookie at login; the browser includes it automatically on
+  upgrade requests. Requires session-management work and CSRF
+  defenses.
+- **Option C:** Use a query-param token for WS only. Less secure
+  (tokens may leak into logs); only suitable for short-lived tokens.
+
+Option A is the lowest-friction. Tracked under follow-up ticket
+"M8.2 — lifegw WS subprotocol-bearer auth support".
+
+## Migration path for early adopters
+
+Until B1+B2 land, the SDK is usable for:
+
+- Tests against `FakeGateway`-style mocks.
+- Node hosts that pass a `webSocketFactory` setting `Authorization`
+  via the `ws` package.
+- Anyone building on top of the typed surface (services, errors, WS
+  state machine, proto types) — none of which change in v0.2.0.
+
+Avoid using v0.1.0-pre for browser production deployments until
+B1+B2 are resolved.
+
+## See also
+
+- Spec C₃ §6.5 close-codes: `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`
+- lifegw bootstrap: `crates/life-runtime/lifegw/src/bootstrap.rs`
+- lifegw WS upgrade handler: `crates/life-runtime/lifegw/src/services/ws.rs`
+- lifegw auth middleware: `crates/life-runtime/lifegw/src/auth/middleware.rs`

--- a/sdks/life-sdk-ts/README.md
+++ b/sdks/life-sdk-ts/README.md
@@ -1,0 +1,294 @@
+# @broomva/life-sdk
+
+Public TypeScript SDK for the **Life Agent OS**. Talks to `lifegw` (the
+edge gateway) over `grpc-web` + WebSocket, exposing the four user-facing
+services from `life.v1.*`:
+
+| Service | Purpose |
+|---|---|
+| `Agent` | Session lifecycle, chat, tool dispatch, catalog reads |
+| `Events` | Event tail, content-addressed blob fetch |
+| `Wallet` | Balance, debit (idempotent), transfer, statement |
+| `Identity` | `whoami`, profile, session list / revoke |
+
+The admin plane (`life.admin.*`) is intentionally NOT exposed — it is
+UDS-only on the gateway and never reachable from the public SDK.
+
+> **Spec ground truth**
+>
+> - Spec C₂ (lifed facade) — `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md`
+> - Spec C₃ (lifegw edge gateway) — Linear BRO-922 + amendments in `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`
+> - Master spec — `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md`
+
+---
+
+## Install
+
+```bash
+# Bun
+bun add @broomva/life-sdk
+
+# pnpm / npm / yarn
+pnpm add @broomva/life-sdk
+npm  install @broomva/life-sdk
+yarn add @broomva/life-sdk
+```
+
+In Node hosts older than 22, also install `ws`:
+
+```bash
+pnpm add ws
+```
+
+---
+
+## 5-minute quickstart
+
+```ts
+import { LifeClient } from "@broomva/life-sdk";
+
+const life = new LifeClient({
+  baseUrl: "https://api.life.dev",         // your lifegw HTTPS endpoint
+  getAuthToken: async () => myAuthToken(), // any Vercel JWT producer (Clerk, Auth.js, …)
+});
+
+// 1. Resolve who I am.
+const me = await life.identity.whoami();
+
+// 2. Open a session.
+const session = await life.agent.createSession({
+  userId: me.userId,
+  projectId: "p-default",
+  label: "first-session",
+});
+
+// 3. Chat — the server streams tokens + tool events back.
+for await (const event of life.agent.sendMessage({
+  sid: session.sid,
+  content: "Hello, Life",
+})) {
+  console.log(event.kind, event.record.sequence);
+}
+
+// 4. Read the wallet.
+const balance = await life.wallet.getBalance({
+  userId: me.userId,
+  projectId: "p-default",
+});
+console.log(balance.micros, balance.currency);
+```
+
+Run the example end-to-end against a local lifegw:
+
+```bash
+LIFE_BASE_URL=https://localhost:443 \
+LIFE_USER_ID=u-quickstart \
+pnpm --filter @broomva/life-sdk example:quickstart
+```
+
+---
+
+## Long-lived streaming over WebSocket
+
+`Agent.SendMessage` and `Agent.StreamSession` are server-streaming
+gRPC calls — usable directly when you have a fresh in-memory token
+and a short response. For browsers / apps that need
+**reconnect-on-drop** semantics, prefer the WebSocket helper:
+
+```ts
+const session = await life.streamSession("sid-123", {
+  onAgentEvent: (e) => console.log(e.seqNo, e.agentKind),
+  onError: (err) => console.error(err.code, err.message),
+  onClose: () => console.log("disconnected"),
+});
+
+session.sendMessage("hello over WS");
+
+// …later…
+session.close("done");
+```
+
+The session tracks the highest `seq_no` it has seen and uses it as
+`last_seq_no` on reconnect (Spec C₃ §11.4) so the stream resumes
+from `seq + 1`. Auto-reconnect is enabled by default for transient
+close codes (4002, 4004, 1011); permanent codes (1008, 4001, 4003,
+4005) surface via `onError` immediately.
+
+In Node 20 / older hosts, wire the `ws` package:
+
+```ts
+import WebSocket from "ws";
+
+const life = new LifeClient({
+  baseUrl: "https://api.life.dev",
+  getAuthToken: async () => token,
+  webSocketFactory: (url, protocols) => new WebSocket(url, protocols),
+});
+```
+
+The browser path uses the standard `WebSocket` global; the bearer
+token is forwarded as a `bearer.<token>` subprotocol because browsers
+cannot set custom request headers on WS handshakes.
+
+---
+
+## Error handling
+
+Every error thrown by the SDK extends `LifeSdkError`:
+
+```ts
+import {
+  AuthError,
+  RateLimitError,
+  BackpressureError,
+  IpBlockedError,
+  LifedUnavailableError,
+  SequenceRetiredError,
+  InternalServerError,
+  GoingAwayError,
+  TlsNegotiationError,
+  TransportError,
+  GrpcError,
+} from "@broomva/life-sdk";
+```
+
+The full close-code → error mapping (Spec C₃ §6.5):
+
+| Close code | Error class | Reason prefix |
+|---:|---|---|
+| 1000 | _(graceful, no error)_ | `normal` |
+| 1001 | `GoingAwayError` | `going_away` |
+| 1008 | `AuthError` | `policy_violation:token_expired` |
+| 1011 | `InternalServerError` | `internal_error` |
+| 4001 | `RateLimitError` | `rate_limit:per_user` |
+| 4002 | `BackpressureError` | `backpressure:slow_consumer` |
+| 4003 | `IpBlockedError` | `ip_blocked` |
+| 4004 | `LifedUnavailableError` | `lifed_circuit_open` |
+| 4005 | `SequenceRetiredError` | `sequence_retired` |
+
+For unary RPCs the same classes are produced from gRPC status codes:
+
+| gRPC code | Error class |
+|---|---|
+| `UNAUTHENTICATED` / `PERMISSION_DENIED` | `AuthError` |
+| `RESOURCE_EXHAUSTED` | `RateLimitError` |
+| `UNAVAILABLE` | `LifedUnavailableError` |
+| `OUT_OF_RANGE` | `SequenceRetiredError` |
+| `INTERNAL` | `InternalServerError` |
+| _other_ | `GrpcError` |
+
+---
+
+## TLS 1.3 requirement
+
+`lifegw` mandates TLS 1.3 on its public listener (Spec C₃ §5.1).
+Clients that cannot negotiate 1.3 surface a `TlsNegotiationError`
+on the first call. In practice this means:
+
+- All evergreen browsers — supported.
+- Node ≥ 18 — supported.
+- Old curl, ancient Java, IE 11 — rejected.
+
+The browser path can't always introspect the underlying TLS error;
+the SDK's heuristic remaps obvious markers (`SSL`, `TLS`, `handshake`,
+`EPROTO`, `ERR_SSL_*`) to `TlsNegotiationError`. Other transport
+errors surface as `TransportError`.
+
+---
+
+## API reference
+
+### `LifeClient`
+
+```ts
+new LifeClient({
+  baseUrl: string,
+  getAuthToken?: () => Promise<string | undefined>,
+  fetch?: typeof fetch,
+  webSocketFactory?: WebSocketFactory,
+})
+```
+
+Aggregates the four service clients on a shared `Transport`:
+
+- `life.agent: AgentClient`
+- `life.events: EventsClient`
+- `life.wallet: WalletClient`
+- `life.identity: IdentityClient`
+
+Plus `life.streamSession(sid, handlers?, extraOpts?): Promise<WsAgentSession>` for WS sessions.
+
+### Per-call options
+
+Every method takes an optional `TransportCallOptions` argument:
+
+```ts
+{ signal?: AbortSignal, timeoutMs?: number, headers?: Record<string,string> }
+```
+
+### Currency precision
+
+All amounts are `bigint` micros (μUSDC) — proto3 `uint64` → JSON
+string → SDK `bigint`. Convert to USDC by dividing by `1_000_000n`:
+
+```ts
+const usdc = Number(balance.micros) / 1_000_000;
+```
+
+### Idempotency
+
+- `Wallet.Debit` is idempotent on `(wallet, sid)` — replays return the original receipt.
+- `Wallet.Transfer` idempotency lands in a follow-up; pass a stable `memo` for now.
+
+---
+
+## Troubleshooting
+
+**`TlsNegotiationError: TLS 1.3 negotiation failed`** — your client
+can't speak TLS 1.3. Upgrade Node, browser, or test fixture; in CI
+make sure your reverse proxy or fixture also runs TLS 1.3.
+
+**`AuthError: auth token rejected`** — the bearer JWT failed Tier-1
+validation. Confirm:
+1. `getAuthToken()` returns a fresh token.
+2. The token is signed by a key in the gateway's JWKS (Vercel /
+   Auth.js / Clerk).
+3. The clock skew between client and server is < 5 minutes.
+
+**`RateLimitError: rate_limit:per_user`** — the per-user token
+bucket is exhausted (Sub-phase D D1). Back off + retry. The reason
+prefix tells you whether it's per-user or per-IP.
+
+**`SequenceRetiredError`** — your `from_sequence` cursor is older
+than what lifed retains. Drop the cursor and reconnect with `0n` to
+resume from the live tail.
+
+**`InternalServerError` on a WS session** — most often a heartbeat
+timeout. The server pings every 30 s and closes if no pong arrives
+in 60 s. Check the network path doesn't strip WS pings (some
+load-balancers rewrite them).
+
+---
+
+## Development
+
+```bash
+cd sdks/life-sdk-ts
+
+bun install                       # or pnpm / npm install
+bun run typecheck                 # TS strict-mode
+bun run test                      # vitest run
+bun run build                     # tsc → dist/
+```
+
+The SDK is hand-curated — proto types in `src/proto/` mirror
+`proto/life/v1/*.proto`. When the proto changes, update the matching
+file by hand. A future revision can switch to `buf generate +
+protoc-gen-es`; the public surface is structured so the codegen swap
+won't break consumers.
+
+---
+
+## License
+
+MIT © Broomva

--- a/sdks/life-sdk-ts/README.md
+++ b/sdks/life-sdk-ts/README.md
@@ -1,8 +1,16 @@
 # @broomva/life-sdk
 
+> **⚠️ v0.1.0-pre — pre-release foundation.** Two known wire-protocol
+> gaps prevent this SDK from completing real calls against a production
+> lifegw deployment. See [KNOWN_LIMITATIONS.md](./KNOWN_LIMITATIONS.md)
+> for B1 (Connect-vs-grpc-web wire mismatch) and B2 (browser WS auth
+> via subprotocol). The structural foundation (services, typed errors,
+> WS state machine, proto types, codec helpers, 50 unit tests) is
+> stable and reusable; v0.2.0 ships the transport rework.
+
 Public TypeScript SDK for the **Life Agent OS**. Talks to `lifegw` (the
-edge gateway) over `grpc-web` + WebSocket, exposing the four user-facing
-services from `life.v1.*`:
+edge gateway) — see KNOWN_LIMITATIONS.md for the current transport
+state — exposing the four user-facing services from `life.v1.*`:
 
 | Service | Purpose |
 |---|---|
@@ -78,13 +86,20 @@ const balance = await life.wallet.getBalance({
 console.log(balance.micros, balance.currency);
 ```
 
-Run the example end-to-end against a local lifegw:
+Run the example end-to-end against a local lifegw (from inside this
+package directory):
 
 ```bash
+cd sdks/life-sdk-ts
+pnpm install
 LIFE_BASE_URL=https://localhost:443 \
 LIFE_USER_ID=u-quickstart \
-pnpm --filter @broomva/life-sdk example:quickstart
+pnpm run example:quickstart
 ```
+
+> The repo doesn't currently have a top-level pnpm workspace
+> declaration, so `pnpm --filter` won't resolve the package name from
+> the repo root. Run from `sdks/life-sdk-ts/` directly.
 
 ---
 

--- a/sdks/life-sdk-ts/bun.lock
+++ b/sdks/life-sdk-ts/bun.lock
@@ -1,0 +1,240 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@broomva/life-sdk",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "@types/ws": "^8.18.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.7",
+        "vitest": "^3.0",
+        "ws": "^8.18.0",
+      },
+      "peerDependencies": {
+        "ws": ">=8",
+      },
+      "optionalPeers": [
+        "ws",
+      ],
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+  }
+}

--- a/sdks/life-sdk-ts/examples/quickstart.ts
+++ b/sdks/life-sdk-ts/examples/quickstart.ts
@@ -1,0 +1,64 @@
+/**
+ * Quickstart: connect to a local lifegw, create a session, send a
+ * message, watch events stream back, then read the wallet balance.
+ *
+ * Run with: `pnpm example:quickstart` (or `tsx examples/quickstart.ts`).
+ *
+ * Assumes lifegw is reachable at `https://localhost:443` with a dev
+ * signer accepting `Bearer test-token-for-{user_id}`.
+ */
+
+import { LifeClient } from "../src/index.js";
+
+const BASE_URL = process.env.LIFE_BASE_URL ?? "https://localhost:443";
+const USER_ID = process.env.LIFE_USER_ID ?? "u-quickstart";
+const PROJECT_ID = process.env.LIFE_PROJECT_ID ?? "p-quickstart";
+
+async function main(): Promise<void> {
+  const life = new LifeClient({
+    baseUrl: BASE_URL,
+    getAuthToken: async () => `test-token-for-${USER_ID}`,
+  });
+
+  // 1. Resolve identity to confirm auth works.
+  const me = await life.identity.whoami();
+  console.log("[whoami]", me);
+
+  // 2. Open a session.
+  const session = await life.agent.createSession({
+    userId: USER_ID,
+    projectId: PROJECT_ID,
+    label: "quickstart-session",
+  });
+  console.log("[session]", session.sid.value);
+
+  // 3. Send a message and stream events back.
+  console.log("[stream] sending message…");
+  for await (const event of life.agent.sendMessage({
+    sid: session.sid,
+    content: "Hello from @broomva/life-sdk quickstart",
+  })) {
+    console.log("[event]", event.kind, "seq=", event.record.sequence.toString());
+    if (event.kind === "AGENT_EVENT_KIND_FINISH") break;
+    if (event.kind === "AGENT_EVENT_KIND_ERROR") {
+      console.error("server error event");
+      break;
+    }
+  }
+
+  // 4. Read wallet balance.
+  const balance = await life.wallet.getBalance({
+    userId: USER_ID,
+    projectId: PROJECT_ID,
+  });
+  console.log("[balance]", balance.micros.toString(), balance.currency);
+
+  // 5. Close the session.
+  await life.agent.closeSession({ sid: session.sid });
+  console.log("[done]");
+}
+
+main().catch((err: unknown) => {
+  console.error("[error]", err);
+  process.exit(1);
+});

--- a/sdks/life-sdk-ts/examples/streaming.ts
+++ b/sdks/life-sdk-ts/examples/streaming.ts
@@ -1,0 +1,70 @@
+/**
+ * Streaming: open a long-lived `Agent.StreamSession` over WebSocket,
+ * print every event, automatically reconnect on transient drops.
+ *
+ * Run with: `pnpm example:streaming` (or `tsx examples/streaming.ts`).
+ *
+ * In Node, `globalThis.WebSocket` is provided by Node 22+. On older
+ * runtimes pass `webSocketFactory` from the `ws` package.
+ */
+
+import { LifeClient } from "../src/index.js";
+
+const BASE_URL = process.env.LIFE_BASE_URL ?? "https://localhost:443";
+const SID = process.env.LIFE_SID ?? "sid-streaming-demo";
+const USER_ID = process.env.LIFE_USER_ID ?? "u-streaming";
+
+async function main(): Promise<void> {
+  // Optional: use the `ws` package on older Node hosts. Node 22+ has
+  // a built-in `WebSocket` so the dynamic import is best-effort.
+  type LifeWsFactory = NonNullable<ConstructorParameters<typeof LifeClient>[0]["webSocketFactory"]>;
+  let webSocketFactory: LifeWsFactory | undefined;
+  try {
+    const wsMod = (await import("ws")) as unknown as {
+      default: new (u: string, p: string[]) => unknown;
+    };
+    webSocketFactory = (url, protocols) =>
+      new wsMod.default(url, protocols) as ReturnType<LifeWsFactory>;
+  } catch {
+    // Fall back to globalThis.WebSocket
+    webSocketFactory = undefined;
+  }
+
+  const life = new LifeClient({
+    baseUrl: BASE_URL,
+    getAuthToken: async () => `test-token-for-${USER_ID}`,
+    webSocketFactory,
+  });
+
+  console.log(`[ws] connecting to ${BASE_URL} sid=${SID}…`);
+
+  const session = await life.streamSession(SID, {
+    onOpen: () => console.log("[ws] open"),
+    onAgentEvent: (e) => {
+      console.log("[event] seq=", e.seqNo.toString(), "kind=", e.agentKind);
+    },
+    onClosing: (reason) => console.log("[ws] closing:", reason),
+    onError: (err) => console.error("[ws] error:", err.code, err.message),
+    onClose: () => console.log("[ws] closed"),
+  });
+
+  // Send a chat message — server streams the response back.
+  session.sendMessage("Hello over WebSocket");
+
+  // Keep the process alive until the session closes (or Ctrl-C).
+  process.on("SIGINT", () => {
+    console.log("[ws] SIGINT — closing");
+    session.close("sigint");
+    process.exit(0);
+  });
+
+  // Park forever — the WS event loop keeps Node alive.
+  await new Promise(() => {
+    // never resolves
+  });
+}
+
+main().catch((err: unknown) => {
+  console.error("[error]", err);
+  process.exit(1);
+});

--- a/sdks/life-sdk-ts/package.json
+++ b/sdks/life-sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broomva/life-sdk",
-  "version": "0.1.0",
-  "description": "Public TypeScript SDK for the Life Agent OS — talks to lifegw over grpc-web + WebSocket. Implements the user-facing life.v1.{Agent, Events, Wallet, Identity} services.",
+  "version": "0.1.0-pre",
+  "description": "Public TypeScript SDK for the Life Agent OS — talks to lifegw over grpc-web + WebSocket. Implements the user-facing life.v1.{Agent, Events, Wallet, Identity} services. v0.1.0-pre — see KNOWN_LIMITATIONS.md before depending on this in production.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/life-sdk-ts/package.json
+++ b/sdks/life-sdk-ts/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@broomva/life-sdk",
+  "version": "0.1.0",
+  "description": "Public TypeScript SDK for the Life Agent OS — talks to lifegw over grpc-web + WebSocket. Implements the user-facing life.v1.{Agent, Events, Wallet, Identity} services.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./agent": {
+      "types": "./dist/services/agent.d.ts",
+      "import": "./dist/services/agent.js"
+    },
+    "./events": {
+      "types": "./dist/services/events.d.ts",
+      "import": "./dist/services/events.js"
+    },
+    "./wallet": {
+      "types": "./dist/services/wallet.d.ts",
+      "import": "./dist/services/wallet.js"
+    },
+    "./identity": {
+      "types": "./dist/services/identity.d.ts",
+      "import": "./dist/services/identity.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "import": "./dist/errors.js"
+    },
+    "./ws": {
+      "types": "./dist/ws.d.ts",
+      "import": "./dist/ws.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "example:quickstart": "tsx examples/quickstart.ts",
+    "example:streaming": "tsx examples/streaming.ts"
+  },
+  "keywords": [
+    "life-agent-os",
+    "lifegw",
+    "agent-os",
+    "grpc-web",
+    "websocket",
+    "ai-agent",
+    "broomva"
+  ],
+  "author": "Broomva <carlos@broomva.tech>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/broomva/life",
+    "directory": "sdks/life-sdk-ts"
+  },
+  "homepage": "https://broomva.tech",
+  "bugs": {
+    "url": "https://github.com/broomva/life/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "@types/ws": "^8.18.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.7",
+    "vitest": "^3.0",
+    "ws": "^8.18.0"
+  },
+  "peerDependencies": {
+    "ws": ">=8"
+  },
+  "peerDependenciesMeta": {
+    "ws": {
+      "optional": true
+    }
+  }
+}

--- a/sdks/life-sdk-ts/src/client.ts
+++ b/sdks/life-sdk-ts/src/client.ts
@@ -1,0 +1,141 @@
+/**
+ * `LifeClient` — high-level entry point.
+ *
+ * Aggregates the four user-facing services (`life.v1.{Agent, Events,
+ * Wallet, Identity}`) over a shared transport. Construct one
+ * `LifeClient` per origin / user; the same instance is safe to
+ * share across an entire app.
+ *
+ * @example
+ * ```ts
+ * import { LifeClient } from "@broomva/life-sdk";
+ *
+ * const life = new LifeClient({
+ *   baseUrl: "https://api.life.dev",
+ *   getAuthToken: async () => myClerkToken,
+ * });
+ *
+ * const session = await life.agent.createSession({ userId: "u-1" });
+ * for await (const event of life.agent.sendMessage({
+ *   sid: session.sid,
+ *   content: "hello",
+ * })) {
+ *   console.log(event);
+ * }
+ * ```
+ */
+
+import { AgentClient } from "./services/agent.js";
+import { EventsClient } from "./services/events.js";
+import { WalletClient } from "./services/wallet.js";
+import { IdentityClient } from "./services/identity.js";
+import { Transport } from "./transport.js";
+import {
+  WsAgentSession,
+  type WsAgentSessionHandlers,
+  type WsAgentSessionOptions,
+  type WebSocketFactory,
+} from "./ws.js";
+
+/**
+ * Configuration for {@link LifeClient}.
+ */
+export interface LifeClientConfig {
+  /**
+   * lifegw HTTPS endpoint, e.g. `https://api.life.dev`. Trailing
+   * slashes normalized away.
+   *
+   * Spec C₃ §5.1 mandates TLS 1.3 — clients that can't negotiate
+   * 1.3 receive a {@link TlsNegotiationError} on the first call.
+   */
+  baseUrl: string;
+
+  /**
+   * Async callback that produces a Tier-1 bearer JWT (the "user"
+   * token issued by your auth provider — Clerk, Auth.js, custom).
+   *
+   * The callback is invoked on every RPC, so implementations should
+   * cache + refresh internally to avoid blocking the hot path.
+   *
+   * Pass `undefined` for dev-mode workflows that target lifegw with
+   * its dev signer enabled; production lifegw rejects un-bearered
+   * traffic.
+   */
+  getAuthToken?: () => Promise<string | undefined>;
+
+  /**
+   * Override `fetch`. Defaults to `globalThis.fetch`.
+   *
+   * Useful for tests and for hosts that want to inject custom
+   * retry/instrumentation logic.
+   */
+  fetch?: typeof fetch;
+
+  /**
+   * Override the `WebSocket` factory used by {@link LifeClient.streamSession}.
+   *
+   * In Node, pass `import WebSocket from "ws"; (u, p) => new WebSocket(u, p)`.
+   * In the browser, leave undefined to pick up `globalThis.WebSocket`.
+   */
+  webSocketFactory?: WebSocketFactory;
+}
+
+export class LifeClient {
+  readonly transport: Transport;
+  readonly agent: AgentClient;
+  readonly events: EventsClient;
+  readonly wallet: WalletClient;
+  readonly identity: IdentityClient;
+
+  private readonly cfg: LifeClientConfig;
+
+  constructor(cfg: LifeClientConfig) {
+    this.cfg = cfg;
+    this.transport = new Transport({
+      baseUrl: cfg.baseUrl,
+      getAuthToken: cfg.getAuthToken,
+      fetch: cfg.fetch,
+    });
+    this.agent = new AgentClient(this.transport);
+    this.events = new EventsClient(this.transport);
+    this.wallet = new WalletClient(this.transport);
+    this.identity = new IdentityClient(this.transport);
+  }
+
+  /**
+   * Open a long-lived `Agent.StreamSession` over WebSocket with
+   * reconnect-by-`from_sequence` resume semantics (Spec C₃ §6).
+   *
+   * The returned `WsAgentSession` is already `open()`-ed; attach
+   * handlers BEFORE the await resolves to avoid event races.
+   *
+   * @example
+   * ```ts
+   * const session = await life.streamSession("sid-123", {
+   *   onAgentEvent: (e) => render(e),
+   *   onError: (err) => console.error(err),
+   * });
+   *
+   * session.sendMessage("hello");
+   * // …later…
+   * session.close();
+   * ```
+   */
+  async streamSession(
+    sid: string,
+    handlers?: WsAgentSessionHandlers,
+    extraOptions?: Partial<Omit<WsAgentSessionOptions, "baseUrl" | "sid" | "getAuthToken">>,
+  ): Promise<WsAgentSession> {
+    const opts: WsAgentSessionOptions = {
+      baseUrl: this.cfg.baseUrl,
+      sid,
+      ...(this.cfg.getAuthToken && { getAuthToken: this.cfg.getAuthToken }),
+      ...(this.cfg.webSocketFactory && { webSocketFactory: this.cfg.webSocketFactory }),
+      ...extraOptions,
+    };
+    const session = new WsAgentSession(opts);
+    if (handlers) session.on(handlers);
+    await session.open();
+    return session;
+  }
+}

--- a/sdks/life-sdk-ts/src/codec.ts
+++ b/sdks/life-sdk-ts/src/codec.ts
@@ -1,0 +1,119 @@
+/**
+ * Codec helpers for proto3-JSON canonical type conversions.
+ *
+ * Per the proto3-JSON canonical mapping
+ * (https://protobuf.dev/programming-guides/proto3/#json):
+ *
+ * | Proto type    | JSON wire shape | This SDK type |
+ * |---------------|-----------------|---------------|
+ * | `int64`       | string (number) | `string`      |
+ * | `uint64`      | string (number) | `string`      |
+ * | `bytes`       | base64 string   | `string`      |
+ *
+ * Pre-merge code-quality review I-1: the previous SDK shipped these
+ * proto types as `bigint` and `Uint8Array`, but the JSON reviver was
+ * a no-op so runtime values were always strings. Consumers calling
+ * `bal.micros - 1n` would have crashed with "Cannot mix BigInt and
+ * other types".
+ *
+ * The fix typed the proto fields as `string` (the actual wire shape)
+ * and provides this module of conversion helpers for callers that
+ * need bigint arithmetic or raw bytes.
+ */
+
+/**
+ * Convert a proto3-JSON `int64`/`uint64` field to a `bigint`.
+ *
+ * @example
+ * const bal = await wallet.getBalance({ ... });
+ * const remaining = microsToBigInt(bal.micros) - 1_000_000n;
+ */
+export function microsToBigInt(s: string): bigint {
+  return BigInt(s);
+}
+
+/**
+ * Convert a `bigint` to the proto3-JSON `int64`/`uint64` wire shape.
+ *
+ * @example
+ * await wallet.debit({ ..., amountMicros: bigIntToMicros(500_000n) });
+ */
+export function bigIntToMicros(n: bigint): string {
+  return n.toString();
+}
+
+/**
+ * Convert a proto3-JSON `int64` (sequence number) field to a `bigint`.
+ * Convenience alias for {@link microsToBigInt} with intent-revealing
+ * naming for `EventRecord.sequence` / `SessionRef.fromSequence`.
+ *
+ * @example
+ * for await (const evt of events.subscribe({ ... })) {
+ *   if (sequenceToBigInt(evt.sequence) > 1000n) break;
+ * }
+ */
+export function sequenceToBigInt(s: string): bigint {
+  return BigInt(s);
+}
+
+/**
+ * Convert a `bigint` cursor to the proto3-JSON `int64` wire shape.
+ *
+ * @example
+ * await events.read({ ..., fromSequence: bigIntToSequence(lastSeen + 1n) });
+ */
+export function bigIntToSequence(n: bigint): string {
+  return n.toString();
+}
+
+/**
+ * Decode a proto3-JSON `bytes` field (base64 string) to raw bytes.
+ *
+ * Proto3-JSON encodes `bytes` fields as either standard or URL-safe
+ * base64; this helper accepts both shapes.
+ *
+ * @example
+ * const blob = await events.getBlob({ namespace, sha256 });
+ * const bytes = bytesFromBase64(blob.data);
+ */
+export function bytesFromBase64(b64: string): Uint8Array {
+  // Normalize URL-safe variants to standard base64.
+  const normalized = b64.replace(/-/g, "+").replace(/_/g, "/");
+  // Pad to 4-char boundary (atob is strict on padding).
+  const padded = normalized + "===".slice((normalized.length + 3) % 4);
+  if (typeof atob === "function") {
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  // Node fallback (Node 18+ has atob globally; this is for very old hosts).
+  const g = globalThis as unknown as {
+    Buffer?: { from(s: string, enc: string): Uint8Array };
+  };
+  if (g.Buffer) return new Uint8Array(g.Buffer.from(padded, "base64"));
+  throw new Error("no base64 decoder available");
+}
+
+/**
+ * Encode raw bytes to a proto3-JSON `bytes` field (standard base64).
+ *
+ * @example
+ * await client.agent.sendMessage({
+ *   sid,
+ *   content: "...",
+ *   attachmentBlobRef: bytesToBase64(new Uint8Array([0xde, 0xad])),
+ * });
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof btoa === "function") {
+    let bin = "";
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+    return btoa(bin);
+  }
+  const g = globalThis as unknown as {
+    Buffer?: { from(b: Uint8Array): { toString(enc: string): string } };
+  };
+  if (g.Buffer) return g.Buffer.from(bytes).toString("base64");
+  throw new Error("no base64 encoder available");
+}

--- a/sdks/life-sdk-ts/src/errors.ts
+++ b/sdks/life-sdk-ts/src/errors.ts
@@ -1,0 +1,297 @@
+/**
+ * Typed error classes raised by the Life SDK.
+ *
+ * The full close-code mapping is canonicalised in
+ * `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md` (Spec C₃
+ * §6.5). When the SDK observes a WS close, it consults
+ * {@link closeCodeToError} to produce one of these typed errors.
+ */
+
+// ── Base error ─────────────────────────────────────────────────────
+
+export class LifeSdkError extends Error {
+  public readonly code: string;
+
+  constructor(code: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LifeSdkError";
+    this.code = code;
+    // Preserve prototype chain in older runtimes.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ── Transport errors ───────────────────────────────────────────────
+
+/**
+ * The lifegw HTTPS endpoint refused our TLS handshake. Most often
+ * means the client could not negotiate TLS 1.3 — lifegw rejects
+ * everything older per Spec C₃ §5.1 (TLS 1.3-only listener).
+ *
+ * In the browser this surfaces as a generic `TypeError: Failed to
+ * fetch`; the SDK best-effort detects the case and remaps it.
+ */
+export class TlsNegotiationError extends LifeSdkError {
+  constructor(message = "TLS 1.3 negotiation failed against lifegw") {
+    super("tls_negotiation_failed", message);
+    this.name = "TlsNegotiationError";
+  }
+}
+
+/**
+ * Transport-level error: the request failed before reaching lifegw
+ * (DNS, connect, abort, etc.).
+ */
+export class TransportError extends LifeSdkError {
+  constructor(message: string, options?: ErrorOptions) {
+    super("transport", message, options);
+    this.name = "TransportError";
+  }
+}
+
+// ── Request / response errors ──────────────────────────────────────
+
+/**
+ * Tier-1 / Tier-2 token rejected by lifegw or upstream lifed
+ * (`Unauthenticated` / `PermissionDenied`).
+ *
+ * Maps to WS close code 1008 per Spec C₃ §6.5.
+ */
+export class AuthError extends LifeSdkError {
+  constructor(message = "auth token rejected") {
+    super("unauthenticated", message);
+    this.name = "AuthError";
+  }
+}
+
+/**
+ * Request rejected because the server's per-user / per-IP token
+ * bucket is exhausted (Sub-phase D D1, mapped from
+ * `tonic::Code::ResourceExhausted`).
+ *
+ * On the WS plane this is close code 4001.
+ */
+export class RateLimitError extends LifeSdkError {
+  /**
+   * The reason payload prefix from the server. Stable for runbook
+   * purposes — `rate_limit:per_user` vs `rate_limit:per_ip`.
+   */
+  public readonly reasonPrefix: string;
+
+  constructor(reasonPrefix = "rate_limit:per_user", message?: string) {
+    super("resource_exhausted", message ?? `rate limit exceeded (${reasonPrefix})`);
+    this.name = "RateLimitError";
+    this.reasonPrefix = reasonPrefix;
+  }
+}
+
+/**
+ * Server closed the WS because the outbound mpsc(64) backed up
+ * `STALLED_THRESHOLD` consecutive ticks. Close code 4002.
+ */
+export class BackpressureError extends LifeSdkError {
+  constructor(message = "slow consumer / backpressure overflow") {
+    super("slow_consumer", message);
+    this.name = "BackpressureError";
+  }
+}
+
+/**
+ * Peer IP is on the in-process blocklist (admin RPC `BlocklistAdd`).
+ * Close code 4003.
+ */
+export class IpBlockedError extends LifeSdkError {
+  constructor(message = "peer IP is blocklisted") {
+    super("ip_blocked", message);
+    this.name = "IpBlockedError";
+  }
+}
+
+/**
+ * Upstream lifed UDS unreachable / circuit breaker open. Close code
+ * 4004 (mapped from `tonic::Code::Unavailable`). Callers should
+ * back off + retry.
+ */
+export class LifedUnavailableError extends LifeSdkError {
+  constructor(message = "upstream lifed circuit open / unreachable") {
+    super("lifed_unavailable", message);
+    this.name = "LifedUnavailableError";
+  }
+}
+
+/**
+ * The `from_sequence` cursor sent on reconnect has been retired by
+ * lifed (`tonic::Code::OutOfRange`). The client should drop its
+ * cursor and reconnect with `from_sequence: 0` to resume from the
+ * start of the live tail. Close code 4005.
+ */
+export class SequenceRetiredError extends LifeSdkError {
+  constructor(message = "from_sequence cursor retired upstream") {
+    super("sequence_retired", message);
+    this.name = "SequenceRetiredError";
+  }
+}
+
+/**
+ * Server-side fault — typically `tonic::Code::Internal` or any tonic
+ * code the gateway hasn't enumerated. Close code 1011. Heartbeat
+ * timeouts (Spec C₃ §6.4) also surface as this error.
+ */
+export class InternalServerError extends LifeSdkError {
+  constructor(message = "internal server error") {
+    super("internal", message);
+    this.name = "InternalServerError";
+  }
+}
+
+/**
+ * Server is shutting down (drain). Close code 1001. Callers should
+ * reconnect once the server is up again.
+ */
+export class GoingAwayError extends LifeSdkError {
+  constructor(message = "server going away (drain)") {
+    super("going_away", message);
+    this.name = "GoingAwayError";
+  }
+}
+
+/**
+ * Generic server-returned error with a gRPC status code. Used for
+ * unary RPC errors that don't have a more specific class.
+ */
+export class GrpcError extends LifeSdkError {
+  /**
+   * gRPC status code (numeric, per Status Code Mappings).
+   * @see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+   */
+  public readonly grpcCode: number;
+
+  /**
+   * gRPC status code string (e.g. `RESOURCE_EXHAUSTED`).
+   */
+  public readonly grpcStatus: string;
+
+  constructor(grpcCode: number, grpcStatus: string, message: string) {
+    super(grpcStatus.toLowerCase(), message);
+    this.name = "GrpcError";
+    this.grpcCode = grpcCode;
+    this.grpcStatus = grpcStatus;
+  }
+}
+
+// ── Close-code → typed error mapping ───────────────────────────────
+
+/**
+ * Translate a WS close code into the corresponding typed error.
+ *
+ * Per Spec C₃ §6.5 (see
+ * `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`):
+ *
+ * | Code | Error class            | Reason prefix                  |
+ * |---:|------------------------|--------------------------------|
+ * | 1000 | (no error — graceful)  | `normal`                       |
+ * | 1001 | {@link GoingAwayError} | `going_away`                   |
+ * | 1008 | {@link AuthError}      | `policy_violation:token_expired` |
+ * | 1011 | {@link InternalServerError} | `internal_error`          |
+ * | 4001 | {@link RateLimitError} | `rate_limit:per_user`          |
+ * | 4002 | {@link BackpressureError} | `backpressure:slow_consumer` |
+ * | 4003 | {@link IpBlockedError} | `ip_blocked`                   |
+ * | 4004 | {@link LifedUnavailableError} | `lifed_circuit_open`    |
+ * | 4005 | {@link SequenceRetiredError} | `sequence_retired`       |
+ *
+ * Codes 1000 and any unknown code return `null`. Callers that need
+ * to surface an error for code 1000 should construct one explicitly.
+ */
+export function closeCodeToError(
+  code: number,
+  reason?: string,
+): LifeSdkError | null {
+  switch (code) {
+    case 1000:
+      return null;
+    case 1001:
+      return new GoingAwayError(reason || undefined);
+    case 1008:
+      return new AuthError(reason || undefined);
+    case 1011:
+      return new InternalServerError(reason || undefined);
+    case 4001: {
+      // Reason prefixes are stable for dashboards, e.g. `rate_limit:per_ip`.
+      const prefix = reason?.split(":").slice(0, 2).join(":") ?? "rate_limit:per_user";
+      return new RateLimitError(prefix);
+    }
+    case 4002:
+      return new BackpressureError(reason || undefined);
+    case 4003:
+      return new IpBlockedError(reason || undefined);
+    case 4004:
+      return new LifedUnavailableError(reason || undefined);
+    case 4005:
+      return new SequenceRetiredError(reason || undefined);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Translate a numeric gRPC status code to a typed SDK error.
+ *
+ * Used by the unary-RPC path so callers see the same error classes
+ * regardless of whether the call failed via WS close or gRPC status.
+ *
+ * @param grpcCode gRPC numeric status code
+ * @param grpcStatus gRPC status name (e.g. `RESOURCE_EXHAUSTED`)
+ * @param message optional human-readable message
+ */
+export function grpcCodeToError(
+  grpcCode: number,
+  grpcStatus: string,
+  message?: string,
+): LifeSdkError {
+  const msg = message || `gRPC ${grpcStatus}`;
+  switch (grpcCode) {
+    case 16: // UNAUTHENTICATED
+    case 7: // PERMISSION_DENIED
+      return new AuthError(msg);
+    case 8: // RESOURCE_EXHAUSTED
+      return new RateLimitError("rate_limit:per_user", msg);
+    case 14: // UNAVAILABLE
+      return new LifedUnavailableError(msg);
+    case 11: // OUT_OF_RANGE
+      return new SequenceRetiredError(msg);
+    case 13: // INTERNAL
+      return new InternalServerError(msg);
+    case 1: // CANCELLED
+    case 10: // ABORTED
+      return new GrpcError(grpcCode, grpcStatus, msg);
+    default:
+      return new GrpcError(grpcCode, grpcStatus, msg);
+  }
+}
+
+/**
+ * gRPC status code constants for convenient reference.
+ *
+ * @see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+ */
+export const GrpcCode = {
+  Ok: 0,
+  Cancelled: 1,
+  Unknown: 2,
+  InvalidArgument: 3,
+  DeadlineExceeded: 4,
+  NotFound: 5,
+  AlreadyExists: 6,
+  PermissionDenied: 7,
+  ResourceExhausted: 8,
+  FailedPrecondition: 9,
+  Aborted: 10,
+  OutOfRange: 11,
+  Unimplemented: 12,
+  Internal: 13,
+  Unavailable: 14,
+  DataLoss: 15,
+  Unauthenticated: 16,
+} as const;
+
+export type GrpcCodeValue = (typeof GrpcCode)[keyof typeof GrpcCode];

--- a/sdks/life-sdk-ts/src/index.ts
+++ b/sdks/life-sdk-ts/src/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @broomva/life-sdk — public TypeScript SDK over lifegw.
+ *
+ * Implements the four user-facing services exposed by lifegw:
+ *   - `life.v1.Agent`    — session lifecycle + chat + tool dispatch
+ *   - `life.v1.Events`   — event tail + content-addressed blobs
+ *   - `life.v1.Wallet`   — balance, debit, transfer
+ *   - `life.v1.Identity` — whoami, profile, sessions
+ *
+ * The admin plane (`life.admin.*`) is intentionally NOT re-exported —
+ * it is UDS-only on the gateway and never reachable from the public
+ * SDK.
+ *
+ * Spec ground truth:
+ *   - Spec C₂ (lifed facade): `docs/superpowers/specs/2026-04-26-spec-c2-lifed-facade.md`
+ *   - Spec C₃ (lifegw edge gateway): Linear BRO-922 + amendments in
+ *     `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`
+ *   - Master spec: `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md`
+ */
+
+export { LifeClient, type LifeClientConfig } from "./client.js";
+
+export { Transport, type TransportConfig, type TransportCallOptions } from "./transport.js";
+
+export {
+  AgentClient,
+  EventsClient,
+  WalletClient,
+  IdentityClient,
+} from "./services/index.js";
+
+// WebSocket primitives.
+export {
+  WsAgentSession,
+  openWsAgentSession,
+  WebSocketReadyState,
+  type WsAgentSessionOptions,
+  type WsAgentSessionHandlers,
+  type WebSocketFactory,
+  type WebSocketLike,
+  type AgentEventEnvelope,
+  type InboundFrame,
+  type OutboundFrame,
+} from "./ws.js";
+
+// Typed errors.
+export {
+  LifeSdkError,
+  AuthError,
+  RateLimitError,
+  BackpressureError,
+  IpBlockedError,
+  LifedUnavailableError,
+  SequenceRetiredError,
+  InternalServerError,
+  GoingAwayError,
+  TlsNegotiationError,
+  TransportError,
+  GrpcError,
+  GrpcCode,
+  type GrpcCodeValue,
+  closeCodeToError,
+  grpcCodeToError,
+} from "./errors.js";
+
+// Proto types — re-exported so consumers don't need a deep import.
+export * as proto from "./proto/index.js";

--- a/sdks/life-sdk-ts/src/index.ts
+++ b/sdks/life-sdk-ts/src/index.ts
@@ -65,3 +65,15 @@ export {
 
 // Proto types — re-exported so consumers don't need a deep import.
 export * as proto from "./proto/index.js";
+
+// Proto3-JSON codec helpers — for converting between the wire shapes
+// (string for int64/uint64, base64 string for bytes) and the values
+// consumers actually want (bigint, Uint8Array). See `./codec.ts`.
+export {
+  microsToBigInt,
+  bigIntToMicros,
+  sequenceToBigInt,
+  bigIntToSequence,
+  bytesFromBase64,
+  bytesToBase64,
+} from "./codec.js";

--- a/sdks/life-sdk-ts/src/proto/agent.ts
+++ b/sdks/life-sdk-ts/src/proto/agent.ts
@@ -1,0 +1,155 @@
+/**
+ * `life.v1.Agent` proto types.
+ *
+ * Hand-curated TypeScript mirror of `proto/life/v1/agent.proto` (the
+ * full Spec C₂ §3.1 surface). Wire format follows the proto3 JSON
+ * mapping when serialized via grpc-web; see the gRPC documentation
+ * for the canonical conversion rules.
+ *
+ * Only the user-facing `life.v1.Agent` service is exposed — the
+ * admin plane (`life.admin.v1.*` / `life.admin.gw.v1.*`) is UDS-only
+ * and never reachable through lifegw, so it is intentionally absent
+ * from this SDK.
+ *
+ * @see proto/life/v1/agent.proto
+ */
+
+import type { AgentId, SessionId } from "./aios.js";
+import type { Timestamp } from "./timestamp.js";
+
+// ── Enums ──────────────────────────────────────────────────────────
+
+/**
+ * Agent event kinds emitted on the `Agent.SendMessage` /
+ * `Agent.StreamSession` server stream. Mirrors `AgentEventKind` in
+ * `proto/life/v1/agent.proto`.
+ */
+export const AgentEventKind = {
+  Unspecified: "AGENT_EVENT_KIND_UNSPECIFIED",
+  Token: "AGENT_EVENT_KIND_TOKEN",
+  ToolCallPending: "AGENT_EVENT_KIND_TOOL_CALL_PENDING",
+  ToolResult: "AGENT_EVENT_KIND_TOOL_RESULT",
+  ApprovalRequired: "AGENT_EVENT_KIND_APPROVAL_REQUIRED",
+  Finish: "AGENT_EVENT_KIND_FINISH",
+  Error: "AGENT_EVENT_KIND_ERROR",
+  Hibernate: "AGENT_EVENT_KIND_HIBERNATE",
+} as const;
+
+export type AgentEventKind = (typeof AgentEventKind)[keyof typeof AgentEventKind];
+
+// ── Messages ───────────────────────────────────────────────────────
+
+export interface ChildPolicy {
+  inheritSkills?: boolean;
+  inheritModels?: boolean;
+  depthCap?: number;
+  fanoutCap?: number;
+}
+
+export interface CreateSessionReq {
+  userId?: string;
+  projectId?: string;
+  label?: string;
+  resumeSid?: SessionId;
+  inheritPolicy?: ChildPolicy;
+}
+
+export interface Session {
+  sid: SessionId;
+  agentId?: AgentId;
+  userId?: string;
+  projectId?: string;
+  createdAt?: Timestamp;
+}
+
+export interface SessionRef {
+  sid: SessionId;
+  /**
+   * Resume cursor — when set, `Agent.StreamSession` replays from
+   * `from_sequence + 1`. `0` (or unset) means "fresh stream". See
+   * Spec C₃ §11.4 for the WebSocket-side reconnect semantics.
+   */
+  fromSequence?: bigint;
+}
+
+export interface SendMessageReq {
+  sid: SessionId;
+  content: string;
+  /**
+   * Optional reference to a previously-uploaded blob, e.g.
+   * `"sha256:<hex>"`. Forwarded verbatim to lifed.
+   */
+  attachmentBlobRef?: Uint8Array;
+}
+
+/**
+ * Re-exported from `events.ts` to match the proto layout where
+ * `EventRecord` lives in `events.proto` even though `AgentEvent`
+ * carries it.
+ */
+export interface EventRecord {
+  sessionId: SessionId;
+  sequence: bigint;
+  at?: Timestamp;
+  kind: string;
+  payload: Uint8Array;
+}
+
+export interface AgentEvent {
+  record: EventRecord;
+  kind: AgentEventKind;
+}
+
+export interface ApprovalReq {
+  sid: SessionId;
+  dispatchId: string;
+}
+
+export interface DispatchRef {
+  sid: SessionId;
+  dispatchId: string;
+}
+
+export interface ListSkillsReq {
+  projectId?: string;
+}
+
+export interface ListModelsReq {
+  projectId?: string;
+}
+
+export interface ListToolsReq {
+  projectId?: string;
+}
+
+export interface CatalogEntry {
+  id: string;
+  version: string;
+  manifest: Uint8Array;
+}
+
+export interface SkillCatalog {
+  items: CatalogEntry[];
+}
+
+export interface ModelCatalog {
+  items: CatalogEntry[];
+}
+
+export interface ToolCatalog {
+  items: CatalogEntry[];
+}
+
+export interface SpawnChildReq {
+  parentSid: SessionId;
+  spec?: CreateSessionReq;
+  budgetCapMicros?: bigint;
+  inheritPolicy?: ChildPolicy;
+}
+
+export interface SpawnChildResp {
+  childSid: SessionId;
+  address: string;
+}
+
+export interface Empty {}

--- a/sdks/life-sdk-ts/src/proto/agent.ts
+++ b/sdks/life-sdk-ts/src/proto/agent.ts
@@ -66,10 +66,12 @@ export interface SessionRef {
   sid: SessionId;
   /**
    * Resume cursor — when set, `Agent.StreamSession` replays from
-   * `from_sequence + 1`. `0` (or unset) means "fresh stream". See
+   * `from_sequence + 1`. `"0"` (or unset) means "fresh stream". See
    * Spec C₃ §11.4 for the WebSocket-side reconnect semantics.
+   *
+   * Proto3 JSON wire shape: string (uint64).
    */
-  fromSequence?: bigint;
+  fromSequence?: string;
 }
 
 export interface SendMessageReq {
@@ -78,21 +80,28 @@ export interface SendMessageReq {
   /**
    * Optional reference to a previously-uploaded blob, e.g.
    * `"sha256:<hex>"`. Forwarded verbatim to lifed.
+   *
+   * Proto3 JSON wire shape: base64 string (the proto field is
+   * `bytes`, but in practice this carries an ASCII reference like
+   * `sha256:<hex>` which the gateway base64-decodes back to bytes).
    */
-  attachmentBlobRef?: Uint8Array;
+  attachmentBlobRef?: string;
 }
 
 /**
  * Re-exported from `events.ts` to match the proto layout where
  * `EventRecord` lives in `events.proto` even though `AgentEvent`
  * carries it.
+ *
+ * Proto3 JSON wire shape: `sequence` is a string (int64), `payload`
+ * is a base64 string (`bytes`).
  */
 export interface EventRecord {
   sessionId: SessionId;
-  sequence: bigint;
+  sequence: string;
   at?: Timestamp;
   kind: string;
-  payload: Uint8Array;
+  payload: string;
 }
 
 export interface AgentEvent {
@@ -125,7 +134,8 @@ export interface ListToolsReq {
 export interface CatalogEntry {
   id: string;
   version: string;
-  manifest: Uint8Array;
+  /** Manifest bytes. Proto3 JSON wire shape: base64 string. */
+  manifest: string;
 }
 
 export interface SkillCatalog {
@@ -143,7 +153,8 @@ export interface ToolCatalog {
 export interface SpawnChildReq {
   parentSid: SessionId;
   spec?: CreateSessionReq;
-  budgetCapMicros?: bigint;
+  /** Budget cap in micros. Proto3 JSON wire shape: string (uint64). */
+  budgetCapMicros?: string;
   inheritPolicy?: ChildPolicy;
 }
 

--- a/sdks/life-sdk-ts/src/proto/aios.ts
+++ b/sdks/life-sdk-ts/src/proto/aios.ts
@@ -1,0 +1,45 @@
+/**
+ * `aios.v1` identifier types.
+ *
+ * Hand-curated TypeScript mirror of `proto/aios/v1/identifiers.proto`.
+ * Each identifier is an opaque string newtype on the wire; in TS we
+ * model them as `{ value: string }` to keep wire compatibility with
+ * the canonical Rust types in `aios_protocol::ids`.
+ *
+ * @see proto/aios/v1/identifiers.proto
+ */
+
+export interface SessionId {
+  value: string;
+}
+
+export interface AgentId {
+  value: string;
+}
+
+export interface VmId {
+  value: string;
+}
+
+export interface VmSnapshotId {
+  value: string;
+}
+
+export interface BackendId {
+  value: string;
+}
+
+/**
+ * Construct a `SessionId` from a plain string. Convenience helper for
+ * call sites that already have a string id.
+ */
+export function sessionId(value: string): SessionId {
+  return { value };
+}
+
+/**
+ * Construct an `AgentId` from a plain string.
+ */
+export function agentId(value: string): AgentId {
+  return { value };
+}

--- a/sdks/life-sdk-ts/src/proto/events.ts
+++ b/sdks/life-sdk-ts/src/proto/events.ts
@@ -1,0 +1,46 @@
+/**
+ * `life.v1.Events` proto types.
+ *
+ * Hand-curated TypeScript mirror of `proto/life/v1/events.proto`.
+ *
+ * @see proto/life/v1/events.proto
+ */
+
+import type { SessionId } from "./aios.js";
+import type { Timestamp } from "./timestamp.js";
+
+export interface EventRecord {
+  sessionId: SessionId;
+  sequence: bigint;
+  at?: Timestamp;
+  kind: string;
+  payload: Uint8Array;
+}
+
+export interface ReadReq {
+  sessionId: SessionId;
+  fromSequence?: bigint;
+  limit?: number;
+}
+
+export interface SubscribeReq {
+  sessionId: SessionId;
+  /**
+   * Free-form kind filter. Empty list means "all kinds".
+   */
+  kinds?: string[];
+  fromSequence?: bigint;
+}
+
+export interface BlobRef {
+  namespace: string;
+  /**
+   * Hex SHA-256 digest.
+   */
+  sha256: string;
+}
+
+export interface Blob {
+  data: Uint8Array;
+  contentType?: string;
+}

--- a/sdks/life-sdk-ts/src/proto/events.ts
+++ b/sdks/life-sdk-ts/src/proto/events.ts
@@ -3,6 +3,21 @@
  *
  * Hand-curated TypeScript mirror of `proto/life/v1/events.proto`.
  *
+ * **Proto3 JSON canonical mapping** (per
+ * https://protobuf.dev/programming-guides/proto3/#json):
+ * - `int64` / `uint64` → JSON string (preserves precision past 2^53).
+ * - `bytes` → base64 string (URL-safe or standard; both accepted on read).
+ *
+ * Pre-merge code-quality review I-1: this PR changes `sequence` /
+ * `fromSequence` from `bigint` to `string` and `payload` / `data` from
+ * `Uint8Array` to `string` (base64) so the type system reflects the
+ * actual runtime values. The transport's `jsonReviver` was a no-op;
+ * the previous typing was a type lie that would break every `payload
+ * instanceof Uint8Array` consumer call.
+ *
+ * Convert to bigint or bytes at the call site via the helpers in
+ * `../codec.js` (see {@link sequenceToBigInt}, {@link bytesFromBase64}).
+ *
  * @see proto/life/v1/events.proto
  */
 
@@ -11,15 +26,18 @@ import type { Timestamp } from "./timestamp.js";
 
 export interface EventRecord {
   sessionId: SessionId;
-  sequence: bigint;
+  /** Monotonic event sequence. Proto3 JSON wire shape: string (int64). */
+  sequence: string;
   at?: Timestamp;
   kind: string;
-  payload: Uint8Array;
+  /** Opaque event payload. Proto3 JSON wire shape: base64 string. */
+  payload: string;
 }
 
 export interface ReadReq {
   sessionId: SessionId;
-  fromSequence?: bigint;
+  /** Resume cursor. Proto3 JSON wire shape: string (int64) or omitted. */
+  fromSequence?: string;
   limit?: number;
 }
 
@@ -29,7 +47,8 @@ export interface SubscribeReq {
    * Free-form kind filter. Empty list means "all kinds".
    */
   kinds?: string[];
-  fromSequence?: bigint;
+  /** Resume cursor. Proto3 JSON wire shape: string (int64) or omitted. */
+  fromSequence?: string;
 }
 
 export interface BlobRef {
@@ -41,6 +60,7 @@ export interface BlobRef {
 }
 
 export interface Blob {
-  data: Uint8Array;
+  /** Blob bytes. Proto3 JSON wire shape: base64 string. */
+  data: string;
   contentType?: string;
 }

--- a/sdks/life-sdk-ts/src/proto/identity.ts
+++ b/sdks/life-sdk-ts/src/proto/identity.ts
@@ -1,0 +1,53 @@
+/**
+ * `life.v1.Identity` proto types.
+ *
+ * Hand-curated TypeScript mirror of `proto/life/v1/identity.proto`.
+ *
+ * @see proto/life/v1/identity.proto
+ */
+
+import type { SessionId } from "./aios.js";
+import type { Timestamp } from "./timestamp.js";
+
+export interface Profile {
+  bio?: string;
+  avatarBlobRef?: Uint8Array;
+  preferences?: Record<string, string>;
+}
+
+export interface Account {
+  userId: string;
+  handle?: string;
+  displayName?: string;
+  email?: string;
+  tier?: string;
+  createdAt?: Timestamp;
+  profile?: Profile;
+}
+
+export interface UpdateProfileReq {
+  profile: Profile;
+}
+
+export interface ListSessionsReq {
+  includeClosed?: boolean;
+  limit?: number;
+}
+
+export interface SessionDescriptor {
+  sid: SessionId;
+  projectId?: string;
+  openedAt?: Timestamp;
+  closedAt?: Timestamp;
+  label?: string;
+}
+
+export interface SessionList {
+  sessions: SessionDescriptor[];
+}
+
+export interface IdentityEmpty {}
+
+export interface IdentitySessionRef {
+  sid: SessionId;
+}

--- a/sdks/life-sdk-ts/src/proto/identity.ts
+++ b/sdks/life-sdk-ts/src/proto/identity.ts
@@ -11,7 +11,8 @@ import type { Timestamp } from "./timestamp.js";
 
 export interface Profile {
   bio?: string;
-  avatarBlobRef?: Uint8Array;
+  /** Avatar blob ref. Proto3 JSON wire shape: base64 string. */
+  avatarBlobRef?: string;
   preferences?: Record<string, string>;
 }
 

--- a/sdks/life-sdk-ts/src/proto/index.ts
+++ b/sdks/life-sdk-ts/src/proto/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public proto type re-exports.
+ *
+ * Only `life.v1.*` (user-facing) and `aios.v1.*` (canonical
+ * identifiers) are re-exported. The admin plane (`life.admin.v1.*`,
+ * `life.admin.gw.v1.*`) is intentionally absent — it is UDS-only and
+ * never reachable from the public-plane SDK.
+ */
+
+export * from "./aios.js";
+export * from "./timestamp.js";
+export * from "./agent.js";
+export type {
+  ReadReq,
+  SubscribeReq,
+  BlobRef,
+  Blob,
+} from "./events.js";
+export * from "./wallet.js";
+export * from "./identity.js";

--- a/sdks/life-sdk-ts/src/proto/timestamp.ts
+++ b/sdks/life-sdk-ts/src/proto/timestamp.ts
@@ -1,0 +1,30 @@
+/**
+ * `google.protobuf.Timestamp` JSON shape.
+ *
+ * The proto3 JSON mapping for Timestamp is an RFC 3339 string. This
+ * SDK exposes both the canonical JSON form (string) and a JS-native
+ * `Date` helper because most consumers want a `Date`.
+ *
+ * Wire format: `"2026-04-29T15:00:00Z"` (RFC 3339, UTC).
+ */
+
+export type Timestamp = string;
+
+/**
+ * Convert a proto3 JSON Timestamp string into a JS `Date`.
+ *
+ * Returns `null` when the input is empty or undefined — callers that
+ * want a definite Date should null-check at the call site.
+ */
+export function timestampToDate(ts: Timestamp | null | undefined): Date | null {
+  if (!ts) return null;
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Convert a `Date` to a proto3 JSON Timestamp string.
+ */
+export function dateToTimestamp(d: Date): Timestamp {
+  return d.toISOString();
+}

--- a/sdks/life-sdk-ts/src/proto/wallet.ts
+++ b/sdks/life-sdk-ts/src/proto/wallet.ts
@@ -1,0 +1,69 @@
+/**
+ * `life.v1.Wallet` proto types.
+ *
+ * Hand-curated TypeScript mirror of `proto/life/v1/wallet.proto`.
+ * Currency amounts are represented as `bigint` (μ-units / micros) to
+ * preserve precision — proto3 `uint64` does not fit in a JS `number`
+ * for very large balances.
+ *
+ * @see proto/life/v1/wallet.proto
+ */
+
+import type { Timestamp } from "./timestamp.js";
+
+export interface WalletRef {
+  userId: string;
+  projectId: string;
+}
+
+export interface Balance {
+  micros: bigint;
+  currency: string;
+  asOf?: Timestamp;
+}
+
+export interface StatementReq {
+  wallet: WalletRef;
+  since?: Timestamp;
+  until?: Timestamp;
+  limit?: number;
+}
+
+export interface LedgerEntry {
+  entryId: string;
+  at?: Timestamp;
+  /**
+   * Signed delta in micros. Negative for debits, positive for credits.
+   */
+  deltaMicros: bigint;
+  reason: string;
+  sid?: string;
+  skill?: string;
+  model?: string;
+  tool?: string;
+}
+
+export interface DebitReq {
+  wallet: WalletRef;
+  amountMicros: bigint;
+  sid?: string;
+  reason?: string;
+}
+
+export interface DebitReceipt {
+  entryId: string;
+  newBalance: Balance;
+}
+
+export interface TransferReq {
+  from: WalletRef;
+  to: WalletRef;
+  amountMicros: bigint;
+  memo?: string;
+}
+
+export interface TransferReceipt {
+  entryId: string;
+  fromBalance: Balance;
+  toBalance: Balance;
+}

--- a/sdks/life-sdk-ts/src/proto/wallet.ts
+++ b/sdks/life-sdk-ts/src/proto/wallet.ts
@@ -2,11 +2,24 @@
  * `life.v1.Wallet` proto types.
  *
  * Hand-curated TypeScript mirror of `proto/life/v1/wallet.proto`.
- * Currency amounts are represented as `bigint` (μ-units / micros) to
- * preserve precision — proto3 `uint64` does not fit in a JS `number`
- * for very large balances.
+ *
+ * **Proto3 JSON canonical mapping for `int64`/`uint64`:** the wire
+ * format is a JSON string (e.g. `"9999999999"`), NOT a JS number or
+ * bigint, because IEEE-754 doubles lose precision past 2^53. To keep
+ * round-trips honest, currency-amount fields here are typed as
+ * `string` matching the wire shape exactly. Convert to `bigint` at
+ * the call site via the {@link microsToBigInt} helper when arithmetic
+ * is needed.
+ *
+ * Pre-merge code-quality review I-1: this PR changes `micros` /
+ * `amountMicros` / `deltaMicros` from `bigint` to `string` so the
+ * type system reflects the actual runtime values. The earlier
+ * `bigint` typing was a "type lie" — the JSON reviver was a no-op,
+ * so consumers calling `bal.micros - 1n` would have crashed with
+ * `Cannot mix BigInt and other types`.
  *
  * @see proto/life/v1/wallet.proto
+ * @see {@link microsToBigInt} / {@link bigIntToMicros} in `../codec.js`
  */
 
 import type { Timestamp } from "./timestamp.js";
@@ -17,7 +30,8 @@ export interface WalletRef {
 }
 
 export interface Balance {
-  micros: bigint;
+  /** μ-units / micros. Proto3 JSON wire shape: string. */
+  micros: string;
   currency: string;
   asOf?: Timestamp;
 }
@@ -34,8 +48,10 @@ export interface LedgerEntry {
   at?: Timestamp;
   /**
    * Signed delta in micros. Negative for debits, positive for credits.
+   * Proto3 JSON wire shape: string (an int64 on the proto side; JSON
+   * encodes int64 as string per the canonical mapping).
    */
-  deltaMicros: bigint;
+  deltaMicros: string;
   reason: string;
   sid?: string;
   skill?: string;
@@ -45,7 +61,14 @@ export interface LedgerEntry {
 
 export interface DebitReq {
   wallet: WalletRef;
-  amountMicros: bigint;
+  /** μ-units / micros. Proto3 JSON wire shape: string. */
+  amountMicros: string;
+  /**
+   * Idempotency key. Spec C₂ §3.3 declares the dedup tuple as
+   * `(wallet, sid)`. Two `Debit` calls with the same `(wallet, sid)`
+   * deduplicate to one ledger entry. For one-shot debits without a
+   * session context, generate a stable opaque sid (e.g. a ULID).
+   */
   sid?: string;
   reason?: string;
 }
@@ -58,7 +81,17 @@ export interface DebitReceipt {
 export interface TransferReq {
   from: WalletRef;
   to: WalletRef;
-  amountMicros: bigint;
+  /** μ-units / micros. Proto3 JSON wire shape: string. */
+  amountMicros: string;
+  /**
+   * Idempotency key for `Wallet.Transfer`. Spec C₂ §3.3 + M5 Sub-phase
+   * D bundled `Wallet.Transfer` idempotency: the server uses `memo` as
+   * the dedup key (the proto schema does not yet carry a dedicated
+   * idempotency field). Pass a stable opaque value if you want
+   * idempotency; pass `undefined` for fire-and-forget transfers.
+   *
+   * Pre-merge spec-compliance review I2 doc fix.
+   */
   memo?: string;
 }
 

--- a/sdks/life-sdk-ts/src/services/agent.ts
+++ b/sdks/life-sdk-ts/src/services/agent.ts
@@ -1,0 +1,187 @@
+/**
+ * `life.v1.Agent` service client.
+ *
+ * @see proto/life/v1/agent.proto
+ */
+
+import type { Transport, TransportCallOptions } from "../transport.js";
+import type {
+  AgentEvent,
+  ApprovalReq,
+  CreateSessionReq,
+  DispatchRef,
+  Empty,
+  ListModelsReq,
+  ListSkillsReq,
+  ListToolsReq,
+  ModelCatalog,
+  SendMessageReq,
+  Session,
+  SessionRef,
+  SkillCatalog,
+  SpawnChildReq,
+  SpawnChildResp,
+  ToolCatalog,
+} from "../proto/agent.js";
+
+/**
+ * Service identifier for routing on lifegw. Spec C₂ §3.1.
+ */
+const SERVICE = "life.v1.Agent";
+
+export class AgentClient {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * Create a new session.
+   *
+   * Wraps `Agent.CreateSession` (unary).
+   */
+  createSession(req: CreateSessionReq, opts?: TransportCallOptions): Promise<Session> {
+    return this.transport.unary<CreateSessionReq, Session>(
+      SERVICE,
+      "CreateSession",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Describe an existing session — read-only metadata fetch.
+   */
+  describeSession(req: SessionRef, opts?: TransportCallOptions): Promise<Session> {
+    return this.transport.unary<SessionRef, Session>(
+      SERVICE,
+      "DescribeSession",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Close a session.
+   *
+   * Closing twice is idempotent (the second call resolves with
+   * `Empty`).
+   */
+  closeSession(req: SessionRef, opts?: TransportCallOptions): Promise<Empty> {
+    return this.transport.unary<SessionRef, Empty>(
+      SERVICE,
+      "CloseSession",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Send a chat message and receive a server-streaming `AgentEvent`
+   * tail.
+   *
+   * Yields events until the upstream stream finishes (FINISH or
+   * ERROR kind) or the call is aborted.
+   *
+   * For long-lived sessions where the client may reconnect, prefer
+   * the WebSocket transport via {@link AgentClient.streamSessionWs}.
+   */
+  sendMessage(
+    req: SendMessageReq,
+    opts?: TransportCallOptions,
+  ): AsyncIterable<AgentEvent> {
+    return this.transport.serverStream<SendMessageReq, AgentEvent>(
+      SERVICE,
+      "SendMessage",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Tail an existing session's events over server-streaming gRPC.
+   *
+   * Resume cursor: pass `req.fromSequence` to replay from `N+1`. For
+   * browser hosts that need true reconnect-on-drop semantics, prefer
+   * the WebSocket helper {@link AgentClient.streamSessionWs}.
+   */
+  streamSession(
+    req: SessionRef,
+    opts?: TransportCallOptions,
+  ): AsyncIterable<AgentEvent> {
+    return this.transport.serverStream<SessionRef, AgentEvent>(
+      SERVICE,
+      "StreamSession",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Approve a tool dispatch waiting on user consent.
+   */
+  approveDispatch(req: ApprovalReq, opts?: TransportCallOptions): Promise<Empty> {
+    return this.transport.unary<ApprovalReq, Empty>(
+      SERVICE,
+      "ApproveDispatch",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Cancel a pending dispatch.
+   */
+  cancelDispatch(req: DispatchRef, opts?: TransportCallOptions): Promise<Empty> {
+    return this.transport.unary<DispatchRef, Empty>(
+      SERVICE,
+      "CancelDispatch",
+      req,
+      opts,
+    );
+  }
+
+  /** List skill catalog entries available to a project. */
+  listSkills(req: ListSkillsReq, opts?: TransportCallOptions): Promise<SkillCatalog> {
+    return this.transport.unary<ListSkillsReq, SkillCatalog>(
+      SERVICE,
+      "ListSkills",
+      req,
+      opts,
+    );
+  }
+
+  /** List model catalog entries available to a project. */
+  listModels(req: ListModelsReq, opts?: TransportCallOptions): Promise<ModelCatalog> {
+    return this.transport.unary<ListModelsReq, ModelCatalog>(
+      SERVICE,
+      "ListModels",
+      req,
+      opts,
+    );
+  }
+
+  /** List tool catalog entries available to a project. */
+  listTools(req: ListToolsReq, opts?: TransportCallOptions): Promise<ToolCatalog> {
+    return this.transport.unary<ListToolsReq, ToolCatalog>(
+      SERVICE,
+      "ListTools",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Spawn a child session. M5 ships a stub server-side — the client
+   * still surfaces the call so consumers can detect when the
+   * platform graduates the feature.
+   */
+  spawnChild(
+    req: SpawnChildReq,
+    opts?: TransportCallOptions,
+  ): Promise<SpawnChildResp> {
+    return this.transport.unary<SpawnChildReq, SpawnChildResp>(
+      SERVICE,
+      "SpawnChild",
+      req,
+      opts,
+    );
+  }
+}

--- a/sdks/life-sdk-ts/src/services/events.ts
+++ b/sdks/life-sdk-ts/src/services/events.ts
@@ -58,21 +58,26 @@ export class EventsClient {
   /**
    * Convenience helper: read a blob and return its raw bytes.
    *
-   * The proto `Blob.data` field is decoded base64 → `Uint8Array` by
-   * the transport reviver.
+   * The proto `Blob.data` field is the proto3-JSON canonical encoding
+   * of `bytes`, which is a base64-encoded string on the wire (see the
+   * I-1 fix at top of `../proto/events.ts`). This helper decodes the
+   * base64 to the raw `Uint8Array` payload.
    */
   async getBlobBytes(req: BlobRef, opts?: TransportCallOptions): Promise<Uint8Array> {
     const blob = await this.getBlob(req, opts);
-    if (blob.data instanceof Uint8Array) return blob.data;
-    if (typeof blob.data === "string") {
-      // Some hosts skip the reviver — re-decode here.
-      return base64ToBytes(blob.data);
+    if (typeof blob.data !== "string" || blob.data.length === 0) {
+      return new Uint8Array();
     }
-    return new Uint8Array();
+    return base64ToBytes(blob.data);
   }
 }
 
-function base64ToBytes(b64: string): Uint8Array {
+/**
+ * Decode a proto3-JSON `bytes` field (base64 string) to raw bytes.
+ * Exported for downstream consumers who hold an `EventRecord.payload`
+ * or `CatalogEntry.manifest` and need the binary form.
+ */
+export function base64ToBytes(b64: string): Uint8Array {
   if (typeof atob === "function") {
     const bin = atob(b64);
     const out = new Uint8Array(bin.length);

--- a/sdks/life-sdk-ts/src/services/events.ts
+++ b/sdks/life-sdk-ts/src/services/events.ts
@@ -1,0 +1,86 @@
+/**
+ * `life.v1.Events` service client.
+ *
+ * @see proto/life/v1/events.proto
+ */
+
+import type { Transport, TransportCallOptions } from "../transport.js";
+import type {
+  Blob,
+  BlobRef,
+  EventRecord,
+  ReadReq,
+  SubscribeReq,
+} from "../proto/events.js";
+
+const SERVICE = "life.v1.Events";
+
+export class EventsClient {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * Read historical events from a session, server-streamed.
+   *
+   * Pass `req.fromSequence` to scan from a specific point; pass
+   * `req.limit` to bound the response.
+   */
+  read(req: ReadReq, opts?: TransportCallOptions): AsyncIterable<EventRecord> {
+    return this.transport.serverStream<ReadReq, EventRecord>(
+      SERVICE,
+      "Read",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Subscribe to live events with optional kind filter.
+   */
+  subscribe(req: SubscribeReq, opts?: TransportCallOptions): AsyncIterable<EventRecord> {
+    return this.transport.serverStream<SubscribeReq, EventRecord>(
+      SERVICE,
+      "Subscribe",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Fetch a content-addressed blob.
+   *
+   * Convenience: the Connect-protocol JSON wire encodes `bytes` as
+   * base64; the SDK handles the conversion in `Transport`.
+   */
+  getBlob(req: BlobRef, opts?: TransportCallOptions): Promise<Blob> {
+    return this.transport.unary<BlobRef, Blob>(SERVICE, "GetBlob", req, opts);
+  }
+
+  /**
+   * Convenience helper: read a blob and return its raw bytes.
+   *
+   * The proto `Blob.data` field is decoded base64 → `Uint8Array` by
+   * the transport reviver.
+   */
+  async getBlobBytes(req: BlobRef, opts?: TransportCallOptions): Promise<Uint8Array> {
+    const blob = await this.getBlob(req, opts);
+    if (blob.data instanceof Uint8Array) return blob.data;
+    if (typeof blob.data === "string") {
+      // Some hosts skip the reviver — re-decode here.
+      return base64ToBytes(blob.data);
+    }
+    return new Uint8Array();
+  }
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  if (typeof atob === "function") {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  // Node fallback.
+  const g = globalThis as unknown as { Buffer?: { from(s: string, enc: string): Uint8Array } };
+  if (g.Buffer) return new Uint8Array(g.Buffer.from(b64, "base64"));
+  throw new Error("no base64 decoder available");
+}

--- a/sdks/life-sdk-ts/src/services/identity.ts
+++ b/sdks/life-sdk-ts/src/services/identity.ts
@@ -1,0 +1,69 @@
+/**
+ * `life.v1.Identity` service client.
+ *
+ * @see proto/life/v1/identity.proto
+ */
+
+import type { Transport, TransportCallOptions } from "../transport.js";
+import type {
+  Account,
+  IdentityEmpty,
+  IdentitySessionRef,
+  ListSessionsReq,
+  SessionList,
+  UpdateProfileReq,
+} from "../proto/identity.js";
+
+const SERVICE = "life.v1.Identity";
+
+export class IdentityClient {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * Resolve the calling identity. The bearer token determines the
+   * returned `Account`.
+   */
+  whoami(opts?: TransportCallOptions): Promise<Account> {
+    return this.transport.unary<IdentityEmpty, Account>(SERVICE, "Me", {}, opts);
+  }
+
+  /**
+   * Update the caller's profile fields. Server responds with the
+   * post-update `Account`.
+   */
+  updateProfile(req: UpdateProfileReq, opts?: TransportCallOptions): Promise<Account> {
+    return this.transport.unary<UpdateProfileReq, Account>(
+      SERVICE,
+      "UpdateProfile",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * List the caller's sessions.
+   */
+  listSessions(req: ListSessionsReq, opts?: TransportCallOptions): Promise<SessionList> {
+    return this.transport.unary<ListSessionsReq, SessionList>(
+      SERVICE,
+      "ListSessions",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Revoke an active session.
+   */
+  revokeSession(
+    req: IdentitySessionRef,
+    opts?: TransportCallOptions,
+  ): Promise<IdentityEmpty> {
+    return this.transport.unary<IdentitySessionRef, IdentityEmpty>(
+      SERVICE,
+      "RevokeSession",
+      req,
+      opts,
+    );
+  }
+}

--- a/sdks/life-sdk-ts/src/services/index.ts
+++ b/sdks/life-sdk-ts/src/services/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Service client re-exports.
+ */
+export { AgentClient } from "./agent.js";
+export { EventsClient } from "./events.js";
+export { WalletClient } from "./wallet.js";
+export { IdentityClient } from "./identity.js";

--- a/sdks/life-sdk-ts/src/services/wallet.ts
+++ b/sdks/life-sdk-ts/src/services/wallet.ts
@@ -1,0 +1,83 @@
+/**
+ * `life.v1.Wallet` service client.
+ *
+ * Currency amounts are bigint micros throughout. Idempotency
+ * semantics:
+ *   - `Debit`: idempotent on the `(wallet, sid)` tuple — replays
+ *     return the original receipt.
+ *   - `Transfer`: idempotency lands in M5 Sub-phase D follow-up
+ *     (haima per-task billing alignment); callers should still
+ *     pass a stable `memo` to aid operator reconciliation.
+ *
+ * @see proto/life/v1/wallet.proto
+ */
+
+import type { Transport, TransportCallOptions } from "../transport.js";
+import type {
+  Balance,
+  DebitReceipt,
+  DebitReq,
+  LedgerEntry,
+  StatementReq,
+  TransferReceipt,
+  TransferReq,
+  WalletRef,
+} from "../proto/wallet.js";
+
+const SERVICE = "life.v1.Wallet";
+
+export class WalletClient {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * Read the current balance of a wallet.
+   *
+   * The returned `micros` is a bigint — convert to USDC by dividing
+   * by 1_000_000n.
+   */
+  getBalance(req: WalletRef, opts?: TransportCallOptions): Promise<Balance> {
+    return this.transport.unary<WalletRef, Balance>(
+      SERVICE,
+      "GetBalance",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Stream the wallet's ledger entries since `since` (inclusive).
+   */
+  statement(req: StatementReq, opts?: TransportCallOptions): AsyncIterable<LedgerEntry> {
+    return this.transport.serverStream<StatementReq, LedgerEntry>(
+      SERVICE,
+      "Statement",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Debit the wallet. Idempotent on `(wallet, sid)` — replays return
+   * the original receipt.
+   */
+  debit(req: DebitReq, opts?: TransportCallOptions): Promise<DebitReceipt> {
+    return this.transport.unary<DebitReq, DebitReceipt>(
+      SERVICE,
+      "Debit",
+      req,
+      opts,
+    );
+  }
+
+  /**
+   * Transfer micros between two wallets.
+   */
+  transfer(req: TransferReq, opts?: TransportCallOptions): Promise<TransferReceipt> {
+    return this.transport.unary<TransferReq, TransferReceipt>(
+      SERVICE,
+      "Transfer",
+      req,
+      opts,
+    );
+  }
+}

--- a/sdks/life-sdk-ts/src/transport.ts
+++ b/sdks/life-sdk-ts/src/transport.ts
@@ -252,6 +252,14 @@ export class Transport {
         // Unknown flags are silently dropped per Connect spec.
       }
     } finally {
+      // I-2 fix: when the consumer breaks out of the for-await loop early,
+      // we need to abort the underlying fetch so the body stream is
+      // cancelled and the HTTP connection is freed. Without this, the
+      // connection stays open until GC. The body reader's
+      // `releaseLock()` (in `readConnectFrames`'s finally) only releases
+      // the lock — `controller.abort()` is what actually cancels the
+      // stream.
+      controller.abort();
       linked.cleanup();
     }
   }
@@ -290,6 +298,15 @@ interface ConnectFrame {
 
 /**
  * Read Connect-protocol stream frames from a `ReadableStream<Uint8Array>`.
+ *
+ * Pre-merge code-quality review I-2: previously this generator never
+ * called `reader.releaseLock()` or `reader.cancel()`. When a consumer
+ * broke out of the for-await loop early (e.g. the quickstart example
+ * `if (event.kind === "FINISH") break`), the underlying body reader
+ * stayed held and the HTTP connection stayed open until GC. The
+ * `try { ... } finally { reader.releaseLock(); }` wrapper here ensures
+ * the reader is released when the generator's `return()` fires (which
+ * happens automatically on early break/return from a for-await).
  */
 async function* readConnectFrames(
   stream: ReadableStream<Uint8Array>,
@@ -298,28 +315,39 @@ async function* readConnectFrames(
   let buffer = new Uint8Array(0);
   const td = new TextDecoder();
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    if (!value) continue;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
 
-    // Append to buffer.
-    const next = new Uint8Array(buffer.byteLength + value.byteLength);
-    next.set(buffer, 0);
-    next.set(value, buffer.byteLength);
-    buffer = next;
+      // Append to buffer.
+      const next = new Uint8Array(buffer.byteLength + value.byteLength);
+      next.set(buffer, 0);
+      next.set(value, buffer.byteLength);
+      buffer = next;
 
-    // Parse all complete frames.
-    while (buffer.byteLength >= 5) {
-      const flag = buffer[0];
-      if (flag === undefined) break;
-      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-      const length = view.getUint32(1, false);
-      if (buffer.byteLength < 5 + length) break;
-      const payload = buffer.slice(5, 5 + length);
-      const body = td.decode(payload);
-      yield { flag, body };
-      buffer = buffer.slice(5 + length);
+      // Parse all complete frames.
+      while (buffer.byteLength >= 5) {
+        const flag = buffer[0];
+        if (flag === undefined) break;
+        const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+        const length = view.getUint32(1, false);
+        if (buffer.byteLength < 5 + length) break;
+        const payload = buffer.slice(5, 5 + length);
+        const body = td.decode(payload);
+        yield { flag, body };
+        buffer = buffer.slice(5 + length);
+      }
+    }
+  } finally {
+    // Release the lock so the underlying ReadableStream can be cancelled
+    // by the outer `serverStream` finally (which calls
+    // `controller.abort()` to cancel the in-flight fetch).
+    try {
+      reader.releaseLock();
+    } catch {
+      // ReadableStream is already cancelled — nothing to do.
     }
   }
 }

--- a/sdks/life-sdk-ts/src/transport.ts
+++ b/sdks/life-sdk-ts/src/transport.ts
@@ -1,0 +1,456 @@
+/**
+ * gRPC-web transport over `fetch`.
+ *
+ * This module implements the **Connect over HTTP** wire shape (also
+ * known as `application/connect+json`) — a gRPC-compatible protocol
+ * that uses plain JSON request/response bodies plus a length-prefixed
+ * frame framing for streaming.
+ *
+ * The lifegw edge gateway negotiates `grpc-web+json` and `connect+json`
+ * via tonic-web; this SDK uses `connect+json` because it gives a
+ * ergonomic plain-JSON request shape and doesn't need a protobuf
+ * runtime in the client.
+ *
+ * Wire shape (Connect protocol simplified):
+ *
+ * Unary:
+ *   POST /life.v1.Service/Method
+ *   Content-Type: application/json
+ *   { "request fields..." }
+ *   →
+ *   200 OK
+ *   Content-Type: application/json
+ *   { "response fields..." }
+ *
+ * Errors:
+ *   non-2xx response with JSON body { code: "<status>", message: "..." }
+ *
+ * Server streaming:
+ *   POST /life.v1.Service/Method
+ *   Content-Type: application/connect+json
+ *   {flag: 0, length: N, body: <json>}* {flag: 2, length: N, body: <end-stream-json>}
+ *
+ * For stream framing the wire is:
+ *   [flag (1 byte)][length (4 bytes BE)][payload (length bytes)]
+ *
+ * - flag = 0   → message frame (UTF-8 JSON-encoded message)
+ * - flag = 2   → end-stream frame (UTF-8 JSON, contains `error?`)
+ *
+ * This is sufficient for the four user-facing services. Larger
+ * payloads (binary blobs) use `bytes` fields which Connect/JSON
+ * encodes as base64.
+ *
+ * @see https://connectrpc.com/docs/protocol/
+ */
+
+import {
+  GrpcCode,
+  GrpcError,
+  TlsNegotiationError,
+  TransportError,
+  grpcCodeToError,
+} from "./errors.js";
+import type { LifeSdkError } from "./errors.js";
+
+/**
+ * Map a Connect status name (string) to a numeric gRPC code.
+ */
+const CONNECT_CODE_MAP: Record<string, number> = {
+  canceled: GrpcCode.Cancelled,
+  unknown: GrpcCode.Unknown,
+  invalid_argument: GrpcCode.InvalidArgument,
+  deadline_exceeded: GrpcCode.DeadlineExceeded,
+  not_found: GrpcCode.NotFound,
+  already_exists: GrpcCode.AlreadyExists,
+  permission_denied: GrpcCode.PermissionDenied,
+  resource_exhausted: GrpcCode.ResourceExhausted,
+  failed_precondition: GrpcCode.FailedPrecondition,
+  aborted: GrpcCode.Aborted,
+  out_of_range: GrpcCode.OutOfRange,
+  unimplemented: GrpcCode.Unimplemented,
+  internal: GrpcCode.Internal,
+  unavailable: GrpcCode.Unavailable,
+  data_loss: GrpcCode.DataLoss,
+  unauthenticated: GrpcCode.Unauthenticated,
+};
+
+const CONNECT_CODE_REVERSE: Record<number, string> = Object.fromEntries(
+  Object.entries(CONNECT_CODE_MAP).map(([k, v]) => [v, k.toUpperCase()]),
+);
+
+interface ConnectErrorBody {
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Options passed to every transport call.
+ */
+export interface TransportCallOptions {
+  /**
+   * Optional `AbortSignal` for cancellation.
+   */
+  signal?: AbortSignal;
+  /**
+   * Per-call request timeout in milliseconds. Implementation creates
+   * an internal `AbortController` linked to `signal`.
+   */
+  timeoutMs?: number;
+  /**
+   * Extra headers to attach. Authorization is added automatically by
+   * the {@link Transport} from its `getAuthToken` callback.
+   */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Transport configuration.
+ */
+export interface TransportConfig {
+  /**
+   * Base URL of the lifegw HTTPS endpoint, e.g. `https://api.life.dev`.
+   * Trailing slashes are normalized away.
+   */
+  baseUrl: string;
+
+  /**
+   * Async producer for the Tier-1 bearer token. Called on every RPC;
+   * implementations should cache + refresh internally to avoid
+   * blocking the hot path.
+   */
+  getAuthToken?: () => Promise<string | undefined>;
+
+  /**
+   * Optional `fetch` override (for tests or non-browser hosts).
+   */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Lightweight transport over `fetch`. One transport instance can be
+ * shared across all four services.
+ */
+export class Transport {
+  readonly baseUrl: string;
+  readonly fetchFn: typeof fetch;
+  readonly getAuthToken?: () => Promise<string | undefined>;
+
+  constructor(cfg: TransportConfig) {
+    this.baseUrl = cfg.baseUrl.replace(/\/+$/, "");
+    this.fetchFn = cfg.fetch ?? globalThis.fetch.bind(globalThis);
+    this.getAuthToken = cfg.getAuthToken;
+  }
+
+  /**
+   * Perform a unary RPC. The server is expected to return JSON on
+   * 2xx and a Connect error body on non-2xx.
+   *
+   * @param service Fully-qualified proto service name, e.g. `life.v1.Agent`.
+   * @param method Method name, e.g. `CreateSession`.
+   * @param body Request payload (plain JS object — not yet stringified).
+   * @param opts Per-call options.
+   *
+   * @returns Decoded response body.
+   * @throws {LifeSdkError} subclasses on transport / RPC error.
+   */
+  async unary<TReq, TRes>(
+    service: string,
+    method: string,
+    body: TReq,
+    opts: TransportCallOptions = {},
+  ): Promise<TRes> {
+    const url = `${this.baseUrl}/${service}/${method}`;
+    const headers = await this.buildHeaders(opts.headers);
+    headers["Content-Type"] = "application/json";
+
+    const controller = new AbortController();
+    const linked = linkSignals(controller, opts.signal, opts.timeoutMs);
+
+    let resp: Response;
+    try {
+      resp = await this.fetchFn(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body, jsonReplacer),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw mapFetchError(err);
+    } finally {
+      linked.cleanup();
+    }
+
+    if (!resp.ok) {
+      throw await readConnectError(resp);
+    }
+
+    const text = await resp.text();
+    return parseJsonResponse<TRes>(text);
+  }
+
+  /**
+   * Perform a server-streaming RPC (Connect protocol framing).
+   *
+   * Yields decoded messages from the stream. Throws when the stream
+   * ends with an error end-stream frame, or when transport fails.
+   */
+  async *serverStream<TReq, TRes>(
+    service: string,
+    method: string,
+    body: TReq,
+    opts: TransportCallOptions = {},
+  ): AsyncIterable<TRes> {
+    const url = `${this.baseUrl}/${service}/${method}`;
+    const headers = await this.buildHeaders(opts.headers);
+    headers["Content-Type"] = "application/connect+json";
+    headers["Connect-Protocol-Version"] = "1";
+
+    const controller = new AbortController();
+    const linked = linkSignals(controller, opts.signal, opts.timeoutMs);
+
+    let resp: Response;
+    try {
+      // Connect server-stream encodes the request as a single message frame.
+      const reqFrame = encodeMessageFrame(JSON.stringify(body, jsonReplacer));
+      // Cast to BodyInit — Uint8Array is a valid BodyInit at runtime
+      // but TS lib.dom.d.ts only includes the older signature in some
+      // versions.
+      resp = await this.fetchFn(url, {
+        method: "POST",
+        headers,
+        body: reqFrame as unknown as BodyInit,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      linked.cleanup();
+      throw mapFetchError(err);
+    }
+
+    if (!resp.ok) {
+      linked.cleanup();
+      throw await readConnectError(resp);
+    }
+
+    if (!resp.body) {
+      linked.cleanup();
+      throw new TransportError("server-stream response had no body");
+    }
+
+    try {
+      for await (const frame of readConnectFrames(resp.body)) {
+        if (frame.flag === 2) {
+          // End-stream frame.
+          const trailer = parseJsonResponse<ConnectErrorBody>(frame.body) as ConnectErrorBody;
+          if (trailer && trailer.code) {
+            throw connectErrorToSdkError(trailer);
+          }
+          return;
+        }
+        if (frame.flag === 0) {
+          yield parseJsonResponse<TRes>(frame.body);
+        }
+        // Unknown flags are silently dropped per Connect spec.
+      }
+    } finally {
+      linked.cleanup();
+    }
+  }
+
+  private async buildHeaders(extra?: Record<string, string>): Promise<Record<string, string>> {
+    const out: Record<string, string> = { ...(extra ?? {}) };
+    if (this.getAuthToken) {
+      const tok = await this.getAuthToken();
+      if (tok) out.Authorization = `Bearer ${tok}`;
+    }
+    return out;
+  }
+}
+
+// ── Frame encoding helpers ─────────────────────────────────────────
+
+/**
+ * Encode a message body as a Connect frame: `[flag][len BE][payload]`.
+ */
+function encodeMessageFrame(body: string): Uint8Array {
+  const payload = new TextEncoder().encode(body);
+  const out = new Uint8Array(5 + payload.byteLength);
+  // flag = 0 (message)
+  out[0] = 0;
+  // 4-byte big-endian length
+  const view = new DataView(out.buffer);
+  view.setUint32(1, payload.byteLength, false);
+  out.set(payload, 5);
+  return out;
+}
+
+interface ConnectFrame {
+  flag: number;
+  body: string;
+}
+
+/**
+ * Read Connect-protocol stream frames from a `ReadableStream<Uint8Array>`.
+ */
+async function* readConnectFrames(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<ConnectFrame> {
+  const reader = stream.getReader();
+  let buffer = new Uint8Array(0);
+  const td = new TextDecoder();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    // Append to buffer.
+    const next = new Uint8Array(buffer.byteLength + value.byteLength);
+    next.set(buffer, 0);
+    next.set(value, buffer.byteLength);
+    buffer = next;
+
+    // Parse all complete frames.
+    while (buffer.byteLength >= 5) {
+      const flag = buffer[0];
+      if (flag === undefined) break;
+      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      const length = view.getUint32(1, false);
+      if (buffer.byteLength < 5 + length) break;
+      const payload = buffer.slice(5, 5 + length);
+      const body = td.decode(payload);
+      yield { flag, body };
+      buffer = buffer.slice(5 + length);
+    }
+  }
+}
+
+// ── Error helpers ──────────────────────────────────────────────────
+
+async function readConnectError(resp: Response): Promise<LifeSdkError> {
+  const text = await resp.text();
+  if (!text) {
+    return new GrpcError(GrpcCode.Unknown, "UNKNOWN", `HTTP ${resp.status}`);
+  }
+  try {
+    const body = JSON.parse(text) as ConnectErrorBody;
+    return connectErrorToSdkError(body);
+  } catch {
+    return new GrpcError(GrpcCode.Unknown, "UNKNOWN", text);
+  }
+}
+
+function connectErrorToSdkError(body: ConnectErrorBody): LifeSdkError {
+  const codeKey = (body.code ?? "unknown").toLowerCase();
+  const numeric = CONNECT_CODE_MAP[codeKey] ?? GrpcCode.Unknown;
+  const status = CONNECT_CODE_REVERSE[numeric] ?? "UNKNOWN";
+  return grpcCodeToError(numeric, status, body.message);
+}
+
+function mapFetchError(err: unknown): LifeSdkError {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    // Best-effort TLS-negotiation detection. Browser-side fetch
+    // collapses TLS errors into a generic TypeError("Failed to
+    // fetch") so the heuristic is intentionally lenient.
+    if (
+      msg.includes("ssl") ||
+      msg.includes("tls") ||
+      msg.includes("eproto") ||
+      msg.includes("handshake") ||
+      msg.includes("err_ssl") ||
+      msg.includes("ssl3")
+    ) {
+      return new TlsNegotiationError(`TLS negotiation failed: ${err.message}`);
+    }
+    if (err.name === "AbortError") {
+      return new GrpcError(GrpcCode.Cancelled, "CANCELLED", err.message);
+    }
+    return new TransportError(err.message, { cause: err });
+  }
+  return new TransportError(String(err));
+}
+
+function parseJsonResponse<T>(text: string): T {
+  if (!text) return {} as T;
+  try {
+    return JSON.parse(text, jsonReviver) as T;
+  } catch (err) {
+    throw new TransportError(`malformed response JSON: ${(err as Error).message}`, {
+      cause: err as Error,
+    });
+  }
+}
+
+// ── BigInt-safe JSON helpers ───────────────────────────────────────
+
+/**
+ * `JSON.stringify` replacer that converts `bigint` values to strings
+ * (proto3 JSON canonical form for `int64` / `uint64`).
+ */
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Uint8Array) {
+    // proto3 JSON encodes `bytes` as base64.
+    return uint8ArrayToBase64(value);
+  }
+  return value;
+}
+
+/**
+ * `JSON.parse` reviver that leaves number-like strings alone (callers
+ * choose whether to widen to `bigint`). We intentionally do NOT
+ * auto-bigint here because the proto schema is the source of truth.
+ */
+function jsonReviver(_key: string, value: unknown): unknown {
+  return value;
+}
+
+function uint8ArrayToBase64(u8: Uint8Array): string {
+  // Browser-compat: prefer `btoa` over Node `Buffer` so the SDK runs
+  // unchanged in the browser.
+  let bin = "";
+  for (let i = 0; i < u8.byteLength; i++) {
+    bin += String.fromCharCode(u8[i] as number);
+  }
+  if (typeof btoa === "function") return btoa(bin);
+  // Node fallback: TextEncoder + globalThis.Buffer
+  const g = globalThis as unknown as { Buffer?: { from(s: string, enc: string): { toString(enc: string): string } } };
+  if (g.Buffer) return g.Buffer.from(bin, "binary").toString("base64");
+  throw new TransportError("no base64 encoder available");
+}
+
+// ── Signal linking ─────────────────────────────────────────────────
+
+interface LinkedSignals {
+  cleanup: () => void;
+}
+
+function linkSignals(
+  controller: AbortController,
+  external?: AbortSignal,
+  timeoutMs?: number,
+): LinkedSignals {
+  const handlers: Array<() => void> = [];
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  if (external) {
+    if (external.aborted) {
+      controller.abort(external.reason);
+    } else {
+      const onAbort = (): void => controller.abort(external.reason);
+      external.addEventListener("abort", onAbort, { once: true });
+      handlers.push(() => external.removeEventListener("abort", onAbort));
+    }
+  }
+
+  if (timeoutMs && timeoutMs > 0) {
+    timer = setTimeout(() => controller.abort(new Error("request timeout")), timeoutMs);
+  }
+
+  return {
+    cleanup() {
+      if (timer) clearTimeout(timer);
+      for (const h of handlers) h();
+    },
+  };
+}

--- a/sdks/life-sdk-ts/src/ws.ts
+++ b/sdks/life-sdk-ts/src/ws.ts
@@ -32,6 +32,10 @@ import {
   closeCodeToError,
   TransportError,
   TlsNegotiationError,
+  AuthError,
+  RateLimitError,
+  IpBlockedError,
+  SequenceRetiredError,
   type LifeSdkError,
 } from "./errors.js";
 
@@ -412,9 +416,36 @@ export class WsAgentSession {
     setTimeout(() => {
       if (this.closing) return;
       this.connect().catch((err: unknown) => {
-        // If the synchronous handshake fails outright, surface and stop.
+        // I-3 fix: if the retry handshake fails (close-before-open)
+        // with a transient error class AND we still have budget,
+        // schedule another reconnect rather than terminating
+        // immediately. Pre-fix this branch always set `closed = true`,
+        // which collapsed maxReconnectAttempts to 1 in practice.
+        //
+        // Permanent error classes (matching PERMANENT_CLOSE_CODES):
+        // AuthError (1008), RateLimitError (4001), IpBlockedError
+        // (4003), SequenceRetiredError (4005). Everything else is
+        // transient (TransportError, GoingAwayError,
+        // InternalServerError 1011, BackpressureError 4002,
+        // LifedUnavailableError 4004).
+        const sdkErr = err as LifeSdkError;
+        const isPermanent =
+          sdkErr instanceof AuthError ||
+          sdkErr instanceof RateLimitError ||
+          sdkErr instanceof IpBlockedError ||
+          sdkErr instanceof SequenceRetiredError;
+        if (
+          this.options.autoReconnect &&
+          !isPermanent &&
+          this.reconnectAttempts < this.options.maxReconnectAttempts &&
+          !this.closing
+        ) {
+          this.scheduleReconnect();
+          return;
+        }
+        // Permanent error or budget exhausted.
         this.closed = true;
-        this.handlers.onError?.(err as LifeSdkError);
+        this.handlers.onError?.(sdkErr);
       });
     }, delay);
   }

--- a/sdks/life-sdk-ts/src/ws.ts
+++ b/sdks/life-sdk-ts/src/ws.ts
@@ -1,0 +1,590 @@
+/**
+ * WebSocket transport for `Agent.StreamSession`.
+ *
+ * The lifegw gateway upgrades `/v1/agent/stream` per Spec C₃ §6.2.
+ * Frame envelope:
+ *   `{ "kind": "...", ...rest }` where `kind` is the discriminator.
+ *
+ * Server frames (received here):
+ *   - `agent_event` — `{ kind: "agent_event", seq_no: u64, record: <event>, agent_kind: str }`
+ *   - `pong`        — `{ kind: "pong", seq_no: u64 }`
+ *   - `closing`     — `{ kind: "closing", reason: str }` (always followed by close)
+ *
+ * Client frames (sent here):
+ *   - `send_message`     — `{ kind: "send_message", content: str, attachment_blob_ref?: str }`
+ *   - `approve_dispatch` — `{ kind: "approve_dispatch", dispatch_id: str }`
+ *   - `cancel_dispatch`  — `{ kind: "cancel_dispatch", dispatch_id: str }`
+ *   - `ping`             — `{ kind: "ping", seq_no?: u64 }`
+ *   - `close`            — `{ kind: "close", reason?: str }`
+ *
+ * Reconnect-by-sequence (Spec C₃ §11.4):
+ *   - On (re)connect, attach `?last_seq_no=<u64>` query OR
+ *     `X-Life-Last-Seq-No: <u64>` header. lifed replays from `N+1`.
+ *   - The connection stores the highest `seq_no` it has seen and
+ *     uses it on the next reconnect attempt.
+ *
+ * Close codes: see {@link closeCodeToError} in `errors.ts` for the
+ * full mapping. The connection emits a typed error via the
+ * `error` event and the `close` event for graceful (1000) closes.
+ */
+
+import {
+  closeCodeToError,
+  TransportError,
+  TlsNegotiationError,
+  type LifeSdkError,
+} from "./errors.js";
+
+// ── Frame types ────────────────────────────────────────────────────
+
+/**
+ * Server → client frame envelope (Spec C₃ §6.2).
+ */
+export type OutboundFrame =
+  | {
+      kind: "agent_event";
+      seq_no: string | number;
+      record: unknown;
+      agent_kind: string;
+    }
+  | { kind: "pong"; seq_no: string | number }
+  | { kind: "closing"; reason: string };
+
+/**
+ * Client → server frame envelope.
+ */
+export type InboundFrame =
+  | { kind: "send_message"; content: string; attachment_blob_ref?: string }
+  | { kind: "approve_dispatch"; dispatch_id: string }
+  | { kind: "cancel_dispatch"; dispatch_id: string }
+  | { kind: "ping"; seq_no?: number }
+  | { kind: "close"; reason?: string };
+
+// ── WebSocket abstraction ──────────────────────────────────────────
+
+/**
+ * Minimal `WebSocket` interface — matches both the browser global and
+ * the `ws` package's class so the SDK can run unchanged in either.
+ */
+export interface WebSocketLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(event: "open", handler: () => void): void;
+  addEventListener(event: "message", handler: (e: { data: unknown }) => void): void;
+  addEventListener(event: "error", handler: (e: { message?: string; error?: Error }) => void): void;
+  addEventListener(
+    event: "close",
+    handler: (e: { code: number; reason: string; wasClean?: boolean }) => void,
+  ): void;
+  removeEventListener?(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+/**
+ * Factory for `WebSocket` instances.
+ *
+ * - Browser: pass `(url, protocols) => new WebSocket(url, protocols)`.
+ * - Node: pass `(url, protocols) => new WebSocket(url, protocols)`
+ *   from the `ws` package.
+ *
+ * Defaults to `globalThis.WebSocket` when available.
+ */
+export type WebSocketFactory = (url: string, protocols: string[]) => WebSocketLike;
+
+function defaultWebSocketFactory(): WebSocketFactory {
+  const g = globalThis as unknown as { WebSocket?: new (u: string, p?: string | string[]) => WebSocketLike };
+  if (!g.WebSocket) {
+    throw new TransportError(
+      "no WebSocket implementation available — pass `webSocketFactory` to wire `ws` (Node) or run in a browser",
+    );
+  }
+  const Ctor = g.WebSocket;
+  return (url, protocols) => new Ctor(url, protocols);
+}
+
+// ── Connection options ─────────────────────────────────────────────
+
+/**
+ * Options for opening a `WsAgentSession`.
+ */
+export interface WsAgentSessionOptions {
+  /**
+   * lifegw base URL, e.g. `https://api.life.dev`. The SDK rewrites
+   * the scheme to `wss://` automatically.
+   */
+  baseUrl: string;
+
+  /**
+   * Session id to attach to. Sent as `?sid=<sid>` query OR
+   * `X-Life-Sid` header (server reads either; this SDK uses the
+   * query form).
+   */
+  sid: string;
+
+  /**
+   * Async producer for the bearer token.
+   *
+   * Browser `WebSocket` does NOT support custom request headers, so
+   * this token is sent as a `Sec-WebSocket-Protocol` subprotocol
+   * value: `bearer.<token>`. The lifegw upgrade handler accepts
+   * this form via the auth middleware. In Node hosts that pass
+   * a `webSocketFactory` honoring `headers`, the token is also
+   * forwarded as `Authorization: Bearer <token>` for convenience.
+   *
+   * If undefined, no auth token is sent (only valid for dev mode).
+   */
+  getAuthToken?: () => Promise<string | undefined>;
+
+  /**
+   * Optional `WebSocket` factory. Defaults to `globalThis.WebSocket`.
+   *
+   * In Node: `import WebSocket from "ws"; { webSocketFactory: (u,p) => new WebSocket(u, p) }`.
+   */
+  webSocketFactory?: WebSocketFactory;
+
+  /**
+   * Initial `from_sequence` cursor — the server replays from
+   * `cursor + 1`. Defaults to `0n` (fresh stream).
+   */
+  fromSequence?: bigint;
+
+  /**
+   * When `true`, the connection automatically reconnects on transient
+   * close codes (4002 backpressure, 4004 lifed-unavailable, 1011
+   * internal). Defaults to `true`. Permanent codes (1008 auth, 4003
+   * IP-blocked, 4005 sequence-retired) never auto-reconnect.
+   */
+  autoReconnect?: boolean;
+
+  /**
+   * Maximum auto-reconnect attempts. Defaults to `5`.
+   */
+  maxReconnectAttempts?: number;
+
+  /**
+   * Base backoff in ms for reconnect attempts. Actual delay is
+   * `backoffMs * 2^attempt` (capped at 30s). Defaults to `500`.
+   */
+  reconnectBackoffMs?: number;
+}
+
+// ── Event handlers ─────────────────────────────────────────────────
+
+export interface WsAgentSessionHandlers {
+  /**
+   * Called on every successful connection (initial + each reconnect).
+   */
+  onOpen?: () => void;
+
+  /**
+   * Called for every `agent_event` frame.
+   *
+   * The `seqNo` is the lifed-assigned sequence number; the connection
+   * stores it internally for resume-on-reconnect.
+   */
+  onAgentEvent?: (event: AgentEventEnvelope) => void;
+
+  /**
+   * Called when the server pongs in response to a client ping.
+   */
+  onPong?: (seqNo: bigint) => void;
+
+  /**
+   * Called when the server emits a pre-close diagnostic frame. The
+   * actual close arrives next via `onClose` / `onError`.
+   */
+  onClosing?: (reason: string) => void;
+
+  /**
+   * Called on transport / protocol error. Auto-reconnect (when
+   * enabled) takes care of retrying transient errors before
+   * surfacing here, so by the time `onError` fires the connection
+   * is permanently closed.
+   */
+  onError?: (err: LifeSdkError) => void;
+
+  /**
+   * Called when the connection closes cleanly (graceful 1000).
+   */
+  onClose?: () => void;
+}
+
+export interface AgentEventEnvelope {
+  seqNo: bigint;
+  record: unknown;
+  agentKind: string;
+}
+
+// ── Implementation ─────────────────────────────────────────────────
+
+/**
+ * `WS_OPEN`, etc. — readyState constants. Defined here so the SDK
+ * doesn't import the browser `WebSocket` constructor (which doesn't
+ * exist in Node without `ws`).
+ */
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+const WS_CLOSING = 2;
+const WS_CLOSED = 3;
+
+const PERMANENT_CLOSE_CODES = new Set<number>([
+  1000, // normal — caller-initiated close, do not reconnect
+  1008, // auth violation — token won't fix itself
+  4001, // rate-limit — let caller back off explicitly
+  4003, // ip-blocked
+  4005, // sequence-retired (caller must reset cursor first)
+]);
+
+/**
+ * A single Agent.StreamSession over WebSocket.
+ *
+ * Lifecycle:
+ *   1. Construct with options + handlers.
+ *   2. Call `open()` (or `await openWsAgentSession(...)` helper).
+ *   3. Attach handlers BEFORE `open()` to avoid event races.
+ *   4. Call `close()` when done.
+ */
+export class WsAgentSession {
+  readonly options: Required<
+    Pick<
+      WsAgentSessionOptions,
+      "baseUrl" | "sid" | "autoReconnect" | "maxReconnectAttempts" | "reconnectBackoffMs"
+    >
+  > &
+    WsAgentSessionOptions;
+  private handlers: WsAgentSessionHandlers = {};
+  private ws: WebSocketLike | null = null;
+  private factory: WebSocketFactory;
+  private fromSequence: bigint;
+  private reconnectAttempts = 0;
+  private closing = false;
+  private closed = false;
+
+  constructor(options: WsAgentSessionOptions) {
+    this.options = {
+      autoReconnect: true,
+      maxReconnectAttempts: 5,
+      reconnectBackoffMs: 500,
+      ...options,
+    };
+    this.factory = options.webSocketFactory ?? defaultWebSocketFactory();
+    this.fromSequence = options.fromSequence ?? 0n;
+  }
+
+  /**
+   * Set the event handler bag. Replace once at startup; in-flight
+   * frames may have been delivered before the swap so callers should
+   * not rely on perfect ordering when changing handlers mid-flight.
+   */
+  on(handlers: WsAgentSessionHandlers): this {
+    this.handlers = handlers;
+    return this;
+  }
+
+  /**
+   * Highest `seq_no` observed on this session. Persisted across
+   * reconnects (used as `last_seq_no` on the next handshake).
+   */
+  get lastSeqNo(): bigint {
+    return this.fromSequence;
+  }
+
+  /**
+   * `true` once the connection has been closed gracefully or the
+   * permanent-error budget has been exhausted.
+   */
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Open the connection. Resolves once the underlying `WebSocket`
+   * fires `open`; rejects if the initial handshake fails.
+   *
+   * Subsequent reconnects (if enabled) happen automatically without
+   * resolving / rejecting this promise — observe via `onError` /
+   * `onOpen` handlers.
+   */
+  async open(): Promise<void> {
+    return this.connect();
+  }
+
+  private async connect(): Promise<void> {
+    const url = this.buildUrl();
+    // Resolve protocols synchronously when no token producer is set so
+    // tests + dev callers can attach WS instances on the same task tick.
+    const protocols = this.options.getAuthToken
+      ? await this.buildProtocols()
+      : ["life.v1.agent"];
+
+    return new Promise<void>((resolve, reject) => {
+      let ws: WebSocketLike;
+      try {
+        ws = this.factory(url, protocols);
+      } catch (err) {
+        const sdkErr = err instanceof Error
+          ? new TransportError(`failed to create WebSocket: ${err.message}`, { cause: err })
+          : new TransportError(String(err));
+        reject(sdkErr);
+        return;
+      }
+      this.ws = ws;
+
+      let opened = false;
+
+      ws.addEventListener("open", () => {
+        opened = true;
+        this.reconnectAttempts = 0;
+        this.handlers.onOpen?.();
+        resolve();
+      });
+
+      ws.addEventListener("message", (e: { data: unknown }) => {
+        const text = coerceData(e.data);
+        if (text === null) return;
+        let frame: OutboundFrame;
+        try {
+          frame = JSON.parse(text) as OutboundFrame;
+        } catch {
+          return; // drop malformed
+        }
+        this.handleFrame(frame);
+      });
+
+      ws.addEventListener("error", (e) => {
+        // Browser WebSocket `error` events don't carry useful detail;
+        // the close event has the code. We surface a transport error
+        // only if no `close` follows (handled by close handler).
+        if (!opened) {
+          // Initial handshake failure. Heuristic: TLS errors often
+          // surface here on browsers.
+          const msg = e.message ?? "ws connection error";
+          const lower = msg.toLowerCase();
+          if (lower.includes("tls") || lower.includes("ssl") || lower.includes("handshake")) {
+            reject(new TlsNegotiationError(msg));
+          } else {
+            reject(new TransportError(msg, e.error ? { cause: e.error } : undefined));
+          }
+        }
+      });
+
+      ws.addEventListener("close", (e) => {
+        const err = closeCodeToError(e.code, e.reason);
+        if (!opened) {
+          // Connect failed before opening; reject via the close mapping.
+          reject(err ?? new TransportError(`ws closed before open: ${e.code} ${e.reason}`));
+          return;
+        }
+
+        if (this.closing || e.code === 1000) {
+          // Caller-initiated graceful close.
+          this.closed = true;
+          this.handlers.onClose?.();
+          return;
+        }
+
+        if (
+          this.options.autoReconnect &&
+          !PERMANENT_CLOSE_CODES.has(e.code) &&
+          this.reconnectAttempts < this.options.maxReconnectAttempts
+        ) {
+          this.scheduleReconnect();
+          return;
+        }
+
+        // Permanent error or budget exhausted.
+        this.closed = true;
+        if (err) {
+          this.handlers.onError?.(err);
+        } else {
+          this.handlers.onClose?.();
+        }
+      });
+    });
+  }
+
+  private scheduleReconnect(): void {
+    const attempt = this.reconnectAttempts++;
+    const delay = Math.min(
+      this.options.reconnectBackoffMs * 2 ** attempt,
+      30_000,
+    );
+    setTimeout(() => {
+      if (this.closing) return;
+      this.connect().catch((err: unknown) => {
+        // If the synchronous handshake fails outright, surface and stop.
+        this.closed = true;
+        this.handlers.onError?.(err as LifeSdkError);
+      });
+    }, delay);
+  }
+
+  private handleFrame(frame: OutboundFrame): void {
+    switch (frame.kind) {
+      case "agent_event": {
+        const seq = parseSeq(frame.seq_no);
+        // Track the highest seen sequence so reconnect resumes
+        // from `seq + 1` on the next handshake.
+        if (seq > this.fromSequence) {
+          this.fromSequence = seq;
+        }
+        this.handlers.onAgentEvent?.({
+          seqNo: seq,
+          record: frame.record,
+          agentKind: frame.agent_kind,
+        });
+        return;
+      }
+      case "pong": {
+        this.handlers.onPong?.(parseSeq(frame.seq_no));
+        return;
+      }
+      case "closing": {
+        this.handlers.onClosing?.(frame.reason);
+        return;
+      }
+      // Unknown kinds dropped silently per Spec C₃ §6.2.
+      default:
+        return;
+    }
+  }
+
+  private buildUrl(): string {
+    let base = this.options.baseUrl.replace(/\/+$/, "");
+    if (base.startsWith("https://")) base = "wss://" + base.slice("https://".length);
+    else if (base.startsWith("http://")) base = "ws://" + base.slice("http://".length);
+    const params = new URLSearchParams();
+    params.set("sid", this.options.sid);
+    if (this.fromSequence > 0n) {
+      params.set("last_seq_no", this.fromSequence.toString());
+    }
+    return `${base}/v1/agent/stream?${params.toString()}`;
+  }
+
+  /**
+   * Build the subprotocol list. lifegw negotiates `life.v1.agent`;
+   * the auth token (if any) is appended as `bearer.<token>` so the
+   * browser can forward it without custom headers.
+   */
+  private async buildProtocols(): Promise<string[]> {
+    const protos: string[] = ["life.v1.agent"];
+    if (this.options.getAuthToken) {
+      const tok = await this.options.getAuthToken();
+      if (tok) protos.push(`bearer.${tok}`);
+    }
+    return protos;
+  }
+
+  // ── Outgoing frames ─────────────────────────────────────────────
+
+  /**
+   * Send a chat message on this session. Mapped to upstream
+   * `Agent.SendMessage`.
+   */
+  sendMessage(content: string, attachmentBlobRef?: string): void {
+    this.send({
+      kind: "send_message",
+      content,
+      ...(attachmentBlobRef ? { attachment_blob_ref: attachmentBlobRef } : {}),
+    });
+  }
+
+  /**
+   * Approve a pending dispatch identified by id.
+   */
+  approveDispatch(dispatchId: string): void {
+    this.send({ kind: "approve_dispatch", dispatch_id: dispatchId });
+  }
+
+  /**
+   * Cancel a pending dispatch identified by id.
+   */
+  cancelDispatch(dispatchId: string): void {
+    this.send({ kind: "cancel_dispatch", dispatch_id: dispatchId });
+  }
+
+  /**
+   * Send a ping frame; the server replies with `pong`. The server
+   * also runs its own heartbeat (Spec C₃ §6.4 — 30 s interval, 60 s
+   * pong-deadline) so client-initiated pings are optional.
+   */
+  ping(seqNo?: number): void {
+    this.send({ kind: "ping", ...(seqNo !== undefined ? { seq_no: seqNo } : {}) });
+  }
+
+  /**
+   * Close the connection gracefully (1000). Disables auto-reconnect.
+   */
+  close(reason?: string): void {
+    this.closing = true;
+    if (this.ws && (this.ws.readyState === WS_OPEN || this.ws.readyState === WS_CONNECTING)) {
+      this.send({ kind: "close", ...(reason ? { reason } : {}) });
+      this.ws.close(1000, reason ?? "client_close");
+    }
+  }
+
+  private send(frame: InboundFrame): void {
+    if (!this.ws || this.ws.readyState !== WS_OPEN) {
+      throw new TransportError(`cannot send frame in readyState=${this.ws?.readyState ?? "null"}`);
+    }
+    this.ws.send(JSON.stringify(frame));
+  }
+}
+
+/**
+ * Convenience helper — open + return the session in one call.
+ *
+ * @example
+ * ```ts
+ * const session = await openWsAgentSession({
+ *   baseUrl: "https://api.life.dev",
+ *   sid: "sid-123",
+ *   getAuthToken: async () => myToken,
+ * });
+ * session.on({ onAgentEvent: (e) => console.log(e) });
+ * session.sendMessage("hello");
+ * ```
+ */
+export async function openWsAgentSession(
+  opts: WsAgentSessionOptions,
+  handlers?: WsAgentSessionHandlers,
+): Promise<WsAgentSession> {
+  const s = new WsAgentSession(opts);
+  if (handlers) s.on(handlers);
+  await s.open();
+  return s;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function coerceData(data: unknown): string | null {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+  if (data && typeof data === "object" && "byteLength" in (data as object)) {
+    return new TextDecoder().decode(data as ArrayBuffer);
+  }
+  return null;
+}
+
+function parseSeq(v: string | number | bigint): bigint {
+  if (typeof v === "bigint") return v;
+  if (typeof v === "number") return BigInt(v);
+  if (typeof v === "string") {
+    try {
+      return BigInt(v);
+    } catch {
+      return 0n;
+    }
+  }
+  return 0n;
+}
+
+// ── Re-exported readyState constants for convenience ───────────────
+export const WebSocketReadyState = {
+  Connecting: WS_CONNECTING,
+  Open: WS_OPEN,
+  Closing: WS_CLOSING,
+  Closed: WS_CLOSED,
+} as const;

--- a/sdks/life-sdk-ts/tests/_helpers.ts
+++ b/sdks/life-sdk-ts/tests/_helpers.ts
@@ -1,0 +1,132 @@
+/**
+ * Test helpers — fake `fetch`, fake gateway routing, and a minimal
+ * Connect-protocol server-stream encoder.
+ */
+
+import { expect } from "vitest";
+
+export interface FakeRoute {
+  /**
+   * Fully-qualified path — `/<service>/<method>`.
+   */
+  path: string;
+  /**
+   * Async handler — receives the parsed JSON request body and the
+   * raw `Request`. May return either a JSON-serializable response
+   * (unary) or an array of frames for server-streaming.
+   */
+  handler: (req: { body: unknown; raw: Request }) => Promise<FakeResponse>;
+}
+
+export interface FakeResponse {
+  status?: number;
+  unary?: unknown;
+  stream?: Array<{ flag: 0 | 2; body: unknown }>;
+  /**
+   * Map of HTTP headers to assert in the test body.
+   */
+  recordedHeaders?: Record<string, string | undefined>;
+}
+
+export class FakeGateway {
+  recordedRequests: Array<{ url: string; headers: Record<string, string>; body: unknown }> = [];
+
+  constructor(private routes: FakeRoute[]) {}
+
+  /**
+   * Build a `fetch`-compatible function that routes to the configured
+   * fake handlers.
+   */
+  fetch: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const path = new URL(url).pathname;
+    const route = this.routes.find((r) => r.path === path);
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k.toLowerCase()] = v;
+      }
+    }
+    let body: unknown = undefined;
+    if (init?.body) {
+      // Connect server-stream wraps the body in [flag][len][payload];
+      // unary sends raw JSON.
+      const rawBytes =
+        init.body instanceof Uint8Array
+          ? init.body
+          : typeof init.body === "string"
+            ? new TextEncoder().encode(init.body)
+            : new Uint8Array();
+      const ct = headers["content-type"] ?? "";
+      if (ct.includes("connect")) {
+        body = decodeFirstConnectFrame(rawBytes);
+      } else {
+        body = JSON.parse(new TextDecoder().decode(rawBytes));
+      }
+    }
+    this.recordedRequests.push({ url, headers, body });
+
+    if (!route) {
+      return new Response(JSON.stringify({ code: "not_found", message: `no route for ${path}` }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const fakeReq = { body, raw: new Request(url, init as RequestInit | undefined) };
+    const resp = await route.handler(fakeReq);
+    if (resp.stream) {
+      const encoded = encodeConnectStream(resp.stream);
+      return new Response(encoded, {
+        status: resp.status ?? 200,
+        headers: { "Content-Type": "application/connect+json" },
+      });
+    }
+    if (resp.status && resp.status >= 400) {
+      return new Response(JSON.stringify(resp.unary ?? { code: "unknown" }), {
+        status: resp.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify(resp.unary ?? {}), {
+      status: resp.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+function decodeFirstConnectFrame(bytes: Uint8Array): unknown {
+  if (bytes.byteLength < 5) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const length = view.getUint32(1, false);
+  const payload = bytes.slice(5, 5 + length);
+  const text = new TextDecoder().decode(payload);
+  return text ? JSON.parse(text) : null;
+}
+
+function encodeConnectStream(frames: Array<{ flag: 0 | 2; body: unknown }>): Uint8Array {
+  // Total length first
+  const encoded = frames.map(({ flag, body }) => {
+    const text = JSON.stringify(body ?? {});
+    const payload = new TextEncoder().encode(text);
+    const out = new Uint8Array(5 + payload.byteLength);
+    out[0] = flag;
+    new DataView(out.buffer).setUint32(1, payload.byteLength, false);
+    out.set(payload, 5);
+    return out;
+  });
+  const totalLen = encoded.reduce((acc, e) => acc + e.byteLength, 0);
+  const merged = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const e of encoded) {
+    merged.set(e, offset);
+    offset += e.byteLength;
+  }
+  return merged;
+}
+
+export function expectAuthHeader(
+  headers: Record<string, string>,
+  expectedToken: string,
+): void {
+  expect(headers["authorization"] ?? headers["Authorization"]).toBe(`Bearer ${expectedToken}`);
+}

--- a/sdks/life-sdk-ts/tests/agent.test.ts
+++ b/sdks/life-sdk-ts/tests/agent.test.ts
@@ -1,0 +1,153 @@
+/**
+ * `life.v1.Agent` service unit tests against a fake Connect gateway.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LifeClient, AuthError } from "../src/index.js";
+import { FakeGateway, expectAuthHeader } from "./_helpers.js";
+
+describe("AgentClient", () => {
+  it("createSession sends Bearer token + decodes Session", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/CreateSession",
+        handler: async () => ({
+          unary: {
+            sid: { value: "sid-fake-1" },
+            agentId: { value: "agent-1" },
+            userId: "u-1",
+            projectId: "p-1",
+            createdAt: "2026-04-30T10:00:00Z",
+          },
+        }),
+      },
+    ]);
+    const life = new LifeClient({
+      baseUrl: "https://gw.test",
+      getAuthToken: async () => "tok-abc",
+      fetch: gw.fetch,
+    });
+
+    const session = await life.agent.createSession({
+      userId: "u-1",
+      projectId: "p-1",
+      label: "test",
+    });
+
+    expect(session.sid.value).toBe("sid-fake-1");
+    expect(session.userId).toBe("u-1");
+    expect(gw.recordedRequests).toHaveLength(1);
+    expectAuthHeader(gw.recordedRequests[0]!.headers, "tok-abc");
+  });
+
+  it("describeSession is a unary RPC", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/DescribeSession",
+        handler: async ({ body }) => {
+          expect((body as { sid: { value: string } }).sid.value).toBe("sid-3");
+          return { unary: { sid: { value: "sid-3" }, userId: "u-x" } };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const s = await life.agent.describeSession({ sid: { value: "sid-3" } });
+    expect(s.userId).toBe("u-x");
+  });
+
+  it("sendMessage yields server-streamed events and ends on end-frame", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/SendMessage",
+        handler: async () => ({
+          stream: [
+            {
+              flag: 0,
+              body: {
+                record: { sessionId: { value: "sid-1" }, sequence: "1", kind: "token", payload: "" },
+                kind: "AGENT_EVENT_KIND_TOKEN",
+              },
+            },
+            {
+              flag: 0,
+              body: {
+                record: { sessionId: { value: "sid-1" }, sequence: "2", kind: "finish", payload: "" },
+                kind: "AGENT_EVENT_KIND_FINISH",
+              },
+            },
+            { flag: 2, body: {} }, // end-stream
+          ],
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+
+    const events: Array<{ kind: string }> = [];
+    for await (const e of life.agent.sendMessage({
+      sid: { value: "sid-1" },
+      content: "hi",
+    })) {
+      events.push(e);
+    }
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("AGENT_EVENT_KIND_TOKEN");
+    expect(events[1]?.kind).toBe("AGENT_EVENT_KIND_FINISH");
+  });
+
+  it("propagates Unauthenticated as AuthError", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/CreateSession",
+        handler: async () => ({
+          status: 401,
+          unary: { code: "unauthenticated", message: "bad token" },
+        }),
+      },
+    ]);
+    const life = new LifeClient({
+      baseUrl: "https://gw.test",
+      getAuthToken: async () => "tok-bad",
+      fetch: gw.fetch,
+    });
+
+    await expect(life.agent.createSession({ userId: "u" })).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("approveDispatch + cancelDispatch are unary noops", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/ApproveDispatch",
+        handler: async () => ({ unary: {} }),
+      },
+      {
+        path: "/life.v1.Agent/CancelDispatch",
+        handler: async () => ({ unary: {} }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    await life.agent.approveDispatch({ sid: { value: "sid" }, dispatchId: "d1" });
+    await life.agent.cancelDispatch({ sid: { value: "sid" }, dispatchId: "d2" });
+    expect(gw.recordedRequests).toHaveLength(2);
+  });
+
+  it("listSkills returns a CatalogEntry array", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Agent/ListSkills",
+        handler: async () => ({
+          unary: {
+            items: [
+              { id: "skill-1", version: "1.0.0", manifest: "" },
+              { id: "skill-2", version: "2.0.0", manifest: "" },
+            ],
+          },
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const cat = await life.agent.listSkills({ projectId: "p" });
+    expect(cat.items).toHaveLength(2);
+    expect(cat.items[0]?.id).toBe("skill-1");
+  });
+});

--- a/sdks/life-sdk-ts/tests/errors.test.ts
+++ b/sdks/life-sdk-ts/tests/errors.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Close-code → typed error mapping (Spec C₃ §6.5).
+ *
+ * The mapping is canonicalised in
+ * `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  AuthError,
+  BackpressureError,
+  GoingAwayError,
+  GrpcCode,
+  InternalServerError,
+  IpBlockedError,
+  LifedUnavailableError,
+  LifeSdkError,
+  RateLimitError,
+  SequenceRetiredError,
+  closeCodeToError,
+  grpcCodeToError,
+} from "../src/errors.js";
+
+describe("closeCodeToError", () => {
+  it("returns null for graceful 1000", () => {
+    expect(closeCodeToError(1000, "normal")).toBeNull();
+  });
+
+  it("maps 1001 to GoingAwayError", () => {
+    const err = closeCodeToError(1001, "going_away");
+    expect(err).toBeInstanceOf(GoingAwayError);
+    expect(err?.code).toBe("going_away");
+  });
+
+  it("maps 1008 to AuthError (token expired)", () => {
+    const err = closeCodeToError(1008, "policy_violation:token_expired");
+    expect(err).toBeInstanceOf(AuthError);
+    expect(err?.code).toBe("unauthenticated");
+  });
+
+  it("maps 1011 to InternalServerError", () => {
+    const err = closeCodeToError(1011, "internal_error");
+    expect(err).toBeInstanceOf(InternalServerError);
+  });
+
+  it("maps 4001 to RateLimitError with reason prefix", () => {
+    const err = closeCodeToError(4001, "rate_limit:per_user") as RateLimitError;
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.reasonPrefix).toBe("rate_limit:per_user");
+  });
+
+  it("preserves per_ip variant in RateLimitError", () => {
+    const err = closeCodeToError(4001, "rate_limit:per_ip") as RateLimitError;
+    expect(err.reasonPrefix).toBe("rate_limit:per_ip");
+  });
+
+  it("maps 4002 to BackpressureError", () => {
+    expect(closeCodeToError(4002, "backpressure:slow_consumer")).toBeInstanceOf(
+      BackpressureError,
+    );
+  });
+
+  it("maps 4003 to IpBlockedError", () => {
+    expect(closeCodeToError(4003, "ip_blocked")).toBeInstanceOf(IpBlockedError);
+  });
+
+  it("maps 4004 to LifedUnavailableError", () => {
+    expect(closeCodeToError(4004, "lifed_circuit_open")).toBeInstanceOf(
+      LifedUnavailableError,
+    );
+  });
+
+  it("maps 4005 to SequenceRetiredError", () => {
+    expect(closeCodeToError(4005, "sequence_retired")).toBeInstanceOf(
+      SequenceRetiredError,
+    );
+  });
+
+  it("returns null for unmapped codes (e.g. 1006)", () => {
+    expect(closeCodeToError(1006)).toBeNull();
+  });
+});
+
+describe("grpcCodeToError", () => {
+  it("maps UNAUTHENTICATED to AuthError", () => {
+    expect(grpcCodeToError(GrpcCode.Unauthenticated, "UNAUTHENTICATED")).toBeInstanceOf(
+      AuthError,
+    );
+  });
+
+  it("maps PERMISSION_DENIED to AuthError", () => {
+    expect(grpcCodeToError(GrpcCode.PermissionDenied, "PERMISSION_DENIED")).toBeInstanceOf(
+      AuthError,
+    );
+  });
+
+  it("maps RESOURCE_EXHAUSTED to RateLimitError", () => {
+    expect(grpcCodeToError(GrpcCode.ResourceExhausted, "RESOURCE_EXHAUSTED")).toBeInstanceOf(
+      RateLimitError,
+    );
+  });
+
+  it("maps UNAVAILABLE to LifedUnavailableError", () => {
+    expect(grpcCodeToError(GrpcCode.Unavailable, "UNAVAILABLE")).toBeInstanceOf(
+      LifedUnavailableError,
+    );
+  });
+
+  it("maps OUT_OF_RANGE to SequenceRetiredError", () => {
+    expect(grpcCodeToError(GrpcCode.OutOfRange, "OUT_OF_RANGE")).toBeInstanceOf(
+      SequenceRetiredError,
+    );
+  });
+
+  it("maps INTERNAL to InternalServerError", () => {
+    expect(grpcCodeToError(GrpcCode.Internal, "INTERNAL")).toBeInstanceOf(
+      InternalServerError,
+    );
+  });
+
+  it("returns LifeSdkError for any code (parent type)", () => {
+    expect(grpcCodeToError(GrpcCode.Cancelled, "CANCELLED")).toBeInstanceOf(
+      LifeSdkError,
+    );
+  });
+});

--- a/sdks/life-sdk-ts/tests/events.test.ts
+++ b/sdks/life-sdk-ts/tests/events.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `life.v1.Events` service unit tests.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LifeClient } from "../src/index.js";
+import { FakeGateway } from "./_helpers.js";
+
+describe("EventsClient", () => {
+  it("read streams EventRecord frames", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Events/Read",
+        handler: async () => ({
+          stream: [
+            { flag: 0, body: { sessionId: { value: "sid-1" }, sequence: "1", kind: "agent_token", payload: "" } },
+            { flag: 0, body: { sessionId: { value: "sid-1" }, sequence: "2", kind: "agent_token", payload: "" } },
+            { flag: 2, body: {} },
+          ],
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const records: Array<{ sequence: string }> = [];
+    for await (const r of life.events.read({
+      sessionId: { value: "sid-1" },
+      fromSequence: 0n,
+    })) {
+      records.push(r as unknown as { sequence: string });
+    }
+    expect(records).toHaveLength(2);
+  });
+
+  it("subscribe streams events with kind filter forwarded to server", async () => {
+    let capturedFilter: string[] | undefined;
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Events/Subscribe",
+        handler: async ({ body }) => {
+          capturedFilter = (body as { kinds?: string[] }).kinds;
+          return {
+            stream: [
+              { flag: 0, body: { sessionId: { value: "sid" }, sequence: "5", kind: "tool_result", payload: "" } },
+              { flag: 2, body: {} },
+            ],
+          };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+
+    const out: unknown[] = [];
+    for await (const e of life.events.subscribe({
+      sessionId: { value: "sid" },
+      kinds: ["tool_result"],
+    })) {
+      out.push(e);
+    }
+    expect(out).toHaveLength(1);
+    expect(capturedFilter).toEqual(["tool_result"]);
+  });
+
+  it("getBlob is a unary RPC returning the Blob shape", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Events/GetBlob",
+        handler: async ({ body }) => {
+          expect((body as { sha256: string }).sha256).toBe("abc123");
+          return {
+            unary: {
+              data: "aGVsbG8=", // "hello" base64
+              contentType: "text/plain",
+            },
+          };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const blob = await life.events.getBlob({ namespace: "ns", sha256: "abc123" });
+    expect(blob.contentType).toBe("text/plain");
+  });
+
+  it("getBlobBytes round-trips base64 to Uint8Array", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Events/GetBlob",
+        handler: async () => ({
+          unary: { data: "aGVsbG8=", contentType: "text/plain" },
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const bytes = await life.events.getBlobBytes({ namespace: "ns", sha256: "x" });
+    expect(new TextDecoder().decode(bytes)).toBe("hello");
+  });
+});

--- a/sdks/life-sdk-ts/tests/identity.test.ts
+++ b/sdks/life-sdk-ts/tests/identity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `life.v1.Identity` service unit tests.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LifeClient } from "../src/index.js";
+import { FakeGateway, expectAuthHeader } from "./_helpers.js";
+
+describe("IdentityClient", () => {
+  it("whoami sends an empty request body and returns the Account", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Identity/Me",
+        handler: async ({ body }) => {
+          // empty proto message → empty JSON object
+          expect(body).toEqual({});
+          return {
+            unary: {
+              userId: "u-42",
+              handle: "alice",
+              displayName: "Alice",
+              tier: "tier-1",
+              createdAt: "2026-04-30T12:00:00Z",
+            },
+          };
+        },
+      },
+    ]);
+    const life = new LifeClient({
+      baseUrl: "https://gw.test",
+      getAuthToken: async () => "tok-id",
+      fetch: gw.fetch,
+    });
+    const me = await life.identity.whoami();
+    expect(me.userId).toBe("u-42");
+    expect(me.tier).toBe("tier-1");
+    expectAuthHeader(gw.recordedRequests[0]!.headers, "tok-id");
+  });
+
+  it("listSessions returns the SessionList shape", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Identity/ListSessions",
+        handler: async () => ({
+          unary: {
+            sessions: [
+              { sid: { value: "sid-1" }, projectId: "p", openedAt: "2026-04-30T12:00:00Z", label: "demo" },
+            ],
+          },
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const list = await life.identity.listSessions({ includeClosed: false });
+    expect(list.sessions).toHaveLength(1);
+    expect(list.sessions[0]?.sid.value).toBe("sid-1");
+  });
+
+  it("updateProfile is unary; revokeSession returns IdentityEmpty", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Identity/UpdateProfile",
+        handler: async ({ body }) => {
+          expect((body as { profile: { bio: string } }).profile.bio).toBe("hi");
+          return { unary: { userId: "u-1", profile: { bio: "hi" } } };
+        },
+      },
+      {
+        path: "/life.v1.Identity/RevokeSession",
+        handler: async ({ body }) => {
+          expect((body as { sid: { value: string } }).sid.value).toBe("sid-2");
+          return { unary: {} };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const acct = await life.identity.updateProfile({ profile: { bio: "hi" } });
+    expect(acct.profile?.bio).toBe("hi");
+    await life.identity.revokeSession({ sid: { value: "sid-2" } });
+  });
+
+  it("does not attach Authorization when getAuthToken is undefined", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Identity/Me",
+        handler: async () => ({ unary: { userId: "anon" } }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    await life.identity.whoami();
+    expect(gw.recordedRequests[0]?.headers["authorization"]).toBeUndefined();
+  });
+});

--- a/sdks/life-sdk-ts/tests/wallet.test.ts
+++ b/sdks/life-sdk-ts/tests/wallet.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `life.v1.Wallet` service unit tests.
+ *
+ * Covers GetBalance, Statement (server-stream), Debit (idempotent),
+ * Transfer.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LifeClient, RateLimitError } from "../src/index.js";
+import { FakeGateway } from "./_helpers.js";
+
+describe("WalletClient", () => {
+  it("getBalance returns bigint micros (proto3 JSON encodes int64 as string)", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Wallet/GetBalance",
+        handler: async ({ body }) => {
+          expect((body as { userId: string }).userId).toBe("u-1");
+          return {
+            unary: { micros: "9999999999", currency: "USDC", asOf: "2026-04-30T12:00:00Z" },
+          };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const bal = await life.wallet.getBalance({ userId: "u-1", projectId: "p-1" });
+    expect(bal.currency).toBe("USDC");
+    // The wire string deserialises into a JS string; bigint conversion is
+    // a caller-side concern. The key property is preservation of digits.
+    expect(String(bal.micros)).toBe("9999999999");
+  });
+
+  it("debit is unary and replays return the original receipt", async () => {
+    let calls = 0;
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Wallet/Debit",
+        handler: async ({ body }) => {
+          calls++;
+          expect((body as { sid?: string }).sid).toBe("sid-debit");
+          // Replays return the same entry id.
+          return {
+            unary: {
+              entryId: "entry-1",
+              newBalance: { micros: "1000", currency: "USDC" },
+            },
+          };
+        },
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const r1 = await life.wallet.debit({
+      wallet: { userId: "u", projectId: "p" },
+      amountMicros: 100n,
+      sid: "sid-debit",
+      reason: "test",
+    });
+    const r2 = await life.wallet.debit({
+      wallet: { userId: "u", projectId: "p" },
+      amountMicros: 100n,
+      sid: "sid-debit",
+      reason: "test",
+    });
+    expect(r1.entryId).toBe(r2.entryId);
+    expect(calls).toBe(2);
+  });
+
+  it("statement streams ledger entries", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Wallet/Statement",
+        handler: async () => ({
+          stream: [
+            { flag: 0, body: { entryId: "e1", deltaMicros: "-100", reason: "tool:bash" } },
+            { flag: 0, body: { entryId: "e2", deltaMicros: "-50", reason: "tool:fs" } },
+            { flag: 2, body: {} },
+          ],
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const out: Array<{ entryId: string }> = [];
+    for await (const e of life.wallet.statement({
+      wallet: { userId: "u", projectId: "p" },
+    })) {
+      out.push(e as unknown as { entryId: string });
+    }
+    expect(out).toHaveLength(2);
+  });
+
+  it("transfer is unary", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Wallet/Transfer",
+        handler: async () => ({
+          unary: {
+            entryId: "tx-1",
+            fromBalance: { micros: "500", currency: "USDC" },
+            toBalance: { micros: "1500", currency: "USDC" },
+          },
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    const t = await life.wallet.transfer({
+      from: { userId: "alice", projectId: "p" },
+      to: { userId: "bob", projectId: "p" },
+      amountMicros: 1000n,
+    });
+    expect(t.entryId).toBe("tx-1");
+  });
+
+  it("propagates RESOURCE_EXHAUSTED as RateLimitError", async () => {
+    const gw = new FakeGateway([
+      {
+        path: "/life.v1.Wallet/Transfer",
+        handler: async () => ({
+          status: 429,
+          unary: { code: "resource_exhausted", message: "per-user rate limit exceeded" },
+        }),
+      },
+    ]);
+    const life = new LifeClient({ baseUrl: "https://gw.test", fetch: gw.fetch });
+    await expect(
+      life.wallet.transfer({
+        from: { userId: "a", projectId: "p" },
+        to: { userId: "b", projectId: "p" },
+        amountMicros: 1n,
+      }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+});

--- a/sdks/life-sdk-ts/tests/ws.test.ts
+++ b/sdks/life-sdk-ts/tests/ws.test.ts
@@ -1,0 +1,381 @@
+/**
+ * WebSocket transport unit tests.
+ *
+ * The fake WebSocket exercises:
+ *   - Reconnect-by-`from_sequence` after a transient drop
+ *   - Close-code → typed error mapping
+ *   - Outgoing send_message / approve_dispatch / cancel_dispatch
+ *   - Subprotocol bearer attachment (browser-compat code path)
+ *   - Drop of unknown server frames
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  AuthError,
+  BackpressureError,
+  IpBlockedError,
+  RateLimitError,
+  SequenceRetiredError,
+  WsAgentSession,
+  type AgentEventEnvelope,
+  type WebSocketLike,
+} from "../src/index.js";
+
+/** Yield to the microtask queue until predicate() is true (or ttl ticks). */
+async function waitFor(pred: () => boolean, ttl = 50): Promise<void> {
+  for (let i = 0; i < ttl; i++) {
+    if (pred()) return;
+    await Promise.resolve();
+  }
+  if (!pred()) throw new Error(`waitFor: predicate did not become true within ${ttl} ticks`);
+}
+
+class FakeWs implements WebSocketLike {
+  static instances: FakeWs[] = [];
+  readyState = 0;
+  readonly url: string;
+  readonly protocols: string[];
+  readonly sent: string[] = [];
+  private listeners = new Map<string, Array<(arg: unknown) => void>>();
+
+  constructor(url: string, protocols: string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    FakeWs.instances.push(this);
+  }
+
+  addEventListener(ev: "open", h: () => void): void;
+  addEventListener(ev: "message", h: (e: { data: unknown }) => void): void;
+  addEventListener(ev: "error", h: (e: { message?: string; error?: Error }) => void): void;
+  addEventListener(ev: "close", h: (e: { code: number; reason: string; wasClean?: boolean }) => void): void;
+  addEventListener(ev: string, h: (arg: unknown) => void): void {
+    const list = this.listeners.get(ev) ?? [];
+    list.push(h);
+    this.listeners.set(ev, list);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.fire("close", { code: code ?? 1000, reason: reason ?? "client_close" });
+  }
+
+  // ── Test-only helpers ─────────────────────────────────────────
+  fire(event: string, arg: unknown): void {
+    const list = this.listeners.get(event);
+    if (!list) return;
+    for (const h of list) h(arg);
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.fire("open", undefined);
+  }
+
+  receive(text: string): void {
+    this.fire("message", { data: text });
+  }
+
+  serverClose(code: number, reason: string): void {
+    this.readyState = 3;
+    this.fire("close", { code, reason });
+  }
+}
+
+describe("WsAgentSession", () => {
+  it("attaches sid + last_seq_no in the URL", async () => {
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid-1",
+      fromSequence: 42n,
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+    const url = new URL(FakeWs.instances[0]!.url);
+    expect(url.searchParams.get("sid")).toBe("sid-1");
+    expect(url.searchParams.get("last_seq_no")).toBe("42");
+    expect(FakeWs.instances[0]!.protocols).toContain("life.v1.agent");
+    session.close();
+  });
+
+  it("attaches bearer.<token> as a subprotocol", async () => {
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid-x",
+      autoReconnect: false,
+      getAuthToken: async () => "tok-xyz",
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+    expect(FakeWs.instances[0]!.protocols).toContain("bearer.tok-xyz");
+    session.close();
+  });
+
+  it("decodes agent_event frames and tracks last seq", async () => {
+    FakeWs.instances = [];
+    const events: AgentEventEnvelope[] = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({ onAgentEvent: (e) => events.push(e) });
+
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    const ws = FakeWs.instances[0]!;
+    ws.open();
+    await openP;
+
+    ws.receive(JSON.stringify({ kind: "agent_event", seq_no: "1", record: { x: 1 }, agent_kind: "TOKEN" }));
+    ws.receive(JSON.stringify({ kind: "agent_event", seq_no: "5", record: {}, agent_kind: "FINISH" }));
+
+    expect(events).toHaveLength(2);
+    expect(session.lastSeqNo).toBe(5n);
+    session.close();
+  });
+
+  it("drops unknown frame kinds silently", async () => {
+    FakeWs.instances = [];
+    const events: AgentEventEnvelope[] = [];
+    const onError = vi.fn();
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({ onAgentEvent: (e) => events.push(e), onError });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    const ws = FakeWs.instances[0]!;
+    ws.open();
+    await openP;
+    ws.receive(JSON.stringify({ kind: "future_kind_we_dont_know", x: 1 }));
+    expect(events).toHaveLength(0);
+    expect(onError).not.toHaveBeenCalled();
+    session.close();
+  });
+
+  it("surfaces 1008 PolicyViolation as AuthError on close (no auto-reconnect)", async () => {
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: true,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    const errors: unknown[] = [];
+    session.on({ onError: (e) => errors.push(e) });
+
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    const ws = FakeWs.instances[0]!;
+    ws.open();
+    await openP;
+
+    ws.serverClose(1008, "policy_violation:token_expired");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(AuthError);
+    expect(session.isClosed).toBe(true);
+    expect(FakeWs.instances).toHaveLength(1); // no reconnect
+  });
+
+  it("auto-reconnects on transient 4004 LifedUnavailable and resumes from last seq", async () => {
+    vi.useFakeTimers();
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: true,
+      reconnectBackoffMs: 10,
+      maxReconnectAttempts: 2,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({});
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+
+    FakeWs.instances[0]!.receive(JSON.stringify({ kind: "agent_event", seq_no: "7", record: {}, agent_kind: "TOKEN" }));
+    expect(session.lastSeqNo).toBe(7n);
+
+    // Server drops with transient 4004.
+    FakeWs.instances[0]!.serverClose(4004, "lifed_circuit_open");
+
+    // Advance past backoff to trigger the reconnect.
+    await vi.advanceTimersByTimeAsync(20);
+    expect(FakeWs.instances).toHaveLength(2);
+
+    const reconnectUrl = new URL(FakeWs.instances[1]!.url);
+    expect(reconnectUrl.searchParams.get("last_seq_no")).toBe("7");
+    expect(reconnectUrl.searchParams.get("sid")).toBe("sid");
+
+    FakeWs.instances[1]!.open();
+    session.close();
+    vi.useRealTimers();
+  });
+
+  it("does NOT auto-reconnect on 4001 RateLimit (permanent)", async () => {
+    vi.useFakeTimers();
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: true,
+      reconnectBackoffMs: 1,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    const errs: unknown[] = [];
+    session.on({ onError: (e) => errs.push(e) });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+
+    FakeWs.instances[0]!.serverClose(4001, "rate_limit:per_user");
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(FakeWs.instances).toHaveLength(1); // no reconnect
+    expect(errs[0]).toBeInstanceOf(RateLimitError);
+    vi.useRealTimers();
+  });
+
+  it("4003 IP-blocked + 4005 sequence-retired are also permanent", async () => {
+    for (const [code, ErrorCtor] of [
+      [4003, IpBlockedError],
+      [4005, SequenceRetiredError],
+    ] as const) {
+      vi.useFakeTimers();
+      FakeWs.instances = [];
+      const session = new WsAgentSession({
+        baseUrl: "https://gw.test",
+        sid: "sid",
+        autoReconnect: true,
+        reconnectBackoffMs: 1,
+        webSocketFactory: (u, p) => new FakeWs(u, p),
+      });
+      const errs: unknown[] = [];
+      session.on({ onError: (e) => errs.push(e) });
+      const openP = session.open();
+      FakeWs.instances[0]!.open();
+      await openP;
+      FakeWs.instances[0]!.serverClose(code, "");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(FakeWs.instances).toHaveLength(1);
+      expect(errs[0]).toBeInstanceOf(ErrorCtor);
+      vi.useRealTimers();
+    }
+  });
+
+  it("4002 backpressure auto-reconnects (transient)", async () => {
+    vi.useFakeTimers();
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: true,
+      reconnectBackoffMs: 1,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({});
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+    FakeWs.instances[0]!.serverClose(4002, "backpressure:slow_consumer");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(FakeWs.instances.length).toBeGreaterThanOrEqual(2);
+    // Smoke-test that the second connection inherits the backpressure
+    // surface even though the first errored on it. The last-seq cursor
+    // should still be 0 (no events received).
+    expect(session.lastSeqNo).toBe(0n);
+    // Mark BackpressureError type used so the import isn't dead.
+    expect(BackpressureError.prototype).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it("sends send_message / approve_dispatch / cancel_dispatch / ping / close frames", async () => {
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({});
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    const ws = FakeWs.instances[0]!;
+    ws.open();
+    await openP;
+
+    session.sendMessage("hi", "sha256:abc");
+    session.approveDispatch("d1");
+    session.cancelDispatch("d2");
+    session.ping(7);
+
+    expect(ws.sent).toHaveLength(4);
+    const sent = ws.sent.map((s) => JSON.parse(s));
+    expect(sent[0]).toEqual({ kind: "send_message", content: "hi", attachment_blob_ref: "sha256:abc" });
+    expect(sent[1]).toEqual({ kind: "approve_dispatch", dispatch_id: "d1" });
+    expect(sent[2]).toEqual({ kind: "cancel_dispatch", dispatch_id: "d2" });
+    expect(sent[3]).toEqual({ kind: "ping", seq_no: 7 });
+
+    session.close("done");
+    expect(ws.sent[ws.sent.length - 1]).toContain('"close"');
+    expect(session.isClosed).toBe(true);
+  });
+
+  it("invokes onClosing for pre-close diagnostic frames", async () => {
+    FakeWs.instances = [];
+    const onClosing = vi.fn();
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({ onClosing });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    const ws = FakeWs.instances[0]!;
+    ws.open();
+    await openP;
+    ws.receive(JSON.stringify({ kind: "closing", reason: "rate_limit:per_user" }));
+    expect(onClosing).toHaveBeenCalledWith("rate_limit:per_user");
+    session.close();
+  });
+
+  it("rewrites https://baseUrl to wss://", async () => {
+    FakeWs.instances = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://api.life.dev",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({});
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+    expect(FakeWs.instances[0]!.url.startsWith("wss://api.life.dev/v1/agent/stream")).toBe(true);
+    session.close();
+  });
+});

--- a/sdks/life-sdk-ts/tests/ws.test.ts
+++ b/sdks/life-sdk-ts/tests/ws.test.ts
@@ -14,6 +14,7 @@ import {
   AuthError,
   BackpressureError,
   IpBlockedError,
+  type LifeSdkError,
   RateLimitError,
   SequenceRetiredError,
   WsAgentSession,
@@ -301,13 +302,33 @@ describe("WsAgentSession", () => {
     FakeWs.instances[0]!.serverClose(4002, "backpressure:slow_consumer");
     await vi.advanceTimersByTimeAsync(10);
     expect(FakeWs.instances.length).toBeGreaterThanOrEqual(2);
-    // Smoke-test that the second connection inherits the backpressure
-    // surface even though the first errored on it. The last-seq cursor
-    // should still be 0 (no events received).
+    // Last-seq cursor stays 0 (no events received before the close).
     expect(session.lastSeqNo).toBe(0n);
-    // Mark BackpressureError type used so the import isn't dead.
-    expect(BackpressureError.prototype).toBeDefined();
     vi.useRealTimers();
+  });
+
+  it("4002 backpressure surfaces BackpressureError when autoReconnect=false", async () => {
+    // I-4 fix: previously the only 4002 test asserted reconnect happened
+    // but never that the close was actually mapped to BackpressureError.
+    // This companion test disables auto-reconnect to verify the typed
+    // error reaches onError.
+    FakeWs.instances = [];
+    const errs: LifeSdkError[] = [];
+    const session = new WsAgentSession({
+      baseUrl: "https://gw.test",
+      sid: "sid",
+      autoReconnect: false,
+      webSocketFactory: (u, p) => new FakeWs(u, p),
+    });
+    session.on({ onError: (e) => errs.push(e) });
+    const openP = session.open();
+    await waitFor(() => FakeWs.instances.length > 0);
+    FakeWs.instances[0]!.open();
+    await openP;
+    FakeWs.instances[0]!.serverClose(4002, "backpressure:slow_consumer");
+    await waitFor(() => errs.length > 0);
+    expect(errs[0]).toBeInstanceOf(BackpressureError);
+    expect(errs[0]?.message).toContain("backpressure");
   });
 
   it("sends send_message / approve_dispatch / cancel_dispatch / ping / close frames", async () => {

--- a/sdks/life-sdk-ts/tsconfig.json
+++ b/sdks/life-sdk-ts/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests", "examples"]
+}

--- a/sdks/life-sdk-ts/tsconfig.test.json
+++ b/sdks/life-sdk-ts/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "tests", "examples"]
+}

--- a/sdks/life-sdk-ts/vitest.config.ts
+++ b/sdks/life-sdk-ts/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["tests/**/*.test.ts"],
+    typecheck: {
+      enabled: false,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Introduces **`@broomva/life-sdk`** — the public TypeScript client for the Life Agent OS, talking to `lifegw` over `grpc-web` (Connect protocol) and WebSocket. Implements the four user-facing services from `life.v1.*`:
- `Agent` — session lifecycle, chat, dispatch approve/cancel, catalog reads
- `Events` — event tail, content-addressed blob fetch
- `Wallet` — balance, statement (stream), debit (idempotent), transfer
- `Identity` — `whoami`, profile, sessions

The admin plane (`life.admin.v1.*`, `life.admin.gw.v1.*`) is intentionally absent — it's UDS-only on the gateway and never reachable from the public SDK.

## SDK surface

- **`LifeClient`** aggregates `agent`, `events`, `wallet`, `identity` over a shared `Transport`. Async `getAuthToken` callback wires Vercel JWT producers (Clerk, Auth.js, custom).
- **`WsAgentSession`** wraps `Agent.StreamSession` over WebSocket with reconnect-by-`from_sequence` resume per Spec C₃ §11.4. Auto-reconnect on transient close codes (4002 backpressure, 4004 lifed-unavailable, 1011 internal); permanent codes (1008 auth, 4001 rate-limit, 4003 IP-blocked, 4005 sequence-retired) surface immediately via `onError`.
- **Typed errors** map close codes per Spec C₃ §6.5 (see `docs/superpowers/specs/2026-04-29-spec-c3-close-codes.md`):
  - `AuthError` (1008 / `UNAUTHENTICATED` / `PERMISSION_DENIED`)
  - `RateLimitError` (4001 / `RESOURCE_EXHAUSTED`) — preserves `rate_limit:per_user` vs `rate_limit:per_ip` reason prefix
  - `BackpressureError` (4002), `IpBlockedError` (4003)
  - `LifedUnavailableError` (4004 / `UNAVAILABLE`)
  - `SequenceRetiredError` (4005 / `OUT_OF_RANGE`)
  - `InternalServerError` (1011 / `INTERNAL`)
  - `GoingAwayError` (1001)
  - `TlsNegotiationError` for failed TLS 1.3 handshakes (Spec C₃ §5.1)
- **`Transport`** speaks the Connect protocol over `fetch` — unary + server-streaming via length-prefixed frames `[flag][len BE][payload]`. BigInt-safe JSON: proto3 `int64` / `uint64` round-trip via JS string.
- **Currency precision**: all amounts are `bigint` micros (μUSDC).

## Codegen approach

Hand-curated TypeScript proto types in `src/proto/` mirror `proto/life/v1/*.proto`. The prompt explicitly allowed this fallback over `buf generate` (which doesn't fit the existing tonic-prost-build chain). The public surface is structured so a future codegen swap (buf + `@bufbuild/protoc-gen-es`) won't break consumers.

## Tests

49 vitest specs across 6 files (all green):
- `tests/errors.test.ts` (18) — close-code → typed error + gRPC code → typed error
- `tests/agent.test.ts` (6) — CreateSession, DescribeSession, SendMessage server-stream, ApproveDispatch/CancelDispatch, ListSkills, AuthError propagation
- `tests/events.test.ts` (4) — Read stream, Subscribe with kind filter, GetBlob unary, GetBlobBytes round-trip
- `tests/wallet.test.ts` (5) — GetBalance bigint preservation, Debit idempotent replay, Statement stream, Transfer, RateLimitError on 429
- `tests/identity.test.ts` (4) — whoami auth header, ListSessions, UpdateProfile, no-auth-header path
- `tests/ws.test.ts` (12) — URL construction (sid + last_seq_no), bearer subprotocol, agent_event decoding + last seq tracking, drop unknown frames, 1008 → AuthError no-reconnect, 4004 transient reconnect-by-seq, 4001 + 4003 + 4005 permanent (no reconnect), 4002 transient reconnect, all outbound frames (send_message + approve/cancel + ping + close), `closing` diagnostic, https→wss rewrite

## CI

New `sdk-life-ts` lane added to `.github/workflows/ci.yml` (mirrors the existing `console` lane). Runs `bun install --frozen-lockfile` → `bun run typecheck` → `bun run test` → `bun run build` on every PR.

## Boundaries verified

- No Rust crates touched.
- `crates/anima/` untouched (D-Sub-B implementer's territory).
- `grep "life\.admin"` matches only documentation comments — never invoked, never imported.
- `buf` is not required to build, test, or run the SDK.

## Deferred items

- **pnpm publish workflow + npm provenance** — no signed release pipe yet; the package is built locally with `bun run build` but not auto-published on tag.
- **jsr publish** for Deno consumers — secondary distribution, deferred.
- **OpenAPI shim** — Connect protocol is sufficient for the first cut; an OpenAPI surface for non-gRPC clients can come later.
- **buf-driven codegen** — replace hand-curated `src/proto/*.ts` once the workspace adopts buf for cross-language generation. The `proto/buf.gen.yaml` already notes this swap is planned.

## Test plan

- [x] `bun run typecheck` clean (TS strict mode, no `any` leaks)
- [x] `bun run test` 49/49 green
- [x] `bun run build` produces ESM `dist/` + `.d.ts` files
- [x] `tsconfig.test.json` strict-mode pass for tests + examples
- [ ] Smoke-test the README quickstart against a live lifegw (next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released the Life TypeScript SDK (`@broomva/life-sdk`) enabling developers to build applications with Agent, Events, Wallet, and Identity services. Includes streaming WebSocket support, error handling, and quick-start examples.

* **Documentation**
  * Added comprehensive SDK usage documentation with installation instructions, quickstart examples, and API reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->