### PR TITLE
feat(life-sdk-ts): D-Sub-C Stream T — WebCryptoAnima + PasskeyOracle + RemoteAnimaClient (browser custody)

### DIFF
--- a/sdks/life-sdk-ts/KNOWN_LIMITATIONS.md
+++ b/sdks/life-sdk-ts/KNOWN_LIMITATIONS.md
@@ -1,9 +1,11 @@
 # Known Limitations — `@broomva/life-sdk` v0.1.0-pre
 
 This SDK ships as **v0.1.0-pre** — the structural foundation (services,
-typed errors, WS state machine, proto type mirrors, codec helpers, 50
-unit tests) is solid and reusable. Two wire-protocol limitations are
-documented here as known follow-ups before v0.2.0 / GA:
+typed errors, WS state machine, proto type mirrors, codec helpers,
+anima browser custody, 125 unit tests) is solid and reusable. One
+wire-protocol limitation remains documented here as a known follow-up
+before v0.2.0 / GA. The browser-custody work in D-Sub-C Stream T
+SIDESTEPS the M8.2 issue (see "M8.2 status" section below).
 
 ## B1 — SDK speaks Connect-protocol JSON; lifegw runs `tonic-web` (gRPC-Web binary)
 
@@ -43,44 +45,29 @@ Option A is the canonical path for SDKs targeting tonic-backed
 gateways. Tracked under follow-up ticket "M8.1 — SDK transport rework
 to gRPC-Web binary framing".
 
-## B2 — Browser WebSocket auth uses subprotocol; gateway reads only `Authorization` header
+## M8.2 status — RESOLVED for browser custody (D-Sub-C Stream T)
 
-**Status:** Browser path of `Agent.StreamSession` will fail Tier-1 auth
-on production lifegw without a gateway-side change. Node hosts can pass
-a `webSocketFactory` that sets the `Authorization` header on the
-underlying `ws` package.
+The original M8.2 entry in v0.1.0-pre identified the
+`Sec-WebSocket-Protocol: bearer.*` subprotocol mismatch on the WS
+upgrade path. D-Sub-C (Stream T) closes the **production-equivalent
+gap** for browser identity custody by introducing the
+`/anima/custody/*` HTTP/JSON route family — see `src/anima/`. Browser
+deployments mint a Tier-User capability via passkey + HTTP/JSON,
+then call wallet operations through the same plain-`fetch`
+transport. The custody RPC code is structurally separate from the
+existing tonic-web SDK paths (M8.1 transport rework remains
+independent), so M8.1 and M8.2 land independently.
 
-### What's wrong
-
-- Browsers cannot set arbitrary headers on the WS upgrade request — the
-  Fetch API doesn't expose `Authorization` for the WS path.
-- The SDK forwards the Tier-1 bearer token via the
-  `Sec-WebSocket-Protocol: bearer.<token>` subprotocol header, which
-  IS settable from the browser.
-- The lifegw gateway's `services::ws::parse_upgrade_request` reads ONLY
-  the `Authorization` header. The subprotocol is silently ignored.
-- The `auth/middleware.rs::AuthLayer` runs BEFORE `WsLayer` and rejects
-  upgrade requests without a `Bearer` token in `Authorization` — the
-  upgrade response is never sent.
-
-### Resolution paths (for v0.2.0)
-
-- **Option A (preferred):** Add `Sec-WebSocket-Protocol: bearer.*`
-  parsing to lifegw's `parse_upgrade_request` + `AuthLayer`. Mirrors
-  the SDK's existing approach. Gateway-side change only.
-- **Option B:** Use cookie-based auth for WS. The gateway sets an
-  HttpOnly cookie at login; the browser includes it automatically on
-  upgrade requests. Requires session-management work and CSRF
-  defenses.
-- **Option C:** Use a query-param token for WS only. Less secure
-  (tokens may leak into logs); only suitable for short-lived tokens.
-
-Option A is the lowest-friction. Tracked under follow-up ticket
-"M8.2 — lifegw WS subprotocol-bearer auth support".
+The original WS-subprotocol handshake (`Agent.StreamSession`) in the
+gateway is unchanged — long-lived agent streaming still uses WS, and
+that path still requires a `webSocketFactory` in Node. The custody
+path no longer needs WS, so the gateway fix tracked as M8.2 is
+deferred until WS-bearer subprotocol parsing becomes a non-custody
+necessity.
 
 ## Migration path for early adopters
 
-Until B1+B2 land, the SDK is usable for:
+Until B1 lands (M8.2 sidestepped per above), the SDK is usable for:
 
 - Tests against `FakeGateway`-style mocks.
 - Node hosts that pass a `webSocketFactory` setting `Authorization`
@@ -88,8 +75,11 @@ Until B1+B2 land, the SDK is usable for:
 - Anyone building on top of the typed surface (services, errors, WS
   state machine, proto types) — none of which change in v0.2.0.
 
-Avoid using v0.1.0-pre for browser production deployments until
-B1+B2 are resolved.
+Browser production deployments using `WebCryptoAnima` (custody only,
+no WS-streaming) are unblocked once Stream R's `/anima/custody/*`
+routes ship. Browser production deployments needing
+`Agent.StreamSession` over WS still require either Node-host wrapping
+or M8.1 transport rework.
 
 ## See also
 

--- a/sdks/life-sdk-ts/README.md
+++ b/sdks/life-sdk-ts/README.md
@@ -147,6 +147,135 @@ cannot set custom request headers on WS handshakes.
 
 ---
 
+## Browser custody (Spec D D-Sub-C — `WebCryptoAnima`)
+
+The SDK ships a passkey-based browser custody surface — Spec D L4-D5
+"split custody" with the auth half (P-256 passkey, non-extractable)
+in the browser and the wallet half (secp256k1) delegated to a
+server-side anima daemon over the `/anima/custody/*` HTTP routes.
+
+```ts
+import {
+  PasskeyOracle,
+  RemoteAnimaClient,
+  SessionCap,
+  enrollWebCryptoAnima,
+  loadWebCryptoAnima,
+} from "@broomva/life-sdk";
+
+const passkey = new PasskeyOracle({
+  rpId: "broomva.tech",
+  rpName: "Broomva",
+});
+
+// First-time enrollment fires the OS auth UI (Touch ID / Windows
+// Hello / iCloud Keychain).
+const remote = new RemoteAnimaClient({
+  baseUrl: "https://api.life.dev",
+  getToken: async () => sessionCap.getValidToken(),
+});
+const sessionCap = new SessionCap({
+  userId: "u-1",
+  passkey,
+  remote,
+});
+
+const handle = await enrollWebCryptoAnima({
+  passkey,
+  remote,
+  sessionCap,
+  userId: "u-1",
+  displayName: "Carlos Escobar",
+  challenge: crypto.getRandomValues(new Uint8Array(32)),
+});
+
+// Subsequent sessions: load the cached credential, no OS prompt
+// fires until the first signing operation.
+const handle2 = await loadWebCryptoAnima({
+  passkey,
+  remote,
+  sessionCap,
+  userId: "u-1",
+});
+
+// Sign an EIP-712 USDC transferWithAuthorization (haima x402 path).
+const sig = await handle.signEip712(
+  {
+    name: "USD Coin",
+    version: "2",
+    chainId: "8453",
+    verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  },
+  {
+    EIP712Domain: [
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ],
+    TransferWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  },
+  {
+    from: handle.walletAddress(),
+    to: "0xFACILITATOR",
+    value: "1000000",
+    validAfter: "0",
+    validBefore: String(Math.floor(Date.now() / 1000) + 600),
+    nonce: "0x" + "00".repeat(32),
+  },
+);
+console.log(sig.bytes); // 65-byte r||s||v signature
+```
+
+### How the split works
+
+| Operation              | Routed to              | Notes |
+|------------------------|------------------------|-------|
+| `signJws` / `signDigest` | Passkey (browser)    | Touch ID / Windows Hello fires per call unless `SessionCap` is fresh |
+| `signEvmTx` / `signEip712` | Remote (server)    | Forwards digest over `/anima/custody/sign_wallet` to server-side `VaultTransitAnima` |
+| `userDid()`            | Local                  | Derived from cached SEC1-compressed P-256 pubkey via `generateDidKeyP256` (cross-language compatible with Rust) |
+| `walletAddress()`      | Cached at enrollment   | Server-resolved address — same for every session |
+| `rotate()`             | Rejects                | Spec D L4-D10 — rotation is journal-driven; server-side anima daemon emits `anima.identity_rotated` |
+
+### Tier-User cap lifecycle
+
+`SessionCap` manages a short-lived (default 15 min) JWT minted by
+lifegw against a passkey-signed challenge. Subsequent custody RPCs
+auto-refresh when < 30 s remain:
+
+```ts
+const sessionCap = new SessionCap({
+  userId: "u-1",
+  passkey,
+  remote,
+  refreshBeforeSecs: 30,
+  onExpiringSoon: () => console.log("re-authenticate soon"),
+});
+```
+
+The cap lives in-memory only — IndexedDB is reserved for the
+credentialId + cached pubkey, not for capability tokens.
+
+### Spec D ground truth + cross-references
+
+- **Spec D**: `docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md`
+- **Trait shape**: `crates/anima/anima-identity/src/custody.rs` (Rust)
+- **DID derivation**: `crates/anima/anima-identity/src/did.rs` (Rust);
+  byte-identical to TS `generateDidKeyP256`. Cross-language fixtures
+  pinned in `tests/fixtures/did_p256_vectors.json`.
+- **Backend matrix**: see Spec D §"Backend matrix" — browser deployments
+  pair `WebCryptoAnima` (auth) with `RemoteAnima` (wallet), both
+  exposed through this SDK.
+
+---
+
 ## Error handling
 
 Every error thrown by the SDK extends `LifeSdkError`:

--- a/sdks/life-sdk-ts/bun.lock
+++ b/sdks/life-sdk-ts/bun.lock
@@ -5,8 +5,14 @@
     "": {
       "name": "@broomva/life-sdk",
       "devDependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@types/node": "^25.5.0",
         "@types/ws": "^8.18.0",
+        "cbor-x": "^1.6.4",
+        "fake-indexeddb": "^6.2.5",
+        "idb": "^8.0.3",
+        "msw": "^2.14.2",
         "tsx": "^4.20.0",
         "typescript": "^5.7",
         "vitest": "^3.0",
@@ -21,6 +27,18 @@
     },
   },
   "packages": {
+    "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA=="],
+
+    "@cbor-extract/cbor-extract-darwin-x64": ["@cbor-extract/cbor-extract-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q=="],
+
+    "@cbor-extract/cbor-extract-linux-arm": ["@cbor-extract/cbor-extract-linux-arm@2.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ=="],
+
+    "@cbor-extract/cbor-extract-linux-arm64": ["@cbor-extract/cbor-extract-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg=="],
+
+    "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
+
+    "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
@@ -73,7 +91,29 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mswjs/interceptors": ["@mswjs/interceptors@0.41.8", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A=="],
+
+    "@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
+
+    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
+
+    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
@@ -133,6 +173,10 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
+
+    "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
@@ -149,31 +193,75 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
+
+    "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
+
+    "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
+
+    "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
@@ -183,7 +271,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msw": ["msw@2.14.2", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
+
+    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -195,19 +293,37 @@
 
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rettime": ["rettime@0.11.8", "", {}, "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -221,11 +337,21 @@
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
+    "tldts": ["tldts@7.0.30", "", { "dependencies": { "tldts-core": "^7.0.30" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw=="],
+
+    "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
 
     "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
@@ -235,6 +361,16 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
   }
 }

--- a/sdks/life-sdk-ts/examples/browser-custody.html
+++ b/sdks/life-sdk-ts/examples/browser-custody.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Browser custody — D-Sub-C demo</title>
+  <style>
+    body {
+      font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+      max-width: 720px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      line-height: 1.5;
+      color: #1f2937;
+    }
+    h1 { font-size: 1.4rem; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; }
+    button {
+      padding: 0.5rem 1rem;
+      margin-right: 0.5rem;
+      cursor: pointer;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      background: #f9fafb;
+    }
+    button:hover { background: #f3f4f6; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    pre {
+      background: #f3f4f6;
+      padding: 0.75rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.85rem;
+    }
+    .status { padding: 0.5rem; margin: 1rem 0; background: #fffbeb; border-left: 4px solid #fbbf24; }
+    .status.ok { background: #ecfdf5; border-color: #10b981; }
+    .status.err { background: #fef2f2; border-color: #ef4444; }
+    code { background: #f3f4f6; padding: 0.1rem 0.3rem; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <h1>Browser custody — D-Sub-C demo</h1>
+
+  <p>
+    This demo exercises the <code>WebCryptoAnima</code> + <code>PasskeyOracle</code> +
+    <code>RemoteAnimaClient</code> flow from <code>@broomva/life-sdk</code>.
+    Steps:
+  </p>
+  <ol>
+    <li>Enroll a passkey (one-time, fires OS auth UI).</li>
+    <li>Mint a Tier-User capability JWT (passkey signs challenge).</li>
+    <li>Sign a fake EIP-712 <code>transferWithAuthorization</code> (delegates to server-side wallet).</li>
+    <li>POST the signature to a fake haima endpoint.</li>
+  </ol>
+
+  <h2>Configuration</h2>
+  <p>
+    Set the lifegw base URL in the form below. For local dev against a
+    mock server, leave the default <code>http://localhost:8787</code>.
+    The lifegw <code>/anima/custody/*</code> routes ship in Stream R
+    (parallel to this PR) — without a real backend, the buttons below
+    will fail at the network step.
+  </p>
+
+  <div>
+    <label>lifegw base URL: <input id="baseUrl" value="http://localhost:8787" style="width: 320px" /></label>
+  </div>
+  <div style="margin-top: 0.5rem">
+    <label>User ID: <input id="userId" value="u-demo" style="width: 200px" /></label>
+  </div>
+
+  <h2>Actions</h2>
+  <button id="btn-enroll">1. Enroll passkey</button>
+  <button id="btn-load">1b. Load existing</button>
+  <button id="btn-mint" disabled>2. Mint Tier-User cap</button>
+  <button id="btn-sign-eip712" disabled>3. Sign fake EIP-712</button>
+  <button id="btn-post" disabled>4. POST to haima</button>
+
+  <div id="status" class="status">Ready.</div>
+
+  <h2>State</h2>
+  <pre id="state-json">{}</pre>
+
+  <p style="margin-top: 3rem; font-size: 0.85rem; color: #6b7280">
+    This is a runbook-only demo — the SDK is bundled via a per-page
+    import map in the script tag below. For production usage, install
+    <code>@broomva/life-sdk</code> from npm and import as a module.
+  </p>
+
+  <!-- The actual SDK code uses ES modules; we'd typically bundle via
+       Vite/esbuild before serving to a browser. For a minimal demo,
+       see the README for full setup. This page is intentionally not
+       wired to a build step — it documents the flow only. -->
+  <script type="module">
+    // NOTE: For a real demo you would import from a bundled URL, e.g.:
+    //   import {
+    //     PasskeyOracle, RemoteAnimaClient, SessionCap,
+    //     enrollWebCryptoAnima, loadWebCryptoAnima
+    //   } from "https://unpkg.com/@broomva/life-sdk@0.1.0-pre/dist/index.js";
+    //
+    // Until v0.2.0 ships a bundled/dist version, run this demo via:
+    //   cd sdks/life-sdk-ts && bun run build
+    //   bun --hot examples/serve.ts  (or any static file server)
+
+    const $ = (id) => document.getElementById(id);
+    const status = $("status");
+    const stateBox = $("state-json");
+
+    let state = {};
+    function setState(patch) {
+      state = { ...state, ...patch };
+      stateBox.textContent = JSON.stringify(
+        state,
+        (k, v) => (v instanceof Uint8Array ? `Uint8Array[${v.byteLength}]` : v),
+        2,
+      );
+    }
+    function setStatus(msg, kind = "info") {
+      status.textContent = msg;
+      status.className = `status ${kind === "info" ? "" : kind}`;
+    }
+
+    $("btn-enroll").addEventListener("click", async () => {
+      try {
+        setStatus("Enrolling passkey — OS UI should fire...");
+        // In a real demo: imported from bundled SDK.
+        setStatus(
+          "Demo stub — see README.md for the full passkey enrollment flow. The SDK's `enrollWebCryptoAnima` helper does the work in 5 lines.",
+          "ok",
+        );
+        setState({ enrolled: true, walletAddress: "0xDEMO" });
+      } catch (err) {
+        setStatus(`enroll failed: ${err.message}`, "err");
+      }
+    });
+
+    $("btn-load").addEventListener("click", () => {
+      setStatus(
+        "Demo stub — production code calls `loadWebCryptoAnima({ passkey, remote, sessionCap, userId })`.",
+        "ok",
+      );
+    });
+    $("btn-mint").addEventListener("click", () => {
+      setStatus("Demo stub — production code calls `sessionCap.getValidToken()`.", "ok");
+    });
+    $("btn-sign-eip712").addEventListener("click", () => {
+      setStatus(
+        "Demo stub — production code calls `handle.signEip712(domain, types, message)`.",
+        "ok",
+      );
+    });
+    $("btn-post").addEventListener("click", () => {
+      setStatus("Demo stub — POST the signature bytes to your haima facilitator.", "ok");
+    });
+  </script>
+</body>
+</html>

--- a/sdks/life-sdk-ts/package.json
+++ b/sdks/life-sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broomva/life-sdk",
   "version": "0.1.0-pre",
-  "description": "Public TypeScript SDK for the Life Agent OS — talks to lifegw over grpc-web + WebSocket. Implements the user-facing life.v1.{Agent, Events, Wallet, Identity} services. v0.1.0-pre — see KNOWN_LIMITATIONS.md before depending on this in production.",
+  "description": "Public TypeScript SDK for the Life Agent OS — talks to lifegw over grpc-web + WebSocket. Implements the user-facing life.v1.{Agent, Events, Wallet, Identity} services plus the anima browser custody surface (Spec D D-Sub-C: WebCryptoAnima + PasskeyOracle + RemoteAnimaClient). v0.1.0-pre — see KNOWN_LIMITATIONS.md before depending on this in production.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,6 +33,10 @@
     "./ws": {
       "types": "./dist/ws.d.ts",
       "import": "./dist/ws.js"
+    },
+    "./anima": {
+      "types": "./dist/anima/index.d.ts",
+      "import": "./dist/anima/index.js"
     }
   },
   "files": ["dist", "README.md", "LICENSE"],
@@ -52,7 +56,13 @@
     "grpc-web",
     "websocket",
     "ai-agent",
-    "broomva"
+    "broomva",
+    "passkey",
+    "webauthn",
+    "did-key",
+    "p256",
+    "secp256k1",
+    "eip-712"
   ],
   "author": "Broomva <carlos@broomva.tech>",
   "license": "MIT",
@@ -68,9 +78,17 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "dependencies": {
+    "cbor-x": "^1.6.4",
+    "idb": "^8.0.3"
+  },
   "devDependencies": {
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@types/node": "^25.5.0",
     "@types/ws": "^8.18.0",
+    "fake-indexeddb": "^6.2.5",
+    "msw": "^2.14.2",
     "tsx": "^4.20.0",
     "typescript": "^5.7",
     "vitest": "^3.0",

--- a/sdks/life-sdk-ts/src/anima/did.ts
+++ b/sdks/life-sdk-ts/src/anima/did.ts
@@ -1,0 +1,219 @@
+/**
+ * `did:key` DID generation + resolution for P-256 (Spec D L4-D6).
+ *
+ * Cross-language compatibility (REQUIRED): produces byte-identical
+ * output to Rust's `crates/anima/anima-identity/src/did.rs` for the
+ * same SEC1-compressed pubkey input. Tests pin this via fixture
+ * vectors generated from the Rust side.
+ *
+ * Format: `did:key:zDn<base58btc-encoded-multicodec-key>`
+ *
+ * Multicodec prefix (varint-encoded):
+ *   - `0x80 0x24` → P-256 public key (Spec D L4-D6, multicodec 0x1200)
+ *   - `0xed 0x01` → Ed25519 (legacy, Pre-D-Sub-A — not exposed here;
+ *                  browser custody only mints P-256)
+ *
+ * @see https://w3c-ccg.github.io/did-method-key/
+ * @see https://github.com/multiformats/multicodec
+ */
+
+/**
+ * Multicodec prefix for P-256 public key (Spec D L4-D6 — current auth curve).
+ *
+ * Two-byte unsigned varint encoding of 0x1200:
+ *   0x1200 binary:  1 0010 0000 0000
+ *   varint encoding (LSB-first 7-bit groups with continuation bit):
+ *     low 7 bits  = 0000000  → with continuation = 0x80
+ *     next 7 bits = 0100100  → terminator        = 0x24
+ *   → bytes: 0x80, 0x24
+ */
+const P256_MULTICODEC_PREFIX = new Uint8Array([0x80, 0x24]);
+
+/** Standard `did:key` scheme + multibase-z prefix. */
+const DID_KEY_PREFIX = "did:key:z";
+
+/**
+ * Generate a `did:key` DID from a P-256 SEC1-compressed public key.
+ *
+ * Steps (mirroring Rust's `generate_did_key_p256`):
+ *   1. Prepend the P-256 multicodec varint prefix `[0x80, 0x24]` to
+ *      the 33-byte compressed public key.
+ *   2. Encode the resulting 35 bytes as base58btc.
+ *   3. Prepend the multibase 'z' prefix and the `did:key:` scheme.
+ *
+ * @param pubkey SEC1-compressed P-256 public key (33 bytes; first byte
+ *               must be `0x02` or `0x03`).
+ * @returns `did:key:zDn…` formatted DID.
+ * @throws if the input is not 33 bytes or doesn't start with 0x02/0x03.
+ */
+export function generateDidKeyP256(pubkey: Uint8Array): string {
+  if (pubkey.byteLength !== 33) {
+    throw new Error(
+      `P-256 SEC1-compressed pubkey must be 33 bytes, got ${pubkey.byteLength}`,
+    );
+  }
+  const first = pubkey[0];
+  if (first !== 0x02 && first !== 0x03) {
+    throw new Error(
+      `P-256 SEC1-compressed point must start with 0x02 or 0x03, got 0x${first?.toString(16).padStart(2, "0")}`,
+    );
+  }
+
+  const buf = new Uint8Array(P256_MULTICODEC_PREFIX.byteLength + pubkey.byteLength);
+  buf.set(P256_MULTICODEC_PREFIX, 0);
+  buf.set(pubkey, P256_MULTICODEC_PREFIX.byteLength);
+
+  return `${DID_KEY_PREFIX}${base58btcEncode(buf)}`;
+}
+
+/**
+ * Resolve a P-256 `did:key` DID and return the SEC1-compressed pubkey.
+ *
+ * Strict — rejects any DID that's not P-256 (multicodec prefix
+ * mismatch). Use {@link verifyDidKeyP256} for a non-throwing check.
+ *
+ * @throws if the DID format is invalid, base58 decoding fails, the
+ *         multicodec prefix isn't P-256, or the inner key bytes aren't
+ *         a valid SEC1-compressed point.
+ */
+export function resolveDidKeyP256(did: string): Uint8Array {
+  if (!did.startsWith(DID_KEY_PREFIX)) {
+    throw new Error(`invalid did:key format (missing prefix): ${did}`);
+  }
+  const encoded = did.slice(DID_KEY_PREFIX.length);
+  const bytes = base58btcDecode(encoded);
+
+  if (bytes.byteLength < 2) {
+    throw new Error("decoded DID too short for multicodec prefix");
+  }
+  if (bytes[0] !== P256_MULTICODEC_PREFIX[0] || bytes[1] !== P256_MULTICODEC_PREFIX[1]) {
+    throw new Error(
+      `unknown multicodec prefix: [0x${bytes[0]?.toString(16).padStart(2, "0")}, 0x${bytes[1]?.toString(16).padStart(2, "0")}] (expected P-256 [0x80, 0x24])`,
+    );
+  }
+
+  const keyBytes = bytes.slice(2);
+  if (keyBytes.byteLength !== 33) {
+    throw new Error(
+      `P-256 SEC1-compressed public key must be 33 bytes, got ${keyBytes.byteLength}`,
+    );
+  }
+  if (keyBytes[0] !== 0x02 && keyBytes[0] !== 0x03) {
+    throw new Error(
+      `P-256 SEC1-compressed point must start with 0x02 or 0x03, got 0x${keyBytes[0]?.toString(16).padStart(2, "0")}`,
+    );
+  }
+  return keyBytes;
+}
+
+/**
+ * Verify that a `did:key` DID was derived from the given P-256 pubkey.
+ *
+ * Non-throwing — returns `false` for any mismatch (wrong format,
+ * wrong curve, wrong key bytes).
+ */
+export function verifyDidKeyP256(did: string, pubkey: Uint8Array): boolean {
+  try {
+    return generateDidKeyP256(pubkey) === did;
+  } catch {
+    return false;
+  }
+}
+
+// ── base58btc encoding ────────────────────────────────────────────────
+//
+// Hand-rolled to avoid pulling in a dedicated dep and to guarantee
+// byte-identical output to Rust's `bs58::encode`. Algorithm: standard
+// big-int base-256 → base-58 conversion with leading-zero preservation.
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+const BASE58_INDEX: Record<string, number> = (() => {
+  const out: Record<string, number> = {};
+  for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+    const ch = BASE58_ALPHABET[i];
+    if (ch !== undefined) out[ch] = i;
+  }
+  return out;
+})();
+
+/**
+ * Encode bytes as base58btc — Bitcoin/Multibase variant.
+ *
+ * Equivalent to Rust's `bs58::encode(bytes).into_string()`. Pure JS
+ * implementation so it works in browsers without subtle deps.
+ */
+function base58btcEncode(bytes: Uint8Array): string {
+  if (bytes.byteLength === 0) return "";
+
+  // Count leading zero bytes — they encode to leading '1's.
+  let zeros = 0;
+  while (zeros < bytes.byteLength && bytes[zeros] === 0) zeros++;
+
+  // Convert to base-58 by repeated division.
+  // We work with a copy of the input as a base-256 big-integer.
+  const buf = Array.from(bytes);
+  const out: number[] = [];
+  let start = zeros;
+  while (start < buf.length) {
+    let remainder = 0;
+    for (let i = start; i < buf.length; i++) {
+      const value = (buf[i] ?? 0) + remainder * 256;
+      buf[i] = Math.floor(value / 58);
+      remainder = value % 58;
+    }
+    out.push(remainder);
+    while (start < buf.length && buf[start] === 0) start++;
+  }
+
+  let str = "";
+  // Leading zeros → leading '1's.
+  for (let i = 0; i < zeros; i++) str += BASE58_ALPHABET[0];
+  // Remaining digits in MSB-first order.
+  for (let i = out.length - 1; i >= 0; i--) {
+    const digit = out[i] ?? 0;
+    str += BASE58_ALPHABET[digit];
+  }
+  return str;
+}
+
+/**
+ * Decode base58btc-encoded text to bytes.
+ *
+ * @throws if any character is outside the base58 alphabet.
+ */
+function base58btcDecode(text: string): Uint8Array {
+  if (text.length === 0) return new Uint8Array(0);
+
+  // Count leading '1's — they decode to leading zero bytes.
+  let zeros = 0;
+  while (zeros < text.length && text[zeros] === BASE58_ALPHABET[0]) zeros++;
+
+  // Convert from base-58 to base-256 (big-endian byte order in `out`).
+  const out: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === undefined) continue;
+    const value = BASE58_INDEX[ch];
+    if (value === undefined) {
+      throw new Error(`invalid base58 character: '${ch}'`);
+    }
+    let carry = value;
+    for (let j = 0; j < out.length; j++) {
+      const x = (out[j] ?? 0) * 58 + carry;
+      out[j] = x & 0xff;
+      carry = x >> 8;
+    }
+    while (carry > 0) {
+      out.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  // out is little-endian; reverse to big-endian + add leading zeros.
+  const bytes = new Uint8Array(zeros + out.length);
+  for (let i = 0; i < out.length; i++) {
+    bytes[zeros + i] = out[out.length - 1 - i] ?? 0;
+  }
+  return bytes;
+}

--- a/sdks/life-sdk-ts/src/anima/errors.ts
+++ b/sdks/life-sdk-ts/src/anima/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * `AnimaError` — typed errors for the browser custody surface.
+ *
+ * Mirrors Rust's `AnimaError` shape with a string `code` discriminator.
+ * Browser code paths surface these as causes of `LifeSdkError` when
+ * possible; standalone `AnimaError`s are thrown by the
+ * `passkey` / `did` / `web_crypto` modules where there's no SDK
+ * transport involved.
+ */
+
+import { LifeSdkError } from "../errors.js";
+
+export class AnimaError extends LifeSdkError {
+  constructor(code: string, message: string, options?: ErrorOptions) {
+    super(code, message, options);
+    this.name = "AnimaError";
+    Object.setPrototypeOf(this, AnimaError.prototype);
+  }
+
+  /** Convenience — the underlying passkey API rejected the operation. */
+  static passkey(message: string, cause?: unknown): AnimaError {
+    return new AnimaError("passkey_failure", message, cause ? { cause } : undefined);
+  }
+
+  /** Convenience — remote `/anima/custody/*` HTTP route returned an error. */
+  static remote(status: number, message: string): AnimaError {
+    return new AnimaError(`remote_anima_${status}`, message);
+  }
+
+  /** Convenience — operation isn't supported on this backend. */
+  static notSupported(message: string): AnimaError {
+    return new AnimaError("not_supported", message);
+  }
+
+  /** Convenience — local state precondition failed (e.g. not enrolled). */
+  static state(message: string): AnimaError {
+    return new AnimaError("invalid_state", message);
+  }
+
+  /** Convenience — a cryptographic primitive failed (parsing, sig, etc.). */
+  static crypto(message: string, cause?: unknown): AnimaError {
+    return new AnimaError("crypto", message, cause ? { cause } : undefined);
+  }
+}

--- a/sdks/life-sdk-ts/src/anima/index.ts
+++ b/sdks/life-sdk-ts/src/anima/index.ts
@@ -1,0 +1,81 @@
+/**
+ * `@broomva/life-sdk/anima` — browser custody surface.
+ *
+ * Spec D D-Sub-C entry point. Public exports:
+ *
+ *   Composition:
+ *     - {@link WebCryptoAnima}      — primary browser custody handle
+ *     - {@link enrollWebCryptoAnima} — first-time setup helper
+ *     - {@link loadWebCryptoAnima}  — subsequent-session helper
+ *
+ *   Building blocks:
+ *     - {@link PasskeyOracle}    — auth-half (P-256 passkey)
+ *     - {@link RemoteAnimaClient} — wallet-half delegate
+ *     - {@link SessionCap}        — Tier-User cap lifecycle
+ *
+ *   DID utilities (Spec D L4-D6):
+ *     - {@link generateDidKeyP256}
+ *     - {@link resolveDidKeyP256}
+ *     - {@link verifyDidKeyP256}
+ *
+ *   Errors:
+ *     - {@link AnimaError}
+ *
+ *   Types (mirroring Rust's `custody.rs`):
+ *     - {@link BackendKind}
+ *     - {@link TxRequest}
+ *     - {@link EvmSignature}
+ *     - {@link Eip712Domain}
+ *     - {@link DidRotationEvent}
+ *     - {@link AttestationObject}
+ *     - {@link Assertion}
+ *
+ * @see docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md
+ */
+
+export {
+  WebCryptoAnima,
+  type WebCryptoAnimaConfig,
+  enrollWebCryptoAnima,
+  loadWebCryptoAnima,
+} from "./web_crypto.js";
+
+export {
+  PasskeyOracle,
+  type PasskeyOracleConfig,
+  type PasskeyEnrollResult,
+  type PasskeyLoadResult,
+  type CredentialsContainerLike,
+  type PublicKeyCredentialLike,
+  type AuthenticatorAttestationResponseLike,
+  type AuthenticatorAssertionResponseLike,
+  parsePubkeyFromAttestation,
+  derSignatureToJoseRaw,
+} from "./passkey.js";
+
+export {
+  RemoteAnimaClient,
+  type RemoteAnimaClientConfig,
+  type EnrollPasskeyResult,
+  type MintSessionCapResult,
+} from "./remote.js";
+
+export { SessionCap, type SessionCapConfig } from "./session_cap.js";
+
+export {
+  generateDidKeyP256,
+  resolveDidKeyP256,
+  verifyDidKeyP256,
+} from "./did.js";
+
+export { AnimaError } from "./errors.js";
+
+export type {
+  BackendKind,
+  TxRequest,
+  EvmSignature,
+  Eip712Domain,
+  DidRotationEvent,
+  AttestationObject,
+  Assertion,
+} from "./types.js";

--- a/sdks/life-sdk-ts/src/anima/passkey.ts
+++ b/sdks/life-sdk-ts/src/anima/passkey.ts
@@ -85,9 +85,22 @@ export interface PasskeyOracleConfig {
    */
   credentials?: CredentialsContainerLike;
   /**
-   * Optional injection point for the IndexedDB DB factory — defaults
-   * to `globalThis.indexedDB`. Tests use `fake-indexeddb` to avoid
-   * a real-browser dependency.
+   * Availability-check override for the IndexedDB DB factory.
+   *
+   * I-3 review fix — clarify the actual semantics: the underlying
+   * `idb` package always reads `globalThis.indexedDB` directly (no
+   * way to inject a custom factory through `openDB`). This field
+   * therefore acts as a **validation hook** only — if you pass a
+   * non-`undefined` value the constructor will short-circuit the
+   * "is IDB available?" check and trust your caller's environment
+   * setup. Tests register `fake-indexeddb/auto` BEFORE constructing
+   * the oracle so `globalThis.indexedDB` is set; production callers
+   * should leave this `undefined`.
+   *
+   * If you need a fully custom IndexedDB backend (e.g. encrypted-at-
+   * rest storage in a service worker), DON'T pass it here — fork
+   * `PasskeyOracle` and replace the `openDb` / `persist` / `read`
+   * methods.
    */
   indexedDB?: IDBFactory;
   /**
@@ -183,15 +196,20 @@ export class PasskeyOracle {
     }
     this.credentials = credentials;
 
+    // I-3 review fix: explicit-only availability check. The `idb`
+    // package always reads `globalThis.indexedDB` directly — no
+    // factory injection — so we just confirm one is available
+    // (either supplied via cfg.indexedDB OR registered globally,
+    // e.g. via `fake-indexeddb/auto` in test setup).
     const idb = cfg.indexedDB ?? this.resolveIndexedDB();
     if (!idb) {
       throw AnimaError.state(
-        "PasskeyOracle: no IndexedDB available — pass `indexedDB` config (e.g. fake-indexeddb)",
+        "PasskeyOracle: no IndexedDB available — register one globally \
+         (e.g. `import 'fake-indexeddb/auto'` in tests, or run in a browser)",
       );
     }
-    // Set the global IDB factory so `idb`'s `openDB()` picks it up.
-    // Tests use `fake-indexeddb` which is registered as the global
-    // before any oracle is constructed.
+    // NB: openDb() reads `globalThis.indexedDB` regardless of what
+    // was supplied here. See the cfg.indexedDB doc-comment.
     this.databaseName = cfg.databaseName ?? PASSKEY_DB_NAME;
   }
 

--- a/sdks/life-sdk-ts/src/anima/passkey.ts
+++ b/sdks/life-sdk-ts/src/anima/passkey.ts
@@ -1,0 +1,794 @@
+/**
+ * `PasskeyOracle` — WebAuthn passkey custody for the auth half of
+ * `WebCryptoAnima` (Spec D D-Sub-C, "Browser path" §1-3).
+ *
+ * Wraps `navigator.credentials.create` (enrollment) and
+ * `navigator.credentials.get` (signing). The underlying CryptoKey is
+ * non-extractable per L4-D5 — we NEVER call `crypto.subtle.exportKey`,
+ * the key is OS-managed (Touch ID / Windows Hello / iCloud Keychain).
+ *
+ * IndexedDB is used to persist the credentialId across browser
+ * sessions. The cached SEC1-compressed pubkey is stored alongside so
+ * we can derive the user's DID without prompting the OS auth UI on
+ * every load.
+ *
+ * The DER-encoded ECDSA signature returned by WebAuthn is normalized
+ * to JOSE compact form (raw 64 bytes, `r||s`) per RFC 7515 + RFC 7518.
+ *
+ * @see Spec D §"Browser path (D-Sub-C in detail)"
+ * @see https://www.w3.org/TR/webauthn-3/
+ */
+
+import { decode as cborDecode } from "cbor-x";
+import { type IDBPDatabase, openDB } from "idb";
+import { AnimaError } from "./errors.js";
+
+/** Database name for the passkey credentialId cache. */
+const PASSKEY_DB_NAME = "broomva-anima-passkeys";
+/** Schema version. Bump if the record shape changes. */
+const PASSKEY_DB_VERSION = 1;
+/** Object store name within the DB. Keyed by `userId`. */
+const PASSKEY_STORE = "credentials";
+
+/**
+ * Stored passkey record — one per `userId`.
+ *
+ * `credentialId` is the opaque authenticator handle echoed back on
+ * subsequent sign requests; `pubkey` is the SEC1-compressed P-256
+ * point parsed once from the COSE_Key at enrollment time.
+ */
+interface StoredCredential {
+  /** Caller-supplied user id (e.g. Clerk user id). Primary key. */
+  userId: string;
+  /** Credential ID bytes — passed to `allowCredentials` on signing. */
+  credentialId: ArrayBuffer;
+  /** SEC1-compressed P-256 public key (33 bytes). */
+  pubkey: Uint8Array;
+  /** WebAuthn relying-party id this credential was enrolled against. */
+  rpId: string;
+  /** Wall-clock when the credential was enrolled (ISO-8601). */
+  createdAt: string;
+}
+
+/** Output of `PasskeyOracle.enroll`. */
+export interface PasskeyEnrollResult {
+  credentialId: ArrayBuffer;
+  attestationObject: Uint8Array;
+  clientDataJson: Uint8Array;
+  /** SEC1-compressed P-256 public key (33 bytes). */
+  pubkey: Uint8Array;
+}
+
+/** Output of `PasskeyOracle.load`. */
+export interface PasskeyLoadResult {
+  credentialId: ArrayBuffer;
+  /** SEC1-compressed P-256 public key (33 bytes). */
+  pubkey: Uint8Array;
+}
+
+/**
+ * Configuration for {@link PasskeyOracle}.
+ *
+ * The defaults target broomva.tech; consumers running embedded in a
+ * tenant deployment should override `rpId` + `rpName` to match their
+ * domain (WebAuthn relying-party id MUST be the suffix of `origin`).
+ */
+export interface PasskeyOracleConfig {
+  /** WebAuthn relying-party id (must be a suffix of the origin). */
+  rpId: string;
+  /** Human-readable RP name shown in the OS auth prompt. */
+  rpName: string;
+  /**
+   * Optional injection point for the WebAuthn API — defaults to
+   * `globalThis.navigator.credentials`. Tests override this with a
+   * deterministic mock; production paths leave this undefined.
+   */
+  credentials?: CredentialsContainerLike;
+  /**
+   * Optional injection point for the IndexedDB DB factory — defaults
+   * to `globalThis.indexedDB`. Tests use `fake-indexeddb` to avoid
+   * a real-browser dependency.
+   */
+  indexedDB?: IDBFactory;
+  /**
+   * Optional injection point for the database name. Tests can pass a
+   * unique name to isolate parallel test runs.
+   */
+  databaseName?: string;
+}
+
+/**
+ * Subset of `CredentialsContainer` we use. Defining a structural type
+ * lets tests mock the API without depending on lib.dom's heavyweight
+ * `PublicKeyCredential` shape.
+ */
+export interface CredentialsContainerLike {
+  create(options: { publicKey: PublicKeyCredentialCreationOptions }): Promise<PublicKeyCredentialLike | null>;
+  get(options: { publicKey: PublicKeyCredentialRequestOptions }): Promise<PublicKeyCredentialLike | null>;
+}
+
+/**
+ * Subset of `PublicKeyCredential` we read. Browser implementations
+ * carry many more fields; for SDK purposes we only need the minimum
+ * surface.
+ */
+export interface PublicKeyCredentialLike {
+  rawId: ArrayBuffer;
+  response:
+    | AuthenticatorAttestationResponseLike
+    | AuthenticatorAssertionResponseLike;
+}
+
+export interface AuthenticatorAttestationResponseLike {
+  clientDataJSON: ArrayBuffer;
+  attestationObject: ArrayBuffer;
+}
+
+export interface AuthenticatorAssertionResponseLike {
+  clientDataJSON: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  signature: ArrayBuffer;
+  userHandle?: ArrayBuffer | null;
+}
+
+// Discriminator helpers for the union response type.
+function isAttestationResponse(
+  resp: AuthenticatorAttestationResponseLike | AuthenticatorAssertionResponseLike,
+): resp is AuthenticatorAttestationResponseLike {
+  return "attestationObject" in resp;
+}
+
+function isAssertionResponse(
+  resp: AuthenticatorAttestationResponseLike | AuthenticatorAssertionResponseLike,
+): resp is AuthenticatorAssertionResponseLike {
+  return "signature" in resp && "authenticatorData" in resp;
+}
+
+/**
+ * `PasskeyOracle` — passkey-managed P-256 keypair custody.
+ *
+ * Lifecycle:
+ *   1. Construct with `rpId` + `rpName` (matching your origin).
+ *   2. Either `enroll(userId, displayName, challenge)` once OR
+ *      `load(userId)` to pick up a previously-enrolled credential.
+ *   3. Call `sign(digest)` to produce a 64-byte JOSE-compact ECDSA
+ *      signature over the supplied digest.
+ *
+ * Note: the WebAuthn `clientDataJSON.challenge` is the digest. The
+ * authenticator hashes (clientDataJSON || authenticatorData) with
+ * SHA-256 before signing, so the signed bytes are NOT exactly the
+ * caller's digest. Callers wanting a JWS over the digest itself must
+ * verify the chain (digest → clientDataJSON.challenge →
+ * authenticatorData → signature). For the SDK's purposes (signing the
+ * Tier-User cap mint challenge), this chain is exactly what lifegw's
+ * `/anima/custody/mint_session_cap` endpoint validates.
+ */
+export class PasskeyOracle {
+  private readonly cfg: PasskeyOracleConfig;
+  private readonly credentials: CredentialsContainerLike;
+  private readonly databaseName: string;
+
+  // In-memory cache populated by enroll() / load(). Cleared by reset().
+  private credentialId: ArrayBuffer | null = null;
+  private cachedPubkey: Uint8Array | null = null;
+  private cachedUserId: string | null = null;
+
+  constructor(cfg: PasskeyOracleConfig) {
+    this.cfg = cfg;
+    const credentials = cfg.credentials ?? this.resolveCredentials();
+    if (!credentials) {
+      throw AnimaError.state(
+        "PasskeyOracle: no WebAuthn API available — pass `credentials` config or run in a browser",
+      );
+    }
+    this.credentials = credentials;
+
+    const idb = cfg.indexedDB ?? this.resolveIndexedDB();
+    if (!idb) {
+      throw AnimaError.state(
+        "PasskeyOracle: no IndexedDB available — pass `indexedDB` config (e.g. fake-indexeddb)",
+      );
+    }
+    // Set the global IDB factory so `idb`'s `openDB()` picks it up.
+    // Tests use `fake-indexeddb` which is registered as the global
+    // before any oracle is constructed.
+    this.databaseName = cfg.databaseName ?? PASSKEY_DB_NAME;
+  }
+
+  /**
+   * First-time enrollment. Calls `navigator.credentials.create` with
+   * alg = -7 (ES256), parses the resulting attestation object to
+   * extract the COSE_Key public key, persists `(credentialId, pubkey)`
+   * to IndexedDB, and returns the raw bits for the caller to forward
+   * to `RemoteAnimaClient.enrollPasskey`.
+   *
+   * @param userId Caller-supplied user id (Clerk user id, etc.).
+   * @param displayName Human-readable name shown in the OS auth UI.
+   * @param challenge 32-byte challenge from lifegw's enrollment flow
+   *                  (typically a random nonce).
+   */
+  async enroll(
+    userId: string,
+    displayName: string,
+    challenge: Uint8Array,
+  ): Promise<PasskeyEnrollResult> {
+    if (challenge.byteLength < 16) {
+      throw AnimaError.state(`enroll challenge must be ≥ 16 bytes, got ${challenge.byteLength}`);
+    }
+
+    let credential: PublicKeyCredentialLike | null;
+    try {
+      credential = await this.credentials.create({
+        publicKey: {
+          challenge: cloneBuffer(challenge),
+          rp: { id: this.cfg.rpId, name: this.cfg.rpName },
+          user: {
+            id: new TextEncoder().encode(userId),
+            name: userId,
+            displayName,
+          },
+          pubKeyCredParams: [{ type: "public-key", alg: -7 /* ES256 */ }],
+          authenticatorSelection: {
+            // Resident key + user verification — passkey defaults.
+            residentKey: "preferred",
+            userVerification: "required",
+          },
+          attestation: "none",
+          timeout: 60_000,
+        },
+      });
+    } catch (err) {
+      throw AnimaError.passkey(
+        `WebAuthn create() failed: ${(err as Error).message}`,
+        err,
+      );
+    }
+    if (!credential) {
+      throw AnimaError.passkey("WebAuthn create() returned null");
+    }
+
+    const response = credential.response;
+    if (!isAttestationResponse(response)) {
+      throw AnimaError.passkey("expected attestation response, got assertion shape");
+    }
+
+    const attestationBytes = new Uint8Array(response.attestationObject);
+    const clientDataBytes = new Uint8Array(response.clientDataJSON);
+    const pubkey = parsePubkeyFromAttestation(attestationBytes);
+
+    // Persist for future sessions.
+    await this.persist({
+      userId,
+      credentialId: cloneBuffer(credential.rawId),
+      pubkey,
+      rpId: this.cfg.rpId,
+      createdAt: new Date().toISOString(),
+    });
+
+    // Hot path: cache in memory.
+    this.credentialId = cloneBuffer(credential.rawId);
+    this.cachedPubkey = pubkey;
+    this.cachedUserId = userId;
+
+    return {
+      credentialId: cloneBuffer(credential.rawId),
+      attestationObject: attestationBytes,
+      clientDataJson: clientDataBytes,
+      pubkey,
+    };
+  }
+
+  /**
+   * Subsequent sessions. Loads the cached `(credentialId, pubkey)`
+   * from IndexedDB and primes the in-memory cache.
+   *
+   * Returns `null` (NOT throws) if the user hasn't enrolled yet. The
+   * caller decides whether to call `enroll()` automatically or to ask
+   * the user to confirm enrollment (recommended).
+   */
+  async load(userId: string): Promise<PasskeyLoadResult | null> {
+    const stored = await this.read(userId);
+    if (!stored) return null;
+    if (stored.rpId !== this.cfg.rpId) {
+      throw AnimaError.state(
+        `passkey was enrolled against rpId="${stored.rpId}" but current oracle uses "${this.cfg.rpId}"`,
+      );
+    }
+    this.credentialId = cloneBuffer(stored.credentialId);
+    this.cachedPubkey = stored.pubkey;
+    this.cachedUserId = userId;
+    return {
+      credentialId: cloneBuffer(stored.credentialId),
+      pubkey: stored.pubkey,
+    };
+  }
+
+  /**
+   * Sign a 32-byte digest. Returns the IEEE-P1363 64-byte form (`r||s`,
+   * NO recovery byte) — same shape as Rust's
+   * `EcdsaP256Identity::sign_digest`.
+   *
+   * The challenge passed to `navigator.credentials.get` is the digest
+   * itself. The authenticator returns a DER-encoded ECDSA signature
+   * over `SHA-256(authenticatorData || SHA-256(clientDataJSON))`. This
+   * method returns the JOSE-compact form (raw 64 bytes) which
+   * downstream `verify_jws_with_pubkey` consumers expect.
+   *
+   * @param digest 32-byte challenge to sign.
+   */
+  async sign(digest: Uint8Array): Promise<Uint8Array> {
+    if (this.credentialId === null) {
+      throw AnimaError.state(
+        "PasskeyOracle.sign: no credential loaded — call enroll() or load() first",
+      );
+    }
+    if (digest.byteLength !== 32) {
+      throw AnimaError.state(`sign digest must be 32 bytes, got ${digest.byteLength}`);
+    }
+
+    let assertion: PublicKeyCredentialLike | null;
+    try {
+      assertion = await this.credentials.get({
+        publicKey: {
+          challenge: cloneBuffer(digest),
+          rpId: this.cfg.rpId,
+          allowCredentials: [
+            {
+              id: cloneBuffer(this.credentialId),
+              type: "public-key",
+            },
+          ],
+          userVerification: "required",
+          timeout: 60_000,
+        },
+      });
+    } catch (err) {
+      throw AnimaError.passkey(
+        `WebAuthn get() failed: ${(err as Error).message}`,
+        err,
+      );
+    }
+    if (!assertion) {
+      throw AnimaError.passkey("WebAuthn get() returned null");
+    }
+
+    const response = assertion.response;
+    if (!isAssertionResponse(response)) {
+      throw AnimaError.passkey("expected assertion response, got attestation shape");
+    }
+
+    return derSignatureToJoseRaw(new Uint8Array(response.signature));
+  }
+
+  /**
+   * Sign a digest and return the full WebAuthn assertion bundle. Used
+   * by `mintSessionCap` flows where lifegw needs to verify the
+   * signature against `clientDataJSON` + `authenticatorData` rather
+   * than the raw digest.
+   */
+  async signWithAssertion(digest: Uint8Array): Promise<{
+    signature: Uint8Array;
+    clientDataJson: Uint8Array;
+    authenticatorData: Uint8Array;
+    credentialId: ArrayBuffer;
+  }> {
+    if (this.credentialId === null) {
+      throw AnimaError.state(
+        "PasskeyOracle.sign: no credential loaded — call enroll() or load() first",
+      );
+    }
+    if (digest.byteLength !== 32) {
+      throw AnimaError.state(`sign digest must be 32 bytes, got ${digest.byteLength}`);
+    }
+
+    let assertion: PublicKeyCredentialLike | null;
+    try {
+      assertion = await this.credentials.get({
+        publicKey: {
+          challenge: cloneBuffer(digest),
+          rpId: this.cfg.rpId,
+          allowCredentials: [
+            {
+              id: cloneBuffer(this.credentialId),
+              type: "public-key",
+            },
+          ],
+          userVerification: "required",
+          timeout: 60_000,
+        },
+      });
+    } catch (err) {
+      throw AnimaError.passkey(
+        `WebAuthn get() failed: ${(err as Error).message}`,
+        err,
+      );
+    }
+    if (!assertion) {
+      throw AnimaError.passkey("WebAuthn get() returned null");
+    }
+
+    const response = assertion.response;
+    if (!isAssertionResponse(response)) {
+      throw AnimaError.passkey("expected assertion response, got attestation shape");
+    }
+
+    return {
+      signature: derSignatureToJoseRaw(new Uint8Array(response.signature)),
+      clientDataJson: new Uint8Array(response.clientDataJSON),
+      authenticatorData: new Uint8Array(response.authenticatorData),
+      credentialId: cloneBuffer(assertion.rawId),
+    };
+  }
+
+  /**
+   * Returns the SEC1-compressed P-256 pubkey loaded for the active
+   * credential.
+   *
+   * @throws if no credential has been enrolled or loaded yet.
+   */
+  pubkey(): Uint8Array {
+    if (this.cachedPubkey === null) {
+      throw AnimaError.state(
+        "PasskeyOracle.pubkey: no credential loaded — call enroll() or load() first",
+      );
+    }
+    return this.cachedPubkey;
+  }
+
+  /**
+   * The user id this oracle is bound to (set by `enroll` / `load`).
+   *
+   * @throws if no credential has been loaded yet.
+   */
+  userId(): string {
+    if (this.cachedUserId === null) {
+      throw AnimaError.state("PasskeyOracle.userId: no credential loaded");
+    }
+    return this.cachedUserId;
+  }
+
+  /**
+   * Drop the in-memory cache. Useful when the user logs out — the
+   * IndexedDB record persists so re-login picks the same credential.
+   */
+  reset(): void {
+    this.credentialId = null;
+    this.cachedPubkey = null;
+    this.cachedUserId = null;
+  }
+
+  /**
+   * Forget the credential entirely (in-memory + IndexedDB). After
+   * calling this the user must `enroll()` again on next login.
+   */
+  async forget(userId: string): Promise<void> {
+    const db = await this.openDb();
+    try {
+      const tx = db.transaction(PASSKEY_STORE, "readwrite");
+      await tx.store.delete(userId);
+      await tx.done;
+    } finally {
+      db.close();
+    }
+    if (this.cachedUserId === userId) this.reset();
+  }
+
+  // ── IndexedDB helpers ────────────────────────────────────────────
+
+  private async openDb(): Promise<IDBPDatabase<PasskeyDb>> {
+    const storeName = PASSKEY_STORE;
+    return openDB<PasskeyDb>(this.databaseName, PASSKEY_DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName, { keyPath: "userId" });
+        }
+      },
+      // openDB picks up the configured factory if one is registered as
+      // the global IDB; our test path injects via `globalThis.indexedDB`.
+    });
+  }
+
+  private async persist(record: StoredCredential): Promise<void> {
+    const db = await this.openDb();
+    try {
+      const tx = db.transaction(PASSKEY_STORE, "readwrite");
+      await tx.store.put(record);
+      await tx.done;
+    } finally {
+      db.close();
+    }
+  }
+
+  private async read(userId: string): Promise<StoredCredential | null> {
+    const db = await this.openDb();
+    try {
+      const tx = db.transaction(PASSKEY_STORE, "readonly");
+      const got = await tx.store.get(userId);
+      await tx.done;
+      return (got as StoredCredential | undefined) ?? null;
+    } finally {
+      db.close();
+    }
+  }
+
+  private resolveCredentials(): CredentialsContainerLike | null {
+    const nav = (globalThis as { navigator?: { credentials?: CredentialsContainerLike } })
+      .navigator;
+    return nav?.credentials ?? null;
+  }
+
+  private resolveIndexedDB(): IDBFactory | null {
+    const g = globalThis as unknown as { indexedDB?: IDBFactory };
+    return g.indexedDB ?? null;
+  }
+}
+
+interface PasskeyDb {
+  [PASSKEY_STORE]: {
+    key: string;
+    value: StoredCredential;
+  };
+}
+
+// ── COSE_Key parser ───────────────────────────────────────────────────
+
+/**
+ * Parse a SEC1-compressed P-256 public key out of a WebAuthn
+ * attestation object.
+ *
+ * The object shape (CBOR):
+ *   { fmt: <text>, attStmt: <map>, authData: <bytes> }
+ *
+ * `authData` is bit-flagged binary:
+ *   [rpIdHash 32][flags 1][signCount 4][attestedCredentialData?][extensions?]
+ *
+ * `attestedCredentialData` (present iff flags bit 6 is set):
+ *   [aaguid 16][credentialIdLen 2 BE][credentialId][credentialPublicKey CBOR]
+ *
+ * `credentialPublicKey` is COSE_Key:
+ *   { 1: 2 (kty=EC2), 3: -7 (alg=ES256), -1: 1 (crv=P-256),
+ *     -2: <x bytes 32>, -3: <y bytes 32> }
+ *
+ * We extract `(x, y)` and return the SEC1-compressed encoding:
+ *   [(0x02 if y even else 0x03)] || x   (33 bytes)
+ *
+ * @throws if any field is missing or malformed.
+ */
+export function parsePubkeyFromAttestation(attestationObject: Uint8Array): Uint8Array {
+  let outer: unknown;
+  try {
+    outer = cborDecode(attestationObject);
+  } catch (err) {
+    throw AnimaError.crypto(
+      `attestationObject CBOR decode failed: ${(err as Error).message}`,
+      err,
+    );
+  }
+  const authDataRaw = readAuthData(outer);
+
+  if (authDataRaw.byteLength < 37) {
+    throw AnimaError.crypto(
+      `authData too short (need 37+ bytes for header, got ${authDataRaw.byteLength})`,
+    );
+  }
+  const flags = authDataRaw[32]!;
+  const attestedCredentialDataPresent = (flags & 0x40) !== 0;
+  if (!attestedCredentialDataPresent) {
+    throw AnimaError.crypto("authData has no attestedCredentialData (AT flag clear)");
+  }
+
+  // Skip rpIdHash (32) + flags (1) + signCount (4) = 37 bytes.
+  let cursor = 37;
+  // attestedCredentialData = aaguid (16) + credentialIdLen (2 BE) + credentialId + credPubKey
+  if (authDataRaw.byteLength < cursor + 18) {
+    throw AnimaError.crypto("authData too short for attestedCredentialData header");
+  }
+  cursor += 16; // skip aaguid
+  const credIdLen = (authDataRaw[cursor]! << 8) | authDataRaw[cursor + 1]!;
+  cursor += 2;
+  if (authDataRaw.byteLength < cursor + credIdLen) {
+    throw AnimaError.crypto(
+      `authData short for credentialId (need ${credIdLen}, have ${authDataRaw.byteLength - cursor})`,
+    );
+  }
+  cursor += credIdLen; // skip credentialId
+
+  // Remaining bytes are the COSE_Key CBOR.
+  const coseBytes = authDataRaw.slice(cursor);
+  let cose: unknown;
+  try {
+    cose = cborDecode(coseBytes);
+  } catch (err) {
+    throw AnimaError.crypto(
+      `COSE_Key CBOR decode failed: ${(err as Error).message}`,
+      err,
+    );
+  }
+  return coseKeyToSec1(cose);
+}
+
+/** Read `authData` from a CBOR-decoded attestationObject. */
+function readAuthData(decoded: unknown): Uint8Array {
+  if (!isCborMap(decoded)) {
+    throw AnimaError.crypto("attestationObject is not a CBOR map");
+  }
+  const auth = mapGet(decoded, "authData");
+  if (auth === undefined) {
+    throw AnimaError.crypto("attestationObject missing authData");
+  }
+  if (auth instanceof Uint8Array) return auth;
+  if (auth instanceof ArrayBuffer) return new Uint8Array(auth);
+  if (Array.isArray(auth)) return new Uint8Array(auth as number[]);
+  throw AnimaError.crypto(`authData has unexpected type: ${typeof auth}`);
+}
+
+/** Convert a COSE_Key map to SEC1 compressed P-256 bytes. */
+function coseKeyToSec1(cose: unknown): Uint8Array {
+  if (!isCborMap(cose)) {
+    throw AnimaError.crypto("credentialPublicKey is not a CBOR map");
+  }
+  // Required: kty == 2 (EC2), alg == -7 (ES256), crv == 1 (P-256).
+  const kty = mapGet(cose, 1);
+  const alg = mapGet(cose, 3);
+  const crv = mapGet(cose, -1);
+  const x = mapGet(cose, -2);
+  const y = mapGet(cose, -3);
+
+  if (kty !== 2) {
+    throw AnimaError.crypto(`COSE_Key kty must be 2 (EC2), got ${String(kty)}`);
+  }
+  if (alg !== -7) {
+    throw AnimaError.crypto(`COSE_Key alg must be -7 (ES256), got ${String(alg)}`);
+  }
+  if (crv !== 1) {
+    throw AnimaError.crypto(`COSE_Key crv must be 1 (P-256), got ${String(crv)}`);
+  }
+  const xBytes = coerceBytes(x, "COSE_Key x");
+  const yBytes = coerceBytes(y, "COSE_Key y");
+
+  if (xBytes.byteLength !== 32) {
+    throw AnimaError.crypto(`COSE_Key x must be 32 bytes, got ${xBytes.byteLength}`);
+  }
+  if (yBytes.byteLength !== 32) {
+    throw AnimaError.crypto(`COSE_Key y must be 32 bytes, got ${yBytes.byteLength}`);
+  }
+
+  // SEC1 compressed: 0x02 if y even, 0x03 if y odd.
+  const yIsOdd = (yBytes[31]! & 0x01) === 0x01;
+  const out = new Uint8Array(33);
+  out[0] = yIsOdd ? 0x03 : 0x02;
+  out.set(xBytes, 1);
+  return out;
+}
+
+function coerceBytes(v: unknown, ctx: string): Uint8Array {
+  if (v instanceof Uint8Array) return v;
+  if (v instanceof ArrayBuffer) return new Uint8Array(v);
+  if (Array.isArray(v)) return new Uint8Array(v as number[]);
+  throw AnimaError.crypto(`${ctx} unexpected type: ${typeof v}`);
+}
+
+/** True if the value is a Map (cbor-x default for canonical maps) or a plain object. */
+function isCborMap(v: unknown): v is Map<unknown, unknown> | Record<string | number, unknown> {
+  return v instanceof Map || (typeof v === "object" && v !== null);
+}
+
+/** Read a value from either a Map or plain-object CBOR-decoded shape. */
+function mapGet(m: Map<unknown, unknown> | Record<string | number, unknown>, key: unknown): unknown {
+  if (m instanceof Map) return m.get(key);
+  return (m as Record<string | number, unknown>)[key as string | number];
+}
+
+// ── DER → JOSE-compact signature conversion ───────────────────────────
+
+/**
+ * Convert a DER-encoded ECDSA signature to JOSE-compact form
+ * (raw 64 bytes: r || s, each padded to 32 bytes big-endian, stripped
+ * of leading zero bytes inserted by ASN.1 INTEGER encoding).
+ *
+ * DER shape (RFC 3279):
+ *   30 <total_len> 02 <r_len> <r_bytes> 02 <s_len> <s_bytes>
+ *
+ * This is the inverse of what `p256::ecdsa::Signature::to_bytes`
+ * returns from the Rust side.
+ */
+export function derSignatureToJoseRaw(der: Uint8Array): Uint8Array {
+  if (der.byteLength < 8 || der[0] !== 0x30) {
+    throw AnimaError.crypto(
+      `DER signature: invalid SEQUENCE tag at offset 0 (got 0x${der[0]?.toString(16) ?? "??"})`,
+    );
+  }
+  let cursor = 1;
+  // Total length — handle short or long-form. For ECDSA P-256 sigs
+  // the total payload is < 128 bytes so short-form is universal, but
+  // we allow long-form to be safe.
+  cursor = skipDerLength(der, cursor).cursor;
+
+  // r INTEGER
+  if (der[cursor] !== 0x02) {
+    throw AnimaError.crypto(
+      `DER signature: expected INTEGER tag for r at offset ${cursor}`,
+    );
+  }
+  cursor++;
+  const rLen = readDerLength(der, cursor);
+  cursor = rLen.cursor;
+  let rBytes = der.slice(cursor, cursor + rLen.length);
+  cursor += rLen.length;
+
+  // s INTEGER
+  if (der[cursor] !== 0x02) {
+    throw AnimaError.crypto(
+      `DER signature: expected INTEGER tag for s at offset ${cursor}`,
+    );
+  }
+  cursor++;
+  const sLen = readDerLength(der, cursor);
+  cursor = sLen.cursor;
+  let sBytes = der.slice(cursor, cursor + sLen.length);
+
+  // ASN.1 INTEGER may have a leading 0x00 byte to disambiguate sign;
+  // strip it for raw form.
+  const rTrimmed = stripLeadingZero(rBytes);
+  const sTrimmed = stripLeadingZero(sBytes);
+
+  if (rTrimmed.byteLength > 32 || sTrimmed.byteLength > 32) {
+    throw AnimaError.crypto(
+      `DER signature: r/s longer than 32 bytes after sign-strip (r=${rTrimmed.byteLength}, s=${sTrimmed.byteLength})`,
+    );
+  }
+
+  // Pad to 32 bytes big-endian.
+  const out = new Uint8Array(64);
+  out.set(rTrimmed, 32 - rTrimmed.byteLength);
+  out.set(sTrimmed, 64 - sTrimmed.byteLength);
+  return out;
+}
+
+function stripLeadingZero(b: Uint8Array): Uint8Array {
+  if (b.byteLength > 0 && b[0] === 0x00) {
+    const tail = new Uint8Array(b.byteLength - 1);
+    tail.set(b.subarray(1));
+    return tail;
+  }
+  return b;
+}
+
+function readDerLength(buf: Uint8Array, cursor: number): { cursor: number; length: number } {
+  const first = buf[cursor];
+  if (first === undefined) {
+    throw AnimaError.crypto(`DER length: unexpected EOF at offset ${cursor}`);
+  }
+  if ((first & 0x80) === 0) {
+    return { cursor: cursor + 1, length: first };
+  }
+  const numBytes = first & 0x7f;
+  if (numBytes > 4) {
+    throw AnimaError.crypto(`DER length: long-form too wide (${numBytes} bytes)`);
+  }
+  let length = 0;
+  for (let i = 0; i < numBytes; i++) {
+    const b = buf[cursor + 1 + i];
+    if (b === undefined) {
+      throw AnimaError.crypto(`DER length: unexpected EOF in long-form at offset ${cursor + 1 + i}`);
+    }
+    length = (length << 8) | b;
+  }
+  return { cursor: cursor + 1 + numBytes, length };
+}
+
+function skipDerLength(buf: Uint8Array, cursor: number): { cursor: number; length: number } {
+  return readDerLength(buf, cursor);
+}
+
+// ── ArrayBuffer/Uint8Array helper ─────────────────────────────────────
+
+function cloneBuffer(input: ArrayBuffer | Uint8Array): ArrayBuffer {
+  if (input instanceof ArrayBuffer) {
+    return input.slice(0);
+  }
+  // Uint8Array — copy into a fresh ArrayBuffer of the exact byte length.
+  const out = new ArrayBuffer(input.byteLength);
+  new Uint8Array(out).set(input);
+  return out;
+}

--- a/sdks/life-sdk-ts/src/anima/remote.ts
+++ b/sdks/life-sdk-ts/src/anima/remote.ts
@@ -7,8 +7,8 @@
  *
  *   POST /anima/custody/sign_auth        { user_id, digest_b64 }
  *   POST /anima/custody/sign_wallet      { user_id, digest_b64 }
- *   GET  /anima/custody/auth_pubkey/:uid
- *   GET  /anima/custody/wallet_pubkey/:uid
+ *   GET  /anima/custody/get_auth_pubkey/:uid
+ *   GET  /anima/custody/get_wallet_pubkey/:uid
  *   POST /anima/custody/mint_session_cap { user_id, attestation, assertion }
  *   POST /anima/custody/enroll_passkey   { user_id, attestation, client_data }
  *
@@ -49,7 +49,30 @@ export interface RemoteAnimaClientConfig {
    * production code lets it default to `globalThis.fetch`).
    */
   fetch?: typeof fetch;
+  /**
+   * I-2 review fix: per-request timeout in milliseconds. A hung
+   * lifegw shouldn't block the browser indefinitely — bare `fetch`
+   * has no built-in timeout. Defaults to 30 000 (30s); tune up for
+   * slow upstream KMS providers, down for tighter UX. Set to `0` to
+   * disable (NOT recommended in production).
+   */
+  requestTimeoutMs?: number;
 }
+
+/**
+ * Default per-request timeout (30 s) — used when
+ * `RemoteAnimaClientConfig.requestTimeoutMs` is unset.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Maximum number of characters of an upstream HTTP error body that
+ * `RemoteAnimaClient` includes in `AnimaError.message`. I-1 review fix:
+ * lifegw error bodies often echo back JWT claims / `request_id` /
+ * upstream error blobs that leak under devtools, in stack traces shipped
+ * to Sentry, or on uncaught-promise reports. Truncate aggressively.
+ */
+const MAX_REMOTE_ERROR_BODY_CHARS = 200;
 
 /** Returned by `enrollPasskey`. */
 export interface EnrollPasskeyResult {
@@ -86,11 +109,34 @@ export class RemoteAnimaClient {
   readonly baseUrl: string;
   private readonly fetchFn: typeof fetch;
   private readonly getToken: () => Promise<string>;
+  private readonly requestTimeoutMs: number;
 
   constructor(cfg: RemoteAnimaClientConfig) {
     this.baseUrl = cfg.baseUrl.replace(/\/+$/, "");
     this.fetchFn = cfg.fetch ?? globalThis.fetch.bind(globalThis);
     this.getToken = cfg.getToken;
+    this.requestTimeoutMs =
+      cfg.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  /**
+   * Build an `AbortSignal` that fires after `requestTimeoutMs` if the
+   * timeout is positive. Returns `undefined` when the timeout is `0`
+   * (caller explicitly opted out). I-2 review fix.
+   */
+  private buildTimeoutSignal(): AbortSignal | undefined {
+    if (this.requestTimeoutMs <= 0) return undefined;
+    // `AbortSignal.timeout` is widely supported (Chrome 103+, FF 100+,
+    // Safari 16+, Node 17.3+). We need it for browser custody and Node
+    // tests; the fake-fetch shim in tests ignores `signal` so this
+    // remains harmless there.
+    if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+      return AbortSignal.timeout(this.requestTimeoutMs);
+    }
+    // Fallback for ancient runtimes — manual controller + setTimeout.
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), this.requestTimeoutMs);
+    return ctrl.signal;
   }
 
   // ── auth half (P-256) ─────────────────────────────────────────────
@@ -117,7 +163,7 @@ export class RemoteAnimaClient {
    */
   async getAuthPubkey(userId: string): Promise<Uint8Array> {
     const json = await this.getJson<{ pubkey_b64: string }>(
-      `/anima/custody/auth_pubkey/${encodeURIComponent(userId)}`,
+      `/anima/custody/get_auth_pubkey/${encodeURIComponent(userId)}`,
     );
     return b64ToBytes(json.pubkey_b64);
   }
@@ -208,7 +254,7 @@ export class RemoteAnimaClient {
    */
   async getWalletPubkey(userId: string): Promise<Uint8Array> {
     const json = await this.getJson<{ pubkey_b64: string }>(
-      `/anima/custody/wallet_pubkey/${encodeURIComponent(userId)}`,
+      `/anima/custody/get_wallet_pubkey/${encodeURIComponent(userId)}`,
     );
     return b64ToBytes(json.pubkey_b64);
   }
@@ -329,12 +375,10 @@ export class RemoteAnimaClient {
         method: "POST",
         headers,
         body: JSON.stringify(body),
+        signal: this.buildTimeoutSignal(),
       });
     } catch (err) {
-      throw AnimaError.remote(
-        0,
-        `fetch failed for ${path}: ${(err as Error).message}`,
-      );
+      throw mapFetchFailure(path, err);
     }
     return await this.parseResponse<T>(path, resp);
   }
@@ -349,12 +393,10 @@ export class RemoteAnimaClient {
       resp = await this.fetchFn(`${this.baseUrl}${path}`, {
         method: "GET",
         headers,
+        signal: this.buildTimeoutSignal(),
       });
     } catch (err) {
-      throw AnimaError.remote(
-        0,
-        `fetch failed for ${path}: ${(err as Error).message}`,
-      );
+      throw mapFetchFailure(path, err);
     }
     return await this.parseResponse<T>(path, resp);
   }
@@ -362,8 +404,14 @@ export class RemoteAnimaClient {
   private async parseResponse<T>(path: string, resp: Response): Promise<T> {
     const text = await resp.text();
     if (!resp.ok) {
-      const message = text || resp.statusText || `HTTP ${resp.status}`;
-      throw AnimaError.remote(resp.status, `${path}: ${message}`);
+      // I-1 review fix: lifegw error bodies often echo back JWT
+      // claims, request IDs, or upstream KMS error blobs. Truncate
+      // aggressively so the error string never leaks an entire
+      // upstream payload into devtools / Sentry / uncaught-promise
+      // reports. Prefer parsed `{ code, message }` JSON shape when
+      // present; fall back to a length-capped raw string.
+      const safeBody = sanitizeErrorBody(text, resp.statusText, resp.status);
+      throw AnimaError.remote(resp.status, `${path}: ${safeBody}`);
     }
     if (!text) return {} as T;
     try {
@@ -407,4 +455,52 @@ function b64ToBytes(b64: string): Uint8Array {
   };
   if (g.Buffer) return new Uint8Array(g.Buffer.from(padded, "base64"));
   throw AnimaError.crypto("no base64 decoder available");
+}
+
+/**
+ * I-1 review fix: turn an upstream error body into a length-capped,
+ * leak-resistant message. If the body parses as JSON with `{ code,
+ * message }` shape, prefer those fields and drop everything else
+ * (avoids accidentally surfacing JWT claims / request IDs / upstream
+ * KMS errors). Otherwise truncate to `MAX_REMOTE_ERROR_BODY_CHARS`.
+ */
+function sanitizeErrorBody(
+  body: string,
+  statusText: string,
+  status: number,
+): string {
+  if (!body) return statusText || `HTTP ${status}`;
+  // Try to extract a structured `{ code, message }` shape — these are
+  // safe by convention (lifegw doesn't put PII in `code`/`message`).
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    const code = typeof parsed.code === "string" ? parsed.code : undefined;
+    const msg = typeof parsed.message === "string" ? parsed.message : undefined;
+    if (code && msg) return `${code}: ${truncate(msg, MAX_REMOTE_ERROR_BODY_CHARS)}`;
+    if (code) return code;
+    if (msg) return truncate(msg, MAX_REMOTE_ERROR_BODY_CHARS);
+  } catch {
+    // Not JSON — fall through to raw truncation.
+  }
+  return truncate(body, MAX_REMOTE_ERROR_BODY_CHARS);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+/**
+ * I-2 review fix: convert a `fetch`-rejection error into a typed
+ * `AnimaError.remote`, distinguishing timeouts (AbortError /
+ * TimeoutError) from generic transport failures. Useful for callers
+ * that want to retry only on timeouts.
+ */
+function mapFetchFailure(path: string, err: unknown): AnimaError {
+  const e = err as { name?: string; message?: string };
+  const name = e?.name ?? "";
+  const message = e?.message ?? String(err);
+  if (name === "TimeoutError" || name === "AbortError") {
+    return AnimaError.remote(0, `request timeout for ${path}`);
+  }
+  return AnimaError.remote(0, `fetch failed for ${path}: ${message}`);
 }

--- a/sdks/life-sdk-ts/src/anima/remote.ts
+++ b/sdks/life-sdk-ts/src/anima/remote.ts
@@ -1,0 +1,410 @@
+/**
+ * `RemoteAnimaClient` — HTTP client for lifegw's `/anima/custody/*`
+ * routes.
+ *
+ * Spec D D-Sub-C ground truth (Stream R ships these routes in
+ * parallel):
+ *
+ *   POST /anima/custody/sign_auth        { user_id, digest_b64 }
+ *   POST /anima/custody/sign_wallet      { user_id, digest_b64 }
+ *   GET  /anima/custody/auth_pubkey/:uid
+ *   GET  /anima/custody/wallet_pubkey/:uid
+ *   POST /anima/custody/mint_session_cap { user_id, attestation, assertion }
+ *   POST /anima/custody/enroll_passkey   { user_id, attestation, client_data }
+ *
+ * Locked architectural decision (HTTP/JSON, NOT gRPC-web): keeping
+ * custody RPC code separate from the existing tonic-web SDK paths
+ * sidesteps M8.1 (Connect-vs-grpc-web mismatch). Custody calls land
+ * regardless of M8.1's status — they're plain `fetch` to JSON
+ * endpoints with bearer-token auth.
+ *
+ * The wallet half delegates to a server-side anima daemon (Spec D
+ * §"Backend matrix" — `RemoteAnima` row) that holds secp256k1 in
+ * `VaultTransitAnima`. The browser-side `WebCryptoAnima` composes
+ * with this client; from the chain's perspective the signature is
+ * still EOA-flavored.
+ */
+
+import { AnimaError } from "./errors.js";
+import type { Eip712Domain, EvmSignature, TxRequest } from "./types.js";
+
+/**
+ * Configuration for {@link RemoteAnimaClient}.
+ */
+export interface RemoteAnimaClientConfig {
+  /**
+   * lifegw HTTPS endpoint, e.g. `https://api.life.dev`. Trailing
+   * slashes are normalized away.
+   *
+   * Spec C₃ §5.1 — TLS 1.3 mandatory.
+   */
+  baseUrl: string;
+  /**
+   * Async producer for the Tier-User cap JWT — typically a
+   * `SessionCap.getValidToken` function. Called on every RPC.
+   */
+  getToken: () => Promise<string>;
+  /**
+   * Optional `fetch` override (tests inject a deterministic shim;
+   * production code lets it default to `globalThis.fetch`).
+   */
+  fetch?: typeof fetch;
+}
+
+/** Returned by `enrollPasskey`. */
+export interface EnrollPasskeyResult {
+  /** Server-issued user DID after enrollment (`did:key:zDn…`). */
+  userDid: string;
+  /**
+   * Wallet address the server resolved/minted for this user. Browser
+   * custody uses this on every `signEvmTx` call as the `from` address
+   * sanity check.
+   */
+  walletAddress: string;
+  /** SEC1-compressed secp256k1 wallet pubkey (33 bytes). */
+  walletPubkey: Uint8Array;
+}
+
+/** Returned by `mintSessionCap`. */
+export interface MintSessionCapResult {
+  /** Tier-User capability JWT (ES256 over the user's auth key). */
+  token: string;
+  /** Unix-seconds expiry from the JWT `exp` claim. */
+  expiresAt: number;
+  /** Wall-clock issued-at (Unix seconds) from the JWT `iat` claim. */
+  issuedAt: number;
+}
+
+/**
+ * Thin `fetch` wrapper for lifegw's HTTP `/anima/custody/*` surface.
+ *
+ * One instance per origin; safe to share across an app. Uses
+ * `getToken` to refresh the bearer on every call, so callers can wire
+ * a `SessionCap` in front to centralise mint + refresh.
+ */
+export class RemoteAnimaClient {
+  readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly getToken: () => Promise<string>;
+
+  constructor(cfg: RemoteAnimaClientConfig) {
+    this.baseUrl = cfg.baseUrl.replace(/\/+$/, "");
+    this.fetchFn = cfg.fetch ?? globalThis.fetch.bind(globalThis);
+    this.getToken = cfg.getToken;
+  }
+
+  // ── auth half (P-256) ─────────────────────────────────────────────
+
+  /**
+   * Forward a digest to the server-side anima for the auth-half
+   * signature. Used internally by `WebCryptoAnima.signJws` only when
+   * the browser is running in a delegated-auth shape (rare).
+   */
+  async signAuth(userId: string, digest: Uint8Array): Promise<Uint8Array> {
+    const json = await this.postJson<{ signature_b64: string }>(
+      "/anima/custody/sign_auth",
+      {
+        user_id: userId,
+        digest_b64: bytesToB64(digest),
+      },
+    );
+    return b64ToBytes(json.signature_b64);
+  }
+
+  /**
+   * SEC1-compressed P-256 auth pubkey for the given user. Cached by
+   * `WebCryptoAnima` at construction time.
+   */
+  async getAuthPubkey(userId: string): Promise<Uint8Array> {
+    const json = await this.getJson<{ pubkey_b64: string }>(
+      `/anima/custody/auth_pubkey/${encodeURIComponent(userId)}`,
+    );
+    return b64ToBytes(json.pubkey_b64);
+  }
+
+  // ── wallet half (secp256k1) ───────────────────────────────────────
+
+  /**
+   * Forward a 32-byte digest for the wallet-half signature. The
+   * server applies the signing key (Vault Transit secp256k1) and
+   * returns the 65-byte `r||s||v` recoverable signature.
+   *
+   * Used by `WebCryptoAnima.signEvmTx` and `signEip712`.
+   */
+  async signWallet(userId: string, digest: Uint8Array): Promise<Uint8Array> {
+    const json = await this.postJson<{ signature_b64: string }>(
+      "/anima/custody/sign_wallet",
+      {
+        user_id: userId,
+        digest_b64: bytesToB64(digest),
+      },
+    );
+    return b64ToBytes(json.signature_b64);
+  }
+
+  /**
+   * Forward an EIP-1559 transaction request. The server computes the
+   * keccak256 RLP digest server-side (so we don't have to ship a
+   * keccak implementation in the SDK) and signs it.
+   *
+   * Returns the 65-byte `r||s||v` legacy recoverable signature
+   * (`v ∈ {27, 28}`) — same shape as Rust's `EvmSignature.bytes`.
+   */
+  async signEvmTx(userId: string, tx: TxRequest): Promise<EvmSignature> {
+    const json = await this.postJson<{ signature_b64: string }>(
+      "/anima/custody/sign_evm_tx",
+      {
+        user_id: userId,
+        tx: {
+          from: tx.from,
+          to: tx.to,
+          value_wei: tx.valueWei,
+          data_hex: tx.dataHex,
+          nonce: tx.nonce,
+          gas_limit: tx.gasLimit,
+          max_fee_per_gas_wei: tx.maxFeePerGasWei,
+          max_priority_fee_per_gas_wei: tx.maxPriorityFeePerGasWei,
+          chain: tx.chain,
+        },
+      },
+    );
+    return { bytes: b64ToBytes(json.signature_b64) };
+  }
+
+  /**
+   * Forward an EIP-712 typed-data signing request (used for x402 +
+   * USDC `transferWithAuthorization`).
+   *
+   * `types` and `message` are passed through opaquely as JSON; lifegw
+   * runs the canonical EIP-712 encoder server-side.
+   */
+  async signEip712(
+    userId: string,
+    domain: Eip712Domain,
+    types: Record<string, unknown>,
+    message: Record<string, unknown>,
+  ): Promise<EvmSignature> {
+    const json = await this.postJson<{ signature_b64: string }>(
+      "/anima/custody/sign_eip712",
+      {
+        user_id: userId,
+        domain: {
+          name: domain.name,
+          version: domain.version,
+          chain_id: domain.chainId,
+          verifying_contract: domain.verifyingContract,
+        },
+        types,
+        message,
+      },
+    );
+    return { bytes: b64ToBytes(json.signature_b64) };
+  }
+
+  /**
+   * SEC1-compressed secp256k1 wallet pubkey for the given user.
+   * Cached by `WebCryptoAnima` at construction time so we don't
+   * re-fetch it on every `signEvmTx`.
+   */
+  async getWalletPubkey(userId: string): Promise<Uint8Array> {
+    const json = await this.getJson<{ pubkey_b64: string }>(
+      `/anima/custody/wallet_pubkey/${encodeURIComponent(userId)}`,
+    );
+    return b64ToBytes(json.pubkey_b64);
+  }
+
+  /**
+   * Resolve the user's wallet address — `0x…` hex for Ethereum, may be
+   * a chain-specific shape for non-EVM in the future.
+   */
+  async getWalletAddress(userId: string): Promise<string> {
+    const json = await this.getJson<{ address: string }>(
+      `/anima/custody/wallet_address/${encodeURIComponent(userId)}`,
+    );
+    return json.address;
+  }
+
+  // ── lifecycle ─────────────────────────────────────────────────────
+
+  /**
+   * One-shot enrollment: send the WebAuthn attestation to lifegw which
+   * provisions per-user Vault keys (or returns existing keys if the
+   * user already has them) and returns the user's DID + wallet
+   * address.
+   */
+  async enrollPasskey(
+    userId: string,
+    params: {
+      attestationObject: Uint8Array;
+      clientDataJson: Uint8Array;
+      credentialId: ArrayBuffer;
+    },
+  ): Promise<EnrollPasskeyResult> {
+    const json = await this.postJson<{
+      user_did: string;
+      wallet_address: string;
+      wallet_pubkey_b64: string;
+    }>("/anima/custody/enroll_passkey", {
+      user_id: userId,
+      attestation_object_b64: bytesToB64(params.attestationObject),
+      client_data_json_b64: bytesToB64(params.clientDataJson),
+      credential_id_b64: bytesToB64(new Uint8Array(params.credentialId)),
+    });
+    return {
+      userDid: json.user_did,
+      walletAddress: json.wallet_address,
+      walletPubkey: b64ToBytes(json.wallet_pubkey_b64),
+    };
+  }
+
+  /**
+   * Mint a Tier-User capability JWT. Spec D §"Browser path" §5
+   * — one passkey-mediated handshake per session mints a short-lived
+   * cap that authorizes subsequent RPCs without re-prompting the OS
+   * UI. Default TTL 15 minutes.
+   *
+   * `attestationObject` is sent on the FIRST mint after enrollment
+   * (verified server-side against the credentialId). Subsequent mints
+   * within the cap's lifetime omit it.
+   */
+  async mintSessionCap(
+    userId: string,
+    params: {
+      assertion: {
+        signature: Uint8Array;
+        clientDataJson: Uint8Array;
+        authenticatorData: Uint8Array;
+        credentialId: ArrayBuffer;
+      };
+    },
+    bearerOverride?: string,
+  ): Promise<MintSessionCapResult> {
+    const body: Record<string, unknown> = {
+      user_id: userId,
+      assertion: {
+        signature_b64: bytesToB64(params.assertion.signature),
+        client_data_json_b64: bytesToB64(params.assertion.clientDataJson),
+        authenticator_data_b64: bytesToB64(params.assertion.authenticatorData),
+        credential_id_b64: bytesToB64(new Uint8Array(params.assertion.credentialId)),
+      },
+    };
+
+    // The mint endpoint is reachable both with the existing cap (for
+    // refresh) and pre-cap (using a one-shot enrollment cookie or a
+    // public mint endpoint). Callers that have just enrolled and don't
+    // yet have a cap pass `bearerOverride: ""` to skip the bearer.
+    const json = await this.postJsonWithExplicitToken<{
+      token: string;
+      expires_at: number;
+      issued_at: number;
+    }>("/anima/custody/mint_session_cap", body, bearerOverride);
+
+    return {
+      token: json.token,
+      expiresAt: json.expires_at,
+      issuedAt: json.issued_at,
+    };
+  }
+
+  // ── HTTP plumbing ─────────────────────────────────────────────────
+
+  private async postJson<T>(path: string, body: unknown): Promise<T> {
+    const token = await this.getToken();
+    return this.postJsonWithExplicitToken<T>(path, body, token);
+  }
+
+  private async postJsonWithExplicitToken<T>(
+    path: string,
+    body: unknown,
+    token: string | undefined,
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    let resp: Response;
+    try {
+      resp = await this.fetchFn(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw AnimaError.remote(
+        0,
+        `fetch failed for ${path}: ${(err as Error).message}`,
+      );
+    }
+    return await this.parseResponse<T>(path, resp);
+  }
+
+  private async getJson<T>(path: string): Promise<T> {
+    const token = await this.getToken();
+    const headers: Record<string, string> = {};
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    let resp: Response;
+    try {
+      resp = await this.fetchFn(`${this.baseUrl}${path}`, {
+        method: "GET",
+        headers,
+      });
+    } catch (err) {
+      throw AnimaError.remote(
+        0,
+        `fetch failed for ${path}: ${(err as Error).message}`,
+      );
+    }
+    return await this.parseResponse<T>(path, resp);
+  }
+
+  private async parseResponse<T>(path: string, resp: Response): Promise<T> {
+    const text = await resp.text();
+    if (!resp.ok) {
+      const message = text || resp.statusText || `HTTP ${resp.status}`;
+      throw AnimaError.remote(resp.status, `${path}: ${message}`);
+    }
+    if (!text) return {} as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch (err) {
+      throw AnimaError.crypto(
+        `malformed JSON from ${path}: ${(err as Error).message}`,
+        err,
+      );
+    }
+  }
+}
+
+// ── base64 helpers (mirror codec.ts but kept local to avoid coupling) ─
+
+function bytesToB64(bytes: Uint8Array): string {
+  if (typeof btoa === "function") {
+    let bin = "";
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+    return btoa(bin);
+  }
+  const g = globalThis as unknown as {
+    Buffer?: { from(b: Uint8Array): { toString(enc: string): string } };
+  };
+  if (g.Buffer) return g.Buffer.from(bytes).toString("base64");
+  throw AnimaError.crypto("no base64 encoder available");
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  // Accept both standard and URL-safe variants for forward-compat.
+  const normalized = b64.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "===".slice((normalized.length + 3) % 4);
+  if (typeof atob === "function") {
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+  const g = globalThis as unknown as {
+    Buffer?: { from(s: string, enc: string): Uint8Array };
+  };
+  if (g.Buffer) return new Uint8Array(g.Buffer.from(padded, "base64"));
+  throw AnimaError.crypto("no base64 decoder available");
+}

--- a/sdks/life-sdk-ts/src/anima/session_cap.ts
+++ b/sdks/life-sdk-ts/src/anima/session_cap.ts
@@ -1,0 +1,207 @@
+/**
+ * `SessionCap` — Tier-User capability JWT lifecycle manager.
+ *
+ * Spec D §"Browser path (D-Sub-C in detail)" §5: "One passkey-mediated
+ * handshake per browser session mints a short-lived in-memory
+ * Tier-User capability that authorizes subsequent signing requests
+ * against an in-tab signing oracle, so the user isn't prompted on
+ * every JWT mint. Default TTL: 15 minutes."
+ *
+ * Stored in-memory ONLY — IndexedDB persistence is too long-lived for
+ * the threat model. If the user closes the tab and reopens, they
+ * complete a fresh passkey handshake to mint a new cap.
+ *
+ * Lifecycle:
+ *   - On `getValidToken()`, check if the cached token has > 30s
+ *     remaining. If yes, return cached.
+ *   - Otherwise, mint a fresh cap by:
+ *       1. Drawing a 32-byte random challenge from the lifegw mint
+ *          endpoint (or a deterministic local nonce + timestamp shape).
+ *       2. Calling `passkey.signWithAssertion(challenge)`.
+ *       3. POSTing the assertion to `/anima/custody/mint_session_cap`.
+ *       4. Caching the returned JWT + `expires_at`.
+ *
+ * Tracks the lifegw Tier-2 pattern from M7 Sub-phase B/C.
+ */
+
+import { AnimaError } from "./errors.js";
+import type { PasskeyOracle } from "./passkey.js";
+import type { RemoteAnimaClient } from "./remote.js";
+
+/** Default refresh threshold — refresh when token has < this many seconds left. */
+const DEFAULT_REFRESH_BEFORE_SECS = 30;
+
+/**
+ * Configuration for {@link SessionCap}.
+ */
+export interface SessionCapConfig {
+  /** User id this cap is bound to. */
+  userId: string;
+  /** Passkey oracle used to sign the mint challenge. */
+  passkey: PasskeyOracle;
+  /** Remote client used to POST the assertion. */
+  remote: RemoteAnimaClient;
+  /**
+   * Optional callback fired when a refresh is imminent (within
+   * `refreshBeforeSecs`). UIs can use this to show a "click to
+   * re-authenticate" prompt before the OS UI fires.
+   */
+  onExpiringSoon?: () => void;
+  /**
+   * Refresh when the token has fewer than this many seconds left.
+   * Default 30s.
+   */
+  refreshBeforeSecs?: number;
+  /**
+   * Optional injection point for the current time (Unix-seconds). Tests
+   * use this with vitest fake timers; production uses `Date.now()`.
+   */
+  now?: () => number;
+  /**
+   * Optional injection point for the random challenge. Defaults to a
+   * 32-byte `crypto.getRandomValues`. Tests pin this to a deterministic
+   * fixture so the test for the assertion shape is reproducible.
+   */
+  randomChallenge?: () => Uint8Array;
+}
+
+/**
+ * Cached cap state.
+ */
+interface CapState {
+  token: string;
+  expiresAt: number; // Unix seconds
+  issuedAt: number; // Unix seconds
+}
+
+/**
+ * In-memory Tier-User capability lifecycle manager.
+ *
+ * One instance per (user, origin). The `getValidToken()` method is
+ * the central entry point — pass it as `getToken` to
+ * `RemoteAnimaClient` to get auto-refresh on the hot path.
+ */
+export class SessionCap {
+  private readonly cfg: Required<
+    Pick<SessionCapConfig, "userId" | "passkey" | "remote" | "refreshBeforeSecs" | "now" | "randomChallenge">
+  > & { onExpiringSoon: (() => void) | undefined };
+
+  private state: CapState | null = null;
+  private inflight: Promise<string> | null = null;
+
+  constructor(cfg: SessionCapConfig) {
+    this.cfg = {
+      userId: cfg.userId,
+      passkey: cfg.passkey,
+      remote: cfg.remote,
+      refreshBeforeSecs: cfg.refreshBeforeSecs ?? DEFAULT_REFRESH_BEFORE_SECS,
+      onExpiringSoon: cfg.onExpiringSoon,
+      now: cfg.now ?? defaultNow,
+      randomChallenge: cfg.randomChallenge ?? defaultRandomChallenge,
+    };
+  }
+
+  /**
+   * Return a Tier-User cap JWT, refreshing it if necessary.
+   *
+   * Concurrent callers that race during a refresh window share the
+   * same in-flight promise — the OS auth prompt fires once.
+   */
+  async getValidToken(): Promise<string> {
+    const now = this.cfg.now();
+
+    if (this.state && this.state.expiresAt - now > this.cfg.refreshBeforeSecs) {
+      return this.state.token;
+    }
+
+    if (this.inflight !== null) {
+      // Another caller is already refreshing — share the promise.
+      return await this.inflight;
+    }
+
+    this.inflight = this.mint().finally(() => {
+      this.inflight = null;
+    });
+    return await this.inflight;
+  }
+
+  /**
+   * Force a refresh now, regardless of cached state. Useful after
+   * the user has clicked "renew session" in a UI prompt.
+   */
+  async forceRefresh(): Promise<string> {
+    if (this.inflight !== null) {
+      // Reuse the in-flight refresh.
+      return await this.inflight;
+    }
+    this.inflight = this.mint().finally(() => {
+      this.inflight = null;
+    });
+    return await this.inflight;
+  }
+
+  /** Drop the cached cap. Next `getValidToken` call mints a fresh one. */
+  invalidate(): void {
+    this.state = null;
+  }
+
+  /** Returns the cached cap state, or null if not minted yet. */
+  current(): CapState | null {
+    return this.state ? { ...this.state } : null;
+  }
+
+  private async mint(): Promise<string> {
+    if (this.cfg.onExpiringSoon) {
+      try {
+        this.cfg.onExpiringSoon();
+      } catch {
+        // Don't propagate UI callback errors.
+      }
+    }
+
+    const challenge = this.cfg.randomChallenge();
+    if (challenge.byteLength !== 32) {
+      throw AnimaError.state(
+        `SessionCap challenge must be 32 bytes, got ${challenge.byteLength}`,
+      );
+    }
+
+    const assertion = await this.cfg.passkey.signWithAssertion(challenge);
+
+    // For first mint after enrollment we don't have a cap yet — pass
+    // an empty bearer so RemoteAnima skips the Authorization header.
+    // The mint endpoint is one of two on lifegw that accepts un-authed
+    // requests (the other being `/anima/custody/enroll_passkey`).
+    const result = await this.cfg.remote.mintSessionCap(
+      this.cfg.userId,
+      { assertion },
+      this.state?.token, // pass current token if we have one (refresh path)
+    );
+
+    this.state = {
+      token: result.token,
+      expiresAt: result.expiresAt,
+      issuedAt: result.issuedAt,
+    };
+    return result.token;
+  }
+}
+
+function defaultNow(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function defaultRandomChallenge(): Uint8Array {
+  const out = new Uint8Array(32);
+  const g = globalThis as unknown as { crypto?: { getRandomValues?: (b: Uint8Array) => Uint8Array } };
+  if (g.crypto?.getRandomValues) {
+    g.crypto.getRandomValues(out);
+    return out;
+  }
+  // Fallback for environments without WebCrypto — should be rare;
+  // tests inject `randomChallenge` directly. Throw instead of
+  // emitting weak randomness.
+  throw AnimaError.state(
+    "SessionCap: no crypto.getRandomValues available — pass `randomChallenge` config",
+  );
+}

--- a/sdks/life-sdk-ts/src/anima/types.ts
+++ b/sdks/life-sdk-ts/src/anima/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Anima types — Spec D D-Sub-C browser custody surface.
+ *
+ * These types mirror the Rust `AnimaCustody` trait shape from
+ * `crates/anima/anima-identity/src/custody.rs`, translated to camelCase.
+ *
+ * Spec D L4-D5..D10 ground truth:
+ *   - L4-D5: split custody (browser auth + delegated wallet)
+ *   - L4-D6: P-256 (ES256) auth keypair
+ *   - L4-D7: secp256k1 wallet keypair (delegated to remote)
+ *   - L4-D10: rotation documented in journal, not implicit
+ *
+ * @see docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md
+ */
+
+/**
+ * Custody backend identifier — Spec D §"Event additions".
+ *
+ * Mirrors Rust's `BackendKind` enum (snake_case serialization). Browser
+ * custody surfaces only `WebCrypto` (auth half via passkey) + `Remote`
+ * (wallet delegate). Other backends live server-side.
+ */
+export type BackendKind =
+  | "in_process"
+  | "vault"
+  | "web_crypto"
+  | "tpm"
+  | "soma"
+  | "hardware_wallet"
+  | "remote";
+
+/**
+ * EVM transaction request — narrow shape used by `signEvmTx`.
+ *
+ * Mirrors `TxRequest` in Rust. Spec D L4-D7 keeps wallet on
+ * secp256k1 + EIP-1559 + EIP-155, so this matches the EVM EOA model.
+ */
+export interface TxRequest {
+  /** `from` address (must equal `walletAddress`). */
+  from: string;
+  /** `to` address (recipient). */
+  to: string;
+  /**
+   * Value in wei (string-encoded for u256 width — chains may exceed
+   * JS number precision).
+   */
+  valueWei: string;
+  /** Calldata; hex-encoded with 0x prefix, may be empty for plain transfers. */
+  dataHex: string;
+  /** Nonce (user's wallet account nonce). */
+  nonce: number;
+  /** Gas limit. */
+  gasLimit: number;
+  /** Maximum fee per gas (EIP-1559) in wei (string-encoded). */
+  maxFeePerGasWei: string;
+  /** Maximum priority fee per gas (EIP-1559) in wei (string-encoded). */
+  maxPriorityFeePerGasWei: string;
+  /** CAIP-2 chain id (e.g. `eip155:8453`). */
+  chain: string;
+}
+
+/**
+ * EVM signature output — `(r, s, v)` in 65-byte recoverable form.
+ *
+ * Mirrors Rust's `EvmSignature`. Browser custody constructs this
+ * by base64-decoding what the Rust wallet backend returned over the
+ * `/anima/custody/sign_wallet` HTTP route.
+ */
+export interface EvmSignature {
+  /** Raw 65-byte recoverable signature (r || s || v). */
+  bytes: Uint8Array;
+}
+
+/**
+ * EIP-712 typed-data domain — re-exported shape from haima-wallet.
+ *
+ * Spec D L4-D7 keeps wallet on secp256k1 + EIP-712 + EIP-155; this
+ * struct is the canonical shape consumers pass to `signEip712`.
+ */
+export interface Eip712Domain {
+  name: string;
+  version: string;
+  /** Chain id as decimal string (EIP-155). For Base mainnet: "8453". */
+  chainId: string;
+  /** Verifying contract address. */
+  verifyingContract: string;
+}
+
+/**
+ * Output of `WebCryptoAnima.rotate()`.
+ *
+ * Browser passkeys are seed-resident in the OS keychain — there is no
+ * software-rotation primitive. This type is included for API symmetry
+ * with the Rust trait shape; in practice `rotate()` rejects with a
+ * `not_supported` error pointing the caller at the journal-driven flow.
+ *
+ * Mirrors Rust's `DidRotationEvent`.
+ */
+export interface DidRotationEvent {
+  /** The DID that was rotated away from. */
+  oldDid: string;
+  /** The DID that signing now flows through. */
+  newDid: string;
+  /**
+   * Detached JWS by the *old* key over the *new* DID. Compact form
+   * `<header>.<body>.<signature>`.
+   */
+  rotationProofJws: string;
+  /** Wall-clock ISO-8601 timestamp of the rotation. */
+  rotatedAt: string;
+}
+
+/**
+ * WebAuthn attestation object — output of `navigator.credentials.create`.
+ *
+ * The browser's PublicKeyCredential gives us:
+ *   - `attestationObject`: CBOR-encoded `{fmt, attStmt, authData}`. Anima
+ *     parses `authData` to extract the COSE_Key public key.
+ *   - `clientDataJSON`: UTF-8 JSON `{type, challenge, origin, ...}`.
+ */
+export interface AttestationObject {
+  /** CBOR-encoded attestation object bytes. */
+  attestationObject: Uint8Array;
+  /** UTF-8 JSON client-data bytes. */
+  clientDataJson: Uint8Array;
+  /** Credential ID — opaque handle the authenticator references later. */
+  credentialId: ArrayBuffer;
+  /** SEC1-compressed P-256 pubkey (33 bytes), parsed from COSE_Key. */
+  pubkey: Uint8Array;
+}
+
+/**
+ * WebAuthn assertion — output of `navigator.credentials.get`.
+ *
+ * Returned on every signing operation. The DER-encoded ECDSA signature
+ * lives in `signature`; anima converts to JOSE compact form (r||s, 64
+ * bytes) before returning to higher layers.
+ */
+export interface Assertion {
+  /** Credential ID echoed back by the authenticator. */
+  credentialId: ArrayBuffer;
+  /** UTF-8 JSON client-data bytes (challenge + origin + type). */
+  clientDataJson: Uint8Array;
+  /** Authenticator data (signature_count, flags, RP ID hash). */
+  authenticatorData: Uint8Array;
+  /** DER-encoded ECDSA signature. */
+  signature: Uint8Array;
+}

--- a/sdks/life-sdk-ts/src/anima/web_crypto.ts
+++ b/sdks/life-sdk-ts/src/anima/web_crypto.ts
@@ -1,0 +1,333 @@
+/**
+ * `WebCryptoAnima` — composition wrapper for the browser custody path.
+ *
+ * Spec D L4-D5 (split custody) ground truth:
+ *   - auth half  → {@link PasskeyOracle} (P-256, non-extractable)
+ *   - wallet half → {@link RemoteAnimaClient} (delegated to server-side
+ *                  anima daemon holding secp256k1 in Vault Transit)
+ *
+ * Mirrors Rust's `HardwareWalletAnima` shape (auth-only wrapping a
+ * delegate, but here it's the wallet half delegated and the auth
+ * half local). The class is composition-of-roles, not a single
+ * keypair holder.
+ *
+ * Spec D §"Browser path (D-Sub-C in detail)" §1-3 implementation:
+ *   - §1 auth keypair via passkey (`PasskeyOracle.enroll/load`)
+ *   - §2 DID derivation (`generateDidKeyP256(authPubkey)`)
+ *   - §3 signing flow (`signJws`/`signDigest` → passkey, `signEvmTx`/
+ *        `signEip712` → remote)
+ */
+
+import { generateDidKeyP256 } from "./did.js";
+import { AnimaError } from "./errors.js";
+import type { PasskeyOracle } from "./passkey.js";
+import type { RemoteAnimaClient } from "./remote.js";
+import type { SessionCap } from "./session_cap.js";
+import type {
+  BackendKind,
+  DidRotationEvent,
+  Eip712Domain,
+  EvmSignature,
+  TxRequest,
+} from "./types.js";
+
+/**
+ * Configuration for {@link WebCryptoAnima}.
+ *
+ * All four fields are mandatory — there are no degraded modes. The
+ * `walletAddress` and `walletPubkey` are cached at enrollment so we
+ * don't re-fetch on every `signEvmTx` / `signEip712`.
+ */
+export interface WebCryptoAnimaConfig {
+  /** Auth-half passkey oracle (already enrolled or loaded). */
+  auth: PasskeyOracle;
+  /** Wallet-half delegate (HTTP client to lifegw `/anima/custody/*`). */
+  wallet: RemoteAnimaClient;
+  /** Tier-User cap JWT manager (passed to wallet for auto-refresh). */
+  sessionCap: SessionCap;
+  /** User id this custody handle is bound to. */
+  userId: string;
+  /** Cached wallet address (`0x…` hex) from enrollment. */
+  walletAddress: string;
+  /** Cached secp256k1 wallet pubkey (33 bytes SEC1-compressed). */
+  walletPubkey: Uint8Array;
+}
+
+/**
+ * `WebCryptoAnima` — the browser-side `AnimaCustody`-equivalent.
+ *
+ * Closely mirrors Rust's `AnimaCustody` trait method names (camelCase
+ * here vs snake_case there). Public methods:
+ *
+ *   - `userDid()`        → `did:key:zDn…`
+ *   - `authPubkey()`     → 33 bytes SEC1-compressed
+ *   - `walletAddress()`  → `0x…` (always populated for this backend)
+ *   - `backendKind()`    → `"web_crypto"`
+ *   - `signJws(header, payload)` → compact JWS string
+ *   - `signDigest(digest)`        → 64 bytes (r||s)
+ *   - `signEvmTx(tx)`             → 65-byte EvmSignature (r||s||v)
+ *   - `signEip712(domain, types, message)` → 65-byte EvmSignature
+ *   - `rotate()`                  → rejects with `not_supported`
+ */
+export class WebCryptoAnima {
+  private readonly cfg: WebCryptoAnimaConfig;
+
+  constructor(cfg: WebCryptoAnimaConfig) {
+    if (cfg.walletPubkey.byteLength !== 33) {
+      throw AnimaError.state(
+        `WebCryptoAnima: walletPubkey must be 33 bytes, got ${cfg.walletPubkey.byteLength}`,
+      );
+    }
+    this.cfg = cfg;
+  }
+
+  /**
+   * SEC1-compressed P-256 auth public key (33 bytes). Pulled from
+   * the passkey oracle's in-memory cache (set at enroll/load time).
+   */
+  authPubkey(): Uint8Array {
+    return this.cfg.auth.pubkey();
+  }
+
+  /**
+   * User-scope DID — `did:key:zDn…` derived from the P-256 auth
+   * pubkey. Cross-language compatible with Rust's
+   * `EcdsaP256Identity::did_key`.
+   */
+  userDid(): string {
+    return generateDidKeyP256(this.authPubkey());
+  }
+
+  /**
+   * Wallet address (`0x…` hex). Always populated for `WebCryptoAnima`
+   * — split custody's wallet half is mandatory.
+   */
+  walletAddress(): string {
+    return this.cfg.walletAddress;
+  }
+
+  /** SEC1-compressed secp256k1 wallet pubkey (33 bytes). */
+  walletPubkey(): Uint8Array {
+    return this.cfg.walletPubkey;
+  }
+
+  /** User id this custody handle is bound to. */
+  userId(): string {
+    return this.cfg.userId;
+  }
+
+  /** Backend identifier (Spec D §"Event additions"). */
+  backendKind(): BackendKind {
+    return "web_crypto";
+  }
+
+  /**
+   * Sign a JWS over the supplied header + claims using the auth key.
+   *
+   * Spec D §"Browser path" §3 — the OS prompts on every signing
+   * operation unless a session-cap is active. Higher layers should
+   * batch where possible.
+   *
+   * The resulting compact JWS shape is `<headerB64>.<bodyB64>.<sigB64>`
+   * with `sigB64` being the JOSE-compact 64-byte raw signature
+   * (mirrors Rust's `EcdsaP256Identity::sign_jws`).
+   *
+   * NOTE on WebAuthn semantics: the authenticator hashes
+   * (clientDataJSON || authenticatorData) before signing, so the bytes
+   * the authenticator actually signs are NOT the JWS signing-input.
+   * For genuine JWS interop the caller MUST verify against the
+   * `clientDataJSON.challenge` mechanism (use `signWithAssertion`
+   * + the WebAuthn assertion verification path on the server). Use
+   * this method only when your server-side verifier is WebAuthn-
+   * aware, e.g. lago-auth's `verify_jwt` with the rotation_chain
+   * + WebAuthn assertion validator extension. For purely-server-
+   * resolved JWS (the lifegw cap mint flow) prefer the
+   * `signWithAssertion` shape on the passkey directly.
+   */
+  async signJws(
+    header: Record<string, unknown>,
+    payload: Record<string, unknown>,
+  ): Promise<string> {
+    const finalHeader = {
+      alg: "ES256",
+      typ: "JWT",
+      kid: this.userDid(),
+      ...header,
+    };
+    const headerB64 = b64UrlEncode(new TextEncoder().encode(JSON.stringify(finalHeader)));
+    const payloadB64 = b64UrlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const digest = await sha256(new TextEncoder().encode(signingInput));
+    const signature = await this.cfg.auth.sign(digest);
+    return `${signingInput}.${b64UrlEncode(signature)}`;
+  }
+
+  /**
+   * Sign a 32-byte digest with the auth (P-256) key. Returns the
+   * 64-byte JOSE-compact form (`r||s`) — same shape as Rust's
+   * `AnimaCustody::sign_digest`.
+   */
+  async signDigest(digest: Uint8Array): Promise<Uint8Array> {
+    if (digest.byteLength !== 32) {
+      throw AnimaError.state(`signDigest digest must be 32 bytes, got ${digest.byteLength}`);
+    }
+    return this.cfg.auth.sign(digest);
+  }
+
+  /**
+   * Sign an EVM transaction with the wallet (secp256k1) key.
+   *
+   * Browser custody delegates this to the server-side anima daemon
+   * (`RemoteAnimaClient.signEvmTx`) which holds the secp256k1 key in
+   * `VaultTransitAnima`. The resulting `r||s||v` signature is
+   * shaped identically to the Rust `EvmSignature.bytes`.
+   *
+   * `from` field MUST equal the cached wallet address — sanity-checked
+   * here to catch caller bugs before the server rejects.
+   */
+  async signEvmTx(tx: TxRequest): Promise<EvmSignature> {
+    if (tx.from.toLowerCase() !== this.cfg.walletAddress.toLowerCase()) {
+      throw AnimaError.state(
+        `signEvmTx: tx.from (${tx.from}) does not match wallet address (${this.cfg.walletAddress})`,
+      );
+    }
+    return this.cfg.wallet.signEvmTx(this.cfg.userId, tx);
+  }
+
+  /**
+   * Sign an EIP-712 typed-data payload (used by haima-x402 + USDC
+   * `transferWithAuthorization` and any future EIP-712 flows).
+   *
+   * Same delegation pattern as `signEvmTx`.
+   */
+  async signEip712(
+    domain: Eip712Domain,
+    types: Record<string, unknown>,
+    message: Record<string, unknown>,
+  ): Promise<EvmSignature> {
+    return this.cfg.wallet.signEip712(this.cfg.userId, domain, types, message);
+  }
+
+  /**
+   * Rotation is journal-driven — `WebCryptoAnima.rotate` rejects.
+   *
+   * Spec D L4-D10: rotation is documented in the journal, not
+   * implicit. To rotate the auth key, the user must:
+   *   1. Enroll a fresh passkey on a still-trusted device.
+   *   2. Have the server-side anima daemon emit
+   *      `anima.identity_rotated` signed by the OLD key.
+   *
+   * Mirrors Rust's `RemoteAnima.rotate()` shape — rejects rather
+   * than silently doing nothing.
+   */
+  async rotate(): Promise<DidRotationEvent> {
+    throw AnimaError.notSupported(
+      "WebCryptoAnima.rotate is journal-driven; use the soma admin RPC or anima-lago::write_rotation_event from the server-side anima daemon",
+    );
+  }
+}
+
+/**
+ * High-level helper: complete the full enrollment flow and return a
+ * ready-to-use `WebCryptoAnima` handle.
+ *
+ * Performs:
+ *   1. `passkey.enroll(userId, displayName, challenge)` — OS UI fires
+ *   2. `remote.enrollPasskey(userId, attestation)` — server provisions
+ *      Vault Transit secp256k1 key + records the user's DID
+ *   3. Construct `WebCryptoAnima` with the cached wallet address +
+ *      pubkey from step 2.
+ */
+export async function enrollWebCryptoAnima(params: {
+  passkey: PasskeyOracle;
+  remote: RemoteAnimaClient;
+  sessionCap: SessionCap;
+  userId: string;
+  displayName: string;
+  challenge: Uint8Array;
+}): Promise<WebCryptoAnima> {
+  const enroll = await params.passkey.enroll(
+    params.userId,
+    params.displayName,
+    params.challenge,
+  );
+  const remoteEnroll = await params.remote.enrollPasskey(params.userId, {
+    attestationObject: enroll.attestationObject,
+    clientDataJson: enroll.clientDataJson,
+    credentialId: enroll.credentialId,
+  });
+  return new WebCryptoAnima({
+    auth: params.passkey,
+    wallet: params.remote,
+    sessionCap: params.sessionCap,
+    userId: params.userId,
+    walletAddress: remoteEnroll.walletAddress,
+    walletPubkey: remoteEnroll.walletPubkey,
+  });
+}
+
+/**
+ * High-level helper: load a previously-enrolled `WebCryptoAnima`.
+ *
+ * Pulls the cached credential from IndexedDB via `passkey.load`, then
+ * fetches the wallet address + pubkey from `remote.getWalletAddress`
+ * + `remote.getWalletPubkey`. No OS UI fires until the first signing
+ * operation.
+ *
+ * Returns `null` if the user hasn't enrolled (caller must run
+ * `enrollWebCryptoAnima` first).
+ */
+export async function loadWebCryptoAnima(params: {
+  passkey: PasskeyOracle;
+  remote: RemoteAnimaClient;
+  sessionCap: SessionCap;
+  userId: string;
+}): Promise<WebCryptoAnima | null> {
+  const loaded = await params.passkey.load(params.userId);
+  if (!loaded) return null;
+
+  const [walletAddress, walletPubkey] = await Promise.all([
+    params.remote.getWalletAddress(params.userId),
+    params.remote.getWalletPubkey(params.userId),
+  ]);
+  return new WebCryptoAnima({
+    auth: params.passkey,
+    wallet: params.remote,
+    sessionCap: params.sessionCap,
+    userId: params.userId,
+    walletAddress,
+    walletPubkey,
+  });
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+/** SHA-256 digest using WebCrypto. */
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  const subtle = (globalThis as unknown as { crypto?: { subtle?: SubtleCrypto } }).crypto?.subtle;
+  if (!subtle) {
+    throw AnimaError.state("SHA-256 requires WebCrypto (crypto.subtle)");
+  }
+  // Copy into a fresh ArrayBuffer to satisfy `BufferSource` shape.
+  const ab = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(ab).set(bytes);
+  const hash = await subtle.digest("SHA-256", ab);
+  return new Uint8Array(hash);
+}
+
+/** base64url (RFC 4648) without padding. */
+function b64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  let std: string;
+  if (typeof btoa === "function") {
+    std = btoa(bin);
+  } else {
+    const g = globalThis as unknown as {
+      Buffer?: { from(s: string, enc: string): { toString(enc: string): string } };
+    };
+    if (!g.Buffer) throw AnimaError.crypto("no base64 encoder available");
+    std = g.Buffer.from(bin, "binary").toString("base64");
+  }
+  return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/sdks/life-sdk-ts/src/index.ts
+++ b/sdks/life-sdk-ts/src/index.ts
@@ -66,6 +66,21 @@ export {
 // Proto types — re-exported so consumers don't need a deep import.
 export * as proto from "./proto/index.js";
 
+// Anima — browser custody surface (Spec D D-Sub-C).
+export * as anima from "./anima/index.js";
+export {
+  WebCryptoAnima,
+  PasskeyOracle,
+  RemoteAnimaClient,
+  SessionCap,
+  enrollWebCryptoAnima,
+  loadWebCryptoAnima,
+  generateDidKeyP256,
+  resolveDidKeyP256,
+  verifyDidKeyP256,
+  AnimaError,
+} from "./anima/index.js";
+
 // Proto3-JSON codec helpers — for converting between the wire shapes
 // (string for int64/uint64, base64 string for bytes) and the values
 // consumers actually want (bigint, Uint8Array). See `./codec.ts`.

--- a/sdks/life-sdk-ts/tests/anima/_mock_authenticator.ts
+++ b/sdks/life-sdk-ts/tests/anima/_mock_authenticator.ts
@@ -1,0 +1,274 @@
+/**
+ * `MockPasskeyAuthenticator` — deterministic WebAuthn authenticator
+ * for unit tests.
+ *
+ * Generates a real P-256 keypair (via `@noble/curves/p256`), produces
+ * structurally-valid attestation objects (CBOR with COSE_Key), and
+ * signs assertion challenges with real ECDSA. This lets the
+ * passkey-oracle tests exercise the full attestation parser + DER →
+ * JOSE conversion paths without a real browser.
+ */
+
+import { p256 } from "@noble/curves/nist.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { encode as cborEncode } from "cbor-x";
+import type {
+  AuthenticatorAssertionResponseLike,
+  AuthenticatorAttestationResponseLike,
+  CredentialsContainerLike,
+  PublicKeyCredentialLike,
+} from "../../src/anima/passkey.js";
+
+interface RegisteredCredential {
+  /** Opaque credential id bytes (we generate random 16-byte ids). */
+  credentialId: Uint8Array;
+  /** Private scalar (32 bytes BE). */
+  priv: Uint8Array;
+  /** Public point — extracted x/y as 32-byte BE big-ints. */
+  pubX: Uint8Array;
+  pubY: Uint8Array;
+  /** SEC1 compressed pubkey (33 bytes). */
+  compressed: Uint8Array;
+  /** RP id this credential was enrolled against. */
+  rpId: string;
+  /** Sign counter (incremented on every assertion). */
+  signCount: number;
+}
+
+/**
+ * Build a synthetic `attestationObject` CBOR blob containing the
+ * given credential's public key. Mirrors WebAuthn's "none" attestation
+ * format (the simplest, used by passkey-style enrollments).
+ */
+function buildAttestationObject(cred: RegisteredCredential): Uint8Array {
+  // authData = rpIdHash(32) || flags(1) || signCount(4) || attestedCredentialData
+  const rpIdHash = sha256(new TextEncoder().encode(cred.rpId));
+  const flags = 0x40 | 0x01 | 0x04; // AT (attested credential data) + UP + UV
+  const signCountBE = new Uint8Array(4); // 0
+  const aaguid = new Uint8Array(16); // all zeros (generic passkey)
+  const credIdLenBE = new Uint8Array(2);
+  credIdLenBE[0] = (cred.credentialId.byteLength >> 8) & 0xff;
+  credIdLenBE[1] = cred.credentialId.byteLength & 0xff;
+
+  // COSE_Key shape (Map):
+  //   1 (kty)  → 2 (EC2)
+  //   3 (alg)  → -7 (ES256)
+  //   -1 (crv) → 1 (P-256)
+  //   -2 (x)   → 32 bytes
+  //   -3 (y)   → 32 bytes
+  const coseKey = new Map<number, number | Uint8Array>([
+    [1, 2],
+    [3, -7],
+    [-1, 1],
+    [-2, cred.pubX],
+    [-3, cred.pubY],
+  ]);
+  const coseBytes = cborEncode(coseKey);
+
+  const authData = concat(
+    rpIdHash,
+    new Uint8Array([flags]),
+    signCountBE,
+    aaguid,
+    credIdLenBE,
+    cred.credentialId,
+    coseBytes,
+  );
+
+  // attestationObject = { fmt: "none", attStmt: {}, authData: bytes }
+  const attestationMap = new Map<string, unknown>([
+    ["fmt", "none"],
+    ["attStmt", new Map()],
+    ["authData", authData],
+  ]);
+  return cborEncode(attestationMap);
+}
+
+function concat(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((acc, a) => acc + a.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.byteLength;
+  }
+  return out;
+}
+
+function bytesEq(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function arrayBufferToUint8(ab: ArrayBuffer | Uint8Array): Uint8Array {
+  if (ab instanceof Uint8Array) return ab;
+  return new Uint8Array(ab);
+}
+
+/**
+ * `MockPasskeyAuthenticator` — implements `CredentialsContainerLike`.
+ *
+ * Each `create()` call produces a fresh keypair and registers it.
+ * `get()` calls look up the matching credential and produce a real
+ * ECDSA signature with the registered private key.
+ */
+export class MockPasskeyAuthenticator implements CredentialsContainerLike {
+  readonly registered: RegisteredCredential[] = [];
+
+  /**
+   * Last challenge signed — useful for tests that want to verify the
+   * authenticator signed exactly the bytes the caller passed in.
+   */
+  lastChallenge: Uint8Array | null = null;
+
+  /**
+   * Hook fired before signing — tests can throw from here to simulate
+   * user-cancelled prompts, etc.
+   */
+  beforeSign?: () => void;
+
+  /**
+   * Optional override for credential id generation. Tests can pin
+   * this to make IDs deterministic.
+   */
+  credentialIdFactory?: () => Uint8Array;
+
+  async create(options: {
+    publicKey: PublicKeyCredentialCreationOptions;
+  }): Promise<PublicKeyCredentialLike | null> {
+    const rpId = options.publicKey.rp.id ?? "localhost";
+    const credId =
+      this.credentialIdFactory?.() ?? randomBytes(16);
+
+    // Generate a fresh P-256 keypair using a random scalar.
+    const priv = p256.utils.randomSecretKey();
+    const pubUncompressed = p256.getPublicKey(priv, false); // 0x04 || x(32) || y(32)
+    if (pubUncompressed.byteLength !== 65) {
+      throw new Error(`unexpected uncompressed pubkey length ${pubUncompressed.byteLength}`);
+    }
+    const pubX = pubUncompressed.slice(1, 33);
+    const pubY = pubUncompressed.slice(33, 65);
+    const compressed = p256.getPublicKey(priv, true);
+
+    const cred: RegisteredCredential = {
+      credentialId: credId,
+      priv,
+      pubX,
+      pubY,
+      compressed,
+      rpId,
+      signCount: 0,
+    };
+    this.registered.push(cred);
+
+    const attestationObject = buildAttestationObject(cred);
+    const clientData = JSON.stringify({
+      type: "webauthn.create",
+      challenge: bytesToB64Url(arrayBufferToUint8(options.publicKey.challenge as ArrayBuffer)),
+      origin: `https://${rpId}`,
+    });
+
+    const response: AuthenticatorAttestationResponseLike = {
+      clientDataJSON: utf8ToBuffer(clientData),
+      attestationObject: bufferOf(attestationObject),
+    };
+    return {
+      rawId: bufferOf(credId),
+      response,
+    };
+  }
+
+  async get(options: {
+    publicKey: PublicKeyCredentialRequestOptions;
+  }): Promise<PublicKeyCredentialLike | null> {
+    if (this.beforeSign) this.beforeSign();
+
+    const rpId = options.publicKey.rpId ?? "localhost";
+    const allowed = options.publicKey.allowCredentials ?? [];
+    if (allowed.length === 0) {
+      throw new Error("MockPasskeyAuthenticator.get: allowCredentials cannot be empty");
+    }
+    let cred: RegisteredCredential | undefined;
+    for (const allow of allowed) {
+      const allowId = arrayBufferToUint8(allow.id as ArrayBuffer);
+      cred = this.registered.find((c) => c.rpId === rpId && bytesEq(c.credentialId, allowId));
+      if (cred) break;
+    }
+    if (!cred) {
+      throw new Error("MockPasskeyAuthenticator.get: no registered credential matches");
+    }
+
+    cred.signCount += 1;
+    const challengeBytes = arrayBufferToUint8(options.publicKey.challenge as ArrayBuffer);
+    this.lastChallenge = challengeBytes;
+
+    // Build authenticator data: rpIdHash || flags || signCount
+    const rpIdHash = sha256(new TextEncoder().encode(rpId));
+    const flags = 0x01 | 0x04; // UP + UV (no AT, no extensions on assertion)
+    const signCountBE = new Uint8Array(4);
+    new DataView(signCountBE.buffer).setUint32(0, cred.signCount, false);
+    const authenticatorData = concat(rpIdHash, new Uint8Array([flags]), signCountBE);
+
+    // ClientDataJSON
+    const clientData = JSON.stringify({
+      type: "webauthn.get",
+      challenge: bytesToB64Url(challengeBytes),
+      origin: `https://${rpId}`,
+    });
+    const clientDataBytes = new TextEncoder().encode(clientData);
+
+    // WebAuthn signs ECDSA over (authenticatorData || SHA-256(clientDataJSON)).
+    // The curve's internal SHA-256 prehash applies to the concatenation;
+    // we let `prehash: true` (the default) handle the final SHA-256 step.
+    const clientDataHash = sha256(clientDataBytes);
+    const signedBytes = concat(authenticatorData, clientDataHash);
+
+    const derSig = p256.sign(signedBytes, cred.priv, {
+      prehash: true,
+      format: "der",
+    });
+
+    const response: AuthenticatorAssertionResponseLike = {
+      clientDataJSON: bufferOf(clientDataBytes),
+      authenticatorData: bufferOf(authenticatorData),
+      signature: bufferOf(derSig),
+    };
+    return {
+      rawId: bufferOf(cred.credentialId),
+      response,
+    };
+  }
+}
+
+function randomBytes(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  const g = globalThis as unknown as { crypto?: { getRandomValues?: (b: Uint8Array) => Uint8Array } };
+  if (g.crypto?.getRandomValues) {
+    g.crypto.getRandomValues(out);
+    return out;
+  }
+  // Fallback for ancient environments — pseudo-random is OK for tests.
+  for (let i = 0; i < n; i++) out[i] = Math.floor(Math.random() * 256);
+  return out;
+}
+
+function utf8ToBuffer(s: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(s);
+  return bufferOf(bytes);
+}
+
+function bufferOf(bytes: Uint8Array): ArrayBuffer {
+  // Always copy into a fresh ArrayBuffer to avoid SharedArrayBuffer
+  // type issues across runtimes.
+  const out = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(out).set(bytes);
+  return out;
+}
+
+function bytesToB64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.byteLength; i++) bin += String.fromCharCode(bytes[i]!);
+  const std = btoa(bin);
+  return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/sdks/life-sdk-ts/tests/anima/did.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/did.test.ts
@@ -1,0 +1,134 @@
+/**
+ * DID `did:key:zDn…` (P-256) cross-language compatibility tests.
+ *
+ * Pinned against fixtures generated from Rust's
+ * `crates/anima/anima-identity/src/did.rs::generate_did_key_p256`.
+ * Any divergence here indicates a multicodec or base58 encoding bug
+ * that would break interop with the server-side anima daemon.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  generateDidKeyP256,
+  resolveDidKeyP256,
+  verifyDidKeyP256,
+} from "../../src/anima/did.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_PATH = resolve(__dirname, "../fixtures/did_p256_vectors.json");
+
+interface Fixture {
+  description: string;
+  pubkey_compressed_hex: string;
+  expected_did: string;
+}
+
+function loadFixtures(): Fixture[] {
+  const raw = readFileSync(FIXTURES_PATH, "utf8");
+  return JSON.parse(raw) as Fixture[];
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("hex length not even");
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.byteLength; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+describe("generateDidKeyP256 — cross-language fixtures", () => {
+  const fixtures = loadFixtures();
+
+  it.each(fixtures)("$description matches Rust output", (fixture) => {
+    const pubkey = hexToBytes(fixture.pubkey_compressed_hex);
+    const did = generateDidKeyP256(pubkey);
+    expect(did).toBe(fixture.expected_did);
+  });
+
+  it("loaded at least 5 fixtures (smoke check)", () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("generateDidKeyP256 — input validation", () => {
+  it("rejects pubkey of wrong length", () => {
+    expect(() => generateDidKeyP256(new Uint8Array(32))).toThrow(/33 bytes/);
+    expect(() => generateDidKeyP256(new Uint8Array(34))).toThrow(/33 bytes/);
+  });
+
+  it("rejects pubkey not starting with 0x02 or 0x03", () => {
+    const bad = new Uint8Array(33);
+    bad[0] = 0x04; // uncompressed marker — disallowed for SEC1 compressed
+    expect(() => generateDidKeyP256(bad)).toThrow(/0x02 or 0x03/);
+  });
+
+  it("accepts both 0x02 and 0x03 parity bytes", () => {
+    const k02 = new Uint8Array(33);
+    k02[0] = 0x02;
+    k02[1] = 0x42;
+    const did02 = generateDidKeyP256(k02);
+    expect(did02).toMatch(/^did:key:zDn/);
+
+    const k03 = new Uint8Array(33);
+    k03[0] = 0x03;
+    k03[1] = 0x42;
+    const did03 = generateDidKeyP256(k03);
+    expect(did03).toMatch(/^did:key:zDn/);
+
+    expect(did02).not.toBe(did03);
+  });
+});
+
+describe("resolveDidKeyP256 — round trip with generate", () => {
+  const fixtures = loadFixtures();
+
+  it.each(fixtures)("$description: resolve recovers original pubkey", (fixture) => {
+    const original = hexToBytes(fixture.pubkey_compressed_hex);
+    const did = generateDidKeyP256(original);
+    const recovered = resolveDidKeyP256(did);
+    expect(recovered).toEqual(original);
+  });
+
+  it("rejects DIDs with wrong scheme", () => {
+    expect(() => resolveDidKeyP256("did:web:example.com")).toThrow(/missing prefix/);
+  });
+
+  it("rejects DIDs with wrong multicodec prefix", () => {
+    // Use Ed25519 multicodec (0xed01) — should be rejected by the
+    // strict P-256 resolver.
+    const ed25519Did = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSshBHqcxz4QEEfwfPQM";
+    expect(() => resolveDidKeyP256(ed25519Did)).toThrow(/multicodec prefix/);
+  });
+
+  it("rejects malformed base58", () => {
+    // 'O' (capital o) is not in the base58 alphabet.
+    expect(() => resolveDidKeyP256("did:key:zDnaeOOO")).toThrow(/base58/);
+  });
+});
+
+describe("verifyDidKeyP256", () => {
+  const fixtures = loadFixtures();
+
+  it.each(fixtures)("$description: verify accepts the canonical DID", (fixture) => {
+    const pubkey = hexToBytes(fixture.pubkey_compressed_hex);
+    expect(verifyDidKeyP256(fixture.expected_did, pubkey)).toBe(true);
+  });
+
+  it("verify rejects mismatched pubkey", () => {
+    const pubkey = new Uint8Array(33);
+    pubkey[0] = 0x02;
+    const did = generateDidKeyP256(pubkey);
+    const wrongPubkey = new Uint8Array(33);
+    wrongPubkey[0] = 0x03; // different parity byte
+    expect(verifyDidKeyP256(did, wrongPubkey)).toBe(false);
+  });
+
+  it("verify returns false (not throws) on malformed input", () => {
+    expect(verifyDidKeyP256("not-a-did", new Uint8Array(33))).toBe(false);
+  });
+});

--- a/sdks/life-sdk-ts/tests/anima/passkey.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/passkey.test.ts
@@ -1,0 +1,278 @@
+/**
+ * `PasskeyOracle` unit tests — exercises COSE_Key parsing, DER → JOSE
+ * conversion, IndexedDB persistence, and the load/enroll/sign flows.
+ */
+
+import { p256 } from "@noble/curves/nist.js";
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { generateDidKeyP256 } from "../../src/anima/did.js";
+import {
+  derSignatureToJoseRaw,
+  parsePubkeyFromAttestation,
+  PasskeyOracle,
+} from "../../src/anima/passkey.js";
+import { MockPasskeyAuthenticator } from "./_mock_authenticator.js";
+
+// Each test gets its own database name to avoid cross-test pollution.
+let testCounter = 0;
+
+function makeOracle(authenticator: MockPasskeyAuthenticator): PasskeyOracle {
+  testCounter += 1;
+  return new PasskeyOracle({
+    rpId: "broomva.test",
+    rpName: "Broomva Test",
+    credentials: authenticator,
+    indexedDB: globalThis.indexedDB,
+    databaseName: `broomva-anima-passkeys-test-${testCounter}`,
+  });
+}
+
+describe("PasskeyOracle.enroll", () => {
+  it("returns a SEC1-compressed P-256 pubkey from the attestation object", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    const challenge = new Uint8Array(32);
+    challenge[0] = 0x42;
+
+    const result = await oracle.enroll("user-1", "Test User", challenge);
+
+    expect(result.pubkey.byteLength).toBe(33);
+    expect([0x02, 0x03]).toContain(result.pubkey[0]);
+    expect(result.attestationObject.byteLength).toBeGreaterThan(50);
+    expect(result.clientDataJson.byteLength).toBeGreaterThan(20);
+  });
+
+  it("persists credentials so a fresh oracle can load them", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    testCounter += 1;
+    const dbName = `broomva-anima-passkeys-test-${testCounter}`;
+
+    const oracleA = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    const enroll = await oracleA.enroll("user-2", "Test User", new Uint8Array(32));
+
+    // Brand-new oracle pointed at the same DB.
+    const oracleB = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    const loaded = await oracleB.load("user-2");
+    expect(loaded).not.toBeNull();
+    expect(loaded?.pubkey).toEqual(enroll.pubkey);
+  });
+
+  it("rejects challenges that are too short", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    await expect(oracle.enroll("u", "U", new Uint8Array(8))).rejects.toThrow(
+      /≥ 16 bytes/,
+    );
+  });
+
+  it("propagates passkey-API failures as AnimaError", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    auth.beforeSign = (): never => {
+      throw new Error("user cancelled");
+    };
+    // Override `create` to also throw — replicates the cancel path.
+    const cancelling = {
+      ...auth,
+      create: async () => {
+        throw new Error("the user cancelled the prompt");
+      },
+      get: auth.get.bind(auth),
+    };
+    const oracle = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: cancelling,
+      indexedDB: globalThis.indexedDB,
+      databaseName: `cancel-test-${++testCounter}`,
+    });
+    await expect(oracle.enroll("u", "U", new Uint8Array(32))).rejects.toThrow(
+      /WebAuthn create/,
+    );
+  });
+});
+
+describe("PasskeyOracle.load", () => {
+  it("returns null when no credential exists", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    const loaded = await oracle.load("never-enrolled");
+    expect(loaded).toBeNull();
+  });
+
+  it("rejects when stored rpId differs from current oracle rpId", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    testCounter += 1;
+    const dbName = `mismatched-rp-test-${testCounter}`;
+
+    const oracle1 = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    await oracle1.enroll("u", "U", new Uint8Array(32));
+
+    const oracle2 = new PasskeyOracle({
+      rpId: "evil.test", // mismatched
+      rpName: "Evil",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    await expect(oracle2.load("u")).rejects.toThrow(/rpId/);
+  });
+});
+
+describe("PasskeyOracle.sign", () => {
+  it("signs a 32-byte digest and returns 64-byte JOSE-raw bytes", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    await oracle.enroll("u", "U", new Uint8Array(32));
+
+    const digest = new Uint8Array(32);
+    digest[0] = 0xab;
+    const sig = await oracle.sign(digest);
+
+    expect(sig.byteLength).toBe(64);
+    expect(auth.lastChallenge).toEqual(digest);
+  });
+
+  it("throws when no credential is loaded", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    await expect(oracle.sign(new Uint8Array(32))).rejects.toThrow(/no credential loaded/);
+  });
+
+  it("throws on wrong digest length", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    await oracle.enroll("u", "U", new Uint8Array(32));
+    await expect(oracle.sign(new Uint8Array(31))).rejects.toThrow(/32 bytes/);
+  });
+
+  it("signWithAssertion returns the full WebAuthn assertion bundle", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    await oracle.enroll("u", "U", new Uint8Array(32));
+
+    const digest = new Uint8Array(32);
+    digest[0] = 0xcd;
+    const bundle = await oracle.signWithAssertion(digest);
+
+    expect(bundle.signature.byteLength).toBe(64);
+    expect(bundle.clientDataJson.byteLength).toBeGreaterThan(0);
+    expect(bundle.authenticatorData.byteLength).toBeGreaterThan(36);
+  });
+
+  it("derived DID matches generateDidKeyP256(authPubkey)", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    const enroll = await oracle.enroll("u", "U", new Uint8Array(32));
+
+    const didFromEnroll = generateDidKeyP256(enroll.pubkey);
+    const didFromOracle = generateDidKeyP256(oracle.pubkey());
+    expect(didFromOracle).toBe(didFromEnroll);
+    expect(didFromOracle).toMatch(/^did:key:zDn/);
+  });
+});
+
+describe("PasskeyOracle.forget", () => {
+  it("removes the credential from IndexedDB", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    testCounter += 1;
+    const dbName = `forget-test-${testCounter}`;
+    const oracle = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    await oracle.enroll("u", "U", new Uint8Array(32));
+    await oracle.forget("u");
+
+    // A fresh oracle should not find the credential.
+    const oracle2 = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    expect(await oracle2.load("u")).toBeNull();
+  });
+});
+
+describe("parsePubkeyFromAttestation — direct invocation", () => {
+  it("extracts the same pubkey the authenticator registered", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const oracle = makeOracle(auth);
+    const enroll = await oracle.enroll("u", "U", new Uint8Array(32));
+    const directParse = parsePubkeyFromAttestation(enroll.attestationObject);
+    expect(directParse).toEqual(enroll.pubkey);
+  });
+});
+
+describe("derSignatureToJoseRaw", () => {
+  it("round-trips an ECDSA signature produced by @noble/curves", () => {
+    // Generate a real signature and verify the conversion.
+    const priv = p256.utils.randomSecretKey();
+    const message = new TextEncoder().encode("hello, mock authenticator");
+    const der = p256.sign(message, priv, { prehash: true, format: "der" });
+
+    const raw = derSignatureToJoseRaw(der);
+    expect(raw.byteLength).toBe(64);
+
+    // Verify we can convert back: the raw form is verifiable by p256.verify
+    // with format: "compact".
+    const valid = p256.verify(raw, message, p256.getPublicKey(priv, true), {
+      prehash: true,
+      format: "compact",
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("strips a leading 0x00 from r when present (DER sign-disambiguation)", () => {
+    // Build a DER signature with a high-bit-set r (forces the 0x00 sign byte)
+    // by signing repeatedly until we see one. The probability is ~50% per try.
+    const priv = p256.utils.randomSecretKey();
+    let der: Uint8Array | null = null;
+    for (let i = 0; i < 50; i++) {
+      const msg = new Uint8Array(32);
+      msg[0] = i;
+      const candidate = p256.sign(msg, priv, { prehash: true, format: "der" });
+      // DER format: 30 LL 02 RL <r_bytes> 02 SL <s_bytes>
+      // Look for r_len > 32 (leading zero present).
+      if (candidate[3]! > 32) {
+        der = candidate;
+        break;
+      }
+    }
+    if (!der) {
+      // Statistically very rare; just assert the basic property.
+      console.warn("did not find a leading-zero r in 50 tries; skipping strict check");
+      return;
+    }
+    const raw = derSignatureToJoseRaw(der);
+    expect(raw.byteLength).toBe(64);
+  });
+
+  it("throws on malformed DER", () => {
+    expect(() => derSignatureToJoseRaw(new Uint8Array([0x00]))).toThrow(/SEQUENCE tag/);
+  });
+});

--- a/sdks/life-sdk-ts/tests/anima/remote.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/remote.test.ts
@@ -1,0 +1,466 @@
+/**
+ * `RemoteAnimaClient` unit tests — verify the HTTP wire shapes against
+ * the routes Stream R is shipping in parallel.
+ *
+ * Mock pattern: rather than pulling msw's full request-interception
+ * machinery (which adds ~MB of test deps), we inject a deterministic
+ * `fetch` shim that records every call. The wire-shape contract is
+ * documented inline.
+ */
+
+import { describe, expect, it } from "vitest";
+import { AnimaError } from "../../src/anima/errors.js";
+import { RemoteAnimaClient } from "../../src/anima/remote.js";
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function makeFakeFetch(
+  routes: Array<{
+    method: string;
+    path: string;
+    handler: (req: RecordedRequest) => { status?: number; json?: unknown };
+  }>,
+): { fetchFn: typeof fetch; calls: RecordedRequest[] } {
+  const calls: RecordedRequest[] = [];
+  const fetchFn: typeof fetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const path = new URL(url).pathname;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k.toLowerCase()] = v;
+      }
+    }
+    let body: unknown = undefined;
+    if (init?.body) {
+      const text =
+        typeof init.body === "string"
+          ? init.body
+          : new TextDecoder().decode(init.body as Uint8Array);
+      body = text ? JSON.parse(text) : undefined;
+    }
+    const recorded: RecordedRequest = { url, method, headers, body };
+    calls.push(recorded);
+
+    const route = routes.find((r) => r.method === method && r.path === path);
+    if (!route) {
+      return new Response(JSON.stringify({ error: `no route for ${method} ${path}` }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const result = route.handler(recorded);
+    return new Response(JSON.stringify(result.json ?? {}), {
+      status: result.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return { fetchFn, calls };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+describe("RemoteAnimaClient.signAuth", () => {
+  it("POSTs digest_b64 + user_id and decodes signature_b64", async () => {
+    const expected = new Uint8Array(64);
+    expected.fill(0xab);
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_auth",
+        handler: (req) => {
+          const body = req.body as { user_id: string; digest_b64: string };
+          expect(body.user_id).toBe("u-1");
+          expect(base64ToBytes(body.digest_b64).byteLength).toBe(32);
+          return { json: { signature_b64: bytesToBase64(expected) } };
+        },
+      },
+    ]);
+
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "user-cap-token",
+      fetch: fetchFn,
+    });
+    const digest = new Uint8Array(32);
+    digest[0] = 1;
+    const sig = await client.signAuth("u-1", digest);
+    expect(sig).toEqual(expected);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers["authorization"]).toBe("Bearer user-cap-token");
+    expect(calls[0]?.headers["content-type"]).toBe("application/json");
+  });
+});
+
+describe("RemoteAnimaClient.signWallet", () => {
+  it("POSTs digest_b64 and returns the 65-byte EvmSignature", async () => {
+    const expected = new Uint8Array(65);
+    expected.fill(0xff);
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_wallet",
+        handler: () => ({ json: { signature_b64: bytesToBase64(expected) } }),
+      },
+    ]);
+
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const sig = await client.signWallet("u-1", new Uint8Array(32));
+    expect(sig).toEqual(expected);
+    expect(calls[0]?.url).toBe("https://gw.test/anima/custody/sign_wallet");
+  });
+});
+
+describe("RemoteAnimaClient.signEvmTx", () => {
+  it("serialises camelCase fields to snake_case wire shape", async () => {
+    const expected = new Uint8Array(65);
+    expected[64] = 27; // legacy v
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_evm_tx",
+        handler: (req) => {
+          const body = req.body as { user_id: string; tx: Record<string, unknown> };
+          expect(body.user_id).toBe("u-1");
+          expect(body.tx).toEqual({
+            from: "0xabc",
+            to: "0xdef",
+            value_wei: "1000",
+            data_hex: "0x",
+            nonce: 5,
+            gas_limit: 21000,
+            max_fee_per_gas_wei: "200",
+            max_priority_fee_per_gas_wei: "100",
+            chain: "eip155:8453",
+          });
+          return { json: { signature_b64: bytesToBase64(expected) } };
+        },
+      },
+    ]);
+
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const sig = await client.signEvmTx("u-1", {
+      from: "0xabc",
+      to: "0xdef",
+      valueWei: "1000",
+      dataHex: "0x",
+      nonce: 5,
+      gasLimit: 21000,
+      maxFeePerGasWei: "200",
+      maxPriorityFeePerGasWei: "100",
+      chain: "eip155:8453",
+    });
+    expect(sig.bytes).toEqual(expected);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("RemoteAnimaClient.signEip712", () => {
+  it("serialises domain to snake_case + passes types/message opaquely", async () => {
+    const expected = new Uint8Array(65);
+    expected[0] = 0xee;
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_eip712",
+        handler: (req) => {
+          const body = req.body as {
+            user_id: string;
+            domain: Record<string, unknown>;
+            types: Record<string, unknown>;
+            message: Record<string, unknown>;
+          };
+          expect(body.user_id).toBe("u-1");
+          expect(body.domain).toEqual({
+            name: "USD Coin",
+            version: "2",
+            chain_id: "8453",
+            verifying_contract: "0xUSDC",
+          });
+          expect(body.types).toEqual({ TransferWithAuthorization: [] });
+          expect(body.message).toEqual({ from: "0xabc", value: "100" });
+          return { json: { signature_b64: bytesToBase64(expected) } };
+        },
+      },
+    ]);
+
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const sig = await client.signEip712(
+      "u-1",
+      {
+        name: "USD Coin",
+        version: "2",
+        chainId: "8453",
+        verifyingContract: "0xUSDC",
+      },
+      { TransferWithAuthorization: [] },
+      { from: "0xabc", value: "100" },
+    );
+    expect(sig.bytes).toEqual(expected);
+  });
+});
+
+describe("RemoteAnimaClient pubkey + address GETs", () => {
+  it("getAuthPubkey URL-encodes the user_id path segment", async () => {
+    const expected = new Uint8Array(33);
+    expected[0] = 0x02;
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "GET",
+        path: "/anima/custody/auth_pubkey/u%3A1",
+        handler: () => ({ json: { pubkey_b64: bytesToBase64(expected) } }),
+      },
+    ]);
+
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const pk = await client.getAuthPubkey("u:1");
+    expect(pk).toEqual(expected);
+    expect(calls[0]?.method).toBe("GET");
+  });
+
+  it("getWalletPubkey returns the secp256k1 SEC1-compressed bytes", async () => {
+    const expected = new Uint8Array(33);
+    expected[0] = 0x03;
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "GET",
+        path: "/anima/custody/wallet_pubkey/u-1",
+        handler: () => ({ json: { pubkey_b64: bytesToBase64(expected) } }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    expect(await client.getWalletPubkey("u-1")).toEqual(expected);
+  });
+
+  it("getWalletAddress returns the address string", async () => {
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "GET",
+        path: "/anima/custody/wallet_address/u-1",
+        handler: () => ({ json: { address: "0x1234567890abcdef" } }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    expect(await client.getWalletAddress("u-1")).toBe("0x1234567890abcdef");
+  });
+});
+
+describe("RemoteAnimaClient.enrollPasskey", () => {
+  it("POSTs base64-encoded attestation bundles + returns DID + wallet info", async () => {
+    const walletPk = new Uint8Array(33);
+    walletPk[0] = 0x02;
+    walletPk[1] = 0xaa;
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/enroll_passkey",
+        handler: (req) => {
+          const body = req.body as {
+            user_id: string;
+            attestation_object_b64: string;
+            client_data_json_b64: string;
+            credential_id_b64: string;
+          };
+          expect(body.user_id).toBe("u-1");
+          expect(base64ToBytes(body.attestation_object_b64).byteLength).toBeGreaterThan(0);
+          expect(base64ToBytes(body.credential_id_b64).byteLength).toBe(16);
+          return {
+            json: {
+              user_did: "did:key:zDnNew",
+              wallet_address: "0xWALLET",
+              wallet_pubkey_b64: bytesToBase64(walletPk),
+            },
+          };
+        },
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "enroll-tok",
+      fetch: fetchFn,
+    });
+    const result = await client.enrollPasskey("u-1", {
+      attestationObject: new Uint8Array([1, 2, 3, 4, 5]),
+      clientDataJson: new Uint8Array([6, 7, 8]),
+      credentialId: new ArrayBuffer(16),
+    });
+    expect(result.userDid).toBe("did:key:zDnNew");
+    expect(result.walletAddress).toBe("0xWALLET");
+    expect(result.walletPubkey).toEqual(walletPk);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("RemoteAnimaClient.mintSessionCap", () => {
+  it("POSTs assertion bundle and returns expiry/issued metadata", async () => {
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/mint_session_cap",
+        handler: (req) => {
+          const body = req.body as {
+            user_id: string;
+            assertion: Record<string, string>;
+          };
+          expect(body.user_id).toBe("u-1");
+          expect(body.assertion["signature_b64"]).toBeTruthy();
+          expect(body.assertion["client_data_json_b64"]).toBeTruthy();
+          expect(body.assertion["authenticator_data_b64"]).toBeTruthy();
+          expect(body.assertion["credential_id_b64"]).toBeTruthy();
+          return {
+            json: {
+              token: "TIER-USER-JWT",
+              expires_at: 1_700_000_000,
+              issued_at: 1_699_999_100,
+            },
+          };
+        },
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "ignored",
+      fetch: fetchFn,
+    });
+    const result = await client.mintSessionCap(
+      "u-1",
+      {
+        assertion: {
+          signature: new Uint8Array(64),
+          clientDataJson: new Uint8Array(8),
+          authenticatorData: new Uint8Array(40),
+          credentialId: new ArrayBuffer(16),
+        },
+      },
+      "explicit-bearer",
+    );
+    expect(result.token).toBe("TIER-USER-JWT");
+    expect(result.expiresAt).toBe(1_700_000_000);
+    expect(result.issuedAt).toBe(1_699_999_100);
+    // The explicit override takes precedence over `getToken`.
+    expect(calls[0]?.headers["authorization"]).toBe("Bearer explicit-bearer");
+  });
+
+  it("omits Authorization header when bearerOverride is empty string", async () => {
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/mint_session_cap",
+        handler: () => ({
+          json: { token: "T", expires_at: 1, issued_at: 0 },
+        }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "outer-tok",
+      fetch: fetchFn,
+    });
+    await client.mintSessionCap(
+      "u-1",
+      {
+        assertion: {
+          signature: new Uint8Array(64),
+          clientDataJson: new Uint8Array(8),
+          authenticatorData: new Uint8Array(40),
+          credentialId: new ArrayBuffer(16),
+        },
+      },
+      "", // explicit empty → unauthed
+    );
+    expect(calls[0]?.headers["authorization"]).toBeUndefined();
+  });
+});
+
+describe("RemoteAnimaClient error handling", () => {
+  it("throws AnimaError on non-2xx response", async () => {
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_auth",
+        handler: () => ({ status: 401, json: { error: "missing token" } }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    let caught: unknown;
+    try {
+      await client.signAuth("u-1", new Uint8Array(32));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AnimaError);
+    expect((caught as AnimaError).code).toBe("remote_anima_401");
+    expect((caught as AnimaError).message).toContain("missing token");
+  });
+
+  it("throws AnimaError on network failure", async () => {
+    const fetchFn: typeof fetch = async () => {
+      throw new Error("network down");
+    };
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    await expect(client.getWalletAddress("u-1")).rejects.toThrow(/fetch failed/);
+  });
+
+  it("normalizes baseUrl trailing slashes", () => {
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test///",
+      getToken: async () => "tok",
+    });
+    expect(client.baseUrl).toBe("https://gw.test");
+  });
+});

--- a/sdks/life-sdk-ts/tests/anima/remote.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/remote.test.ts
@@ -242,7 +242,7 @@ describe("RemoteAnimaClient pubkey + address GETs", () => {
     const { fetchFn, calls } = makeFakeFetch([
       {
         method: "GET",
-        path: "/anima/custody/auth_pubkey/u%3A1",
+        path: "/anima/custody/get_auth_pubkey/u%3A1",
         handler: () => ({ json: { pubkey_b64: bytesToBase64(expected) } }),
       },
     ]);
@@ -263,7 +263,7 @@ describe("RemoteAnimaClient pubkey + address GETs", () => {
     const { fetchFn } = makeFakeFetch([
       {
         method: "GET",
-        path: "/anima/custody/wallet_pubkey/u-1",
+        path: "/anima/custody/get_wallet_pubkey/u-1",
         handler: () => ({ json: { pubkey_b64: bytesToBase64(expected) } }),
       },
     ]);
@@ -462,5 +462,94 @@ describe("RemoteAnimaClient error handling", () => {
       getToken: async () => "tok",
     });
     expect(client.baseUrl).toBe("https://gw.test");
+  });
+
+  // I-1 review fix: structured `{ code, message }` errors surface
+  // those fields only — never the raw body.
+  it("surfaces only code+message from structured error bodies (I-1)", async () => {
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_auth",
+        handler: () => ({
+          status: 403,
+          json: {
+            code: "tier_user_revoked",
+            message: "session cap revoked",
+            // Sensitive fields that MUST NOT leak into AnimaError.message.
+            jwt: "eyJhbGciOiJFUzI1NiI.dot.dot",
+            request_id: "req_abc123",
+            upstream_kms_error: "vault: 403 lease expired",
+          },
+        }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    let caught: unknown;
+    try {
+      await client.signAuth("u-1", new Uint8Array(32));
+    } catch (err) {
+      caught = err;
+    }
+    const msg = (caught as AnimaError).message;
+    expect(msg).toContain("tier_user_revoked");
+    expect(msg).toContain("session cap revoked");
+    // Critical: none of these sensitive fields leak.
+    expect(msg).not.toContain("eyJhbGciOiJFUzI1NiI");
+    expect(msg).not.toContain("req_abc123");
+    expect(msg).not.toContain("vault: 403 lease expired");
+  });
+
+  // I-1 review fix: long unstructured bodies get truncated to
+  // MAX_REMOTE_ERROR_BODY_CHARS (200) + ellipsis. The fake-fetch
+  // helper always JSON-encodes responses; an enormous unstructured
+  // string lands as a JSON-string body, which sanitizeErrorBody falls
+  // through to truncate (no `code`/`message` shape).
+  it("truncates oversized error bodies to ~200 chars + ellipsis (I-1)", async () => {
+    const huge = "x".repeat(2_000);
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_auth",
+        // `json: huge` serializes to '"xxxx..."' (~2002 chars total)
+        handler: () => ({ status: 500, json: huge }),
+      },
+    ]);
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    let caught: unknown;
+    try {
+      await client.signAuth("u-1", new Uint8Array(32));
+    } catch (err) {
+      caught = err;
+    }
+    const msg = (caught as AnimaError).message;
+    expect(msg.length).toBeLessThan(huge.length);
+    expect(msg).toContain("…");
+  });
+
+  // I-2 review fix: fetch failures with TimeoutError/AbortError name
+  // map to a typed "request timeout" AnimaError.
+  it("maps AbortError/TimeoutError to a request-timeout error (I-2)", async () => {
+    const fetchFn: typeof fetch = async () => {
+      const e = new Error("aborted") as Error & { name: string };
+      e.name = "TimeoutError";
+      throw e;
+    };
+    const client = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    await expect(client.getAuthPubkey("u-1")).rejects.toThrow(
+      /request timeout/,
+    );
   });
 });

--- a/sdks/life-sdk-ts/tests/anima/session_cap.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/session_cap.test.ts
@@ -1,0 +1,287 @@
+/**
+ * `SessionCap` lifecycle tests — enrollment + mint, refresh-on-expiry,
+ * concurrent in-flight handling, force refresh, invalidate.
+ *
+ * Uses vitest fake timers + injected `now` to drive the lifecycle
+ * deterministically.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PasskeyOracle } from "../../src/anima/passkey.js";
+import { RemoteAnimaClient } from "../../src/anima/remote.js";
+import { SessionCap } from "../../src/anima/session_cap.js";
+
+/** Build a SessionCap with hand-rolled stubs for passkey + remote. */
+function makeHarness(opts?: {
+  refreshBeforeSecs?: number;
+  initialNow?: number;
+}): {
+  cap: SessionCap;
+  passkeyCalls: number;
+  remoteCalls: number;
+  expiresAt: () => number;
+  setExpiresAt: (n: number) => void;
+  now: () => number;
+  setNow: (n: number) => void;
+} {
+  let now = opts?.initialNow ?? 1_000_000;
+  let expiresAt = now + 900; // 15-minute default
+
+  const harnessInternal = {
+    passkeyCalls: 0,
+    remoteCalls: 0,
+  };
+
+  // Stub PasskeyOracle.signWithAssertion via a structurally-typed
+  // shim — we only need the one method.
+  const passkeyStub = {
+    signWithAssertion: async (_digest: Uint8Array) => {
+      harnessInternal.passkeyCalls += 1;
+      return {
+        signature: new Uint8Array(64),
+        clientDataJson: new Uint8Array(8),
+        authenticatorData: new Uint8Array(40),
+        credentialId: new ArrayBuffer(16),
+      };
+    },
+  } as unknown as PasskeyOracle;
+
+  // Stub RemoteAnimaClient.mintSessionCap.
+  const remoteStub = {
+    mintSessionCap: async (
+      _userId: string,
+      _params: unknown,
+      _bearerOverride: string | undefined,
+    ) => {
+      harnessInternal.remoteCalls += 1;
+      return {
+        token: `tok-${harnessInternal.remoteCalls}`,
+        expiresAt,
+        issuedAt: now,
+      };
+    },
+  } as unknown as RemoteAnimaClient;
+
+  const cap = new SessionCap({
+    userId: "u-1",
+    passkey: passkeyStub,
+    remote: remoteStub,
+    refreshBeforeSecs: opts?.refreshBeforeSecs ?? 30,
+    now: () => now,
+    randomChallenge: () => {
+      const c = new Uint8Array(32);
+      c[0] = 0x42;
+      return c;
+    },
+  });
+
+  return {
+    cap,
+    get passkeyCalls() {
+      return harnessInternal.passkeyCalls;
+    },
+    get remoteCalls() {
+      return harnessInternal.remoteCalls;
+    },
+    expiresAt: () => expiresAt,
+    setExpiresAt: (n: number) => {
+      expiresAt = n;
+    },
+    now: () => now,
+    setNow: (n: number) => {
+      now = n;
+    },
+  } as unknown as ReturnType<typeof makeHarness>;
+}
+
+describe("SessionCap.getValidToken — initial mint", () => {
+  it("triggers a passkey + remote call on first invocation", async () => {
+    const h = makeHarness();
+    const tok = await h.cap.getValidToken();
+    expect(tok).toBe("tok-1");
+    expect(h.passkeyCalls).toBe(1);
+    expect(h.remoteCalls).toBe(1);
+  });
+
+  it("subsequent calls within TTL return cached token without prompting", async () => {
+    const h = makeHarness();
+    const tok1 = await h.cap.getValidToken();
+    const tok2 = await h.cap.getValidToken();
+    const tok3 = await h.cap.getValidToken();
+    expect(tok1).toBe(tok2);
+    expect(tok1).toBe(tok3);
+    expect(h.passkeyCalls).toBe(1);
+    expect(h.remoteCalls).toBe(1);
+  });
+});
+
+describe("SessionCap.getValidToken — refresh on expiry", () => {
+  it("refreshes when remaining < refreshBeforeSecs", async () => {
+    const h = makeHarness({ refreshBeforeSecs: 30 });
+    const tok1 = await h.cap.getValidToken();
+    expect(tok1).toBe("tok-1");
+
+    // Advance time so token has 20s remaining (< 30s threshold).
+    h.setNow(h.expiresAt() - 20);
+    const tok2 = await h.cap.getValidToken();
+    expect(tok2).toBe("tok-2");
+    expect(h.remoteCalls).toBe(2);
+  });
+
+  it("does not refresh while > threshold remains", async () => {
+    const h = makeHarness({ refreshBeforeSecs: 30 });
+    await h.cap.getValidToken();
+    h.setNow(h.expiresAt() - 60); // 60s remaining > 30s threshold
+    await h.cap.getValidToken();
+    expect(h.remoteCalls).toBe(1);
+  });
+});
+
+describe("SessionCap.forceRefresh", () => {
+  it("forces a fresh mint regardless of cached state", async () => {
+    const h = makeHarness();
+    const t1 = await h.cap.getValidToken();
+    const t2 = await h.cap.forceRefresh();
+    expect(t1).toBe("tok-1");
+    expect(t2).toBe("tok-2");
+    expect(h.remoteCalls).toBe(2);
+  });
+});
+
+describe("SessionCap.invalidate", () => {
+  it("clears the cached cap so next call mints", async () => {
+    const h = makeHarness();
+    await h.cap.getValidToken();
+    h.cap.invalidate();
+    expect(h.cap.current()).toBeNull();
+    await h.cap.getValidToken();
+    expect(h.remoteCalls).toBe(2);
+  });
+});
+
+describe("SessionCap concurrent callers", () => {
+  it("multiple callers during a refresh share the same in-flight promise", async () => {
+    let releaseRemote!: (token: { token: string; expiresAt: number; issuedAt: number }) => void;
+    const remotePending = new Promise<{ token: string; expiresAt: number; issuedAt: number }>(
+      (resolve) => {
+        releaseRemote = resolve;
+      },
+    );
+    let mintCalls = 0;
+    const passkeyStub = {
+      signWithAssertion: async () => ({
+        signature: new Uint8Array(64),
+        clientDataJson: new Uint8Array(8),
+        authenticatorData: new Uint8Array(40),
+        credentialId: new ArrayBuffer(16),
+      }),
+    } as unknown as PasskeyOracle;
+    const remoteStub = {
+      mintSessionCap: async () => {
+        mintCalls += 1;
+        return await remotePending;
+      },
+    } as unknown as RemoteAnimaClient;
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey: passkeyStub,
+      remote: remoteStub,
+      refreshBeforeSecs: 30,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+
+    // Three concurrent callers — only one mintSessionCap fires.
+    const p1 = cap.getValidToken();
+    const p2 = cap.getValidToken();
+    const p3 = cap.getValidToken();
+
+    // Resolve the one in-flight call.
+    releaseRemote({ token: "shared-tok", expiresAt: 999_999, issuedAt: 0 });
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe("shared-tok");
+    expect(r2).toBe("shared-tok");
+    expect(r3).toBe("shared-tok");
+    expect(mintCalls).toBe(1);
+  });
+});
+
+describe("SessionCap.onExpiringSoon", () => {
+  it("fires the callback before a refresh", async () => {
+    let fired = 0;
+    const passkeyStub = {
+      signWithAssertion: async () => ({
+        signature: new Uint8Array(64),
+        clientDataJson: new Uint8Array(8),
+        authenticatorData: new Uint8Array(40),
+        credentialId: new ArrayBuffer(16),
+      }),
+    } as unknown as PasskeyOracle;
+    const remoteStub = {
+      mintSessionCap: async () => ({ token: "T", expiresAt: 999, issuedAt: 0 }),
+    } as unknown as RemoteAnimaClient;
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey: passkeyStub,
+      remote: remoteStub,
+      onExpiringSoon: () => {
+        fired += 1;
+      },
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    await cap.getValidToken();
+    expect(fired).toBe(1);
+  });
+
+  it("does not propagate callback errors", async () => {
+    const passkeyStub = {
+      signWithAssertion: async () => ({
+        signature: new Uint8Array(64),
+        clientDataJson: new Uint8Array(8),
+        authenticatorData: new Uint8Array(40),
+        credentialId: new ArrayBuffer(16),
+      }),
+    } as unknown as PasskeyOracle;
+    const remoteStub = {
+      mintSessionCap: async () => ({ token: "T", expiresAt: 999, issuedAt: 0 }),
+    } as unknown as RemoteAnimaClient;
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey: passkeyStub,
+      remote: remoteStub,
+      onExpiringSoon: () => {
+        throw new Error("ui blew up");
+      },
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    // Should NOT throw despite the broken callback.
+    await expect(cap.getValidToken()).resolves.toBe("T");
+  });
+});
+
+describe("SessionCap input validation", () => {
+  it("throws if randomChallenge returns wrong length", async () => {
+    const passkeyStub = {
+      signWithAssertion: async () => ({
+        signature: new Uint8Array(64),
+        clientDataJson: new Uint8Array(8),
+        authenticatorData: new Uint8Array(40),
+        credentialId: new ArrayBuffer(16),
+      }),
+    } as unknown as PasskeyOracle;
+    const remoteStub = {
+      mintSessionCap: async () => ({ token: "T", expiresAt: 999, issuedAt: 0 }),
+    } as unknown as RemoteAnimaClient;
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey: passkeyStub,
+      remote: remoteStub,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(16),
+    });
+    await expect(cap.getValidToken()).rejects.toThrow(/32 bytes/);
+  });
+});

--- a/sdks/life-sdk-ts/tests/anima/web_crypto.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/web_crypto.test.ts
@@ -1,0 +1,624 @@
+/**
+ * `WebCryptoAnima` composition tests — exercise the split-custody
+ * flow with mocked passkey + mocked RemoteAnima.
+ */
+
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
+
+import { generateDidKeyP256 } from "../../src/anima/did.js";
+import { AnimaError } from "../../src/anima/errors.js";
+import { PasskeyOracle } from "../../src/anima/passkey.js";
+import { RemoteAnimaClient } from "../../src/anima/remote.js";
+import { SessionCap } from "../../src/anima/session_cap.js";
+import {
+  enrollWebCryptoAnima,
+  loadWebCryptoAnima,
+  WebCryptoAnima,
+} from "../../src/anima/web_crypto.js";
+import { MockPasskeyAuthenticator } from "./_mock_authenticator.js";
+
+let testCounter = 0;
+function uniqueDb(): string {
+  testCounter += 1;
+  return `web-crypto-test-${testCounter}`;
+}
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function makeFakeFetch(
+  routes: Array<{
+    method: string;
+    path: string;
+    handler: (req: RecordedRequest) => unknown;
+  }>,
+): { fetchFn: typeof fetch; calls: RecordedRequest[] } {
+  const calls: RecordedRequest[] = [];
+  const fetchFn: typeof fetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const path = new URL(url).pathname;
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body) {
+      const text =
+        typeof init.body === "string"
+          ? init.body
+          : new TextDecoder().decode(init.body as Uint8Array);
+      body = text ? JSON.parse(text) : undefined;
+    }
+    const recorded: RecordedRequest = { url, method, body };
+    calls.push(recorded);
+    const route = routes.find((r) => r.method === method && r.path === path);
+    if (!route) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(JSON.stringify(route.handler(recorded)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return { fetchFn, calls };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  return btoa(bin);
+}
+
+function makeWalletPubkey(): Uint8Array {
+  const out = new Uint8Array(33);
+  out[0] = 0x02;
+  out[1] = 0xaa;
+  return out;
+}
+
+describe("WebCryptoAnima — basic shape", () => {
+  it("exposes user_did derived from authPubkey", () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+
+    const fakePubkey = new Uint8Array(33);
+    fakePubkey[0] = 0x02;
+    fakePubkey[5] = 0xff;
+    // Inject the cached pubkey via the enroll path so authPubkey() works.
+    auth.credentialIdFactory = () => new Uint8Array(16);
+
+    return passkey.enroll("u-1", "U", new Uint8Array(32)).then(() => {
+      const remote = new RemoteAnimaClient({
+        baseUrl: "https://gw.test",
+        getToken: async () => "tok",
+      });
+      const cap = new SessionCap({
+        userId: "u-1",
+        passkey,
+        remote,
+        now: () => 0,
+        randomChallenge: () => new Uint8Array(32),
+      });
+      const handle = new WebCryptoAnima({
+        auth: passkey,
+        wallet: remote,
+        sessionCap: cap,
+        userId: "u-1",
+        walletAddress: "0xabcdef",
+        walletPubkey: makeWalletPubkey(),
+      });
+
+      expect(handle.userId()).toBe("u-1");
+      expect(handle.walletAddress()).toBe("0xabcdef");
+      expect(handle.backendKind()).toBe("web_crypto");
+      expect(handle.authPubkey().byteLength).toBe(33);
+      expect(handle.userDid()).toMatch(/^did:key:zDn/);
+      expect(handle.userDid()).toBe(generateDidKeyP256(handle.authPubkey()));
+    });
+  });
+
+  it("rejects construction with wrong-length walletPubkey", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    expect(
+      () =>
+        new WebCryptoAnima({
+          auth: passkey,
+          wallet: remote,
+          sessionCap: cap,
+          userId: "u-1",
+          walletAddress: "0xabc",
+          walletPubkey: new Uint8Array(32),
+        }),
+    ).toThrow(/33 bytes/);
+  });
+});
+
+describe("WebCryptoAnima.signJws", () => {
+  it("produces a 3-part compact JWS with ES256 header", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xabcdef",
+      walletPubkey: makeWalletPubkey(),
+    });
+
+    const jws = await handle.signJws({}, { sub: "u-1", iss: "broomva", iat: 0 });
+    const parts = jws.split(".");
+    expect(parts).toHaveLength(3);
+
+    // Decode header — should declare ES256 + JWT typ + a `did:key:zDn…` kid.
+    const headerJson = atob(parts[0]!.replace(/-/g, "+").replace(/_/g, "/").padEnd(parts[0]!.length + ((4 - (parts[0]!.length % 4)) % 4), "="));
+    const header = JSON.parse(headerJson);
+    expect(header.alg).toBe("ES256");
+    expect(header.typ).toBe("JWT");
+    expect(header.kid).toMatch(/^did:key:zDn/);
+
+    // Decode body — should contain our payload claims.
+    const bodyJson = atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/").padEnd(parts[1]!.length + ((4 - (parts[1]!.length % 4)) % 4), "="));
+    const body = JSON.parse(bodyJson);
+    expect(body.sub).toBe("u-1");
+    expect(body.iss).toBe("broomva");
+  });
+});
+
+describe("WebCryptoAnima.signDigest", () => {
+  it("returns 64-byte raw signature from passkey", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xabc",
+      walletPubkey: makeWalletPubkey(),
+    });
+
+    const sig = await handle.signDigest(new Uint8Array(32));
+    expect(sig.byteLength).toBe(64);
+  });
+
+  it("rejects digest of wrong length", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xabc",
+      walletPubkey: makeWalletPubkey(),
+    });
+    await expect(handle.signDigest(new Uint8Array(31))).rejects.toThrow(/32 bytes/);
+  });
+});
+
+describe("WebCryptoAnima.signEvmTx — wallet delegation", () => {
+  it("delegates to RemoteAnimaClient.signEvmTx when from matches walletAddress", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+
+    const sigBytes = new Uint8Array(65);
+    sigBytes[64] = 27;
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_evm_tx",
+        handler: () => ({ signature_b64: bytesToBase64(sigBytes) }),
+      },
+    ]);
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xWALLET",
+      walletPubkey: makeWalletPubkey(),
+    });
+
+    const result = await handle.signEvmTx({
+      from: "0xwallet", // case-insensitive comparison
+      to: "0xrecv",
+      valueWei: "1000",
+      dataHex: "0x",
+      nonce: 0,
+      gasLimit: 21000,
+      maxFeePerGasWei: "1",
+      maxPriorityFeePerGasWei: "1",
+      chain: "eip155:8453",
+    });
+    expect(result.bytes).toEqual(sigBytes);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("rejects tx.from not matching walletAddress (case-insensitive)", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xCORRECT",
+      walletPubkey: makeWalletPubkey(),
+    });
+    await expect(
+      handle.signEvmTx({
+        from: "0xWRONG",
+        to: "0xrecv",
+        valueWei: "1",
+        dataHex: "0x",
+        nonce: 0,
+        gasLimit: 21000,
+        maxFeePerGasWei: "1",
+        maxPriorityFeePerGasWei: "1",
+        chain: "eip155:8453",
+      }),
+    ).rejects.toThrow(/does not match wallet address/);
+  });
+});
+
+describe("WebCryptoAnima.signEip712 — wallet delegation", () => {
+  it("forwards the typed-data payload to RemoteAnimaClient.signEip712", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+
+    const sigBytes = new Uint8Array(65);
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/sign_eip712",
+        handler: () => ({ signature_b64: bytesToBase64(sigBytes) }),
+      },
+    ]);
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xwallet",
+      walletPubkey: makeWalletPubkey(),
+    });
+
+    await handle.signEip712(
+      {
+        name: "USD Coin",
+        version: "2",
+        chainId: "8453",
+        verifyingContract: "0xUSDC",
+      },
+      { TransferWithAuthorization: [] },
+      { from: "0xwallet", value: "100" },
+    );
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("WebCryptoAnima.rotate", () => {
+  it("rejects with not_supported error", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    await passkey.enroll("u-1", "U", new Uint8Array(32));
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = new WebCryptoAnima({
+      auth: passkey,
+      wallet: remote,
+      sessionCap: cap,
+      userId: "u-1",
+      walletAddress: "0xabc",
+      walletPubkey: makeWalletPubkey(),
+    });
+
+    let caught: unknown;
+    try {
+      await handle.rotate();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AnimaError);
+    expect((caught as AnimaError).code).toBe("not_supported");
+  });
+});
+
+describe("enrollWebCryptoAnima — full flow", () => {
+  it("calls passkey.enroll then remote.enrollPasskey and returns a configured handle", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+
+    const walletPk = makeWalletPubkey();
+    const { fetchFn, calls } = makeFakeFetch([
+      {
+        method: "POST",
+        path: "/anima/custody/enroll_passkey",
+        handler: () => ({
+          user_did: "did:key:zDnSERVER",
+          wallet_address: "0xWALLET",
+          wallet_pubkey_b64: bytesToBase64(walletPk),
+        }),
+      },
+    ]);
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+    const cap = new SessionCap({
+      userId: "u-1",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = await enrollWebCryptoAnima({
+      passkey,
+      remote,
+      sessionCap: cap,
+      userId: "u-1",
+      displayName: "Test User",
+      challenge: new Uint8Array(32),
+    });
+    expect(handle.walletAddress()).toBe("0xWALLET");
+    expect(handle.walletPubkey()).toEqual(walletPk);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("loadWebCryptoAnima — load existing", () => {
+  it("returns null when not enrolled", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: uniqueDb(),
+    });
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+    });
+    const cap = new SessionCap({
+      userId: "u-never",
+      passkey,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = await loadWebCryptoAnima({
+      passkey,
+      remote,
+      sessionCap: cap,
+      userId: "u-never",
+    });
+    expect(handle).toBeNull();
+  });
+
+  it("loads stored passkey + fetches wallet info from remote", async () => {
+    const auth = new MockPasskeyAuthenticator();
+    testCounter += 1;
+    const dbName = `load-test-${testCounter}`;
+    const passkey = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    await passkey.enroll("u-load", "U", new Uint8Array(32));
+    passkey.reset();
+
+    const walletPk = makeWalletPubkey();
+    const { fetchFn } = makeFakeFetch([
+      {
+        method: "GET",
+        path: "/anima/custody/wallet_address/u-load",
+        handler: () => ({ address: "0xCACHED" }),
+      },
+      {
+        method: "GET",
+        path: "/anima/custody/wallet_pubkey/u-load",
+        handler: () => ({ pubkey_b64: bytesToBase64(walletPk) }),
+      },
+    ]);
+    const remote = new RemoteAnimaClient({
+      baseUrl: "https://gw.test",
+      getToken: async () => "tok",
+      fetch: fetchFn,
+    });
+
+    // Use a fresh oracle with same DB to validate the load path.
+    const passkey2 = new PasskeyOracle({
+      rpId: "broomva.test",
+      rpName: "Broomva Test",
+      credentials: auth,
+      indexedDB: globalThis.indexedDB,
+      databaseName: dbName,
+    });
+    const cap = new SessionCap({
+      userId: "u-load",
+      passkey: passkey2,
+      remote,
+      now: () => 0,
+      randomChallenge: () => new Uint8Array(32),
+    });
+    const handle = await loadWebCryptoAnima({
+      passkey: passkey2,
+      remote,
+      sessionCap: cap,
+      userId: "u-load",
+    });
+    expect(handle).not.toBeNull();
+    expect(handle?.walletAddress()).toBe("0xCACHED");
+    expect(handle?.walletPubkey()).toEqual(walletPk);
+  });
+});

--- a/sdks/life-sdk-ts/tests/anima/web_crypto.test.ts
+++ b/sdks/life-sdk-ts/tests/anima/web_crypto.test.ts
@@ -586,7 +586,7 @@ describe("loadWebCryptoAnima — load existing", () => {
       },
       {
         method: "GET",
-        path: "/anima/custody/wallet_pubkey/u-load",
+        path: "/anima/custody/get_wallet_pubkey/u-load",
         handler: () => ({ pubkey_b64: bytesToBase64(walletPk) }),
       },
     ]);

--- a/sdks/life-sdk-ts/tests/fixtures/did_p256_vectors.json
+++ b/sdks/life-sdk-ts/tests/fixtures/did_p256_vectors.json
@@ -1,0 +1,27 @@
+[
+  {
+    "description": "parity_02_random",
+    "expected_did": "did:key:zDnaebnYfb4cmGGMbzeENo7Ek9T1fpnC7BvyvN2SXRY2EYCPr",
+    "pubkey_compressed_hex": "02a8b62fc1c3d8e1c4e1c1c0c1d1e1c1d1c1c1c1d1d1c1c1d1d1c1c1d1d1c1c1c1"
+  },
+  {
+    "description": "parity_03_random",
+    "expected_did": "did:key:zDnaevAWTtDuhBK1DwsQHAoCgLKLL2KnuNRvDgGKPBCFvNDXt",
+    "pubkey_compressed_hex": "03b9c8d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7"
+  },
+  {
+    "description": "parity_02_low_x",
+    "expected_did": "did:key:zDnaeQRy3dcKsKa1zmKtVKsTy3m2HYoQnFnfKuxD6HfSTQgbc",
+    "pubkey_compressed_hex": "0200000000000000000000000000000000000000000000000000000000000000ab"
+  },
+  {
+    "description": "parity_03_high_x",
+    "expected_did": "did:key:zDnaeztbndBq4ufVXuVTKnDpZSCdL3nhRkCoWt47k1WHzSatP",
+    "pubkey_compressed_hex": "03fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe00"
+  },
+  {
+    "description": "parity_02_zero_pad",
+    "expected_did": "did:key:zDnaeQRywL8RCtEJDKtEc1emuUcg1Da4GJgQ5Pk6mJqGE3yQU",
+    "pubkey_compressed_hex": "020001020304050607080910111213141516171819202122232425262728293031"
+  }
+]


### PR DESCRIPTION
## Summary

Closes Spec D D-Sub-C's TypeScript half (Stream T) — the M9-blocking browser-custody gap. Introduces `@broomva/life-sdk/anima` with passkey-managed P-256 auth + delegated secp256k1 wallet via `/anima/custody/*` HTTP/JSON routes (Stream R ships those routes in parallel).

- **Spec D L4-D5..D10 implemented**: split custody, P-256 auth via passkey (non-extractable, OS-managed), secp256k1 wallet stays delegated, rotation journal-driven.
- **5 new modules** at `sdks/life-sdk-ts/src/anima/`: `did.ts`, `passkey.ts`, `remote.ts`, `session_cap.ts`, `web_crypto.ts`, plus `types.ts` + `errors.ts` + `index.ts`.
- **Cross-language compatibility**: `generateDidKeyP256` produces byte-identical output to Rust's `did.rs::generate_did_key_p256`. Pinned via 5 fixture vectors at `tests/fixtures/did_p256_vectors.json` (covering parity 0x02/0x03 + leading-zero edge cases) generated from the Rust side.
- **Composition pattern**: `WebCryptoAnima { auth: PasskeyOracle, wallet: RemoteAnimaClient }`. Mirrors Rust's `HardwareWalletAnima` shape (auth-only wrapping a delegate, here it's wallet delegated).

## Architectural decisions (locked)

1. **HTTP/JSON wire format** for browser ↔ lifegw `/anima/custody/*` routes — sidesteps M8.1 (Connect-vs-grpc-web mismatch). Custody RPC code structurally separate from existing tonic-web SDK paths.
2. **Long-lived in-tab signing oracle** — passkey prompts only on enrollment + Tier-User cap renewal (every 15 min OR after explicit revoke). Subsequent JWT mints use the cached cap.
3. **DID multicodec match** — TS produces byte-identical output to Rust for the same SEC1 compressed pubkey input.
4. **No `crypto.subtle.exportKey` calls** — passkey-managed `CryptoKey` stays non-extractable per L4-D5. The whole point of WebAuthn.

## What ships

- `WebCryptoAnima` (composition wrapper) + `enrollWebCryptoAnima` / `loadWebCryptoAnima` helpers
- `PasskeyOracle` — `navigator.credentials.create/get`, COSE_Key parser, DER → JOSE-raw conversion, IndexedDB cache via `idb`
- `RemoteAnimaClient` — thin `fetch` wrapper for `/anima/custody/*`
- `SessionCap` — Tier-User cap lifecycle (mint/refresh/concurrent in-flight)
- `generateDidKeyP256`/`resolveDidKeyP256`/`verifyDidKeyP256` (cross-language compatible)
- `AnimaError` typed error class
- TypeScript types mirroring Rust's `custody.rs` shapes

## Tests

**75 new / 125 total** (was 50). All passing.

- `did.test.ts` (24): cross-language fixtures + input validation + round-trip + verify
- `passkey.test.ts` (16): `MockPasskeyAuthenticator` with real ECDSA via `@noble/curves`; full enroll → load → sign + COSE_Key parse + DER conversion
- `remote.test.ts` (13): HTTP wire shape contract — every `/anima/custody/*` route's request + response shape pinned (Stream R parity)
- `session_cap.test.ts` (10): mint/refresh/concurrent in-flight/UI callback safety
- `web_crypto.test.ts` (12): composition + signJws/signDigest + signEvmTx delegation + signEip712 + `enrollWebCryptoAnima`/`loadWebCryptoAnima`

`bun run typecheck` clean. `bun run test` clean.

## Stream R coordination

This PR is independent of Stream R (Rust gateway routes). Both sides mock the wire shape internally and integrate at the wire-shape contract level. The full e2e (browser TS calling real Rust lifegw) lands in a future glue/acceptance commit.

## Spec D progress

Closes Spec D D-Sub-C TypeScript half. Spec D = 100% (6/6 sub-phases) once Stream R's gateway routes ship. Unblocks M9 (apps migration).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 125/125 passing
- [x] Cross-language DID fixtures byte-identical to Rust output
- [x] `KNOWN_LIMITATIONS.md` M8.2 entry struck (sidestepped via new HTTP routes)
- [x] `README.md` has new "Browser custody" section
- [x] `examples/browser-custody.html` runbook-only demo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
  * Added browser custody surface with passkey-based authentication for local signing operations
  * Introduced P-256 DID key generation, resolution, and verification utilities
  * Added session token lifecycle management with automatic refresh
  * Implemented HTTP client for remote custody operations
  * Added browser custody documentation, guides, and interactive demo

<!-- end of auto-generated comment: release notes by coderabbit.ai -->