### PR TITLE
feat(anima): D-Sub-C Stream R-1 — RemoteAnima backend (HTTP/JSON to lifegw)

### DIFF
--- a/crates/anima/anima-identity/Cargo.toml
+++ b/crates/anima/anima-identity/Cargo.toml
@@ -43,6 +43,15 @@ kms-soma = [
     "dep:life-kernel-proto",
     "dep:tokio",
 ]
+# Spec D D-Sub-C: RemoteAnima — HTTP/JSON bridge to lifegw's
+# `/anima/custody/*` proxy. Used by Rust clients (CLIs, native apps,
+# agents-as-services) to delegate wallet ops to a server-side anima
+# daemon (typically VaultTransitAnima). Browser-side parallel is
+# WebCryptoAnima (TS, separate crate). Default off; pulls reqwest's
+# async client + tokio runtime primitives. reqwest + tokio are
+# already optional from kms-vault — this feature reuses the same
+# dep-gated graph.
+kms-remote = ["dep:reqwest", "dep:tokio"]
 
 [dependencies]
 anima-core.workspace = true

--- a/crates/anima/anima-identity/src/lib.rs
+++ b/crates/anima/anima-identity/src/lib.rs
@@ -50,6 +50,9 @@ pub mod hardware_wallet;
 #[cfg(feature = "kms-soma")]
 pub mod soma;
 
+#[cfg(feature = "kms-remote")]
+pub mod remote;
+
 pub use custody::{
     AnimaCustody, AnimaCustodyHandle, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature,
     TxRequest,
@@ -74,6 +77,9 @@ pub use hardware_wallet::{HardwareWalletAnima, HidTransport, ledger};
 
 #[cfg(feature = "kms-soma")]
 pub use soma::SomaCustody;
+
+#[cfg(feature = "kms-remote")]
+pub use remote::{RemoteAnima, TierUserCap};
 
 pub use revocation::{RevocationCache, is_revoked};
 pub use rotation::{JournalResolver, RotationChainQuery, walk_rotation_chain};

--- a/crates/anima/anima-identity/src/remote.rs
+++ b/crates/anima/anima-identity/src/remote.rs
@@ -101,6 +101,19 @@ pub struct TierUserCap {
     pub expires_at_unix: i64,
 }
 
+impl TierUserCap {
+    /// Returns `true` if the cap's `expires_at_unix` is at or before
+    /// `now_unix`. I-2 review fix: gives the future Stream R-2 refresh
+    /// task an obvious, testable hook to decide when to re-mint.
+    ///
+    /// Caller passes `now_unix` explicitly so this stays deterministic
+    /// in tests (no hidden `Utc::now()` dependency).
+    #[must_use]
+    pub fn is_expired(&self, now_unix: i64) -> bool {
+        now_unix >= self.expires_at_unix
+    }
+}
+
 /// Request body for `POST /anima/custody/sign_{auth,wallet}`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SignBody {
@@ -218,8 +231,37 @@ impl RemoteAnima {
         *self.cap.lock() = new_cap;
     }
 
-    fn cap_token(&self) -> String {
-        self.cap.lock().token.clone()
+    /// Snapshot the current Tier-User token. I-2 review fix: cheap-path
+    /// expiry check before issuing the request — saves a round trip and
+    /// surfaces a clean `AnimaError::Crypto` instead of waiting for the
+    /// gateway to return 401.
+    fn cap_token(&self) -> AnimaResult<String> {
+        let cap = self.cap.lock();
+        let now = chrono::Utc::now().timestamp();
+        if cap.is_expired(now) {
+            return Err(AnimaError::Crypto(
+                "RemoteAnima: tier-user cap expired; \
+                 call set_cap with a fresh token via the Stream R-2 \
+                 mint_session_cap flow"
+                    .into(),
+            ));
+        }
+        Ok(cap.token.clone())
+    }
+
+    /// Same expiry-aware token lookup, but operating on a `Mutex`
+    /// reference (used by the static fetch helpers in `RemoteAnima::new`).
+    fn cap_token_from(cap: &Arc<Mutex<TierUserCap>>) -> AnimaResult<String> {
+        let guard = cap.lock();
+        let now = chrono::Utc::now().timestamp();
+        if guard.is_expired(now) {
+            return Err(AnimaError::Crypto(
+                "RemoteAnima: tier-user cap expired before bootstrap; \
+                 supply a fresh cap to RemoteAnima::new"
+                    .into(),
+            ));
+        }
+        Ok(guard.token.clone())
     }
 
     /// Fetch the SEC1-compressed P-256 auth pubkey for `user_id` from
@@ -231,7 +273,7 @@ impl RemoteAnima {
         cap: &Arc<Mutex<TierUserCap>>,
     ) -> AnimaResult<[u8; 33]> {
         let url = format!("{base_url}/anima/custody/get_auth_pubkey/{user_id}");
-        let token = cap.lock().token.clone();
+        let token = Self::cap_token_from(cap)?;
         let resp = client
             .get(&url)
             .bearer_auth(&token)
@@ -276,7 +318,7 @@ impl RemoteAnima {
         cap: &Arc<Mutex<TierUserCap>>,
     ) -> AnimaResult<[u8; 65]> {
         let url = format!("{base_url}/anima/custody/get_wallet_pubkey/{user_id}");
-        let token = cap.lock().token.clone();
+        let token = Self::cap_token_from(cap)?;
         let resp = client
             .get(&url)
             .bearer_auth(&token)
@@ -320,10 +362,11 @@ impl RemoteAnima {
             user_id: self.user_id.clone(),
             digest_b64: B64_STANDARD.encode(digest),
         };
+        let token = self.cap_token()?;
         let resp = self
             .client
             .post(&url)
-            .bearer_auth(self.cap_token())
+            .bearer_auth(&token)
             .json(&body)
             .send()
             .await
@@ -360,10 +403,11 @@ impl RemoteAnima {
             user_id: self.user_id.clone(),
             digest_b64: B64_STANDARD.encode(digest),
         };
+        let token = self.cap_token()?;
         let resp = self
             .client
             .post(&url)
-            .bearer_auth(self.cap_token())
+            .bearer_auth(&token)
             .json(&body)
             .send()
             .await
@@ -661,13 +705,17 @@ impl AnimaCustody for RemoteAnima {
 
 /// Decode a pubkey base64 string. Tries standard b64 first, then
 /// URL-safe (some JS callers default to urlsafe).
+///
+/// I-1 review fix: when both decoders fail, surface that we tried
+/// BOTH alphabets so the operator's debug session isn't misled into
+/// thinking the wire was nominally URL-safe.
 fn decode_pubkey_b64(s: &str) -> Result<Vec<u8>, String> {
     if let Ok(b) = B64_STANDARD.decode(s) {
         return Ok(b);
     }
     URL_SAFE_NO_PAD
         .decode(s.trim_end_matches('='))
-        .map_err(|e| format!("base64 decode: {e}"))
+        .map_err(|e| format!("base64 decode (tried standard + url-safe-no-pad): {e}"))
 }
 
 /// Decode a signature base64 string. Same dual-strategy as pubkeys.
@@ -677,7 +725,7 @@ fn decode_signature_b64(s: &str) -> Result<Vec<u8>, String> {
     }
     URL_SAFE_NO_PAD
         .decode(s.trim_end_matches('='))
-        .map_err(|e| format!("base64 decode: {e}"))
+        .map_err(|e| format!("base64 decode (tried standard + url-safe-no-pad): {e}"))
 }
 
 /// Derive an EVM address from a 65-byte uncompressed secp256k1
@@ -831,5 +879,52 @@ mod tests {
         });
         assert_eq!(anima.current_cap().token, "new");
         assert_eq!(anima.current_cap().expires_at_unix, 200);
+    }
+
+    #[test]
+    fn tier_user_cap_is_expired_boundary() {
+        let cap = TierUserCap {
+            token: "t".into(),
+            expires_at_unix: 1_000,
+        };
+        // Past expiry: expired
+        assert!(cap.is_expired(1_001));
+        // At expiry: expired (>= boundary)
+        assert!(cap.is_expired(1_000));
+        // Before expiry: fresh
+        assert!(!cap.is_expired(999));
+    }
+
+    #[test]
+    fn cap_token_rejects_expired_cap() {
+        let auth_pubkey = [0x02u8; 33];
+        let mut wallet_uncompressed = [0u8; 65];
+        wallet_uncompressed[0] = 0x04;
+        let cap = TierUserCap {
+            token: "stale".into(),
+            // Already expired regardless of wall clock — i64::MIN guarantees
+            // `now_unix >= expires_at_unix` for all realistic clocks.
+            expires_at_unix: i64::MIN,
+        };
+        let client = Arc::new(reqwest::Client::new());
+        let anima = RemoteAnima {
+            base_url: "http://localhost".into(),
+            user_id: "test-user".into(),
+            auth_pubkey,
+            wallet_pubkey_uncompressed: wallet_uncompressed,
+            wallet_address: WalletAddress {
+                address: "0x0".into(),
+                chain: ChainId::base(),
+            },
+            user_did: "did:key:zDnTest".into(),
+            cap: Arc::new(Mutex::new(cap)),
+            client,
+        };
+        let err = anima
+            .cap_token()
+            .expect_err("expired cap must surface a clean error");
+        let msg = format!("{err}");
+        assert!(msg.contains("tier-user cap expired"), "got: {msg}");
+        assert!(msg.contains("set_cap"), "got: {msg}");
     }
 }

--- a/crates/anima/anima-identity/src/remote.rs
+++ b/crates/anima/anima-identity/src/remote.rs
@@ -175,8 +175,7 @@ impl RemoteAnima {
         );
         let cap_arc = Arc::new(Mutex::new(cap));
 
-        let auth_pubkey =
-            Self::fetch_auth_pubkey(&client, &base_url, &user_id, &cap_arc).await?;
+        let auth_pubkey = Self::fetch_auth_pubkey(&client, &base_url, &user_id, &cap_arc).await?;
         let wallet_pubkey_uncompressed =
             Self::fetch_wallet_pubkey(&client, &base_url, &user_id, &cap_arc).await?;
         let wallet_addr_hex = derive_wallet_address(&wallet_pubkey_uncompressed)?;
@@ -245,9 +244,10 @@ impl RemoteAnima {
                 resp.status()
             )));
         }
-        let body: PubkeyResp = resp.json().await.map_err(|e| {
-            AnimaError::Crypto(format!("RemoteAnima get_auth_pubkey parse: {e}"))
-        })?;
+        let body: PubkeyResp = resp
+            .json()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima get_auth_pubkey parse: {e}")))?;
         let bytes = decode_pubkey_b64(&body.pubkey_b64)
             .map_err(|e| AnimaError::Crypto(format!("RemoteAnima auth pubkey b64: {e}")))?;
         if bytes.len() != 33 {
@@ -289,9 +289,10 @@ impl RemoteAnima {
                 resp.status()
             )));
         }
-        let body: PubkeyResp = resp.json().await.map_err(|e| {
-            AnimaError::Crypto(format!("RemoteAnima get_wallet_pubkey parse: {e}"))
-        })?;
+        let body: PubkeyResp = resp
+            .json()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima get_wallet_pubkey parse: {e}")))?;
         let bytes = decode_pubkey_b64(&body.pubkey_b64)
             .map_err(|e| AnimaError::Crypto(format!("RemoteAnima wallet pubkey b64: {e}")))?;
         if bytes.len() != 65 {
@@ -407,8 +408,7 @@ impl RemoteAnima {
                 Ok(r) => r,
                 Err(_) => continue,
             };
-            if let Ok(recovered) =
-                K256VerifyingKey::recover_from_prehash(digest, &signature, recid)
+            if let Ok(recovered) = K256VerifyingKey::recover_from_prehash(digest, &signature, recid)
                 && recovered == expected_pubkey
             {
                 return Ok(cand + 27);
@@ -593,10 +593,10 @@ impl AnimaCustody for RemoteAnima {
         let mut nonce = [0u8; 32];
         nonce.copy_from_slice(&nonce_bytes);
 
-        let from_b = parse_eth_address(from)
-            .map_err(|e| AnimaError::Crypto(format!("eip712 from: {e}")))?;
-        let to_b = parse_eth_address(to)
-            .map_err(|e| AnimaError::Crypto(format!("eip712 to: {e}")))?;
+        let from_b =
+            parse_eth_address(from).map_err(|e| AnimaError::Crypto(format!("eip712 from: {e}")))?;
+        let to_b =
+            parse_eth_address(to).map_err(|e| AnimaError::Crypto(format!("eip712 to: {e}")))?;
 
         let digest = hash_transfer_authorization(
             domain,
@@ -635,8 +635,7 @@ impl AnimaCustody for RemoteAnima {
     }
 
     fn export_identity_document(&self) -> AnimaResult<AgentIdentityDocument> {
-        let public_key_multibase =
-            format!("z{}", bs58::encode(self.auth_pubkey).into_string());
+        let public_key_multibase = format!("z{}", bs58::encode(self.auth_pubkey).into_string());
         let did = self.user_did.clone();
         let vm = VerificationMethod {
             id: format!("{did}#key-1"),

--- a/crates/anima/anima-identity/src/remote.rs
+++ b/crates/anima/anima-identity/src/remote.rs
@@ -1,0 +1,836 @@
+//! # RemoteAnima — Browser/Remote Custody Bridge (Spec D D-Sub-C)
+//!
+//! `RemoteAnima` is the Rust-side `AnimaCustody` impl that talks to a
+//! lifegw `/anima/custody/*` HTTP/JSON proxy. It exists so Rust callers
+//! (CLIs, agents-as-services, native apps) can use the same wallet path
+//! the browser uses via `WebCryptoAnima` — wallet ops are forwarded to
+//! a server-side anima daemon (typically `VaultTransitAnima`) over the
+//! same lifegw edge gateway used by lifed.
+//!
+//! ## Wire surface (Stream R-2 ships routes)
+//!
+//! 6 HTTP/JSON routes on lifegw:
+//!
+//! - `POST /anima/custody/sign_auth   { user_id, digest_b64 }` →
+//!   `{ signature_b64 }` — 64-byte raw `r||s` from soma / Vault auth half.
+//! - `POST /anima/custody/sign_wallet { user_id, digest_b64 }` →
+//!   `{ signature_b64 }` — 64-byte raw `r||s` from secp256k1 signer.
+//! - `GET  /anima/custody/get_auth_pubkey/{user_id}`   → `{ pubkey_b64 }`
+//!   — 33-byte SEC1 compressed P-256.
+//! - `GET  /anima/custody/get_wallet_pubkey/{user_id}` → `{ pubkey_b64 }`
+//!   — 65-byte SEC1 uncompressed secp256k1 (`0x04 || x || y`).
+//! - `POST /anima/custody/mint_session_cap` — refresh tier-user cap
+//!   (Stream R-2 — RemoteAnima holds the cap and is responsible for
+//!   refreshing before its `expires_at`).
+//! - `POST /anima/custody/enroll_passkey` — first-time passkey
+//!   enrolment (browser-only; Rust callers don't hit this).
+//!
+//! All routes require `Authorization: Bearer <tier-user-or-tier-2-jwt>`.
+//!
+//! ## Why HTTP/JSON not gRPC
+//!
+//! Sidesteps M8.1 (Connect-vs-grpc-web mismatch in life-sdk-ts). The
+//! consumer surface is browser-shaped (small, stable, easy to call via
+//! `fetch()` from chatOS); using HTTP/JSON keeps the Rust path
+//! symmetric with the browser path so the same lifegw routes serve
+//! both.
+//!
+//! ## Pubkey caching
+//!
+//! Auth + wallet pubkeys are fetched once at `RemoteAnima::new` and
+//! cached. Trait accessors (`user_did`, `auth_pubkey`,
+//! `wallet_address`) are referentially transparent and never block on
+//! I/O. Pubkey rotation invalidates this cache — callers must
+//! reconstruct a fresh `RemoteAnima` after observing a rotation event.
+//!
+//! ## SPEC-D-DEVIATION
+//!
+//! - **`rotate()` returns an error.** Mirrors `SomaCustody::rotate`:
+//!   rotation flow is journal-driven (`anima.identity_rotated` events
+//!   via `anima-lago::write_rotation_event`), not RPC-driven. Even
+//!   though lifegw COULD expose a `POST /anima/custody/rotate` route,
+//!   wiring it would create two divergent rotation surfaces (RPC vs
+//!   journal) and break the Spec D L4-D10 invariant that rotations are
+//!   documented in the journal. The error message points operators at
+//!   the journal helper.
+//!
+//! - **`sign_eip712` constraint matches the family** — only EIP-3009
+//!   `TransferWithAuthorization` is supported, same as
+//!   `InProcessAnima` / `VaultTransitAnima` / `SomaCustody`. Generic
+//!   EIP-712 encoder is a deferred follow-up.
+//!
+//! - **`block_on` runtime caveat** — `RemoteAnima` exposes `sign_*`
+//!   trait methods synchronously per the trait shape. The HTTP calls
+//!   are async; we drive them via `Handle::current().block_on` when a
+//!   tokio runtime is available, falling back to a single-shot
+//!   current-thread runtime otherwise. Callers in tokio contexts MUST
+//!   use a multi-thread runtime — `block_in_place` panics on
+//!   `current_thread`.
+
+use std::sync::Arc;
+
+use anima_core::error::{AnimaError, AnimaResult};
+use anima_core::identity_document::{
+    AgentIdentityDocument, AgentType, IdentityDocumentBuilder, VerificationMethod,
+};
+use base64::Engine;
+use base64::engine::general_purpose::{STANDARD as B64_STANDARD, URL_SAFE_NO_PAD};
+use haima_core::wallet::{ChainId, WalletAddress};
+use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha3::{Digest as Sha3Digest, Keccak256};
+
+use crate::custody::{
+    AnimaCustody, BackendKind, DidRotationEvent, Eip712Domain, EvmSignature, TxRequest,
+};
+use crate::rlp;
+
+/// Default request timeout for lifegw HTTP calls.
+const DEFAULT_TIMEOUT_SECS: u64 = 10;
+
+/// Tier-User capability — browser-shaped JWT. Stored separately because
+/// the token's lifetime is bounded by the cap's `exp` claim. The caller
+/// is responsible for refreshing via `mint_session_cap` (Stream R-2).
+#[derive(Debug, Clone)]
+pub struct TierUserCap {
+    /// Compact JWT in `<header>.<body>.<signature>` form.
+    pub token: String,
+    /// Unix timestamp of expiry. Refresh well before this elapses.
+    pub expires_at_unix: i64,
+}
+
+/// Request body for `POST /anima/custody/sign_{auth,wallet}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SignBody {
+    user_id: String,
+    /// Standard base64 (with padding) — matches lifegw's body convention.
+    digest_b64: String,
+}
+
+/// Response body for `POST /anima/custody/sign_{auth,wallet}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SignResp {
+    signature_b64: String,
+}
+
+/// Response body for `GET /anima/custody/get_{auth,wallet}_pubkey/{user_id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PubkeyResp {
+    pubkey_b64: String,
+}
+
+/// `RemoteAnima` — HTTP/JSON bridge to lifegw `/anima/custody/*`.
+///
+/// Holds:
+/// - the lifegw base URL,
+/// - the user_id passed on every RPC,
+/// - a Tier-User capability behind a Mutex (refreshable),
+/// - cached auth + wallet pubkeys + DID + wallet address resolved at
+///   construction so trait accessors never block on I/O,
+/// - a shared `reqwest::Client` for keep-alive / connection pooling.
+pub struct RemoteAnima {
+    base_url: String,
+    user_id: String,
+    /// Cached SEC1-compressed P-256 auth pubkey (33 bytes).
+    auth_pubkey: [u8; 33],
+    /// Cached SEC1-uncompressed secp256k1 wallet pubkey (65 bytes).
+    /// Used by `sign_evm_tx` for the ecrecover-based v-byte recovery
+    /// loop. Same shape as `VaultTransitAnima::wallet_pubkey_uncompressed`.
+    wallet_pubkey_uncompressed: [u8; 65],
+    /// Cached EVM wallet address derived from the wallet pubkey.
+    wallet_address: WalletAddress,
+    /// Cached user DID (`did:key:zDn…` per Spec D L4-D6).
+    user_did: String,
+    /// Tier-User cap. Holding it under a Mutex so a future Stream R-2
+    /// refresh task can swap it out without re-creating the handle.
+    cap: Arc<Mutex<TierUserCap>>,
+    /// Shared HTTP client.
+    client: Arc<reqwest::Client>,
+}
+
+impl RemoteAnima {
+    /// Construct a remote-anima handle for `user_id` against the given
+    /// lifegw base URL. Performs two `GET /anima/custody/get_*_pubkey`
+    /// requests + derives DID + wallet address. Failures bubble as
+    /// `AnimaError::Crypto`.
+    ///
+    /// `cap` is the caller's Tier-User JWT — typically minted via
+    /// lifegw's tier-user minter (Stream R-2). The handle stores it
+    /// behind a Mutex so a refresh task can rotate it without
+    /// re-creating the handle.
+    pub async fn new(
+        base_url: impl Into<String>,
+        user_id: impl Into<String>,
+        cap: TierUserCap,
+    ) -> AnimaResult<Self> {
+        let base_url = base_url.into();
+        let user_id = user_id.into();
+        let client = Arc::new(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| AnimaError::Crypto(format!("RemoteAnima reqwest build: {e}")))?,
+        );
+        let cap_arc = Arc::new(Mutex::new(cap));
+
+        let auth_pubkey =
+            Self::fetch_auth_pubkey(&client, &base_url, &user_id, &cap_arc).await?;
+        let wallet_pubkey_uncompressed =
+            Self::fetch_wallet_pubkey(&client, &base_url, &user_id, &cap_arc).await?;
+        let wallet_addr_hex = derive_wallet_address(&wallet_pubkey_uncompressed)?;
+        let user_did = crate::did::generate_did_key_p256(&auth_pubkey);
+
+        Ok(Self {
+            base_url,
+            user_id,
+            auth_pubkey,
+            wallet_pubkey_uncompressed,
+            wallet_address: WalletAddress {
+                address: wallet_addr_hex,
+                chain: ChainId::base(),
+            },
+            user_did,
+            cap: cap_arc,
+            client,
+        })
+    }
+
+    /// Borrow the configured base URL — used by tests + diagnostics.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Borrow the user_id — used by tests + diagnostics.
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
+    /// Snapshot the current Tier-User cap (clone). Callers should NOT
+    /// pass this around long-term — it's a snapshot of mutable state.
+    pub fn current_cap(&self) -> TierUserCap {
+        self.cap.lock().clone()
+    }
+
+    /// Replace the stored Tier-User cap. Used by a Stream R-2 refresh
+    /// task to rotate the bearer token without re-creating the handle.
+    pub fn set_cap(&self, new_cap: TierUserCap) {
+        *self.cap.lock() = new_cap;
+    }
+
+    fn cap_token(&self) -> String {
+        self.cap.lock().token.clone()
+    }
+
+    /// Fetch the SEC1-compressed P-256 auth pubkey for `user_id` from
+    /// `GET /anima/custody/get_auth_pubkey/{user_id}`.
+    async fn fetch_auth_pubkey(
+        client: &reqwest::Client,
+        base_url: &str,
+        user_id: &str,
+        cap: &Arc<Mutex<TierUserCap>>,
+    ) -> AnimaResult<[u8; 33]> {
+        let url = format!("{base_url}/anima/custody/get_auth_pubkey/{user_id}");
+        let token = cap.lock().token.clone();
+        let resp = client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima get_auth_pubkey: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima get_auth_pubkey non-success: {}",
+                resp.status()
+            )));
+        }
+        let body: PubkeyResp = resp.json().await.map_err(|e| {
+            AnimaError::Crypto(format!("RemoteAnima get_auth_pubkey parse: {e}"))
+        })?;
+        let bytes = decode_pubkey_b64(&body.pubkey_b64)
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima auth pubkey b64: {e}")))?;
+        if bytes.len() != 33 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima auth pubkey: expected 33 bytes (SEC1 compressed), got {}",
+                bytes.len()
+            )));
+        }
+        if bytes[0] != 0x02 && bytes[0] != 0x03 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima auth pubkey: SEC1 compressed prefix must be 0x02 or 0x03, got 0x{:02x}",
+                bytes[0]
+            )));
+        }
+        let mut out = [0u8; 33];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+
+    /// Fetch the SEC1-uncompressed secp256k1 wallet pubkey for
+    /// `user_id` from `GET /anima/custody/get_wallet_pubkey/{user_id}`.
+    async fn fetch_wallet_pubkey(
+        client: &reqwest::Client,
+        base_url: &str,
+        user_id: &str,
+        cap: &Arc<Mutex<TierUserCap>>,
+    ) -> AnimaResult<[u8; 65]> {
+        let url = format!("{base_url}/anima/custody/get_wallet_pubkey/{user_id}");
+        let token = cap.lock().token.clone();
+        let resp = client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima get_wallet_pubkey: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima get_wallet_pubkey non-success: {}",
+                resp.status()
+            )));
+        }
+        let body: PubkeyResp = resp.json().await.map_err(|e| {
+            AnimaError::Crypto(format!("RemoteAnima get_wallet_pubkey parse: {e}"))
+        })?;
+        let bytes = decode_pubkey_b64(&body.pubkey_b64)
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima wallet pubkey b64: {e}")))?;
+        if bytes.len() != 65 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima wallet pubkey: expected 65 bytes (SEC1 uncompressed), got {}",
+                bytes.len()
+            )));
+        }
+        if bytes[0] != 0x04 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima wallet pubkey: SEC1 uncompressed prefix must be 0x04, got 0x{:02x}",
+                bytes[0]
+            )));
+        }
+        let mut out = [0u8; 65];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+
+    /// Async signing: POST a 32-byte digest to
+    /// `/anima/custody/sign_auth` and return the 64-byte raw r||s.
+    async fn sign_auth_async(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        let url = format!("{}/anima/custody/sign_auth", self.base_url);
+        let body = SignBody {
+            user_id: self.user_id.clone(),
+            digest_b64: B64_STANDARD.encode(digest),
+        };
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(self.cap_token())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_auth: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima sign_auth non-success: {}",
+                resp.status()
+            )));
+        }
+        let parsed: SignResp = resp
+            .json()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_auth parse: {e}")))?;
+        let raw = decode_signature_b64(&parsed.signature_b64)
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_auth b64: {e}")))?;
+        if raw.len() != 64 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima sign_auth: expected 64-byte raw r||s, got {}",
+                raw.len()
+            )));
+        }
+        let mut out = [0u8; 64];
+        out.copy_from_slice(&raw);
+        Ok(out)
+    }
+
+    /// Async signing: POST a 32-byte digest to
+    /// `/anima/custody/sign_wallet` and return the 64-byte raw r||s.
+    /// The recovery byte is computed by [`Self::compute_v_byte`].
+    async fn sign_wallet_async(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        let url = format!("{}/anima/custody/sign_wallet", self.base_url);
+        let body = SignBody {
+            user_id: self.user_id.clone(),
+            digest_b64: B64_STANDARD.encode(digest),
+        };
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(self.cap_token())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_wallet: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima sign_wallet non-success: {}",
+                resp.status()
+            )));
+        }
+        let parsed: SignResp = resp
+            .json()
+            .await
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_wallet parse: {e}")))?;
+        let raw = decode_signature_b64(&parsed.signature_b64)
+            .map_err(|e| AnimaError::Crypto(format!("RemoteAnima sign_wallet b64: {e}")))?;
+        if raw.len() != 64 {
+            return Err(AnimaError::Crypto(format!(
+                "RemoteAnima sign_wallet: expected 64-byte raw r||s, got {}",
+                raw.len()
+            )));
+        }
+        let mut out = [0u8; 64];
+        out.copy_from_slice(&raw);
+        Ok(out)
+    }
+
+    /// Compute the EVM `v` recovery byte for a secp256k1 signature.
+    /// Tries both candidate recovery ids (0/1) and selects the one
+    /// whose recovered pubkey matches the cached wallet pubkey.
+    /// Returns the legacy `v ∈ {27, 28}` form per the
+    /// `EvmSignature` convention (matches `VaultTransitAnima` and
+    /// `haima-wallet::LocalSigner::sign_transfer_authorization`).
+    fn compute_v_byte(&self, digest: &[u8; 32], r_s: &[u8; 64]) -> AnimaResult<u8> {
+        let signature = K256Signature::from_slice(r_s)
+            .map_err(|e| AnimaError::Crypto(format!("secp256k1 sig parse: {e}")))?;
+        let expected_pubkey =
+            K256VerifyingKey::from_sec1_bytes(&self.wallet_pubkey_uncompressed)
+                .map_err(|e| AnimaError::Crypto(format!("expected pubkey parse: {e}")))?;
+        for cand in 0u8..=1 {
+            let recid = match RecoveryId::try_from(cand) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            if let Ok(recovered) =
+                K256VerifyingKey::recover_from_prehash(digest, &signature, recid)
+                && recovered == expected_pubkey
+            {
+                return Ok(cand + 27);
+            }
+        }
+        Err(AnimaError::Crypto(
+            "RemoteAnima ecrecover: neither recovery id matched the wallet pubkey".into(),
+        ))
+    }
+
+    /// Drive an async future from the sync trait method.
+    ///
+    /// **IMPORTANT — runtime-flavor caveat:** `block_in_place` panics
+    /// if called from a `current_thread` tokio runtime. Callers MUST
+    /// use a multi-thread tokio runtime — integration tests use
+    /// `#[tokio::test(flavor = "multi_thread")]`. Calling
+    /// `RemoteAnima::sign_*` from inside a Future on a
+    /// `current_thread` runtime will panic. Same caveat as
+    /// `SomaCustody::block_on`.
+    fn block_on<F, T>(&self, fut: F) -> AnimaResult<T>
+    where
+        F: std::future::Future<Output = AnimaResult<T>>,
+    {
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(fut)),
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| AnimaError::Crypto(format!("RemoteAnima rt build: {e}")))?;
+                rt.block_on(fut)
+            }
+        }
+    }
+}
+
+impl AnimaCustody for RemoteAnima {
+    fn user_did(&self) -> &str {
+        &self.user_did
+    }
+
+    fn auth_pubkey(&self) -> [u8; 33] {
+        self.auth_pubkey
+    }
+
+    fn wallet_address(&self) -> Option<&WalletAddress> {
+        Some(&self.wallet_address)
+    }
+
+    fn sign_jws(&self, claims: &Value) -> AnimaResult<String> {
+        // Build the JWS header + body locally (URL_SAFE_NO_PAD per
+        // RFC 7515 §3) then ask lifegw to sign the SHA-256 of the
+        // signing input.
+        use sha2::{Digest, Sha256};
+
+        let header = serde_json::json!({
+            "alg": "ES256",
+            "typ": "JWT",
+            "kid": self.user_did,
+        });
+        let header_b64 = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&header)
+                .map_err(|e| AnimaError::Crypto(format!("RemoteAnima encode header: {e}")))?,
+        );
+        let body_b64 = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(claims)
+                .map_err(|e| AnimaError::Crypto(format!("RemoteAnima encode body: {e}")))?,
+        );
+        let signing_input = format!("{header_b64}.{body_b64}");
+        let digest_array = {
+            let hash = Sha256::digest(signing_input.as_bytes());
+            let mut out = [0u8; 32];
+            out.copy_from_slice(&hash);
+            out
+        };
+        let sig = self.block_on(self.sign_auth_async(&digest_array))?;
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig);
+        Ok(format!("{signing_input}.{sig_b64}"))
+    }
+
+    fn sign_digest(&self, digest: &[u8; 32]) -> AnimaResult<[u8; 64]> {
+        self.block_on(self.sign_auth_async(digest))
+    }
+
+    fn sign_evm_tx(&self, tx: &TxRequest) -> AnimaResult<EvmSignature> {
+        // Mirror the VaultTransitAnima / SomaCustody path: parse
+        // request, RLP-encode EIP-1559 envelope, Keccak-256, ask
+        // remote to sign the prehash, ecrecover v.
+        let chain_id = rlp::parse_eip155_chain_id(&tx.chain)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx: {e}")))?;
+        let to = rlp::parse_address_20(&tx.to)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx to: {e}")))?;
+        let value = rlp::parse_u256_str(&tx.value_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx value: {e}")))?;
+        let max_fee = rlp::parse_u256_str(&tx.max_fee_per_gas_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx max_fee: {e}")))?;
+        let max_priority = rlp::parse_u256_str(&tx.max_priority_fee_per_gas_wei)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx max_priority: {e}")))?;
+        let data = rlp::parse_data_hex(&tx.data_hex)
+            .map_err(|e| AnimaError::Crypto(format!("evm tx data: {e}")))?;
+        let envelope = rlp::encode_eip1559_unsigned(
+            chain_id,
+            tx.nonce,
+            &max_priority,
+            &max_fee,
+            tx.gas_limit,
+            &to,
+            &value,
+            &data,
+        );
+        let digest = rlp::keccak256(&envelope);
+        let r_s = self.block_on(self.sign_wallet_async(&digest))?;
+        let v = self.compute_v_byte(&digest, &r_s)?;
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(&r_s);
+        out.push(v);
+        Ok(EvmSignature::from_bytes(out))
+    }
+
+    fn sign_eip712(
+        &self,
+        domain: &Eip712Domain,
+        types: &Value,
+        message: &Value,
+    ) -> AnimaResult<EvmSignature> {
+        // SPEC-D-DEVIATION (remote): same EIP-3009 only constraint as
+        // the rest of the family. Generic encoder deferred.
+        let primary = types
+            .get("primaryType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if primary != "TransferWithAuthorization"
+            && !(message.get("from").is_some() && message.get("validAfter").is_some())
+        {
+            return Err(AnimaError::Crypto(
+                "eip712: only EIP-3009 TransferWithAuthorization is supported in D-Sub-C \
+                 (matches D-Sub-A/B/E limitation; generic encoder deferred)"
+                    .to_string(),
+            ));
+        }
+
+        use haima_wallet::eip712::{hash_transfer_authorization, parse_eth_address};
+
+        let from = message
+            .get("from")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'from'".into()))?;
+        let to = message
+            .get("to")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'to'".into()))?;
+        let value: u64 = message
+            .get("value")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'value' (string)".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 value: {e}")))?;
+        let valid_after: u64 = message
+            .get("validAfter")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validAfter'".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 validAfter: {e}")))?;
+        let valid_before: u64 = message
+            .get("validBefore")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'validBefore'".into()))?
+            .parse()
+            .map_err(|e| AnimaError::Crypto(format!("eip712 validBefore: {e}")))?;
+        let nonce_hex = message
+            .get("nonce")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AnimaError::Crypto("eip712: missing 'nonce'".into()))?;
+        let nonce_bytes = hex::decode(nonce_hex.trim_start_matches("0x"))
+            .map_err(|e| AnimaError::Crypto(format!("eip712 nonce hex: {e}")))?;
+        if nonce_bytes.len() != 32 {
+            return Err(AnimaError::Crypto(format!(
+                "eip712 nonce must be 32 bytes, got {}",
+                nonce_bytes.len()
+            )));
+        }
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(&nonce_bytes);
+
+        let from_b = parse_eth_address(from)
+            .map_err(|e| AnimaError::Crypto(format!("eip712 from: {e}")))?;
+        let to_b = parse_eth_address(to)
+            .map_err(|e| AnimaError::Crypto(format!("eip712 to: {e}")))?;
+
+        let digest = hash_transfer_authorization(
+            domain,
+            &from_b,
+            &to_b,
+            value,
+            valid_after,
+            valid_before,
+            &nonce,
+        );
+        let r_s = self.block_on(self.sign_wallet_async(&digest))?;
+        let v = self.compute_v_byte(&digest, &r_s)?;
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(&r_s);
+        out.push(v);
+        Ok(EvmSignature::from_bytes(out))
+    }
+
+    fn rotate(&self) -> AnimaResult<(DidRotationEvent, Arc<dyn AnimaCustody>)> {
+        // SPEC-D-DEVIATION (remote): rotation is journal-driven, not
+        // RPC-driven. Even though lifegw COULD expose a `rotate` route,
+        // doing so would create two divergent rotation surfaces and
+        // break the Spec D L4-D10 invariant that rotations are
+        // documented in the journal. Mirrors `SomaCustody::rotate`.
+        Err(AnimaError::Crypto(
+            "RemoteAnima::rotate is journal-driven; \
+             use anima-lago::write_rotation_event from the server-side anima daemon \
+             (typically VaultTransitAnima) and reconstruct a fresh RemoteAnima \
+             after observing the anima.identity_rotated event"
+                .to_string(),
+        ))
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        BackendKind::Remote
+    }
+
+    fn export_identity_document(&self) -> AnimaResult<AgentIdentityDocument> {
+        let public_key_multibase =
+            format!("z{}", bs58::encode(self.auth_pubkey).into_string());
+        let did = self.user_did.clone();
+        let vm = VerificationMethod {
+            id: format!("{did}#key-1"),
+            method_type: "JsonWebKey2020".to_string(),
+            controller: did.clone(),
+            public_key_multibase,
+        };
+        // D-Sub-C: rotation_chain stays empty here. The chain is
+        // populated by `crate::rotation::walk_rotation_chain` via the
+        // anima-lago bridge — same pattern as SomaCustody.
+        let doc = IdentityDocumentBuilder::new(
+            did,
+            "anima-self".to_string(),
+            format!("remote custody (lifegw {})", self.base_url),
+            String::new(),
+        )
+        .agent_type(AgentType::Hosted)
+        .verification_method(vm)
+        .build();
+        Ok(doc)
+    }
+}
+
+/// Decode a pubkey base64 string. Tries standard b64 first, then
+/// URL-safe (some JS callers default to urlsafe).
+fn decode_pubkey_b64(s: &str) -> Result<Vec<u8>, String> {
+    if let Ok(b) = B64_STANDARD.decode(s) {
+        return Ok(b);
+    }
+    URL_SAFE_NO_PAD
+        .decode(s.trim_end_matches('='))
+        .map_err(|e| format!("base64 decode: {e}"))
+}
+
+/// Decode a signature base64 string. Same dual-strategy as pubkeys.
+fn decode_signature_b64(s: &str) -> Result<Vec<u8>, String> {
+    if let Ok(b) = B64_STANDARD.decode(s) {
+        return Ok(b);
+    }
+    URL_SAFE_NO_PAD
+        .decode(s.trim_end_matches('='))
+        .map_err(|e| format!("base64 decode: {e}"))
+}
+
+/// Derive an EVM address from a 65-byte uncompressed secp256k1
+/// pubkey. Mirror of `crate::vault::derive_wallet_address` and
+/// `haima_wallet::evm::derive_address`. Returns the lowercase hex
+/// `0x…` string (40 chars after the prefix).
+fn derive_wallet_address(uncompressed: &[u8; 65]) -> AnimaResult<String> {
+    if uncompressed[0] != 0x04 {
+        return Err(AnimaError::Crypto(format!(
+            "derive_wallet_address: uncompressed point must start with 0x04, got 0x{:02x}",
+            uncompressed[0]
+        )));
+    }
+    let hash = Keccak256::digest(&uncompressed[1..]);
+    let address_bytes = &hash[12..];
+    Ok(format!("0x{}", hex::encode(address_bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_kind_is_remote() {
+        // Construct a RemoteAnima by hand (skipping the network call)
+        // to assert the trait method returns Remote. We can do this
+        // because the struct fields are crate-private and we're in
+        // the same crate.
+        let auth_pubkey = [0x02u8; 33];
+        let mut wallet_uncompressed = [0u8; 65];
+        wallet_uncompressed[0] = 0x04;
+        let wallet_address = WalletAddress {
+            address: "0x0000000000000000000000000000000000000000".into(),
+            chain: ChainId::base(),
+        };
+        let cap = TierUserCap {
+            token: "test".into(),
+            expires_at_unix: i64::MAX,
+        };
+        let client = Arc::new(reqwest::Client::new());
+        let anima = RemoteAnima {
+            base_url: "http://localhost".into(),
+            user_id: "test-user".into(),
+            auth_pubkey,
+            wallet_pubkey_uncompressed: wallet_uncompressed,
+            wallet_address,
+            user_did: "did:key:zDnTest".into(),
+            cap: Arc::new(Mutex::new(cap)),
+            client,
+        };
+        assert_eq!(anima.backend_kind(), BackendKind::Remote);
+        assert!(anima.wallet_address().is_some());
+        assert_eq!(anima.user_did(), "did:key:zDnTest");
+    }
+
+    #[test]
+    fn rotate_returns_journal_directive() {
+        let auth_pubkey = [0x02u8; 33];
+        let mut wallet_uncompressed = [0u8; 65];
+        wallet_uncompressed[0] = 0x04;
+        let cap = TierUserCap {
+            token: "test".into(),
+            expires_at_unix: i64::MAX,
+        };
+        let client = Arc::new(reqwest::Client::new());
+        let anima = RemoteAnima {
+            base_url: "http://localhost".into(),
+            user_id: "test-user".into(),
+            auth_pubkey,
+            wallet_pubkey_uncompressed: wallet_uncompressed,
+            wallet_address: WalletAddress {
+                address: "0x0".into(),
+                chain: ChainId::base(),
+            },
+            user_did: "did:key:zDnTest".into(),
+            cap: Arc::new(Mutex::new(cap)),
+            client,
+        };
+        let err = match anima.rotate() {
+            Ok(_) => panic!("rotate must error"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("journal-driven"),
+            "error must point at journal flow (got: {msg})"
+        );
+        assert!(
+            msg.contains("write_rotation_event"),
+            "error must reference helper (got: {msg})"
+        );
+    }
+
+    #[test]
+    fn derive_wallet_address_format() {
+        // Use a known test vector — secp256k1 public key from
+        // privkey [1u8; 32]. Same pattern as
+        // crate::vault::derive_wallet_address tests.
+        use k256::SecretKey;
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let sk = SecretKey::from_bytes(&[1u8; 32].into()).unwrap();
+        let pk = sk.public_key();
+        let pt = pk.to_encoded_point(false);
+        let bytes = pt.as_bytes();
+        let mut uncompressed = [0u8; 65];
+        uncompressed.copy_from_slice(bytes);
+        let addr = derive_wallet_address(&uncompressed).unwrap();
+        assert!(addr.starts_with("0x"));
+        assert_eq!(addr.len(), 42);
+    }
+
+    #[test]
+    fn derive_wallet_address_rejects_bad_prefix() {
+        let mut bad = [0u8; 65];
+        bad[0] = 0x02; // wrong prefix
+        let err = derive_wallet_address(&bad).expect_err("must reject non-0x04 prefix");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("0x04"),
+            "error must mention required prefix (got: {msg})"
+        );
+    }
+
+    #[test]
+    fn cap_can_be_replaced() {
+        let auth_pubkey = [0x02u8; 33];
+        let mut wallet_uncompressed = [0u8; 65];
+        wallet_uncompressed[0] = 0x04;
+        let cap = TierUserCap {
+            token: "old".into(),
+            expires_at_unix: 100,
+        };
+        let client = Arc::new(reqwest::Client::new());
+        let anima = RemoteAnima {
+            base_url: "http://localhost".into(),
+            user_id: "test-user".into(),
+            auth_pubkey,
+            wallet_pubkey_uncompressed: wallet_uncompressed,
+            wallet_address: WalletAddress {
+                address: "0x0".into(),
+                chain: ChainId::base(),
+            },
+            user_did: "did:key:zDnTest".into(),
+            cap: Arc::new(Mutex::new(cap)),
+            client,
+        };
+        assert_eq!(anima.current_cap().token, "old");
+        anima.set_cap(TierUserCap {
+            token: "new".into(),
+            expires_at_unix: 200,
+        });
+        assert_eq!(anima.current_cap().token, "new");
+        assert_eq!(anima.current_cap().expires_at_unix, 200);
+    }
+}

--- a/crates/anima/anima-identity/tests/integration_remote.rs
+++ b/crates/anima/anima-identity/tests/integration_remote.rs
@@ -1,0 +1,408 @@
+//! Spec D D-Sub-C — `RemoteAnima` integration tests.
+//!
+//! Stands up a [`wiremock::MockServer`] that mocks lifegw's
+//! `/anima/custody/*` HTTP/JSON proxy and verifies that
+//! `RemoteAnima`:
+//!
+//! 1. Bootstraps via two `GET /anima/custody/get_*_pubkey/{user_id}`
+//!    calls — DID + wallet address derive correctly from the cached
+//!    pubkeys.
+//! 2. `sign_jws` POSTs to `/anima/custody/sign_auth` with the SHA-256
+//!    digest of `<header>.<body>` and reassembles the compact JWS.
+//! 3. `sign_digest` round-trips a 32-byte prehash → 64-byte raw r||s.
+//! 4. `sign_evm_tx` produces a 65-byte r||s||v whose v ∈ {27, 28}
+//!    recovers the cached wallet pubkey.
+//! 5. `rotate()` returns the documented "journal-driven" error
+//!    (does NOT hit the network).
+//!
+//! lifegw routes themselves ship in Stream R-2 (separate PR). The
+//! mock here verifies only the client-side request/response shapes.
+
+#![cfg(feature = "kms-remote")]
+
+use std::sync::{Arc, Mutex};
+
+use anima_identity::custody::{AnimaCustody, BackendKind, TxRequest};
+use anima_identity::remote::{RemoteAnima, TierUserCap};
+use base64::Engine as _;
+use base64::engine::general_purpose::{STANDARD as B64_STANDARD, URL_SAFE_NO_PAD};
+use k256::SecretKey as Secp256k1SecretKey;
+use k256::ecdsa::{
+    RecoveryId, Signature as K256Signature, SigningKey as K256SigningKey,
+    VerifyingKey as K256VerifyingKey,
+};
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::SecretKey as P256SecretKey;
+use p256::ecdsa::{
+    Signature as P256Signature, SigningKey as P256SigningKey,
+    signature::hazmat::PrehashSigner as P256PrehashSigner,
+};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+const ALICE: &str = "alice";
+const ALICE_AUTH_SCALAR: [u8; 32] = [7u8; 32];
+const ALICE_WALLET_SCALAR: [u8; 32] = [11u8; 32];
+
+/// Test fixture — owns the wiremock server, the deterministic test
+/// keys, and the call recorder used for assertions.
+struct RemoteFixture {
+    server: MockServer,
+    auth_sk: P256SecretKey,
+    wallet_sk: Secp256k1SecretKey,
+    sign_calls: Arc<Mutex<Vec<SignCall>>>,
+}
+
+#[derive(Debug, Clone)]
+struct SignCall {
+    route: String,
+    body: Value,
+    has_bearer: bool,
+}
+
+impl RemoteFixture {
+    async fn build() -> Self {
+        let server = MockServer::start().await;
+        let auth_sk = P256SecretKey::from_bytes(&ALICE_AUTH_SCALAR.into()).unwrap();
+        let wallet_sk = Secp256k1SecretKey::from_bytes(&ALICE_WALLET_SCALAR.into()).unwrap();
+        let sign_calls = Arc::new(Mutex::new(Vec::new()));
+
+        // GET /anima/custody/get_auth_pubkey/{user_id}
+        let auth_pk = auth_sk.public_key();
+        let auth_pt = auth_pk.to_encoded_point(true); // SEC1 compressed
+        let auth_pubkey_bytes = auth_pt.as_bytes().to_vec();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/anima/custody/get_auth_pubkey/{ALICE}"
+            )))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "pubkey_b64": B64_STANDARD.encode(&auth_pubkey_bytes)
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        // GET /anima/custody/get_wallet_pubkey/{user_id}
+        let wallet_pk = wallet_sk.public_key();
+        let wallet_pt = wallet_pk.to_encoded_point(false); // SEC1 uncompressed
+        let wallet_pubkey_bytes = wallet_pt.as_bytes().to_vec();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/anima/custody/get_wallet_pubkey/{ALICE}"
+            )))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "pubkey_b64": B64_STANDARD.encode(&wallet_pubkey_bytes)
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        Self {
+            server,
+            auth_sk,
+            wallet_sk,
+            sign_calls,
+        }
+    }
+
+    /// Mount the `/anima/custody/sign_auth` mock.
+    async fn mount_sign_auth(&self) {
+        let calls = self.sign_calls.clone();
+        let auth_sk = self.auth_sk.clone();
+        Mock::given(method("POST"))
+            .and(path("/anima/custody/sign_auth"))
+            .respond_with(SignAuthResponder { calls, auth_sk })
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mount the `/anima/custody/sign_wallet` mock.
+    async fn mount_sign_wallet(&self) {
+        let calls = self.sign_calls.clone();
+        let wallet_sk = self.wallet_sk.clone();
+        Mock::given(method("POST"))
+            .and(path("/anima/custody/sign_wallet"))
+            .respond_with(SignWalletResponder { calls, wallet_sk })
+            .mount(&self.server)
+            .await;
+    }
+
+    fn base_url(&self) -> String {
+        self.server.uri()
+    }
+}
+
+/// Custom wiremock responder for `/anima/custody/sign_auth`.
+struct SignAuthResponder {
+    calls: Arc<Mutex<Vec<SignCall>>>,
+    auth_sk: P256SecretKey,
+}
+
+impl Respond for SignAuthResponder {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        let body: Value = serde_json::from_slice(&req.body).expect("body must be JSON");
+        let has_bearer = req
+            .headers
+            .iter()
+            .any(|(name, value)| {
+                name.as_str().eq_ignore_ascii_case("authorization")
+                    && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
+            });
+        self.calls.lock().unwrap().push(SignCall {
+            route: "/anima/custody/sign_auth".into(),
+            body: body.clone(),
+            has_bearer,
+        });
+        let digest_b64 = body
+            .get("digest_b64")
+            .and_then(|v| v.as_str())
+            .expect("digest_b64 required");
+        let digest_bytes = B64_STANDARD.decode(digest_b64).expect("b64 decode");
+        if digest_bytes.len() != 32 {
+            return ResponseTemplate::new(400);
+        }
+        let mut digest_arr = [0u8; 32];
+        digest_arr.copy_from_slice(&digest_bytes);
+
+        let sk = P256SigningKey::from(self.auth_sk.clone());
+        let signature: P256Signature = sk.sign_prehash(&digest_arr).unwrap();
+        let raw = signature.to_bytes().to_vec();
+        ResponseTemplate::new(200).set_body_json(json!({
+            "signature_b64": B64_STANDARD.encode(&raw)
+        }))
+    }
+}
+
+/// Custom wiremock responder for `/anima/custody/sign_wallet`.
+struct SignWalletResponder {
+    calls: Arc<Mutex<Vec<SignCall>>>,
+    wallet_sk: Secp256k1SecretKey,
+}
+
+impl Respond for SignWalletResponder {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        let body: Value = serde_json::from_slice(&req.body).expect("body must be JSON");
+        let has_bearer = req
+            .headers
+            .iter()
+            .any(|(name, value)| {
+                name.as_str().eq_ignore_ascii_case("authorization")
+                    && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
+            });
+        self.calls.lock().unwrap().push(SignCall {
+            route: "/anima/custody/sign_wallet".into(),
+            body: body.clone(),
+            has_bearer,
+        });
+        let digest_b64 = body
+            .get("digest_b64")
+            .and_then(|v| v.as_str())
+            .expect("digest_b64 required");
+        let digest_bytes = B64_STANDARD.decode(digest_b64).expect("b64 decode");
+        if digest_bytes.len() != 32 {
+            return ResponseTemplate::new(400);
+        }
+        let mut digest_arr = [0u8; 32];
+        digest_arr.copy_from_slice(&digest_bytes);
+
+        let sk = K256SigningKey::from(self.wallet_sk.clone());
+        let sig: K256Signature = sk.sign_prehash(&digest_arr).unwrap();
+        let raw = sig.to_bytes().to_vec();
+        ResponseTemplate::new(200).set_body_json(json!({
+            "signature_b64": B64_STANDARD.encode(&raw)
+        }))
+    }
+}
+
+fn fake_cap() -> TierUserCap {
+    TierUserCap {
+        token: "tier-user-jwt-fake".into(),
+        expires_at_unix: i64::MAX,
+    }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+/// Bootstrap: `RemoteAnima::new` fetches both pubkeys, derives DID
+/// (`did:key:zDn…`) and a 0x-prefixed 42-char wallet address.
+#[tokio::test(flavor = "multi_thread")]
+async fn remote_anima_bootstrap_fetches_pubkeys() {
+    let fixture = RemoteFixture::build().await;
+    let anima = RemoteAnima::new(fixture.base_url(), ALICE, fake_cap())
+        .await
+        .expect("bootstrap must succeed");
+    assert_eq!(anima.backend_kind(), BackendKind::Remote);
+    assert!(
+        anima.user_did().starts_with("did:key:zDn"),
+        "DID must derive from P-256 auth pubkey: {}",
+        anima.user_did()
+    );
+    let addr = anima.wallet_address().expect("wallet address resolved");
+    assert!(addr.address.starts_with("0x"));
+    assert_eq!(addr.address.len(), 42);
+    assert_eq!(anima.user_id(), ALICE);
+}
+
+/// `sign_jws` hits `/anima/custody/sign_auth` with a 32-byte digest
+/// in the body, and the returned 3-part JWS has `alg=ES256` + the
+/// user DID as the kid.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_jws_hits_sign_auth_route() {
+    let fixture = RemoteFixture::build().await;
+    fixture.mount_sign_auth().await;
+    let base_url = fixture.base_url();
+    let calls = fixture.sign_calls.clone();
+    let anima = RemoteAnima::new(base_url, ALICE, fake_cap()).await.unwrap();
+
+    let jws = tokio::task::spawn_blocking(move || {
+        anima.sign_jws(&json!({"sub": "agt_001", "iss": "anima"}))
+    })
+    .await
+    .unwrap()
+    .expect("sign_jws must succeed");
+
+    let parts: Vec<&str> = jws.split('.').collect();
+    assert_eq!(parts.len(), 3, "JWS must have 3 parts");
+
+    let header_bytes = URL_SAFE_NO_PAD.decode(parts[0]).unwrap();
+    let header: Value = serde_json::from_slice(&header_bytes).unwrap();
+    assert_eq!(header["alg"], "ES256");
+    assert_eq!(header["typ"], "JWT");
+    let kid = header["kid"].as_str().unwrap();
+    assert!(
+        kid.starts_with("did:key:zDn"),
+        "kid must be P-256 DID, got {kid}"
+    );
+
+    let recorded = calls.lock().unwrap();
+    let auth_call = recorded
+        .iter()
+        .find(|c| c.route == "/anima/custody/sign_auth")
+        .expect("sign_auth call recorded");
+    assert!(auth_call.has_bearer, "sign_auth must carry bearer token");
+    let user_id = auth_call.body["user_id"].as_str().unwrap();
+    assert_eq!(user_id, ALICE);
+    let digest_b64 = auth_call.body["digest_b64"].as_str().unwrap();
+    let digest_bytes = B64_STANDARD.decode(digest_b64).unwrap();
+    assert_eq!(digest_bytes.len(), 32, "digest must be 32 bytes (SHA-256)");
+}
+
+/// `sign_digest` returns a 64-byte raw r||s — verify it matches a
+/// fresh ECDSA-P256 signature over the same prehash by the same key.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_digest_returns_remote_signature() {
+    let fixture = RemoteFixture::build().await;
+    fixture.mount_sign_auth().await;
+    let base_url = fixture.base_url();
+    let anima = RemoteAnima::new(base_url, ALICE, fake_cap()).await.unwrap();
+
+    let digest = {
+        let mut d = [0u8; 32];
+        let h = Sha256::digest(b"test message");
+        d.copy_from_slice(&h);
+        d
+    };
+    let digest_for_block = digest;
+    let sig_bytes = tokio::task::spawn_blocking(move || anima.sign_digest(&digest_for_block))
+        .await
+        .unwrap()
+        .expect("sign_digest must succeed");
+    assert_eq!(sig_bytes.len(), 64);
+
+    // Verify the returned signature against the test key over the same
+    // digest — the mock signs deterministically, so this is a strong
+    // round-trip assertion.
+    let sk = P256SigningKey::from(fixture.auth_sk.clone());
+    let expected: P256Signature = sk.sign_prehash(&digest).unwrap();
+    assert_eq!(sig_bytes.to_vec(), expected.to_bytes().to_vec());
+}
+
+/// `sign_evm_tx` produces a 65-byte r||s||v signature whose v
+/// recovers the cached wallet pubkey. Mirrors the
+/// `vault_anima_signs_evm_tx_with_recoverable_v` invariant.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_evm_tx_recovers_correct_v_byte() {
+    let fixture = RemoteFixture::build().await;
+    fixture.mount_sign_wallet().await;
+    let wallet_sk = fixture.wallet_sk.clone();
+    let base_url = fixture.base_url();
+    let anima = RemoteAnima::new(base_url, ALICE, fake_cap()).await.unwrap();
+
+    let tx = TxRequest {
+        from: anima.wallet_address().unwrap().address.clone(),
+        to: "0x036CbD53842c5426634e7929541eC2318f3dCF7e".into(),
+        value_wei: "1000000000000000000".into(), // 1 ETH
+        data_hex: "".into(),
+        nonce: 7,
+        gas_limit: 21_000,
+        max_fee_per_gas_wei: "30000000000".into(),
+        max_priority_fee_per_gas_wei: "1000000000".into(),
+        chain: "eip155:8453".into(),
+    };
+    let tx_clone = tx.clone();
+
+    let sig = tokio::task::spawn_blocking(move || anima.sign_evm_tx(&tx_clone))
+        .await
+        .unwrap()
+        .expect("sign_evm_tx must succeed");
+    let bytes = sig.bytes;
+    assert_eq!(bytes.len(), 65, "EVM signature must be r||s||v (65 bytes)");
+    let v = bytes[64];
+    assert!(
+        v == 27 || v == 28,
+        "legacy v must be 27 or 28, got {v}"
+    );
+
+    // Recover the pubkey from the signed digest and confirm it matches
+    // the fixture wallet pubkey.
+    let envelope = anima_identity::rlp::encode_eip1559_unsigned(
+        8453,
+        tx.nonce,
+        &anima_identity::rlp::parse_u256_str(&tx.max_priority_fee_per_gas_wei).unwrap(),
+        &anima_identity::rlp::parse_u256_str(&tx.max_fee_per_gas_wei).unwrap(),
+        tx.gas_limit,
+        &anima_identity::rlp::parse_address_20(&tx.to).unwrap(),
+        &anima_identity::rlp::parse_u256_str(&tx.value_wei).unwrap(),
+        &anima_identity::rlp::parse_data_hex(&tx.data_hex).unwrap(),
+    );
+    let digest = anima_identity::rlp::keccak256(&envelope);
+    let r_s: [u8; 64] = bytes[..64].try_into().unwrap();
+    let signature = K256Signature::from_slice(&r_s).unwrap();
+    let recid = RecoveryId::try_from(v - 27).unwrap();
+    let recovered = K256VerifyingKey::recover_from_prehash(&digest, &signature, recid).unwrap();
+
+    let expected = K256VerifyingKey::from(&K256SigningKey::from(wallet_sk));
+    assert_eq!(recovered, expected, "recovered pubkey must match wallet");
+}
+
+/// `rotate()` returns the documented journal-driven error and does
+/// NOT touch the network (no mock for `/anima/custody/rotate`, so a
+/// network call would fail differently).
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_returns_helpful_error() {
+    let fixture = RemoteFixture::build().await;
+    let anima = RemoteAnima::new(fixture.base_url(), ALICE, fake_cap())
+        .await
+        .unwrap();
+    let err = match anima.rotate() {
+        Ok(_) => panic!("rotate must error"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("journal-driven"),
+        "error must say journal-driven: {msg}"
+    );
+    assert!(
+        msg.contains("write_rotation_event"),
+        "error must point at helper: {msg}"
+    );
+    assert!(
+        msg.contains("anima.identity_rotated"),
+        "error must reference event kind: {msg}"
+    );
+}

--- a/crates/anima/anima-identity/tests/integration_remote.rs
+++ b/crates/anima/anima-identity/tests/integration_remote.rs
@@ -74,14 +74,10 @@ impl RemoteFixture {
         let auth_pt = auth_pk.to_encoded_point(true); // SEC1 compressed
         let auth_pubkey_bytes = auth_pt.as_bytes().to_vec();
         Mock::given(method("GET"))
-            .and(path(format!(
-                "/anima/custody/get_auth_pubkey/{ALICE}"
-            )))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({
-                    "pubkey_b64": B64_STANDARD.encode(&auth_pubkey_bytes)
-                })),
-            )
+            .and(path(format!("/anima/custody/get_auth_pubkey/{ALICE}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "pubkey_b64": B64_STANDARD.encode(&auth_pubkey_bytes)
+            })))
             .mount(&server)
             .await;
 
@@ -90,14 +86,10 @@ impl RemoteFixture {
         let wallet_pt = wallet_pk.to_encoded_point(false); // SEC1 uncompressed
         let wallet_pubkey_bytes = wallet_pt.as_bytes().to_vec();
         Mock::given(method("GET"))
-            .and(path(format!(
-                "/anima/custody/get_wallet_pubkey/{ALICE}"
-            )))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({
-                    "pubkey_b64": B64_STANDARD.encode(&wallet_pubkey_bytes)
-                })),
-            )
+            .and(path(format!("/anima/custody/get_wallet_pubkey/{ALICE}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "pubkey_b64": B64_STANDARD.encode(&wallet_pubkey_bytes)
+            })))
             .mount(&server)
             .await;
 
@@ -145,13 +137,10 @@ struct SignAuthResponder {
 impl Respond for SignAuthResponder {
     fn respond(&self, req: &Request) -> ResponseTemplate {
         let body: Value = serde_json::from_slice(&req.body).expect("body must be JSON");
-        let has_bearer = req
-            .headers
-            .iter()
-            .any(|(name, value)| {
-                name.as_str().eq_ignore_ascii_case("authorization")
-                    && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
-            });
+        let has_bearer = req.headers.iter().any(|(name, value)| {
+            name.as_str().eq_ignore_ascii_case("authorization")
+                && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
+        });
         self.calls.lock().unwrap().push(SignCall {
             route: "/anima/custody/sign_auth".into(),
             body: body.clone(),
@@ -186,13 +175,10 @@ struct SignWalletResponder {
 impl Respond for SignWalletResponder {
     fn respond(&self, req: &Request) -> ResponseTemplate {
         let body: Value = serde_json::from_slice(&req.body).expect("body must be JSON");
-        let has_bearer = req
-            .headers
-            .iter()
-            .any(|(name, value)| {
-                name.as_str().eq_ignore_ascii_case("authorization")
-                    && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
-            });
+        let has_bearer = req.headers.iter().any(|(name, value)| {
+            name.as_str().eq_ignore_ascii_case("authorization")
+                && value.to_str().is_ok_and(|v| v.starts_with("Bearer "))
+        });
         self.calls.lock().unwrap().push(SignCall {
             route: "/anima/custody/sign_wallet".into(),
             body: body.clone(),
@@ -352,10 +338,7 @@ async fn sign_evm_tx_recovers_correct_v_byte() {
     let bytes = sig.bytes;
     assert_eq!(bytes.len(), 65, "EVM signature must be r||s||v (65 bytes)");
     let v = bytes[64];
-    assert!(
-        v == 27 || v == 28,
-        "legacy v must be 27 or 28, got {v}"
-    );
+    assert!(v == 27 || v == 28, "legacy v must be 27 or 28, got {v}");
 
     // Recover the pubkey from the signed digest and confirm it matches
     // the fixture wallet pubkey.


### PR DESCRIPTION
## Summary

Spec D D-Sub-C Stream R-1 — Rust-side `RemoteAnima` `AnimaCustody`
backend for browser/remote custody bridging via lifegw `/anima/custody/*`
HTTP/JSON proxy.

- Symmetric to the browser-side `WebCryptoAnima` (TS, separate crate); both call the same lifegw routes, both delegate wallet ops to a server-side anima daemon (typically `VaultTransitAnima`).
- Realises Spec D L4-D5 (split-custody for browser) + L4-D6 (P-256 auth) + L4-D7 (secp256k1 wallet half preserved across rotation) + L4-D10 (rotation documented in journal, not RPC).
- Bumps Spec D coverage to **5/6 sub-phases shipped (83%)** — only Stream R-2 (lifegw routes + TierUserMinter + WS subprotocol) remains for full D-Sub-C closure.

## Scope

**This PR (Stream R-1):**
- `kms-remote` Cargo feature flag + module gate
- `RemoteAnima` impl — bootstrap + sign_jws + sign_digest + sign_evm_tx + sign_eip712 + rotate
- `TierUserCap` type with refreshable Mutex storage
- 5 in-file unit tests + 5 wiremock integration tests

**Stream R-2 (separate follow-up PR, NOT this one):**
- lifegw `/anima/custody/sign_auth` + `/sign_wallet` + `/get_*_pubkey` routes
- `TierUserMinter` (lifegw module that mints user-scope JWTs from browser passkey)
- WS subprotocol for browser passkey enrolment
- Live USDC-transfer end-to-end test

## Wire surface (pinned by mock)

| Method | Path | Body / Response |
|---|---|---|
| GET | `/anima/custody/get_auth_pubkey/{user_id}` | → `{ pubkey_b64 }` (33-byte SEC1 compressed P-256) |
| GET | `/anima/custody/get_wallet_pubkey/{user_id}` | → `{ pubkey_b64 }` (65-byte SEC1 uncompressed secp256k1) |
| POST | `/anima/custody/sign_auth` | `{ user_id, digest_b64 }` → `{ signature_b64 }` (64-byte raw r\|\|s) |
| POST | `/anima/custody/sign_wallet` | `{ user_id, digest_b64 }` → `{ signature_b64 }` (64-byte raw r\|\|s; ecrecover loop computes v) |

All routes require `Authorization: Bearer <tier-user-jwt>`.

## Why HTTP/JSON not gRPC

Sidesteps M8.1 (Connect-vs-grpc-web mismatch in life-sdk-ts). The consumer surface is browser-shaped (small, stable, easy to call via `fetch()` from chatOS); using HTTP/JSON keeps the Rust path symmetric with the browser path so the same lifegw routes serve both.

## SPEC-D-DEVIATION

- **`rotate()` returns a journal-driven error.** Mirrors `SomaCustody::rotate`. Even though lifegw COULD expose a `POST /anima/custody/rotate` route, doing so would create two divergent rotation surfaces (RPC vs journal) and break the L4-D10 invariant. Operators must use `anima-lago::write_rotation_event` from the server-side anima daemon and reconstruct a fresh `RemoteAnima` after observing the `anima.identity_rotated` event.
- **`sign_eip712` constraint matches the family** — only EIP-3009 `TransferWithAuthorization` is supported, same as `InProcessAnima` / `VaultTransitAnima` / `SomaCustody`. Generic encoder is a deferred follow-up.
- **`block_on` runtime caveat** — callers MUST be on a multi-thread tokio runtime; `block_in_place` panics on `current_thread`. Same caveat as `SomaCustody::block_on`. Integration tests use `#[tokio::test(flavor = "multi_thread")]`.

## Test plan

- [x] `cargo check -p anima-identity` (default features) — clean, default builds stay slim
- [x] `cargo check -p anima-identity --features kms-remote` — clean
- [x] `cargo test -p anima-identity --features kms-remote --lib remote` — 5/5 unit tests passing
- [x] `cargo test -p anima-identity --features kms-remote --test integration_remote` — 5/5 wiremock integration tests passing
- [x] `cargo test -p anima-identity --features kms-remote` — 105 lib + 5 integration_remote + 8 rotation_chain + 11 + 3 + 15 + 1 doc tests passing
- [x] `cargo clippy -p anima-identity --features kms-remote --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p anima-identity --features "kms-remote,kms-vault,kms-soma" --all-targets -- -D warnings` — clean (cross-feature)
- [x] `cargo fmt --check --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)