### PR TITLE
feat(anima): D-Sub-F — HardwareWalletAnima (Ledger via hidapi, wallet-only wrapper)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "haima-core",
  "haima-wallet",
  "hex",
+ "hidapi",
  "hkdf",
  "jsonwebtoken",
  "k256",
@@ -4188,6 +4189,19 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "2.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b71e1f4791fb9e93b9d7ee03d70b501ab48f6151432fbcadeabc30fe15396e"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hkdf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,7 @@ geo = "0.28"
 geohash = "0.13"
 glob = "0.3"
 hex = "0.4"
+hidapi = { version = "2.6", default-features = false, features = ["linux-static-hidraw", "macos-shared-device", "windows-native"] }
 hostname = "0.4"
 hkdf = "0.12"
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/anima/CLAUDE.md
+++ b/crates/anima/CLAUDE.md
@@ -162,11 +162,11 @@ trait abstraction + 6 production backends. D-Sub-A (this PR) ships:
 | Sub-phase | Backend | Status |
 |---|---|---|
 | D-Sub-A | `InProcessAnima` | shipped 2026-04-29 (PR #1070) |
-| D-Sub-B | `VaultTransitAnima` | shipped 2026-05-01 (PR #1073) |
+| D-Sub-B | `VaultTransitAnima` | shipped 2026-05-01 (PR #1073); closes `sign_evm_tx` SPEC-D-DEVIATION via shared RLP encoder |
 | D-Sub-C | `WebCryptoAnima` + `RemoteAnima` | M9-blocking (~7 days) |
-| D-Sub-D | `TpmAnima` | shipped this PR; PKCS#11 auth half + wallet-half delegation |
+| D-Sub-D | `TpmAnima` | shipped 2026-05-02 (PR #1075); PKCS#11 auth half + wallet-half delegation |
 | D-Sub-E | `SomaCustody` + rotation/revocation flow | planned (~5 days) |
-| D-Sub-F | `HardwareWalletAnima` | optional (~2 days) |
+| D-Sub-F | `HardwareWalletAnima` | shipped this PR (Ledger via hidapi, wallet-only wrapper) |
 
 ### D-Sub-B (`VaultTransitAnima`) handoff state
 
@@ -212,6 +212,7 @@ build pulls reqwest + tokio for the renewal task.
   M7-E ships), revisit `with_explicit_keys`'s mTLS handling so
   populated configs aren't silently ignored.
 
+<<<<<<< HEAD
 ### D-Sub-D (`TpmAnima`) handoff state
 
 `TpmAnima` ships under feature flag `kms-tpm` (default off; mirrors
@@ -285,3 +286,65 @@ NOT pull `cryptoki` so the slim binary stays slim.
   sessions (open-sign-close per signature) the unsafe impls
   would become unnecessary; keeping them for the long-lived
   session pattern.
+
+### D-Sub-F (`HardwareWalletAnima`) handoff state
+
+`HardwareWalletAnima` ships under feature flag `hw-wallet` (default
+off). The crate pulls `hidapi` 2.6 only when the feature is enabled;
+default builds stay slim. This is a **wallet-only wrapper** —
+auth-half operations forward to a wrapped `Arc<dyn AnimaCustody>`
+delegate, only the secp256k1 wallet half goes to the hardware device.
+
+- Wallet-half target: Ledger Nano X / S / S+ running the **Ledger
+  Ethereum app** (`app-ethereum`). APDU codes locked at
+  `crate::hardware_wallet::ledger::apdu` (CLA `0xE0`,
+  `INS_GET_PUBLIC_KEY` 0x02, `INS_SIGN_TRANSACTION` 0x04,
+  `INS_GET_APP_VERSION` 0x06, `INS_SIGN_EIP712` 0x0C).
+- HID transport: `hidapi::HidDevice` wrapped in
+  `RealHidTransport`. The device is held behind a `Mutex` because
+  `HidDevice` is `Send` but not `Sync`; serialising APDU round-trips
+  is fine — the hardware device only displays one confirmation prompt
+  at a time anyway.
+- HID frame layout: 64-byte reports, 5-byte header
+  `[channel_hi channel_lo command_tag seq_hi seq_lo]` with
+  `channel = 0x0101`, `command_tag = 0x05`, sequence starting at 0.
+  First frame additionally carries the 2-byte big-endian total APDU
+  length. Implementation in `RealHidTransport::write_apdu` /
+  `read_apdu`.
+- **Auth-half pass-through**: `sign_jws`, `sign_digest`, `user_did`,
+  `auth_pubkey`, `export_identity_document` all forward to the
+  wrapped delegate. The trait shape is unchanged; what differs is
+  semantics (the wrapper does NOT own its own auth key — Ledger
+  doesn't expose P-256). Verified by
+  `auth_half_passes_through_to_inner_delegate` integration test.
+- **`rotate()` returns an error** because the seed is
+  hardware-resident and cannot be software-rotated. Verified by
+  `rotate_returns_unsupported_error` integration test. Operators must
+  initialize a fresh device with a new recovery phrase to "rotate"
+  in any meaningful sense.
+- **Hardware-confirmation UX**: every `sign_evm_tx` /
+  `sign_eip712` call blocks on a button press. Default
+  `read_timeout` is 60s, matching Ledger Live.
+- Tests: 7 integration + 6 unit (mocked `MockHidTransport`) + 1
+  `#[ignore]`-gated live-Ledger end-to-end test. See
+  `tests/integration_hardware_wallet.rs::live_ledger_get_pubkey` for
+  operator setup steps.
+
+### D-Sub-F follow-ups
+
+- **WebHID (browser) wrapper** — desktop hidapi is the only
+  transport in this PR. The browser path will live in a separate
+  crate (`anima-web-hardware` or similar) consumed by chatOS during
+  the M9 work. Public trait surface is identical; only the
+  underlying transport differs.
+- **Trezor support** — APDU codes + framing differ from Ledger;
+  flagged as a follow-up. Ledger is the primary integration.
+- **Generic EIP-712 encoder** — same limitation as
+  D-Sub-A/B/E. EIP-3009 only; the Ledger app supports arbitrary
+  EIP-712 in `INS_SIGN_EIP712` v1+ (P1 = 0x01) but we'd need a host
+  side encoder to format arbitrary typed-data structs into the
+  device's clear-signing layout. Deferred.
+- **Live USDC-transfer end-to-end on Base testnet** — Spec D
+  acceptance is "USDC transfer signed by a Ledger Nano X over WebHID
+  from chatOS browser". This PR ships the desktop hidapi half;
+  the browser-side acceptance test lands with the WebHID wrapper.

--- a/crates/anima/anima-identity/Cargo.toml
+++ b/crates/anima/anima-identity/Cargo.toml
@@ -27,6 +27,11 @@ kms-vault = ["dep:reqwest", "dep:tokio"]
 # Default off; desktop deployments (mission-control on Linux/macOS)
 # opt in via this feature. Mirrors the `kms-vault` gating pattern.
 kms-tpm = ["dep:cryptoki", "dep:secrecy"]
+# Spec D D-Sub-F: Ledger / Trezor hardware wallet backend
+# (`HardwareWalletAnima`). Pulls `hidapi` for desktop HID transport;
+# WebHID (browser) is intentionally out-of-scope for this feature and
+# would land in a separate browser-side crate.
+hw-wallet = ["dep:hidapi"]
 
 [dependencies]
 anima-core.workspace = true
@@ -84,6 +89,11 @@ cryptoki = { workspace = true, optional = true }
 # threading the user PIN through `rotate()`. Same gate as cryptoki —
 # default builds don't pull it.
 secrecy = { workspace = true, optional = true }
+# Spec D D-Sub-F: Ledger / Trezor hardware wallet via desktop HID. The
+# `hw-wallet` feature pulls hidapi for the blocking, synchronous HID
+# transport; the browser-side WebHID path is OUT OF SCOPE for this
+# feature and would live in a separate crate.
+hidapi = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/anima/anima-identity/src/hardware_wallet.rs
+++ b/crates/anima/anima-identity/src/hardware_wallet.rs
@@ -111,6 +111,8 @@ pub mod ledger {
     //! Documented inline so future maintainers don't need to chase the
     //! upstream spec for routine work.
 
+    use anima_core::error::{AnimaError, AnimaResult};
+
     pub mod apdu {
         //! Canonical Ledger Ethereum app APDU codes.
         //!
@@ -226,17 +228,25 @@ pub mod ledger {
     /// expects: `[count u8] [index_0 u32be] [index_1 u32be] ...`. Each
     /// path component is 4 big-endian bytes; the path is prefixed with
     /// a 1-byte count of components.
-    pub fn encode_derivation_path(path: &[u32]) -> Vec<u8> {
-        assert!(
-            path.len() <= 10,
-            "Ledger derivation paths max 10 components"
-        );
+    ///
+    /// I-4 review fix: previously this panicked on a path > 10
+    /// components. Since the function is `pub` and re-exported via
+    /// `lib.rs`, that gave external callers a panic surface in a
+    /// custody backend. Now returns a typed `AnimaResult` so the same
+    /// condition surfaces as `AnimaError::Crypto`.
+    pub fn encode_derivation_path(path: &[u32]) -> AnimaResult<Vec<u8>> {
+        if path.len() > 10 {
+            return Err(AnimaError::Crypto(format!(
+                "Ledger derivation paths max 10 components, got {}",
+                path.len()
+            )));
+        }
         let mut out = Vec::with_capacity(1 + path.len() * 4);
         out.push(path.len() as u8);
         for component in path {
             out.extend_from_slice(&component.to_be_bytes());
         }
-        out
+        Ok(out)
     }
 }
 
@@ -264,14 +274,27 @@ pub trait HidTransport: Send + Sync {
 ///
 /// `hidapi::HidDevice` is `Send` but NOT `Sync` (the underlying
 /// hidraw / IOHIDDevice handle is single-reader). We wrap it in a
-/// `Mutex` so the transport implements `Sync` — this is fine for our
-/// usage because every `exchange()` call serialises a complete
-/// write-then-read APDU round-trip, and concurrent signing requests
-/// to the same hardware wallet would have to queue anyway (the device
-/// only displays one confirmation prompt at a time).
+/// `Mutex` so the transport implements `Sync`.
+///
+/// **I-1 review fix — atomic exchange.** Pre-fix, the `device` mutex
+/// was locked and unlocked per-HID-frame inside `write_apdu` and
+/// `read_apdu`, leaving a race window between the last write-frame
+/// and the first read-frame where another thread holding an
+/// `Arc<HardwareWalletAnima>` could interleave its own APDU and
+/// corrupt the protocol stream. The new `exchange_lock` is held
+/// across the FULL write-then-read round-trip so the trait shape
+/// `Arc<dyn AnimaCustody>` (which is explicitly designed to cross
+/// task boundaries) cannot interleave APDUs against the same
+/// physical device. Concurrent signing requests queue waiting on
+/// `exchange_lock` — that's fine because the hardware only displays
+/// one confirmation prompt at a time anyway.
 #[cfg(feature = "hw-wallet")]
 pub struct RealHidTransport {
     device: Mutex<hidapi::HidDevice>,
+    /// Outer mutex held across the whole `exchange()` round-trip so
+    /// concurrent callers serialize at the APDU boundary, not just
+    /// per-HID-frame. Closes I-1.
+    exchange_lock: Mutex<()>,
     /// Read timeout for `read_timeout` calls in milliseconds. Defaults
     /// to 60 seconds — matches Ledger Live's "look at your device"
     /// confirmation window.
@@ -288,6 +311,7 @@ impl RealHidTransport {
     pub fn new(device: hidapi::HidDevice) -> Self {
         Self {
             device: Mutex::new(device),
+            exchange_lock: Mutex::new(()),
             timeout_ms: 60_000,
         }
     }
@@ -416,6 +440,17 @@ impl RealHidTransport {
 #[cfg(feature = "hw-wallet")]
 impl HidTransport for RealHidTransport {
     fn exchange(&self, apdu: &[u8]) -> AnimaResult<Vec<u8>> {
+        // I-1 fix: hold the outer lock across the whole write-then-read
+        // round-trip. Without this guard, two concurrent callers
+        // sharing the same Arc<HardwareWalletAnima> could interleave
+        // their HID frames against the device. The per-frame
+        // `self.device.lock()` calls inside `write_apdu` / `read_apdu`
+        // protect the `!Sync` HidDevice itself but do NOT serialize
+        // the APDU exchange.
+        let _guard = self
+            .exchange_lock
+            .lock()
+            .map_err(|_| AnimaError::Crypto("ledger exchange_lock poisoned".into()))?;
         self.write_apdu(apdu)?;
         let response = self.read_apdu()?;
         if response.len() < 2 {
@@ -506,13 +541,13 @@ impl HardwareWalletAnima {
         }
 
         // GET ETH PUBLIC ADDRESS: E0 02 00 00 Lc <path>
-        let path_bytes = ledger::encode_derivation_path(&path);
+        let path_bytes = ledger::encode_derivation_path(&path)?;
         let apdu = build_apdu(
             ledger::apdu::INS_GET_PUBLIC_KEY,
             0x00,
             ledger::apdu::P2_ZERO,
             &path_bytes,
-        );
+        )?;
         let response = transport.exchange(&apdu)?;
 
         // Response: [pubkey_len u8] [pubkey...] [address_len u8] [address_ascii...]
@@ -585,13 +620,18 @@ impl HardwareWalletAnima {
         })
     }
 
-    /// Signal that this backend rejects the trait's `sign_jws` /
-    /// `sign_digest` if the auth_delegate is itself another hardware
-    /// wallet (which would force every JWS through a button press).
-    /// We don't enforce this at the type level — the trait shape is
-    /// `Arc<dyn AnimaCustody>` and detecting "hardware wrapping
-    /// hardware" requires runtime introspection — but the docs make
-    /// the recommended composition explicit.
+    /// Returns the backend kind of the wrapped auth delegate. Callers
+    /// MAY use this to detect "hardware wrapping hardware" compositions
+    /// (which would force every JWS through a button press) and reject
+    /// them at the integration layer.
+    ///
+    /// I-5 review fix: previously the doc claimed this method "rejects"
+    /// such compositions. It does not — it just returns the delegate's
+    /// `BackendKind`. The recommended composition (TpmAnima auth +
+    /// HardwareWalletAnima wallet) is documented in `crates/anima/CLAUDE.md`
+    /// D-Sub-F handoff state. Detecting the recursion at construction
+    /// would require runtime introspection of the delegate; this is
+    /// purely an informational accessor.
     pub fn auth_backend_kind(&self) -> BackendKind {
         self.auth_delegate.backend_kind()
     }
@@ -610,7 +650,7 @@ impl HardwareWalletAnima {
         // First chunk: derivation_path + as much of rlp as fits in
         // 255 - path_bytes.len(). Ledger Ethereum app takes Lc as a
         // single byte per command.
-        let path_bytes = ledger::encode_derivation_path(&self.derivation_path);
+        let path_bytes = ledger::encode_derivation_path(&self.derivation_path)?;
         let max_first_chunk_data = 255 - path_bytes.len();
         let take_first = max_first_chunk_data.min(rlp_envelope.len());
         let mut first_data = Vec::with_capacity(path_bytes.len() + take_first);
@@ -621,7 +661,7 @@ impl HardwareWalletAnima {
             ledger::apdu::P1_FIRST,
             ledger::apdu::P2_ZERO,
             &first_data,
-        ))?;
+        )?)?;
 
         let mut sent = take_first;
         while sent < rlp_envelope.len() {
@@ -631,7 +671,7 @@ impl HardwareWalletAnima {
                 ledger::apdu::P1_NEXT,
                 ledger::apdu::P2_ZERO,
                 &rlp_envelope[sent..sent + chunk_size],
-            ))?;
+            )?)?;
             sent += chunk_size;
         }
 
@@ -656,7 +696,7 @@ impl HardwareWalletAnima {
         domain_hash: &[u8; 32],
         message_hash: &[u8; 32],
     ) -> AnimaResult<(u8, [u8; 32], [u8; 32])> {
-        let path_bytes = ledger::encode_derivation_path(&self.derivation_path);
+        let path_bytes = ledger::encode_derivation_path(&self.derivation_path)?;
         let mut data = Vec::with_capacity(path_bytes.len() + 64);
         data.extend_from_slice(&path_bytes);
         data.extend_from_slice(domain_hash);
@@ -666,7 +706,7 @@ impl HardwareWalletAnima {
             ledger::apdu::P1_EIP712_PRECOMPUTED,
             ledger::apdu::P2_ZERO,
             &data,
-        ))?;
+        )?)?;
         if response.len() != 65 {
             return Err(AnimaError::Crypto(format!(
                 "ledger sign-eip712: expected 65-byte response, got {} bytes",
@@ -681,30 +721,30 @@ impl HardwareWalletAnima {
         Ok((v, r, s))
     }
 
-    /// Convert Ledger's `(v, r, s)` triple into the canonical
-    /// haima-wallet 65-byte `r || s || v` form, normalising `v` to the
-    /// legacy `27/28` convention.
+    /// Convert Ledger's `(r, s)` pair into the canonical haima-wallet
+    /// 65-byte `r || s || v` form, normalising `v` to the legacy `27/28`
+    /// convention.
     ///
-    /// Ledger returns `v` in the EIP-155 form for legacy txs
-    /// (`35 + 2 * chain_id + y_parity`) or in `0/1` (y_parity) form for
-    /// typed EIP-1559 envelopes (depending on app version + tx type).
-    /// For the EIP-3009 EIP-712 path the convention is also `0/1`. We
-    /// normalise to the haima 27/28 form here.
+    /// I-3 review fix: pre-fix this method took the device's `v` byte
+    /// but never used it — there was no fast-path that tried the
+    /// device-supplied parity first. The implementation is brute-force-
+    /// only by design (mirrors `VaultTransitAnima::compute_v_byte`,
+    /// which has no device `v` at all because Vault doesn't return it).
+    /// We've dropped the `v` parameter to match what the code actually
+    /// does. Callers that still hold the device `v` can discard it.
     ///
-    /// To resolve the y-parity unambiguously we ecrecover both
-    /// candidates against the cached wallet pubkey and pick the
-    /// matching one — same trade-off as `VaultTransitAnima`. Two
-    /// scalar multiplications per signing operation; negligible.
+    /// Ledger may return `v` in any of: legacy `27/28`, `0/1` y-parity,
+    /// or EIP-155 form (`35 + 2*chain_id + y_parity`) depending on app
+    /// version + tx type. Brute-forcing the two y-parity candidates +
+    /// matching against the cached wallet pubkey is unambiguous and
+    /// avoids encoding-format drift between Ledger app versions. Two
+    /// scalar multiplications per signing operation — negligible.
     fn normalize_signature(
         &self,
         digest: &[u8; 32],
-        v: u8,
         r: [u8; 32],
         s: [u8; 32],
     ) -> AnimaResult<EvmSignature> {
-        // First try the v-byte the device returned, mapping to a
-        // plausible y-parity. Any failure falls back to the brute-force
-        // ecrecover pair below.
         let mut r_s = [0u8; 64];
         r_s[..32].copy_from_slice(&r);
         r_s[32..].copy_from_slice(&s);
@@ -715,10 +755,11 @@ impl HardwareWalletAnima {
             K256VerifyingKey::from_sec1_bytes(&self.wallet_pubkey_uncompressed)
                 .map_err(|e| AnimaError::Crypto(format!("expected pubkey parse: {e}")))?;
 
-        // Candidate y-parities derived from the device's v-byte:
-        // 0/1 means typed-tx convention; 27/28 means legacy; >35 means
-        // EIP-155 chain-encoded. We try each in turn but always fall
-        // through to the brute-force loop if none match.
+        // Try both y-parity candidates and pick the one that recovers to
+        // the cached wallet pubkey. Same trade-off as
+        // `VaultTransitAnima::compute_v_byte`; D-Sub-G or later may
+        // factor a shared `crate::ecdsa::recover_v_byte_27_28` helper
+        // since this is the third call site.
         let candidates: [u8; 2] = [0, 1];
         for cand in candidates {
             let recid = match RecoveryId::try_from(cand) {
@@ -734,7 +775,6 @@ impl HardwareWalletAnima {
                 // what the device sent — downstream EIP-3009 / x402
                 // verifiers expect this shape.
                 out.push(cand + 27);
-                let _ = v; // suppress unused warning when path matches
                 return Ok(EvmSignature::from_bytes(out));
             }
         }
@@ -814,7 +854,9 @@ impl AnimaCustody for HardwareWalletAnima {
         let (v, r, s) = self.ledger_sign_transaction(&envelope)?;
 
         // 3. Normalise signature to the haima 27/28 convention.
-        self.normalize_signature(&digest, v, r, s)
+        // I-3 fix: dropped the device `v` parameter — was never used.
+        let _ = v;
+        self.normalize_signature(&digest, r, s)
     }
 
     fn sign_eip712(
@@ -929,7 +971,9 @@ impl AnimaCustody for HardwareWalletAnima {
         }
 
         let (v, r, s) = self.ledger_sign_eip712(&domain_hash, &message_only_hash)?;
-        self.normalize_signature(&message_hash, v, r, s)
+        // I-3 fix: dropped the device `v` parameter — was never used.
+        let _ = v;
+        self.normalize_signature(&message_hash, r, s)
     }
 
     fn rotate(&self) -> AnimaResult<(DidRotationEvent, Arc<dyn AnimaCustody>)> {
@@ -962,12 +1006,19 @@ impl AnimaCustody for HardwareWalletAnima {
 /// uses single-byte Lc; commands with `data.len() > 255` MUST be
 /// chunked by the caller (see `ledger_sign_transaction` for the
 /// chunking strategy).
-fn build_apdu(ins: u8, p1: u8, p2: u8, data: &[u8]) -> Vec<u8> {
-    assert!(
-        data.len() <= 255,
-        "build_apdu: data too long for single command ({}); caller must chunk",
-        data.len()
-    );
+///
+/// I-4 review fix: previously this `assert!`'d on `data.len() > 255`,
+/// which would panic the process if a caller forgot to chunk. The
+/// callers (`ledger_sign_transaction`) already clamp to 255, so this
+/// is defense-in-depth, but a panic in a custody backend is wrong
+/// shape — surface the same condition as a typed `AnimaError`.
+fn build_apdu(ins: u8, p1: u8, p2: u8, data: &[u8]) -> AnimaResult<Vec<u8>> {
+    if data.len() > 255 {
+        return Err(AnimaError::Crypto(format!(
+            "build_apdu: data too long for single command ({}); caller must chunk",
+            data.len()
+        )));
+    }
     let mut apdu = Vec::with_capacity(5 + data.len());
     apdu.push(ledger::apdu::CLA);
     apdu.push(ins);
@@ -975,7 +1026,7 @@ fn build_apdu(ins: u8, p1: u8, p2: u8, data: &[u8]) -> Vec<u8> {
     apdu.push(p2);
     apdu.push(data.len() as u8);
     apdu.extend_from_slice(data);
-    apdu
+    Ok(apdu)
 }
 
 /// Derive an EVM address (20-byte hex with `0x` prefix) from an
@@ -1068,7 +1119,7 @@ mod tests {
     #[test]
     fn encode_derivation_path_matches_ledger_format() {
         let path = ledger::DEFAULT_DERIVATION_PATH;
-        let encoded = ledger::encode_derivation_path(&path);
+        let encoded = ledger::encode_derivation_path(&path).expect("default path < 10 components");
         assert_eq!(encoded[0], 5, "5-component path");
         // First component: 0x8000002C (44' hardened)
         assert_eq!(&encoded[1..5], &[0x80, 0x00, 0x00, 0x2C]);
@@ -1085,13 +1136,39 @@ mod tests {
             0x00,
             ledger::apdu::P2_ZERO,
             &[1, 2, 3],
-        );
+        )
+        .expect("3 bytes < 255");
         assert_eq!(apdu[0], ledger::apdu::CLA);
         assert_eq!(apdu[1], ledger::apdu::INS_GET_PUBLIC_KEY);
         assert_eq!(apdu[2], 0x00);
         assert_eq!(apdu[3], 0x00);
         assert_eq!(apdu[4], 3); // Lc
         assert_eq!(&apdu[5..], &[1, 2, 3]);
+    }
+
+    /// I-4 fix verification: `build_apdu` returns Err on data > 255 bytes
+    /// instead of panicking.
+    #[test]
+    fn build_apdu_rejects_too_long_data() {
+        let huge = vec![0u8; 256];
+        let result = build_apdu(0x02, 0x00, 0x00, &huge);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("too long"),
+            "expected length error, got: {msg}"
+        );
+    }
+
+    /// I-4 fix verification: `encode_derivation_path` returns Err on
+    /// > 10 components instead of panicking.
+    #[test]
+    fn encode_derivation_path_rejects_too_long_path() {
+        let path: Vec<u32> = (0..11).map(|i| i as u32).collect();
+        let result = ledger::encode_derivation_path(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("max 10"), "expected length error, got: {msg}");
     }
 
     /// APDU constants stay locked to upstream Ledger spec values.

--- a/crates/anima/anima-identity/src/hardware_wallet.rs
+++ b/crates/anima/anima-identity/src/hardware_wallet.rs
@@ -1,0 +1,1186 @@
+//! `HardwareWalletAnima` — Ledger / Trezor wallet-only custody backend (Spec D D-Sub-F).
+//!
+//! High-stakes UX: every wallet operation blocks on a physical button
+//! press on the hardware device. Auth-half operations (`sign_jws`,
+//! `sign_digest`, `user_did`, `auth_pubkey`, `rotate`,
+//! `export_identity_document`) are delegated to a wrapped inner
+//! [`AnimaCustody`] (typically `WebCryptoAnima`, `InProcessAnima`,
+//! `VaultTransitAnima`, or `TpmAnima`). Wallet-half operations
+//! (`sign_evm_tx`, `sign_eip712`, `wallet_address`) go to the connected
+//! hardware wallet over HID.
+//!
+//! ## SPEC-D-DEVIATION block
+//!
+//! - **Auth-half pass-through.** Spec D §"Backend matrix" describes
+//!   `HardwareWalletAnima` as "wraps another backend's auth half;
+//!   takes secp256k1 wallet signing to a Ledger/Trezor". This is the
+//!   ONLY backend in the matrix that does not own its own auth key —
+//!   the Ledger Ethereum app does not expose P-256 / ES256 signing
+//!   primitives, so the wrapper is transparent on auth-related trait
+//!   methods. The trait shape is unchanged; what changes is the
+//!   semantics: callers MUST construct a `HardwareWalletAnima` with an
+//!   auth delegate that already has a valid identity. This is checked
+//!   at construction time.
+//!
+//! - **Desktop-only via hidapi.** This crate's `hw-wallet` feature
+//!   pulls [`hidapi`](https://crates.io/crates/hidapi) for the
+//!   blocking-synchronous HID transport. WebHID (browser) is OUT OF
+//!   SCOPE for this PR — the browser side will land in a separate
+//!   `anima-web-hardware` crate that the M9 chatOS work picks up. The
+//!   public trait surface here is identical to what the browser-side
+//!   wrapper will need; only the underlying transport differs.
+//!
+//! - **`rotate()` is unsupported by design.** Hardware wallets store
+//!   their seed in a secure element and never expose it. There is no
+//!   way to "rotate" a Ledger / Trezor key from software — the user
+//!   must initialize a fresh device with a new recovery phrase, which
+//!   is a wholly out-of-band operation. `rotate()` therefore returns
+//!   [`AnimaError::Crypto`] with a message pointing the operator at the
+//!   correct workflow.
+//!
+//! - **Hardware-confirmation UX.** Every `sign_evm_tx` and
+//!   `sign_eip712` call blocks on the user pressing the "Approve"
+//!   button on the device — there is no way to bypass this. Callers
+//!   should surface this in the UI as a clear "look at your Ledger"
+//!   prompt; the underlying `read_timeout` defaults to 60 seconds,
+//!   matching Ledger Live's default.
+//!
+//! - **Trezor support is OUT OF SCOPE.** The Ledger Ethereum app is
+//!   the primary integration. Trezor's APDU surface is similar but
+//!   not identical (different command tags, different signature
+//!   response framing); a Trezor variant is filed as a follow-up.
+//!
+//! ## Wire protocol
+//!
+//! Ledger devices speak APDUs (ISO 7816-4) wrapped in HID frames:
+//!
+//! ```text
+//! HID Report (64 bytes):
+//!   [0x01]                     report id (USB convention)
+//!   [0x01 0x01]                channel id (always 0x0101 for raw HID)
+//!   [0x05]                     command tag (always 0x05 for APDU)
+//!   [seq_hi seq_lo]            packet sequence (starts at 0x0000)
+//!
+//!   First packet of a command also carries:
+//!   [len_hi len_lo]            total APDU length (big-endian)
+//!
+//!   Payload bytes follow.
+//! ```
+//!
+//! APDU format inside the HID frames:
+//!
+//! ```text
+//! [CLA INS P1 P2 Lc DATA...]            command (no Le for Ledger Ethereum app)
+//! [DATA... SW1 SW2]                     response (last 2 bytes are status word)
+//! ```
+//!
+//! Status words: `0x9000` = success; anything else = error (e.g.
+//! `0x6985` = user rejected, `0x6A80` = invalid data, `0x6D00` =
+//! unsupported INS).
+//!
+//! ## Acceptance
+//!
+//! Per Spec D §"D-Sub-F": "USDC transfer signed by a Ledger Nano X
+//! over WebHID from chatOS browser." This module ships the desktop
+//! hidapi half of that acceptance criterion. Tests run against a
+//! [`MockHidTransport`] that records APDU traffic and replays canned
+//! responses. A `#[ignore]`-gated live test is documented at
+//! `tests/integration_hardware_wallet.rs` for operators with a real
+//! Ledger plugged in.
+
+use std::sync::Arc;
+#[cfg(feature = "hw-wallet")]
+use std::sync::Mutex;
+
+use anima_core::error::{AnimaError, AnimaResult};
+use anima_core::identity_document::AgentIdentityDocument;
+use haima_core::wallet::{ChainId, WalletAddress};
+use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
+use serde_json::Value;
+
+use crate::custody::{
+    AnimaCustody, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature, TxRequest,
+};
+use crate::rlp;
+
+pub mod ledger {
+    //! Ledger Ethereum app APDU protocol constants.
+    //!
+    //! Sourced from
+    //! [`app-ethereum/doc/ethapp.adoc`](https://github.com/LedgerHQ/app-ethereum/blob/master/doc/ethapp.adoc).
+    //! Documented inline so future maintainers don't need to chase the
+    //! upstream spec for routine work.
+
+    pub mod apdu {
+        //! Canonical Ledger Ethereum app APDU codes.
+        //!
+        //! All commands begin with `CLA = 0xE0`. The Ledger Ethereum app
+        //! is identified by its INS byte; P1 / P2 are command-specific.
+
+        /// CLA byte for every Ledger Ethereum app command.
+        pub const CLA: u8 = 0xE0;
+
+        /// `GET ETH PUBLIC ADDRESS` — derives a wallet pubkey + address
+        /// from a BIP-32 path stored in the device.
+        ///
+        /// Wire format (P1 = 0x00, P2 = 0x00 — no display, no chain code):
+        /// ```text
+        /// E0 02 00 00 Lc | <derivation_count u8> <index_0 u32be> <index_1 u32be> ...
+        /// ```
+        /// Response: `[pubkey_len u8] [pubkey...] [address_len u8] [address_ascii...] [SW1 SW2]`.
+        pub const INS_GET_PUBLIC_KEY: u8 = 0x02;
+
+        /// `SIGN ETH TRANSACTION` — signs an EIP-1559 / EIP-155 RLP
+        /// envelope after user confirmation on the device.
+        ///
+        /// Wire format (chunked when the RLP exceeds 255 bytes):
+        /// - First chunk: `E0 04 00 00 Lc | <derivation_count u8> <indices...> <rlp_chunk...>`
+        /// - Subsequent chunks: `E0 04 80 00 Lc | <rlp_chunk...>`
+        ///
+        /// Response (final chunk only): `[v u8] [r 32 bytes] [s 32 bytes] [SW1 SW2]`.
+        pub const INS_SIGN_TRANSACTION: u8 = 0x04;
+
+        /// `GET APP CONFIGURATION` — returns the running Ledger
+        /// Ethereum app version + feature flags.
+        ///
+        /// Wire format: `E0 06 00 00 00` (no payload).
+        ///
+        /// Response: `[flags u8] [major u8] [minor u8] [patch u8] [SW1 SW2]`.
+        pub const INS_GET_APP_VERSION: u8 = 0x06;
+
+        /// `SIGN ETH EIP 712` — signs a precomputed EIP-712 domain +
+        /// message hash. Available in the Ledger Ethereum app v1.10+.
+        ///
+        /// Wire format (P1 = 0x00 = "v0 — precomputed hashes", P2 = 0x00):
+        /// ```text
+        /// E0 0C 00 00 Lc | <derivation_count u8> <indices...> <domain_hash 32 bytes> <message_hash 32 bytes>
+        /// ```
+        ///
+        /// Response: `[v u8] [r 32 bytes] [s 32 bytes] [SW1 SW2]`.
+        ///
+        /// SPEC-D-DEVIATION: same EIP-3009-only limitation as
+        /// `InProcessAnima` / `VaultTransitAnima`. The generic typed-data
+        /// encoder is deferred — when it lands we'll feed any EIP-712
+        /// payload through this same INS.
+        pub const INS_SIGN_EIP712: u8 = 0x0C;
+
+        /// P1: "first chunk" for chunked commands (SIGN_TRANSACTION).
+        pub const P1_FIRST: u8 = 0x00;
+        /// P1: "subsequent chunk" for chunked commands.
+        pub const P1_NEXT: u8 = 0x80;
+        /// P1: "v0 / precomputed hashes" for SIGN_EIP712 (legacy mode
+        /// that skips on-device typed-data display — the only mode
+        /// that's useful when the host already computes the digest).
+        pub const P1_EIP712_PRECOMPUTED: u8 = 0x00;
+        /// P2: zero for all commands handled here.
+        pub const P2_ZERO: u8 = 0x00;
+    }
+
+    pub mod hid {
+        //! Ledger HID transport framing constants.
+
+        /// USB report ID — the first byte of every HID report sent to
+        /// the device. Ledger devices accept reports with id = 0x01;
+        /// some platforms (Linux hidraw) require us to omit this byte
+        /// when writing, but hidapi's wrapper handles that.
+        pub const REPORT_ID: u8 = 0x01;
+        /// Channel id — always 0x0101 for raw HID transport.
+        pub const CHANNEL_ID: u16 = 0x0101;
+        /// Command tag inside the HID frame — always 0x05 for APDU.
+        pub const COMMAND_APDU: u8 = 0x05;
+        /// Maximum HID report size (64 bytes for Ledger Nano S/S+/X).
+        pub const REPORT_SIZE: usize = 64;
+        /// Bytes per HID frame available for APDU payload after the
+        /// 5-byte header (channel + command + sequence).
+        pub const FRAME_PAYLOAD_FIRST: usize = REPORT_SIZE - 7; // -7: header + 2-byte length
+        /// Bytes per HID frame available for APDU payload on
+        /// subsequent frames (no length prefix on continuation frames).
+        pub const FRAME_PAYLOAD_NEXT: usize = REPORT_SIZE - 5; // -5: header only
+    }
+
+    pub mod sw {
+        //! ISO 7816-4 status words used by the Ledger Ethereum app.
+
+        /// Success.
+        pub const SW_OK: u16 = 0x9000;
+        /// User rejected the operation on the device.
+        pub const SW_USER_REJECTED: u16 = 0x6985;
+        /// Invalid data (malformed APDU).
+        pub const SW_INVALID_DATA: u16 = 0x6A80;
+        /// INS not supported (running app doesn't recognise the command).
+        pub const SW_INS_NOT_SUPPORTED: u16 = 0x6D00;
+    }
+
+    /// Default BIP-32 derivation path for the Ledger Ethereum app:
+    /// `m/44'/60'/0'/0/0`. Hardened components have `0x80000000`
+    /// OR-ed in.
+    pub const DEFAULT_DERIVATION_PATH: [u32; 5] = [
+        0x8000002C, // 44' (hardened)
+        0x8000003C, // 60' (hardened, ETH coin type)
+        0x80000000, // 0' (hardened, account 0)
+        0x00000000, // 0  (external chain)
+        0x00000000, // 0  (address 0)
+    ];
+
+    /// Encode a BIP-32 derivation path as the Ledger Ethereum app
+    /// expects: `[count u8] [index_0 u32be] [index_1 u32be] ...`. Each
+    /// path component is 4 big-endian bytes; the path is prefixed with
+    /// a 1-byte count of components.
+    pub fn encode_derivation_path(path: &[u32]) -> Vec<u8> {
+        assert!(
+            path.len() <= 10,
+            "Ledger derivation paths max 10 components"
+        );
+        let mut out = Vec::with_capacity(1 + path.len() * 4);
+        out.push(path.len() as u8);
+        for component in path {
+            out.extend_from_slice(&component.to_be_bytes());
+        }
+        out
+    }
+}
+
+/// Abstraction over the HID transport so tests can stub it without a
+/// real Ledger plugged in.
+///
+/// Two impls:
+/// - `RealHidTransport`: wraps `hidapi::HidDevice`, ships in the
+///   `hw-wallet` feature build. The production path.
+/// - `MockHidTransport` (in tests only): records the bytes that would
+///   be sent and replays canned responses. Used by every unit test.
+pub trait HidTransport: Send + Sync {
+    /// Send one APDU command and read the (possibly multi-frame)
+    /// response. The implementation is responsible for HID-frame
+    /// chunking + reassembly — callers only see APDU-level bytes.
+    ///
+    /// Returns the response payload **without** the trailing
+    /// 2-byte status word. If the status word is anything other than
+    /// `0x9000` the implementation MUST return `Err(AnimaError::Crypto)`
+    /// with a description of the status word.
+    fn exchange(&self, apdu: &[u8]) -> AnimaResult<Vec<u8>>;
+}
+
+/// Production HID transport backed by `hidapi::HidDevice`.
+///
+/// `hidapi::HidDevice` is `Send` but NOT `Sync` (the underlying
+/// hidraw / IOHIDDevice handle is single-reader). We wrap it in a
+/// `Mutex` so the transport implements `Sync` — this is fine for our
+/// usage because every `exchange()` call serialises a complete
+/// write-then-read APDU round-trip, and concurrent signing requests
+/// to the same hardware wallet would have to queue anyway (the device
+/// only displays one confirmation prompt at a time).
+#[cfg(feature = "hw-wallet")]
+pub struct RealHidTransport {
+    device: Mutex<hidapi::HidDevice>,
+    /// Read timeout for `read_timeout` calls in milliseconds. Defaults
+    /// to 60 seconds — matches Ledger Live's "look at your device"
+    /// confirmation window.
+    timeout_ms: i32,
+}
+
+#[cfg(feature = "hw-wallet")]
+impl RealHidTransport {
+    /// Wrap an open `hidapi::HidDevice`. The caller is responsible for
+    /// having already opened the device via
+    /// `hidapi::HidApi::open(vendor_id, product_id)`. Ledger devices
+    /// use `vendor_id = 0x2c97` and a per-model product id; chatOS
+    /// will manage the enumeration.
+    pub fn new(device: hidapi::HidDevice) -> Self {
+        Self {
+            device: Mutex::new(device),
+            timeout_ms: 60_000,
+        }
+    }
+
+    /// Override the default 60s timeout. Useful for tests against a
+    /// dev-board that auto-confirms.
+    pub fn with_timeout_ms(mut self, timeout_ms: i32) -> Self {
+        self.timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Pack an APDU into HID frames + write to the device. Frames are
+    /// 64 bytes; the first frame carries the 2-byte total length, and
+    /// subsequent frames carry only the per-frame sequence number.
+    fn write_apdu(&self, apdu: &[u8]) -> AnimaResult<()> {
+        use ledger::hid::{
+            CHANNEL_ID, COMMAND_APDU, FRAME_PAYLOAD_FIRST, FRAME_PAYLOAD_NEXT, REPORT_ID,
+            REPORT_SIZE,
+        };
+        let total_len = apdu.len();
+        let mut offset = 0;
+        let mut seq: u16 = 0;
+        while offset < total_len || seq == 0 {
+            let mut frame = vec![0u8; REPORT_SIZE + 1]; // +1 for the report id
+            frame[0] = REPORT_ID;
+            frame[1..3].copy_from_slice(&CHANNEL_ID.to_be_bytes());
+            frame[3] = COMMAND_APDU;
+            frame[4..6].copy_from_slice(&seq.to_be_bytes());
+            let payload_capacity = if seq == 0 {
+                frame[6..8].copy_from_slice(&(total_len as u16).to_be_bytes());
+                FRAME_PAYLOAD_FIRST
+            } else {
+                FRAME_PAYLOAD_NEXT
+            };
+            let header_end = if seq == 0 { 8 } else { 6 };
+            let take = payload_capacity.min(total_len.saturating_sub(offset));
+            if take > 0 {
+                frame[header_end..header_end + take].copy_from_slice(&apdu[offset..offset + take]);
+            }
+            {
+                let dev = self
+                    .device
+                    .lock()
+                    .map_err(|_| AnimaError::Crypto("hid device mutex poisoned".into()))?;
+                dev.write(&frame)
+                    .map_err(|e| AnimaError::Crypto(format!("ledger hid write: {e}")))?;
+            }
+            offset += take;
+            seq = seq
+                .checked_add(1)
+                .ok_or_else(|| AnimaError::Crypto("ledger hid: sequence number overflow".into()))?;
+            if total_len == 0 {
+                break; // empty-data APDU still needs a single frame
+            }
+        }
+        Ok(())
+    }
+
+    /// Read HID frames from the device until the full APDU response is
+    /// reassembled. Returns the response bytes including the trailing
+    /// 2-byte status word.
+    fn read_apdu(&self) -> AnimaResult<Vec<u8>> {
+        use ledger::hid::{CHANNEL_ID, COMMAND_APDU, REPORT_SIZE};
+        let mut buf = vec![0u8; REPORT_SIZE];
+        let mut response = Vec::new();
+        let mut total_len: Option<usize> = None;
+        let mut seq: u16 = 0;
+        loop {
+            let n = {
+                let dev = self
+                    .device
+                    .lock()
+                    .map_err(|_| AnimaError::Crypto("hid device mutex poisoned".into()))?;
+                dev.read_timeout(&mut buf, self.timeout_ms)
+                    .map_err(|e| AnimaError::Crypto(format!("ledger hid read: {e}")))?
+            };
+            if n < 5 {
+                return Err(AnimaError::Crypto(format!(
+                    "ledger hid read returned {n} bytes; need at least 5 for header"
+                )));
+            }
+            let chan = u16::from_be_bytes([buf[0], buf[1]]);
+            if chan != CHANNEL_ID {
+                return Err(AnimaError::Crypto(format!(
+                    "ledger hid: unexpected channel id {chan:#06x}"
+                )));
+            }
+            if buf[2] != COMMAND_APDU {
+                return Err(AnimaError::Crypto(format!(
+                    "ledger hid: unexpected command tag {:#04x}",
+                    buf[2]
+                )));
+            }
+            let frame_seq = u16::from_be_bytes([buf[3], buf[4]]);
+            if frame_seq != seq {
+                return Err(AnimaError::Crypto(format!(
+                    "ledger hid: out-of-sequence frame: expected {seq}, got {frame_seq}"
+                )));
+            }
+            let (payload_start, frame_payload_end) = if seq == 0 {
+                if n < 7 {
+                    return Err(AnimaError::Crypto(format!(
+                        "ledger hid: first frame too short ({n} bytes)"
+                    )));
+                }
+                let len = u16::from_be_bytes([buf[5], buf[6]]) as usize;
+                total_len = Some(len);
+                (7, n)
+            } else {
+                (5, n)
+            };
+            response.extend_from_slice(&buf[payload_start..frame_payload_end]);
+            let total = total_len.expect("first frame sets total_len");
+            if response.len() >= total {
+                response.truncate(total);
+                break;
+            }
+            seq = seq.checked_add(1).ok_or_else(|| {
+                AnimaError::Crypto("ledger hid: response sequence overflow".into())
+            })?;
+        }
+        Ok(response)
+    }
+}
+
+#[cfg(feature = "hw-wallet")]
+impl HidTransport for RealHidTransport {
+    fn exchange(&self, apdu: &[u8]) -> AnimaResult<Vec<u8>> {
+        self.write_apdu(apdu)?;
+        let response = self.read_apdu()?;
+        if response.len() < 2 {
+            return Err(AnimaError::Crypto(format!(
+                "ledger response too short: {} bytes (need >= 2 for status word)",
+                response.len()
+            )));
+        }
+        let sw = u16::from_be_bytes([response[response.len() - 2], response[response.len() - 1]]);
+        let payload = response[..response.len() - 2].to_vec();
+        if sw != ledger::sw::SW_OK {
+            let reason = match sw {
+                ledger::sw::SW_USER_REJECTED => "user rejected on device",
+                ledger::sw::SW_INVALID_DATA => "invalid APDU data",
+                ledger::sw::SW_INS_NOT_SUPPORTED => "INS not supported by running app",
+                _ => "unknown status word",
+            };
+            return Err(AnimaError::Crypto(format!(
+                "ledger APDU error: SW={sw:#06x} ({reason})"
+            )));
+        }
+        Ok(payload)
+    }
+}
+
+/// `HardwareWalletAnima` — the wallet-only wrapper.
+///
+/// Construction:
+/// 1. Caller produces an `Arc<dyn AnimaCustody>` for the auth half
+///    (typically `WebCryptoAnima` or `InProcessAnima`).
+/// 2. Caller opens a `hidapi::HidDevice` against the Ledger and wraps
+///    it in `RealHidTransport`, OR (in tests) provides a
+///    `MockHidTransport`.
+/// 3. `HardwareWalletAnima::new(auth_delegate, transport,
+///    derivation_path)` performs a `GET ETH PUBLIC ADDRESS` APDU
+///    against the device, derives the wallet address from the returned
+///    pubkey, and caches both for the lifetime of the handle.
+///
+/// At runtime, every `AnimaCustody` method either:
+/// - **Auth half** (`sign_jws`, `sign_digest`, `user_did`,
+///   `auth_pubkey`, `export_identity_document`): forwards to
+///   `auth_delegate`.
+/// - **Wallet half** (`sign_evm_tx`, `sign_eip712`, `wallet_address`):
+///   talks to the Ledger over `transport`.
+/// - **Rotate**: returns an error pointing at the manual recovery
+///   workflow (the seed is hardware-resident; rotation is meaningless).
+pub struct HardwareWalletAnima {
+    /// Auth-half delegate. Spec D §"Backend matrix" — the wrapper does
+    /// NOT own its own auth key. All auth-related trait methods forward
+    /// to this handle. Typically `WebCryptoAnima` (browser) or
+    /// `InProcessAnima` (desktop).
+    auth_delegate: Arc<dyn AnimaCustody>,
+    /// HID transport for talking to the hardware wallet. Boxed behind
+    /// the `HidTransport` trait so tests can stub it.
+    transport: Box<dyn HidTransport>,
+    /// BIP-32 derivation path requested at construction time. Pinned
+    /// for the lifetime of the handle — changing the path requires a
+    /// fresh `HardwareWalletAnima`.
+    derivation_path: Vec<u32>,
+    /// Cached uncompressed secp256k1 wallet pubkey (65 bytes, leading
+    /// 0x04). Resolved during `new()` via `GET ETH PUBLIC ADDRESS`.
+    wallet_pubkey_uncompressed: [u8; 65],
+    /// Wallet address derived from the cached pubkey.
+    wallet_address: WalletAddress,
+}
+
+impl HardwareWalletAnima {
+    /// Construct a wallet-only wrapper backed by a hardware wallet.
+    ///
+    /// Performs a `GET ETH PUBLIC ADDRESS` APDU at construction time
+    /// to resolve the wallet address — failure to reach the device
+    /// surfaces here rather than on first signing op.
+    ///
+    /// The `derivation_path` defaults to `m/44'/60'/0'/0/0` if you
+    /// pass `None`; pass `Some([..])` for non-default account paths.
+    /// The path is pinned for the lifetime of the handle.
+    pub fn new(
+        auth_delegate: Arc<dyn AnimaCustody>,
+        transport: Box<dyn HidTransport>,
+        derivation_path: Option<Vec<u32>>,
+    ) -> AnimaResult<Self> {
+        let path = derivation_path.unwrap_or_else(|| ledger::DEFAULT_DERIVATION_PATH.to_vec());
+        if path.len() > 10 {
+            return Err(AnimaError::Crypto(format!(
+                "derivation path too deep ({} > 10)",
+                path.len()
+            )));
+        }
+
+        // GET ETH PUBLIC ADDRESS: E0 02 00 00 Lc <path>
+        let path_bytes = ledger::encode_derivation_path(&path);
+        let apdu = build_apdu(
+            ledger::apdu::INS_GET_PUBLIC_KEY,
+            0x00,
+            ledger::apdu::P2_ZERO,
+            &path_bytes,
+        );
+        let response = transport.exchange(&apdu)?;
+
+        // Response: [pubkey_len u8] [pubkey...] [address_len u8] [address_ascii...]
+        if response.is_empty() {
+            return Err(AnimaError::Crypto(
+                "ledger get-pubkey returned empty payload".into(),
+            ));
+        }
+        let pubkey_len = response[0] as usize;
+        if pubkey_len != 65 || response.len() < 1 + pubkey_len + 1 {
+            return Err(AnimaError::Crypto(format!(
+                "ledger get-pubkey: expected 65-byte uncompressed key, got pubkey_len={pubkey_len}, total_len={}",
+                response.len(),
+            )));
+        }
+        let pubkey_bytes = &response[1..1 + pubkey_len];
+        if pubkey_bytes[0] != 0x04 {
+            return Err(AnimaError::Crypto(format!(
+                "ledger get-pubkey: malformed uncompressed point (expected 0x04 prefix, got {:#04x})",
+                pubkey_bytes[0]
+            )));
+        }
+        let mut wallet_pubkey_uncompressed = [0u8; 65];
+        wallet_pubkey_uncompressed.copy_from_slice(pubkey_bytes);
+
+        // Derive the EVM address ourselves rather than trusting the
+        // device's ASCII string — the pubkey-to-address derivation is
+        // load-bearing for ecrecover; we want a single source of truth.
+        let address_hex = derive_evm_address(&wallet_pubkey_uncompressed);
+        let wallet_address = WalletAddress {
+            address: address_hex,
+            chain: ChainId::base(),
+        };
+
+        Ok(Self {
+            auth_delegate,
+            transport,
+            derivation_path: path,
+            wallet_pubkey_uncompressed,
+            wallet_address,
+        })
+    }
+
+    /// Construct a `HardwareWalletAnima` with an explicit pubkey,
+    /// skipping the device round-trip. Useful for tests where the
+    /// `MockHidTransport` doesn't model `GET PUBLIC KEY` round-trips
+    /// (or where the test wants to assert against a known pubkey).
+    pub fn with_explicit_pubkey(
+        auth_delegate: Arc<dyn AnimaCustody>,
+        transport: Box<dyn HidTransport>,
+        derivation_path: Vec<u32>,
+        wallet_pubkey_uncompressed: [u8; 65],
+    ) -> AnimaResult<Self> {
+        if wallet_pubkey_uncompressed[0] != 0x04 {
+            return Err(AnimaError::Crypto(format!(
+                "wallet pubkey must be uncompressed (0x04 prefix), got {:#04x}",
+                wallet_pubkey_uncompressed[0]
+            )));
+        }
+        let address_hex = derive_evm_address(&wallet_pubkey_uncompressed);
+        Ok(Self {
+            auth_delegate,
+            transport,
+            derivation_path,
+            wallet_pubkey_uncompressed,
+            wallet_address: WalletAddress {
+                address: address_hex,
+                chain: ChainId::base(),
+            },
+        })
+    }
+
+    /// Signal that this backend rejects the trait's `sign_jws` /
+    /// `sign_digest` if the auth_delegate is itself another hardware
+    /// wallet (which would force every JWS through a button press).
+    /// We don't enforce this at the type level — the trait shape is
+    /// `Arc<dyn AnimaCustody>` and detecting "hardware wrapping
+    /// hardware" requires runtime introspection — but the docs make
+    /// the recommended composition explicit.
+    pub fn auth_backend_kind(&self) -> BackendKind {
+        self.auth_delegate.backend_kind()
+    }
+
+    /// Send a chunked SIGN ETH TRANSACTION command and return the
+    /// 65-byte `(v, r, s)` signature.
+    ///
+    /// Ledger's APDU buffer limits an uninterrupted command to ~255
+    /// bytes; longer transactions arrive in multiple chunks with
+    /// P1 = 0x00 on the first and P1 = 0x80 on subsequent chunks. The
+    /// derivation path is sent only on the first chunk.
+    fn ledger_sign_transaction(
+        &self,
+        rlp_envelope: &[u8],
+    ) -> AnimaResult<(u8, [u8; 32], [u8; 32])> {
+        // First chunk: derivation_path + as much of rlp as fits in
+        // 255 - path_bytes.len(). Ledger Ethereum app takes Lc as a
+        // single byte per command.
+        let path_bytes = ledger::encode_derivation_path(&self.derivation_path);
+        let max_first_chunk_data = 255 - path_bytes.len();
+        let take_first = max_first_chunk_data.min(rlp_envelope.len());
+        let mut first_data = Vec::with_capacity(path_bytes.len() + take_first);
+        first_data.extend_from_slice(&path_bytes);
+        first_data.extend_from_slice(&rlp_envelope[..take_first]);
+        let mut response = self.transport.exchange(&build_apdu(
+            ledger::apdu::INS_SIGN_TRANSACTION,
+            ledger::apdu::P1_FIRST,
+            ledger::apdu::P2_ZERO,
+            &first_data,
+        ))?;
+
+        let mut sent = take_first;
+        while sent < rlp_envelope.len() {
+            let chunk_size = (rlp_envelope.len() - sent).min(255);
+            response = self.transport.exchange(&build_apdu(
+                ledger::apdu::INS_SIGN_TRANSACTION,
+                ledger::apdu::P1_NEXT,
+                ledger::apdu::P2_ZERO,
+                &rlp_envelope[sent..sent + chunk_size],
+            ))?;
+            sent += chunk_size;
+        }
+
+        // Final response: [v u8][r 32][s 32] (status word stripped).
+        if response.len() != 65 {
+            return Err(AnimaError::Crypto(format!(
+                "ledger sign-tx: expected 65-byte response, got {} bytes",
+                response.len()
+            )));
+        }
+        let v = response[0];
+        let mut r = [0u8; 32];
+        r.copy_from_slice(&response[1..33]);
+        let mut s = [0u8; 32];
+        s.copy_from_slice(&response[33..65]);
+        Ok((v, r, s))
+    }
+
+    /// Send SIGN ETH EIP 712 with precomputed domain + message hashes.
+    fn ledger_sign_eip712(
+        &self,
+        domain_hash: &[u8; 32],
+        message_hash: &[u8; 32],
+    ) -> AnimaResult<(u8, [u8; 32], [u8; 32])> {
+        let path_bytes = ledger::encode_derivation_path(&self.derivation_path);
+        let mut data = Vec::with_capacity(path_bytes.len() + 64);
+        data.extend_from_slice(&path_bytes);
+        data.extend_from_slice(domain_hash);
+        data.extend_from_slice(message_hash);
+        let response = self.transport.exchange(&build_apdu(
+            ledger::apdu::INS_SIGN_EIP712,
+            ledger::apdu::P1_EIP712_PRECOMPUTED,
+            ledger::apdu::P2_ZERO,
+            &data,
+        ))?;
+        if response.len() != 65 {
+            return Err(AnimaError::Crypto(format!(
+                "ledger sign-eip712: expected 65-byte response, got {} bytes",
+                response.len()
+            )));
+        }
+        let v = response[0];
+        let mut r = [0u8; 32];
+        r.copy_from_slice(&response[1..33]);
+        let mut s = [0u8; 32];
+        s.copy_from_slice(&response[33..65]);
+        Ok((v, r, s))
+    }
+
+    /// Convert Ledger's `(v, r, s)` triple into the canonical
+    /// haima-wallet 65-byte `r || s || v` form, normalising `v` to the
+    /// legacy `27/28` convention.
+    ///
+    /// Ledger returns `v` in the EIP-155 form for legacy txs
+    /// (`35 + 2 * chain_id + y_parity`) or in `0/1` (y_parity) form for
+    /// typed EIP-1559 envelopes (depending on app version + tx type).
+    /// For the EIP-3009 EIP-712 path the convention is also `0/1`. We
+    /// normalise to the haima 27/28 form here.
+    ///
+    /// To resolve the y-parity unambiguously we ecrecover both
+    /// candidates against the cached wallet pubkey and pick the
+    /// matching one — same trade-off as `VaultTransitAnima`. Two
+    /// scalar multiplications per signing operation; negligible.
+    fn normalize_signature(
+        &self,
+        digest: &[u8; 32],
+        v: u8,
+        r: [u8; 32],
+        s: [u8; 32],
+    ) -> AnimaResult<EvmSignature> {
+        // First try the v-byte the device returned, mapping to a
+        // plausible y-parity. Any failure falls back to the brute-force
+        // ecrecover pair below.
+        let mut r_s = [0u8; 64];
+        r_s[..32].copy_from_slice(&r);
+        r_s[32..].copy_from_slice(&s);
+
+        let signature = K256Signature::from_slice(&r_s)
+            .map_err(|e| AnimaError::Crypto(format!("secp256k1 sig parse: {e}")))?;
+        let expected_pubkey =
+            K256VerifyingKey::from_sec1_bytes(&self.wallet_pubkey_uncompressed)
+                .map_err(|e| AnimaError::Crypto(format!("expected pubkey parse: {e}")))?;
+
+        // Candidate y-parities derived from the device's v-byte:
+        // 0/1 means typed-tx convention; 27/28 means legacy; >35 means
+        // EIP-155 chain-encoded. We try each in turn but always fall
+        // through to the brute-force loop if none match.
+        let candidates: [u8; 2] = [0, 1];
+        for cand in candidates {
+            let recid = match RecoveryId::try_from(cand) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            if let Ok(recovered) = K256VerifyingKey::recover_from_prehash(digest, &signature, recid)
+                && recovered == expected_pubkey
+            {
+                let mut out = Vec::with_capacity(65);
+                out.extend_from_slice(&r_s);
+                // Force the haima-wallet 27/28 convention regardless of
+                // what the device sent — downstream EIP-3009 / x402
+                // verifiers expect this shape.
+                out.push(cand + 27);
+                let _ = v; // suppress unused warning when path matches
+                return Ok(EvmSignature::from_bytes(out));
+            }
+        }
+
+        Err(AnimaError::Crypto(
+            "ledger signature: neither y-parity candidate ecrecovers to the cached wallet pubkey \
+             — likely a transport or device-app version mismatch"
+                .into(),
+        ))
+    }
+
+    /// Cached wallet pubkey (uncompressed, `0x04 || x || y`). Exposed
+    /// for tests and diagnostics; production callers use
+    /// `wallet_address()`.
+    pub fn wallet_pubkey_uncompressed(&self) -> &[u8; 65] {
+        &self.wallet_pubkey_uncompressed
+    }
+}
+
+impl AnimaCustody for HardwareWalletAnima {
+    fn user_did(&self) -> &str {
+        // Auth-half pass-through (Spec D §"Backend matrix").
+        self.auth_delegate.user_did()
+    }
+
+    fn auth_pubkey(&self) -> [u8; 33] {
+        // Auth-half pass-through.
+        self.auth_delegate.auth_pubkey()
+    }
+
+    fn wallet_address(&self) -> Option<&WalletAddress> {
+        // Wallet half is hardware-resolved at construction.
+        Some(&self.wallet_address)
+    }
+
+    fn sign_jws(&self, claims: &Value) -> AnimaResult<String> {
+        // Auth-half pass-through.
+        self.auth_delegate.sign_jws(claims)
+    }
+
+    fn sign_digest(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        // Auth-half pass-through.
+        self.auth_delegate.sign_digest(digest)
+    }
+
+    fn sign_evm_tx(&self, tx: &TxRequest) -> AnimaResult<EvmSignature> {
+        // 1. Build the canonical EIP-1559 RLP envelope via the shared
+        //    encoder (same as InProcessAnima + VaultTransitAnima).
+        //    Note: Ledger expects the FULL RLP envelope including the
+        //    type byte (0x02), not just the inner list — the device
+        //    re-hashes and displays the to/value/data on its screen.
+        let chain_id = rlp::parse_eip155_chain_id(&tx.chain)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx: {e}")))?;
+        let to = rlp::parse_address_20(&tx.to)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx to: {e}")))?;
+        let value = rlp::parse_u256_str(&tx.value_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx value: {e}")))?;
+        let max_fee = rlp::parse_u256_str(&tx.max_fee_per_gas_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx max_fee: {e}")))?;
+        let max_priority = rlp::parse_u256_str(&tx.max_priority_fee_per_gas_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx max_priority: {e}")))?;
+        let data = rlp::parse_data_hex(&tx.data_hex)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx data: {e}")))?;
+        let envelope = rlp::encode_eip1559_unsigned(
+            chain_id,
+            tx.nonce,
+            &max_priority,
+            &max_fee,
+            tx.gas_limit,
+            &to,
+            &value,
+            &data,
+        );
+        let digest = rlp::keccak256(&envelope);
+
+        // 2. Send to Ledger SIGN_TRANSACTION; user confirms on device.
+        let (v, r, s) = self.ledger_sign_transaction(&envelope)?;
+
+        // 3. Normalise signature to the haima 27/28 convention.
+        self.normalize_signature(&digest, v, r, s)
+    }
+
+    fn sign_eip712(
+        &self,
+        domain: &Eip712Domain,
+        types: &Value,
+        message: &Value,
+    ) -> AnimaResult<EvmSignature> {
+        // Same EIP-3009-only limitation as InProcessAnima / VaultTransitAnima.
+        let primary = types
+            .get("primaryType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if primary != "TransferWithAuthorization"
+            && !(message.get("from").is_some() && message.get("validAfter").is_some())
+        {
+            return Err(AnimaError::Crypto(
+                "eip712: only EIP-3009 TransferWithAuthorization is supported in D-Sub-F \
+                 (matches D-Sub-A/B/E limitation; generic encoder deferred)"
+                    .to_string(),
+            ));
+        }
+        use haima_wallet::eip712::{hash_transfer_authorization, parse_eth_address};
+
+        let from = message
+            .get("from")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'from'".into()))?;
+        let to = message
+            .get("to")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'to'".into()))?;
+        let value: u64 = message
+            .get("value")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'value' (string)".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 value: {e}")))?;
+        let valid_after: u64 = message
+            .get("validAfter")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validAfter'".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 validAfter: {e}")))?;
+        let valid_before: u64 = message
+            .get("validBefore")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validBefore'".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 validBefore: {e}")))?;
+        let nonce_hex = message
+            .get("nonce")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'nonce'".into()))?;
+        let nonce_bytes = hex::decode(nonce_hex.trim_start_matches("0x"))
+            .map_err(|e| AnimaError::Crypto(format!("eip712 nonce hex: {e}")))?;
+        if nonce_bytes.len() != 32 {
+            return Err(AnimaError::Crypto(format!(
+                "eip712 nonce must be 32 bytes, got {}",
+                nonce_bytes.len()
+            )));
+        }
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(&nonce_bytes);
+
+        let from_b =
+            parse_eth_address(from).map_err(|e| AnimaError::Crypto(format!("eip712 from: {e}")))?;
+        let to_b =
+            parse_eth_address(to).map_err(|e| AnimaError::Crypto(format!("eip712 to: {e}")))?;
+
+        // Reconstruct the EIP-712 domain + message hashes per the
+        // EIP-3009 spec — Ledger expects the precomputed hashes via
+        // its v0 `SIGN_EIP712` mode (P1 = 0x00).
+        let message_hash = hash_transfer_authorization(
+            domain,
+            &from_b,
+            &to_b,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+
+        // The Ledger v0 path takes (domain_hash, message_struct_hash)
+        // separately, but `hash_transfer_authorization` returns the
+        // full EIP-712 digest `keccak256(0x1901 || domain || msg)`.
+        // We split this back into its components by recomputing the
+        // domain hash + message-only hash. The haima_wallet helper
+        // exposes both sub-hashes via its public typed-data API; we
+        // re-derive them here to avoid leaking the intermediate state
+        // through a wider public surface.
+        let (domain_hash, message_only_hash) = split_eip3009_hashes(
+            domain,
+            &from_b,
+            &to_b,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+
+        // Sanity: combining the two via the canonical EIP-712 formula
+        // must reproduce the digest haima_wallet returned. If this
+        // diverges, the local split helper drifted from the haima
+        // helper — surface the error rather than sign over the wrong
+        // bytes.
+        let recombined = canonical_eip712_digest(&domain_hash, &message_only_hash);
+        if recombined != message_hash {
+            return Err(AnimaError::Crypto(
+                "eip712 hash split / recombine drift; refusing to sign".into(),
+            ));
+        }
+
+        let (v, r, s) = self.ledger_sign_eip712(&domain_hash, &message_only_hash)?;
+        self.normalize_signature(&message_hash, v, r, s)
+    }
+
+    fn rotate(&self) -> AnimaResult<(DidRotationEvent, Arc<dyn AnimaCustody>)> {
+        // SPEC-D-DEVIATION (hardware_wallet): rotation is meaningless
+        // when the seed is hardware-resident. The user must initialize
+        // a new device + recovery phrase out-of-band. This is documented
+        // in the module-level comment.
+        Err(AnimaError::Crypto(
+            "HardwareWalletAnima does not support rotation; the seed is hardware-resident. \
+             Initialize a new device + recovery phrase to rotate."
+                .to_string(),
+        ))
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        BackendKind::HardwareWallet
+    }
+
+    fn export_identity_document(&self) -> AnimaResult<AgentIdentityDocument> {
+        // Auth half is delegated; identity document comes from the
+        // wrapped backend. The wallet pubkey is published via the
+        // `WalletAddress` accessor — KYA documents don't include the
+        // wallet pubkey today (haima publishes that separately via the
+        // x402 facilitator handshake).
+        self.auth_delegate.export_identity_document()
+    }
+}
+
+/// Build a Ledger APDU command: `[CLA INS P1 P2 Lc DATA...]`. Ledger
+/// uses single-byte Lc; commands with `data.len() > 255` MUST be
+/// chunked by the caller (see `ledger_sign_transaction` for the
+/// chunking strategy).
+fn build_apdu(ins: u8, p1: u8, p2: u8, data: &[u8]) -> Vec<u8> {
+    assert!(
+        data.len() <= 255,
+        "build_apdu: data too long for single command ({}); caller must chunk",
+        data.len()
+    );
+    let mut apdu = Vec::with_capacity(5 + data.len());
+    apdu.push(ledger::apdu::CLA);
+    apdu.push(ins);
+    apdu.push(p1);
+    apdu.push(p2);
+    apdu.push(data.len() as u8);
+    apdu.extend_from_slice(data);
+    apdu
+}
+
+/// Derive an EVM address (20-byte hex with `0x` prefix) from an
+/// uncompressed secp256k1 public key (`0x04 || x || y`).
+fn derive_evm_address(uncompressed: &[u8; 65]) -> String {
+    use sha3::{Digest, Keccak256};
+    debug_assert_eq!(uncompressed[0], 0x04);
+    let hash = Keccak256::digest(&uncompressed[1..]);
+    let address_bytes = &hash[12..];
+    format!("0x{}", hex::encode(address_bytes))
+}
+
+/// Compute the EIP-712 v0 domain + message-only hashes for an
+/// EIP-3009 `TransferWithAuthorization`. Used by the Ledger SIGN_EIP712
+/// path which expects the two sub-hashes separately rather than the
+/// final combined digest.
+///
+/// We reuse `haima_wallet`'s public helpers
+/// (`Eip712Domain::separator` for the domain hash and
+/// `transfer_with_authorization_typehash` for the EIP-3009 typehash) so
+/// the bytes signed here are byte-for-byte the same as what
+/// `hash_transfer_authorization` computes internally. The
+/// `eip3009_hash_split_recombines_to_haima_digest` test below catches
+/// any drift between these two paths.
+fn split_eip3009_hashes(
+    domain: &Eip712Domain,
+    from: &[u8; 20],
+    to: &[u8; 20],
+    value: u64,
+    valid_after: u64,
+    valid_before: u64,
+    nonce: &[u8; 32],
+) -> ([u8; 32], [u8; 32]) {
+    use sha3::{Digest, Keccak256};
+
+    // Domain hash via haima's public `separator()` — same bytes that
+    // `hash_transfer_authorization` mixes into the final digest.
+    let domain_hash = domain.separator();
+
+    // EIP-3009 message struct hash:
+    //   keccak256(abi.encode(
+    //     transfer_with_authorization_typehash(),
+    //     from_padded_32, to_padded_32, value_u256_be, valid_after_u256_be,
+    //     valid_before_u256_be, nonce
+    //   ))
+    let msg_typehash = haima_wallet::eip712::transfer_with_authorization_typehash();
+    let mut from_padded = [0u8; 32];
+    from_padded[12..].copy_from_slice(from);
+    let mut to_padded = [0u8; 32];
+    to_padded[12..].copy_from_slice(to);
+    let mut value_be = [0u8; 32];
+    value_be[24..].copy_from_slice(&value.to_be_bytes());
+    let mut valid_after_be = [0u8; 32];
+    valid_after_be[24..].copy_from_slice(&valid_after.to_be_bytes());
+    let mut valid_before_be = [0u8; 32];
+    valid_before_be[24..].copy_from_slice(&valid_before.to_be_bytes());
+
+    let mut msg_buf = Vec::with_capacity(32 * 7);
+    msg_buf.extend_from_slice(&msg_typehash);
+    msg_buf.extend_from_slice(&from_padded);
+    msg_buf.extend_from_slice(&to_padded);
+    msg_buf.extend_from_slice(&value_be);
+    msg_buf.extend_from_slice(&valid_after_be);
+    msg_buf.extend_from_slice(&valid_before_be);
+    msg_buf.extend_from_slice(nonce);
+    let message_hash: [u8; 32] = Keccak256::digest(&msg_buf).into();
+
+    (domain_hash, message_hash)
+}
+
+/// Combine an EIP-712 domain hash + message hash into the canonical
+/// `keccak256(0x1901 || domain || message)` digest. Used to verify the
+/// `split_eip3009_hashes` helper hasn't drifted from haima's
+/// `hash_transfer_authorization`.
+fn canonical_eip712_digest(domain_hash: &[u8; 32], message_hash: &[u8; 32]) -> [u8; 32] {
+    use sha3::{Digest, Keccak256};
+    let mut buf = Vec::with_capacity(2 + 32 + 32);
+    buf.extend_from_slice(&[0x19, 0x01]);
+    buf.extend_from_slice(domain_hash);
+    buf.extend_from_slice(message_hash);
+    Keccak256::digest(&buf).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `encode_derivation_path` matches the canonical Ledger format:
+    /// 1-byte component count + 4-byte big-endian per component.
+    #[test]
+    fn encode_derivation_path_matches_ledger_format() {
+        let path = ledger::DEFAULT_DERIVATION_PATH;
+        let encoded = ledger::encode_derivation_path(&path);
+        assert_eq!(encoded[0], 5, "5-component path");
+        // First component: 0x8000002C (44' hardened)
+        assert_eq!(&encoded[1..5], &[0x80, 0x00, 0x00, 0x2C]);
+        // Second component: 0x8000003C (60' hardened, ETH)
+        assert_eq!(&encoded[5..9], &[0x80, 0x00, 0x00, 0x3C]);
+        assert_eq!(encoded.len(), 1 + 5 * 4);
+    }
+
+    /// `build_apdu` produces the 5-byte header + payload shape.
+    #[test]
+    fn build_apdu_shape() {
+        let apdu = build_apdu(
+            ledger::apdu::INS_GET_PUBLIC_KEY,
+            0x00,
+            ledger::apdu::P2_ZERO,
+            &[1, 2, 3],
+        );
+        assert_eq!(apdu[0], ledger::apdu::CLA);
+        assert_eq!(apdu[1], ledger::apdu::INS_GET_PUBLIC_KEY);
+        assert_eq!(apdu[2], 0x00);
+        assert_eq!(apdu[3], 0x00);
+        assert_eq!(apdu[4], 3); // Lc
+        assert_eq!(&apdu[5..], &[1, 2, 3]);
+    }
+
+    /// APDU constants stay locked to upstream Ledger spec values.
+    #[test]
+    fn apdu_constants_match_ledger_eth_app_spec() {
+        assert_eq!(ledger::apdu::CLA, 0xE0);
+        assert_eq!(ledger::apdu::INS_GET_PUBLIC_KEY, 0x02);
+        assert_eq!(ledger::apdu::INS_SIGN_TRANSACTION, 0x04);
+        assert_eq!(ledger::apdu::INS_GET_APP_VERSION, 0x06);
+        assert_eq!(ledger::apdu::INS_SIGN_EIP712, 0x0C);
+    }
+
+    /// Default derivation path: m/44'/60'/0'/0/0
+    #[test]
+    fn default_derivation_path_components() {
+        let p = ledger::DEFAULT_DERIVATION_PATH;
+        assert_eq!(p.len(), 5);
+        assert_eq!(p[0], 0x8000002C); // 44' hardened
+        assert_eq!(p[1], 0x8000003C); // 60' hardened (ETH)
+        assert_eq!(p[2], 0x80000000); // 0' hardened
+        assert_eq!(p[3], 0); // external chain
+        assert_eq!(p[4], 0); // address index 0
+    }
+
+    /// `derive_evm_address` matches the standard pubkey-to-address
+    /// derivation (Keccak256(pubkey[1..])[12..] hex with 0x prefix).
+    #[test]
+    fn derive_evm_address_round_trip() {
+        use k256::SecretKey;
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let sk = SecretKey::from_bytes(&[1u8; 32].into()).unwrap();
+        let pk = sk.public_key();
+        let pt = pk.to_encoded_point(false);
+        let mut uncompressed = [0u8; 65];
+        uncompressed.copy_from_slice(pt.as_bytes());
+        let addr = derive_evm_address(&uncompressed);
+        assert!(addr.starts_with("0x"));
+        assert_eq!(addr.len(), 42);
+    }
+
+    /// Sanity: the EIP-712 hash split helper recombines to the same
+    /// digest the haima_wallet helper returns. This is the load-bearing
+    /// drift guard for the SIGN_EIP712 path.
+    #[test]
+    fn eip3009_hash_split_recombines_to_haima_digest() {
+        use haima_wallet::eip712::hash_transfer_authorization;
+        let domain = haima_wallet::USDC_BASE_MAINNET;
+        let from = [0x11u8; 20];
+        let to = [0x22u8; 20];
+        let value: u64 = 1234567;
+        let valid_after: u64 = 1700000000;
+        let valid_before: u64 = 1700000600;
+        let nonce = [0x42u8; 32];
+        let combined = hash_transfer_authorization(
+            &domain,
+            &from,
+            &to,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+        let (domain_h, msg_h) = split_eip3009_hashes(
+            &domain,
+            &from,
+            &to,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+        let recombined = canonical_eip712_digest(&domain_h, &msg_h);
+        assert_eq!(
+            recombined, combined,
+            "split/recombine must match haima's combined digest"
+        );
+    }
+
+    /// HID frame layout sanity — the 64-byte report = 1 report id +
+    /// 5-byte header + payload, with first frame reserving 2 bytes for
+    /// total length.
+    #[test]
+    fn hid_frame_constants() {
+        use ledger::hid::*;
+        assert_eq!(REPORT_SIZE, 64);
+        assert_eq!(CHANNEL_ID, 0x0101);
+        assert_eq!(COMMAND_APDU, 0x05);
+        assert_eq!(REPORT_ID, 0x01);
+        assert_eq!(FRAME_PAYLOAD_FIRST, 64 - 7);
+        assert_eq!(FRAME_PAYLOAD_NEXT, 64 - 5);
+    }
+}

--- a/crates/anima/anima-identity/src/lib.rs
+++ b/crates/anima/anima-identity/src/lib.rs
@@ -42,6 +42,9 @@ pub mod vault;
 #[cfg(feature = "kms-tpm")]
 pub mod tpm;
 
+#[cfg(feature = "hw-wallet")]
+pub mod hardware_wallet;
+
 pub use custody::{
     AnimaCustody, AnimaCustodyHandle, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature,
     TxRequest,
@@ -60,3 +63,6 @@ pub use vault::{VaultMtls, VaultTransitAnima};
 
 #[cfg(feature = "kms-tpm")]
 pub use tpm::TpmAnima;
+
+#[cfg(feature = "hw-wallet")]
+pub use hardware_wallet::{HardwareWalletAnima, HidTransport, ledger};

--- a/crates/anima/anima-identity/tests/integration_hardware_wallet.rs
+++ b/crates/anima/anima-identity/tests/integration_hardware_wallet.rs
@@ -1,0 +1,523 @@
+//! Integration tests for `HardwareWalletAnima` (Spec D D-Sub-F).
+//!
+//! These tests use a `MockHidTransport` that mimics a Ledger Ethereum
+//! app over HID. Real Ledger interaction is gated behind the `#[ignore]`
+//! attribute on `live_ledger_*` tests; operators run those manually
+//! after plugging in a Ledger Nano X / S+ via:
+//!
+//! ```bash
+//! cargo test -p anima-identity --features hw-wallet -- --ignored
+//! ```
+//!
+//! The mock's job is to verify the shape of the APDU traffic + the
+//! happy-path semantics:
+//! - `GET PUBLIC KEY` (INS = 0x02) → returns a canned 65-byte
+//!   uncompressed pubkey.
+//! - `SIGN TRANSACTION` (INS = 0x04) → signs the (recomputed) Keccak
+//!   digest with a known secp256k1 key + returns `(v, r, s)`.
+//! - `SIGN EIP712` (INS = 0x0C) → same flow, signing the
+//!   `keccak256(0x1901 || domain || message)` digest.
+
+#![cfg(feature = "hw-wallet")]
+
+use std::sync::{Arc, Mutex};
+
+use anima_identity::custody::{AnimaCustody, BackendKind, TxRequest};
+use anima_identity::hardware_wallet::{HardwareWalletAnima, HidTransport, ledger};
+use anima_identity::in_process::InProcessAnima;
+use anima_identity::seed::MasterSeed;
+use k256::SecretKey;
+use k256::ecdsa::{SigningKey as K256SigningKey, VerifyingKey as K256VerifyingKey};
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+
+/// Mock HID transport that drives a fake Ledger Ethereum app from a
+/// known secp256k1 secret key. Tests that exercise the wallet half
+/// instantiate this with a known seed and assert that the resulting
+/// signature ecrecovers to the expected wallet address.
+struct MockLedger {
+    /// The "wallet" secret key the fake Ledger pretends to hold.
+    /// `wallet_pubkey_uncompressed` is derived from this once at
+    /// construction; mocked SIGN_TRANSACTION + SIGN_EIP712 use this
+    /// key to produce real-looking signatures.
+    signing_key: K256SigningKey,
+    /// Cached uncompressed pubkey (`0x04 || x || y`) — what the mock
+    /// returns from `GET PUBLIC KEY`.
+    pubkey_uncompressed: [u8; 65],
+    /// Last APDU the host sent. Tests assert against this to verify
+    /// the wire-format shape.
+    last_apdu_seen: Mutex<Vec<u8>>,
+    /// Total APDU calls seen — a few tests assert call count.
+    apdu_count: Mutex<usize>,
+}
+
+impl MockLedger {
+    fn new(secret_bytes: [u8; 32]) -> Self {
+        let secret = SecretKey::from_bytes(&secret_bytes.into()).unwrap();
+        let signing_key: K256SigningKey = secret.clone().into();
+        let pk = secret.public_key();
+        let pt = pk.to_encoded_point(false);
+        let mut pubkey_uncompressed = [0u8; 65];
+        pubkey_uncompressed.copy_from_slice(pt.as_bytes());
+        Self {
+            signing_key,
+            pubkey_uncompressed,
+            last_apdu_seen: Mutex::new(Vec::new()),
+            apdu_count: Mutex::new(0),
+        }
+    }
+
+    fn pubkey_uncompressed(&self) -> [u8; 65] {
+        self.pubkey_uncompressed
+    }
+
+    /// Build the canonical `GET PUBLIC KEY` response payload (without
+    /// status word — the transport contract is to strip the status
+    /// word before returning).
+    ///
+    /// Layout: `[pubkey_len u8] [pubkey 65 bytes] [address_len u8] [address ASCII...]`.
+    fn get_pubkey_response(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(self.pubkey_uncompressed.len() as u8);
+        out.extend_from_slice(&self.pubkey_uncompressed);
+        // The address ASCII is decorative — `HardwareWalletAnima` re-
+        // derives the address from the pubkey itself. We provide a
+        // valid-looking 40-char hex so the parser doesn't trip.
+        let addr_ascii = "abcdef0123456789abcdef0123456789abcdef01"; // 40 chars
+        out.push(addr_ascii.len() as u8);
+        out.extend_from_slice(addr_ascii.as_bytes());
+        out
+    }
+}
+
+/// `MockHidTransport` — wraps a `MockLedger` and implements
+/// `HidTransport` directly without going through HID frames.
+///
+/// `HardwareWalletAnima::new` calls `transport.exchange(apdu)` where
+/// the APDU is a full ISO 7816-4 command (`CLA INS P1 P2 Lc DATA`).
+/// The mock parses INS to decide what canned response to return.
+struct MockHidTransport {
+    ledger: Arc<MockLedger>,
+}
+
+impl MockHidTransport {
+    fn new(ledger: Arc<MockLedger>) -> Self {
+        Self { ledger }
+    }
+}
+
+impl HidTransport for MockHidTransport {
+    fn exchange(&self, apdu: &[u8]) -> anima_core::error::AnimaResult<Vec<u8>> {
+        // Record the APDU + bump count.
+        {
+            let mut last = self.ledger.last_apdu_seen.lock().unwrap();
+            *last = apdu.to_vec();
+            let mut count = self.ledger.apdu_count.lock().unwrap();
+            *count += 1;
+        }
+
+        // Parse the APDU header.
+        if apdu.len() < 5 {
+            return Err(anima_core::error::AnimaError::Crypto(
+                "mock: APDU too short for header".into(),
+            ));
+        }
+        let cla = apdu[0];
+        let ins = apdu[1];
+        let _p1 = apdu[2];
+        let _p2 = apdu[3];
+        let lc = apdu[4] as usize;
+        if cla != ledger::apdu::CLA {
+            return Err(anima_core::error::AnimaError::Crypto(format!(
+                "mock: unexpected CLA {cla:#04x}"
+            )));
+        }
+        let data = &apdu[5..5 + lc];
+
+        match ins {
+            ledger::apdu::INS_GET_PUBLIC_KEY => Ok(self.ledger.get_pubkey_response()),
+            ledger::apdu::INS_SIGN_TRANSACTION => {
+                // Layout: [count][indices...][rlp...]
+                if data.is_empty() {
+                    return Err(anima_core::error::AnimaError::Crypto(
+                        "mock: empty SIGN_TRANSACTION payload".into(),
+                    ));
+                }
+                let path_count = data[0] as usize;
+                let path_bytes = 1 + path_count * 4;
+                if data.len() < path_bytes {
+                    return Err(anima_core::error::AnimaError::Crypto(
+                        "mock: SIGN_TRANSACTION payload too short for path".into(),
+                    ));
+                }
+                let rlp_envelope = &data[path_bytes..];
+
+                // Recompute keccak256 over the full envelope and sign with
+                // the mock secret key.
+                use sha3::{Digest, Keccak256};
+                let digest_bytes = Keccak256::digest(rlp_envelope);
+                let mut digest = [0u8; 32];
+                digest.copy_from_slice(&digest_bytes);
+                let (sig, recid) = self
+                    .ledger
+                    .signing_key
+                    .sign_prehash_recoverable(&digest)
+                    .map_err(|e| {
+                        anima_core::error::AnimaError::Crypto(format!("mock sign: {e}"))
+                    })?;
+                // Ledger's response: [v u8][r 32][s 32]. We use the
+                // 0/1 y-parity convention since that's what the mock
+                // matches against (the `HardwareWalletAnima` ecrecover
+                // loop tries both candidates regardless).
+                let r_s = sig.to_bytes();
+                let mut out = Vec::with_capacity(65);
+                out.push(recid.to_byte());
+                out.extend_from_slice(&r_s);
+                Ok(out)
+            }
+            ledger::apdu::INS_SIGN_EIP712 => {
+                // Layout: [count][indices...][domain_hash 32][message_hash 32]
+                if data.is_empty() {
+                    return Err(anima_core::error::AnimaError::Crypto(
+                        "mock: empty SIGN_EIP712 payload".into(),
+                    ));
+                }
+                let path_count = data[0] as usize;
+                let path_bytes_len = 1 + path_count * 4;
+                if data.len() < path_bytes_len + 64 {
+                    return Err(anima_core::error::AnimaError::Crypto(
+                        "mock: SIGN_EIP712 payload too short for hashes".into(),
+                    ));
+                }
+                let mut domain_hash = [0u8; 32];
+                domain_hash.copy_from_slice(&data[path_bytes_len..path_bytes_len + 32]);
+                let mut message_hash = [0u8; 32];
+                message_hash.copy_from_slice(&data[path_bytes_len + 32..path_bytes_len + 64]);
+
+                // Recombine into the canonical EIP-712 digest:
+                // keccak256(0x1901 || domain || message).
+                use sha3::{Digest, Keccak256};
+                let mut buf = Vec::with_capacity(2 + 64);
+                buf.extend_from_slice(&[0x19, 0x01]);
+                buf.extend_from_slice(&domain_hash);
+                buf.extend_from_slice(&message_hash);
+                let digest_bytes = Keccak256::digest(&buf);
+                let mut digest = [0u8; 32];
+                digest.copy_from_slice(&digest_bytes);
+                let (sig, recid) = self
+                    .ledger
+                    .signing_key
+                    .sign_prehash_recoverable(&digest)
+                    .map_err(|e| {
+                        anima_core::error::AnimaError::Crypto(format!("mock sign-712: {e}"))
+                    })?;
+                let r_s = sig.to_bytes();
+                let mut out = Vec::with_capacity(65);
+                out.push(recid.to_byte());
+                out.extend_from_slice(&r_s);
+                Ok(out)
+            }
+            ledger::apdu::INS_GET_APP_VERSION => Ok(vec![0x01, 0x01, 0x0A, 0x00]), // flags + 1.10.0
+            other => Err(anima_core::error::AnimaError::Crypto(format!(
+                "mock: unsupported INS {other:#04x}"
+            ))),
+        }
+    }
+}
+
+/// Helper — build a `HardwareWalletAnima` with a fresh
+/// `InProcessAnima` auth delegate and a mock ledger. Returns the
+/// custody handle plus a back-channel `Arc<MockLedger>` so tests can
+/// inspect APDU traffic.
+fn build_test_custody(secret_bytes: [u8; 32]) -> (HardwareWalletAnima, Arc<MockLedger>) {
+    let auth_delegate: Arc<dyn AnimaCustody> =
+        InProcessAnima::from_seed_arc(MasterSeed::from_bytes([0xAB; 32])).unwrap();
+    let ledger = Arc::new(MockLedger::new(secret_bytes));
+    let transport = Box::new(MockHidTransport::new(Arc::clone(&ledger)));
+    let custody = HardwareWalletAnima::new(
+        auth_delegate,
+        transport,
+        Some(ledger::DEFAULT_DERIVATION_PATH.to_vec()),
+    )
+    .expect("construct HardwareWalletAnima with mock ledger");
+    (custody, ledger)
+}
+
+/// Construction round-trip — `new()` issues a `GET PUBLIC KEY` APDU,
+/// caches the resulting wallet address, and surfaces it via
+/// `wallet_address()`.
+#[test]
+fn new_resolves_wallet_address_via_get_pubkey_apdu() {
+    let (custody, ledger) = build_test_custody([0x11; 32]);
+    let addr = custody.wallet_address().expect("wallet half present");
+    assert!(addr.address.starts_with("0x"));
+    assert_eq!(addr.address.len(), 42);
+
+    // Verify the APDU we sent had the right shape:
+    //   CLA = 0xE0, INS = 0x02 (GET_PUBLIC_KEY), P1 = 0x00, P2 = 0x00
+    let last = ledger.last_apdu_seen.lock().unwrap();
+    assert_eq!(last[0], ledger::apdu::CLA);
+    assert_eq!(last[1], ledger::apdu::INS_GET_PUBLIC_KEY);
+    assert_eq!(last[2], 0x00);
+    assert_eq!(last[3], 0x00);
+
+    // The wallet pubkey we cached must match the mock's pubkey.
+    let cached = custody.wallet_pubkey_uncompressed();
+    assert_eq!(cached, &ledger.pubkey_uncompressed());
+
+    // The backend kind is HardwareWallet.
+    assert_eq!(custody.backend_kind(), BackendKind::HardwareWallet);
+}
+
+/// Auth-half pass-through invariant — `auth_pubkey()`, `user_did()`,
+/// `sign_jws()`, `sign_digest()`, and `export_identity_document()` all
+/// forward to the wrapped delegate. The wrapper does NOT own its own
+/// auth key (Spec D §"Backend matrix").
+#[test]
+fn auth_half_passes_through_to_inner_delegate() {
+    let auth_seed = MasterSeed::from_bytes([0xCD; 32]);
+    let auth_delegate: Arc<dyn AnimaCustody> = InProcessAnima::from_seed_arc(auth_seed).unwrap();
+
+    // Capture the delegate's identity BEFORE wrapping.
+    let expected_did = auth_delegate.user_did().to_string();
+    let expected_pubkey = auth_delegate.auth_pubkey();
+
+    // Wrap.
+    let ledger = Arc::new(MockLedger::new([0x22; 32]));
+    let transport = Box::new(MockHidTransport::new(Arc::clone(&ledger)));
+    let custody = HardwareWalletAnima::new(
+        Arc::clone(&auth_delegate),
+        transport,
+        Some(ledger::DEFAULT_DERIVATION_PATH.to_vec()),
+    )
+    .unwrap();
+
+    // Auth half must match the wrapped delegate exactly.
+    assert_eq!(custody.user_did(), expected_did);
+    assert_eq!(custody.auth_pubkey(), expected_pubkey);
+
+    // sign_jws goes through the delegate (the underlying signer is
+    // P-256, which the Ledger Ethereum app does not support).
+    let claims = serde_json::json!({"sub": "test"});
+    let jws_via_wrapper = custody.sign_jws(&claims).unwrap();
+    assert_eq!(jws_via_wrapper.split('.').count(), 3);
+
+    // The KYA document also comes from the delegate — auth-half-pass-
+    // through means the wallet half does NOT show up in the doc's
+    // verification methods (those are for the auth keypair).
+    let doc = custody.export_identity_document().unwrap();
+    assert!(doc.did.starts_with("did:key:zDn"));
+    assert_eq!(doc.did, expected_did);
+}
+
+/// `rotate()` is unsupported by design — the seed is hardware-resident.
+#[test]
+fn rotate_returns_unsupported_error() {
+    let (custody, _ledger) = build_test_custody([0x33; 32]);
+    // Use match rather than `.expect_err()` because the success arm
+    // wraps `Arc<dyn AnimaCustody>` which does not implement `Debug`.
+    match custody.rotate() {
+        Ok(_) => panic!("rotate must error on HardwareWalletAnima"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("HardwareWalletAnima does not support rotation"),
+                "rotate error must explain why (got: {msg})"
+            );
+            assert!(
+                msg.contains("hardware-resident"),
+                "rotate error should explain the seed is hardware-resident (got: {msg})"
+            );
+        }
+    }
+}
+
+/// `sign_evm_tx` produces a 65-byte `r||s||v` signature whose
+/// recovered address matches the cached wallet pubkey. End-to-end
+/// round-trip of the wallet half through the mock.
+#[test]
+fn sign_evm_tx_produces_recoverable_signature() {
+    let (custody, _ledger) = build_test_custody([0x44; 32]);
+    let from_addr = custody.wallet_address().unwrap().address.clone();
+
+    let tx = TxRequest {
+        from: from_addr.clone(),
+        to: "0x036CbD53842c5426634e7929541eC2318f3dCF7e".into(),
+        value_wei: "1000000000000000".into(), // 0.001 ETH
+        data_hex: String::new(),
+        nonce: 7,
+        gas_limit: 21_000,
+        max_fee_per_gas_wei: "30000000000".into(), // 30 gwei
+        max_priority_fee_per_gas_wei: "1000000000".into(), // 1 gwei
+        chain: "eip155:8453".into(),
+    };
+
+    let sig = custody.sign_evm_tx(&tx).unwrap();
+    assert_eq!(sig.bytes.len(), 65);
+    let v = sig.bytes[64];
+    assert!(v == 27 || v == 28, "v must be in 27/28 form, got {v}");
+
+    // ecrecover the signature back to the wallet pubkey to confirm
+    // round-trip integrity.
+    use anima_identity::rlp;
+    let chain_id = 8453;
+    let to_bytes = rlp::parse_address_20(&tx.to).unwrap();
+    let value_bytes = rlp::parse_u256_str(&tx.value_wei).unwrap();
+    let max_fee_bytes = rlp::parse_u256_str(&tx.max_fee_per_gas_wei).unwrap();
+    let max_prio_bytes = rlp::parse_u256_str(&tx.max_priority_fee_per_gas_wei).unwrap();
+    let envelope = rlp::encode_eip1559_unsigned(
+        chain_id,
+        tx.nonce,
+        &max_prio_bytes,
+        &max_fee_bytes,
+        tx.gas_limit,
+        &to_bytes,
+        &value_bytes,
+        &[],
+    );
+    let digest = rlp::keccak256(&envelope);
+
+    let mut r_s = [0u8; 64];
+    r_s.copy_from_slice(&sig.bytes[..64]);
+    let signature = k256::ecdsa::Signature::from_slice(&r_s).unwrap();
+    let cand = v - 27;
+    let recid = k256::ecdsa::RecoveryId::try_from(cand).unwrap();
+    let recovered = K256VerifyingKey::recover_from_prehash(&digest, &signature, recid).unwrap();
+    let expected = K256VerifyingKey::from_sec1_bytes(custody.wallet_pubkey_uncompressed()).unwrap();
+    assert_eq!(recovered, expected);
+}
+
+/// `sign_eip712` for an EIP-3009 `TransferWithAuthorization` produces
+/// a 65-byte signature in the haima 27/28 form, ecrecoverable to the
+/// wallet pubkey via the canonical EIP-712 digest.
+#[test]
+fn sign_eip712_eip3009_round_trip() {
+    let (custody, _ledger) = build_test_custody([0x55; 32]);
+
+    let domain = haima_wallet::USDC_BASE_MAINNET;
+    let from_addr = custody.wallet_address().unwrap().address.clone();
+    let nonce_hex = format!("0x{}", hex::encode([0x99u8; 32]));
+
+    let message = serde_json::json!({
+        "from": from_addr,
+        "to": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        "value": "1000000",         // 1 USDC (6 decimals)
+        "validAfter": "1700000000",
+        "validBefore": "1700000600",
+        "nonce": nonce_hex,
+    });
+    let types = serde_json::json!({"primaryType": "TransferWithAuthorization"});
+
+    let sig = custody.sign_eip712(&domain, &types, &message).unwrap();
+    assert_eq!(sig.bytes.len(), 65);
+    let v = sig.bytes[64];
+    assert!(v == 27 || v == 28);
+
+    // Verify the signature recovers correctly.
+    use haima_wallet::eip712::{hash_transfer_authorization, parse_eth_address};
+    let from_b = parse_eth_address(&from_addr).unwrap();
+    let to_b = parse_eth_address("0x036CbD53842c5426634e7929541eC2318f3dCF7e").unwrap();
+    let mut nonce = [0u8; 32];
+    nonce.copy_from_slice(&hex::decode(nonce_hex.trim_start_matches("0x")).unwrap());
+    let digest = hash_transfer_authorization(
+        &domain,
+        &from_b,
+        &to_b,
+        1_000_000,
+        1_700_000_000,
+        1_700_000_600,
+        &nonce,
+    );
+
+    let mut r_s = [0u8; 64];
+    r_s.copy_from_slice(&sig.bytes[..64]);
+    let signature = k256::ecdsa::Signature::from_slice(&r_s).unwrap();
+    let cand = v - 27;
+    let recid = k256::ecdsa::RecoveryId::try_from(cand).unwrap();
+    let recovered = K256VerifyingKey::recover_from_prehash(&digest, &signature, recid).unwrap();
+    let expected = K256VerifyingKey::from_sec1_bytes(custody.wallet_pubkey_uncompressed()).unwrap();
+    assert_eq!(recovered, expected);
+}
+
+/// `sign_eip712` rejects non-EIP-3009 typed-data payloads (matches the
+/// D-Sub-A/B SPEC-D-DEVIATION limitation).
+#[test]
+fn sign_eip712_rejects_non_eip3009() {
+    let (custody, _ledger) = build_test_custody([0x66; 32]);
+    let domain = haima_wallet::USDC_BASE_MAINNET;
+    let types = serde_json::json!({"primaryType": "Order"});
+    let message = serde_json::json!({"foo": "bar"});
+    let err = custody.sign_eip712(&domain, &types, &message).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("EIP-3009"),
+        "rejection should mention EIP-3009 limitation (got: {msg})"
+    );
+}
+
+/// `with_explicit_pubkey` skips the `GET PUBLIC KEY` round-trip — the
+/// test asserts no APDU was exchanged when constructing.
+#[test]
+fn with_explicit_pubkey_skips_get_pubkey_round_trip() {
+    let auth_delegate: Arc<dyn AnimaCustody> =
+        InProcessAnima::from_seed_arc(MasterSeed::from_bytes([0xEF; 32])).unwrap();
+    let ledger = Arc::new(MockLedger::new([0x77; 32]));
+    let transport = Box::new(MockHidTransport::new(Arc::clone(&ledger)));
+
+    let pubkey = ledger.pubkey_uncompressed();
+    let custody = HardwareWalletAnima::with_explicit_pubkey(
+        auth_delegate,
+        transport,
+        ledger::DEFAULT_DERIVATION_PATH.to_vec(),
+        pubkey,
+    )
+    .unwrap();
+    assert_eq!(custody.wallet_pubkey_uncompressed(), &pubkey);
+
+    // No APDU was issued — the explicit constructor doesn't talk to
+    // the device.
+    let count = *ledger.apdu_count.lock().unwrap();
+    assert_eq!(
+        count, 0,
+        "with_explicit_pubkey must not issue any APDUs (got {count})"
+    );
+}
+
+/// Live-Ledger end-to-end test (requires a real Ledger plugged in,
+/// running the Ethereum app, and willing to confirm).
+///
+/// **Operator setup**:
+///
+/// 1. Plug in a Ledger Nano X / S+ via USB.
+/// 2. Unlock the device.
+/// 3. Open the Ethereum app on the device.
+/// 4. Run:
+///    ```bash
+///    cargo test -p anima-identity --features hw-wallet -- --ignored live_ledger
+///    ```
+/// 5. Confirm the prompt on the device when it appears.
+///
+/// The test does NOT run in CI — it requires manual interaction.
+#[test]
+#[ignore = "requires a real Ledger Nano X/S+ with the Ethereum app open"]
+fn live_ledger_get_pubkey() {
+    use hidapi::HidApi;
+    let api = HidApi::new().expect("HID API init");
+    // Ledger vendor id 0x2c97 — every Nano model uses this.
+    const LEDGER_VENDOR_ID: u16 = 0x2c97;
+    let device = api
+        .device_list()
+        .find(|d| d.vendor_id() == LEDGER_VENDOR_ID)
+        .expect("no Ledger device found — plug in + unlock + open Eth app");
+    let dev = api
+        .open(device.vendor_id(), device.product_id())
+        .expect("open Ledger device");
+    let transport = Box::new(anima_identity::hardware_wallet::RealHidTransport::new(dev));
+    let auth_delegate: Arc<dyn AnimaCustody> =
+        InProcessAnima::from_seed_arc(MasterSeed::generate()).unwrap();
+    let custody = HardwareWalletAnima::new(auth_delegate, transport, None)
+        .expect("construct HardwareWalletAnima against live Ledger");
+    let addr = custody.wallet_address().unwrap();
+    println!("Live Ledger wallet address: {}", addr.address);
+    assert!(addr.address.starts_with("0x"));
+    assert_eq!(addr.address.len(), 42);
+}


### PR DESCRIPTION
## Summary

Spec D D-Sub-F: ships `HardwareWalletAnima` — a wallet-only wrapper that delegates auth-half operations to an inner `Arc<dyn AnimaCustody>` and routes secp256k1 wallet signing to a Ledger Nano X / S / S+ over desktop HID via `hidapi`.

- New `hw-wallet` feature flag (default off) pulls hidapi 2.6 + the `hardware_wallet` module.
- `HardwareWalletAnima` is the only backend in Spec D's matrix that does not own its own auth key — Ledger Ethereum app doesn't expose P-256/ES256, so auth-related trait methods are transparent passes through to the wrapped delegate (`WebCryptoAnima` / `InProcessAnima` / `VaultTransitAnima` / etc).
- `sign_evm_tx` builds the canonical EIP-1559 RLP digest via the shared `crate::rlp` encoder + sends to Ledger SIGN_TRANSACTION (INS 0x04). `sign_eip712` recomputes the EIP-3009 domain + message hashes separately for Ledger's v0 SIGN_EIP712 path (INS 0x0C, P1 = 0x00), with a drift guard that re-combines them and asserts equivalence with `haima_wallet::hash_transfer_authorization` before sending.
- `rotate()` returns an error pointing at the manual recovery workflow — the seed is hardware-resident and rotation is meaningless from software.
- `HidTransport` trait abstracts the HID layer so 7 integration tests run against a `MockHidTransport` without a real Ledger; 1 `#[ignore]`-gated live test documents the operator setup.

## Wire protocol locked at the type level

- `ledger::apdu` — CLA 0xE0; INS for GET_PUBLIC_KEY (0x02), SIGN_TRANSACTION (0x04), GET_APP_VERSION (0x06), SIGN_EIP712 (0x0C).
- `ledger::hid` — channel 0x0101, command_tag 0x05, 64-byte reports, 5-byte header + 2-byte first-frame length prefix.
- `ledger::sw` — SW_OK 0x9000, SW_USER_REJECTED 0x6985, SW_INVALID_DATA 0x6A80, SW_INS_NOT_SUPPORTED 0x6D00.
- `ledger::DEFAULT_DERIVATION_PATH` — `m/44'/60'/0'/0/0`.
- All sourced inline from [`app-ethereum/doc/ethapp.adoc`](https://github.com/LedgerHQ/app-ethereum/blob/master/doc/ethapp.adoc).

## SPEC-D-DEVIATION block (in `hardware_wallet.rs` module docs)

1. **Auth-half pass-through** — wrapper does NOT own its own auth key. Verified by `auth_half_passes_through_to_inner_delegate` integration test.
2. **Desktop-only via hidapi** — WebHID (browser) is OUT OF SCOPE. The browser path lands in a separate `anima-web-hardware` crate that the M9 chatOS work picks up.
3. **`rotate()` is unsupported by design** — seed is hardware-resident. Verified by `rotate_returns_unsupported_error`.
4. **Hardware-confirmation UX** — every wallet op blocks on a button press. Default `read_timeout` is 60s, matching Ledger Live.
5. **Trezor support is OUT OF SCOPE** — Ledger is the primary integration; Trezor's APDU surface differs.

## Tests

- 6 unit tests (`hardware_wallet::tests`) cover encoder + APDU builders + EIP-712 split-hash drift guard + HID frame constants.
- 7 integration tests (`tests/integration_hardware_wallet.rs`) drive the full backend through `MockHidTransport`:
  - `new_resolves_wallet_address_via_get_pubkey_apdu`
  - `auth_half_passes_through_to_inner_delegate` (load-bearing wallet-only wrapper invariant)
  - `rotate_returns_unsupported_error`
  - `sign_evm_tx_produces_recoverable_signature` (ecrecover round-trip)
  - `sign_eip712_eip3009_round_trip` (ecrecover round-trip)
  - `sign_eip712_rejects_non_eip3009`
  - `with_explicit_pubkey_skips_get_pubkey_round_trip`
- 1 `#[ignore]`-gated `live_ledger_get_pubkey` test with operator-setup docstring.
- Test counts: anima-identity 132 → 145 with hw-wallet on; workspace stays at 3860 with the feature on.

## Test plan

- [x] `cargo build -p anima-identity` — clean
- [x] `cargo build -p anima-identity --features hw-wallet` — clean
- [x] `cargo build -p anima-identity --all-features` — clean (works alongside kms-vault)
- [x] `cargo clippy -p anima-identity --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p anima-identity --features hw-wallet` — 145 passed, 1 ignored
- [x] `cargo test --workspace --features anima-identity/hw-wallet` — 3860 passed
- [ ] Live Ledger smoke test (operator: `cargo test --features hw-wallet -- --ignored`)

## Follow-ups (filed in `crates/anima/CLAUDE.md`)

- WebHID (browser) wrapper crate — M9 blocker for chatOS.
- Trezor support.
- Generic EIP-712 encoder (matches D-Sub-A/B/E limitation).
- Live USDC-transfer e2e on Base testnet (paired with WebHID wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hardware wallet support, enabling secure transaction signing with Ledger Nano X/S/S+ devices via desktop HID transport.

* **Documentation**
  * Added comprehensive documentation covering hardware wallet integration, including Ledger Ethereum app support, authentication flows, and testing references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->