### PR TITLE
docs(status): annotate Wave 3 — Spec D D-Sub-C SHIPPED — Spec D 100% complete

### DIFF
--- a/crates/anima/CLAUDE.md
+++ b/crates/anima/CLAUDE.md
@@ -163,10 +163,12 @@ trait abstraction + 6 production backends. D-Sub-A (this PR) ships:
 |---|---|---|
 | D-Sub-A | `InProcessAnima` | shipped 2026-04-29 (PR #1070) |
 | D-Sub-B | `VaultTransitAnima` | shipped 2026-05-01 (PR #1073); closes `sign_evm_tx` SPEC-D-DEVIATION via shared RLP encoder |
-| D-Sub-C | `WebCryptoAnima` + `RemoteAnima` | M9-blocking (~7 days) |
+| D-Sub-C | `WebCryptoAnima` + `RemoteAnima` + lifegw `/anima/custody/*` | shipped 2026-05-02 (PRs #1082 + #1083 + #1084); browser passkey custody + Tier-User caps + WS bearer subprotocol (closes M8.2) |
 | D-Sub-D | `TpmAnima` | shipped 2026-05-02 (PR #1075); PKCS#11 auth half + wallet-half delegation |
-| D-Sub-E | `SomaCustody` + rotation/revocation flow + lago-auth verifier | shipped this PR |
+| D-Sub-E | `SomaCustody` + rotation/revocation flow + lago-auth verifier | shipped 2026-05-02 (PR #1076) |
 | D-Sub-F | `HardwareWalletAnima` | shipped 2026-05-02 (PR #1074); Ledger via hidapi, wallet-only wrapper |
+
+**Spec D = 100% complete (6/6 sub-phases).** All 6 production custody backends ship. M9 (apps/chat migration to AnimaCustody) is now unblocked.
 
 ### D-Sub-B (`VaultTransitAnima`) handoff state
 
@@ -426,3 +428,98 @@ delegate, only the secp256k1 wallet half goes to the hardware device.
   acceptance is "USDC transfer signed by a Ledger Nano X over WebHID
   from chatOS browser". This PR ships the desktop hidapi half;
   the browser-side acceptance test lands with the WebHID wrapper.
+
+### D-Sub-C (`WebCryptoAnima` + `RemoteAnima` + lifegw routes) handoff state
+
+D-Sub-C is the M9-blocking sub-phase that closes Spec D. It ships in
+THREE parallel PRs (Stream R-1 + Stream T + Stream R-2) merging in
+order R-1 → T → R-2 to keep history clean.
+
+**Stream R-1 (PR #1082, commit `4f4394c8`):** `RemoteAnima` Rust
+backend at `crates/anima/anima-identity/src/remote.rs`.
+HTTP/JSON-over-lifegw bridge for non-browser callers (CLIs,
+agents-as-services, native apps). Mirror of `SomaCustody` (D-Sub-E)
+but transport is `reqwest` to lifegw `/anima/custody/*` instead of
+tonic UDS. `kms-remote` Cargo feature (default off; pulls reqwest
++ tokio). Caches auth + wallet pubkeys at construction; sign_*
+methods route through HTTP; `rotate()` returns the journal-flow
+error mirroring soma. `TierUserCap { token, expires_at_unix }` with
+`is_expired(now_unix)` helper. `cap_token()` cheap-path-checks
+expiry before issuing the request — surfaces clean
+`AnimaError::Crypto` instead of waiting for lifegw 401. 112 tests
+(107 lib + 5 wiremock integration).
+
+**Stream T (PR #1083, commit `93bf7687`):** `WebCryptoAnima`
+TypeScript browser backend at `sdks/life-sdk-ts/src/anima/`. Composes
+`PasskeyOracle` (auth via WebAuthn `navigator.credentials`) with a
+`RemoteAnimaClient` (wallet half delegated to lifegw via fetch).
+DID multicodec `0x1200` → `did:key:zDn…` byte-identical to Rust;
+cross-language fixtures pin this. `SessionCap` lifecycle (15-min
+Tier-User cap, refresh-on-expiry, concurrent-mint-coalescing). 128
+vitest tests + cross-language DID fixture vectors.
+HTTP/JSON request shape matches Stream R-1 + R-2's wire fixtures.
+Per spec compliance review: route paths use `get_auth_pubkey` /
+`get_wallet_pubkey` (NOT bare `auth_pubkey`) to match the Rust
+`RemoteAnima` shape. Per code-quality review: response body
+sanitization (`sanitizeErrorBody` + `MAX_REMOTE_ERROR_BODY_CHARS`),
+`requestTimeoutMs` config (DEFAULT 30s) with `AbortSignal.timeout`,
+`mapFetchFailure` distinguishing TimeoutError from generic. 128 tests
+total.
+
+**Stream R-2 (PR #1084, commit `b082ee52`):** lifegw HTTP/JSON
+`/anima/custody/*` routes + `TierUserMinter` + WS bearer
+subprotocol (closes M8.2). 6 routes:
+`POST /sign_auth`, `POST /sign_wallet`,
+`GET /get_auth_pubkey/{user_id}`, `GET /get_wallet_pubkey/{user_id}`,
+`POST /mint_session_cap`, `POST /enroll_passkey`. Each route
+verifies the bearer JWT (signature + audience + sub-binding via
+`JwksCache::verify_capability_token`), enforces per-route scope
+intersection (e.g., Tier-User cap with `anima.user.sign_auth` cannot
+call `/sign_wallet`), and binds `claims.sub == body.user_id` to
+prevent cross-user impersonation. Mint + enroll require Tier-2
+audience exclusively. `TierUserMinter` is a sibling of
+`Tier2Minter`: same `KmsSigner` trait (VaultTransit / StaticKeystore
+/ AwsKms / GcpKms all work transparently), separate
+`aud="anima.user-cap"`, 15-min default TTL via `cfg.auth.tier_user_ttl`.
+WS bearer subprotocol parses `Sec-WebSocket-Protocol: bearer.<jwt>`
+(Tier-1 caps only; subprotocol-bearer auth specifically for browser
+WS clients that can't set Authorization headers). Strict char
+validation (rejects whitespace / control chars / commas). soma admin
+UDS connector via `service_fn` (mirror of `SomaCustody::new`); each
+route opens a fresh tonic channel per request (pooling deferred —
+filed as follow-up in module docstring). All upstream errors are
+sanitized (no `tonic::Status` leaked verbatim into HTTP body); per-RPC
+deadline 10s; `validate_user_id` rejects empty / >64 chars / control
+chars at gateway boundary; request bodies use `deny_unknown_fields`.
+199 lifegw tests (151 lib + 19 anima_custody integration + 29
+others). Graceful degradation: if `cfg.anima_custody = None` the
+routes return 501 with helpful message — lifegw still starts cleanly.
+
+### D-Sub-C follow-ups
+
+- **Generic EIP-712 encoder** — same limitation as D-Sub-A/B/E/F.
+  EIP-3009 `TransferWithAuthorization` only; generic typed-data
+  shapes return server-side errors.
+- **Live USDC-transfer e2e on Base testnet** — Spec D acceptance is
+  "USDC transfer initiated in chatOS browser, signed via server-side
+  Vault, settled on Base testnet". The wire shape lands in this PR
+  triplet; the live e2e against a real chain ships with M9 (chatOS
+  apps integration).
+- **Connection pooling for lifegw → soma admin UDS** — currently
+  per-request connect. Production deploys with high JWT mint
+  throughput should pool channels via `life-runtime-pool`. Filed as
+  Sub-phase F-ish hardening.
+- **Full FIDO2 attestation chain verification on `enroll_passkey`** —
+  current implementation extracts the COSE_Key but doesn't verify
+  the AAGUID / cert chain / TPM-or-yubikey-vendor claims. Trusts the
+  browser's WebAuthn impl. Production hardening tracked as a
+  follow-up; for D-Sub-C launch the browser-side WebAuthn semantics
+  + lifegw-side JWT verification are sufficient.
+- **WebHID hardware wallet for browser** — D-Sub-F desktop hidapi is
+  the only transport today. The browser path lives in a separate
+  crate (`anima-web-hardware` or similar) consumed by chatOS during
+  M9. Public trait surface is identical; only the underlying HID
+  transport differs.
+- **chatOS UI integration** — D-Sub-C ships the substrate +
+  contracts; chatOS settings UI (passkey enrollment, custody status,
+  rotation history, revocation) lands in M9.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1362,6 +1362,127 @@ L4-D5..D10. Closes BRO-XXX (D-Sub-E).
 
 PR #1075 + #1074 + #1076 merged 2026-05-02.
 
+### 2026-05-02 — Wave 3: D-Sub-C (browser path + Rust bridge + lifegw routes) — Spec D 100% complete
+
+Three PRs merged the same day (2026-05-02) closing the final Spec D
+sub-phase. **Spec D is now 100% complete (6/6 sub-phases shipped).**
+M9 (apps/chat migration to AnimaCustody) is unblocked. The wave
+shipped via 3 parallel streams (R-1 Rust + T TypeScript + R-2 lifegw)
+using the worktree-driven dispatch pattern proven in Wave 2B.
+
+**Stream R-1 — `RemoteAnima` Rust backend (PR #1082, commit
+`4f4394c8`):** HTTP/JSON bridge to lifegw `/anima/custody/*` for
+non-browser callers (CLIs, agents-as-services, native apps). Mirrors
+SomaCustody (D-Sub-E) but with reqwest-over-HTTPS instead of tonic
+UDS. Caches auth + wallet pubkeys at construction; sign_* methods
+route through HTTP; `rotate()` returns the journal-flow error.
+`TierUserCap { token, expires_at_unix }` with `is_expired(now_unix)`
+helper. `kms-remote` Cargo feature default off (pulls reqwest +
+tokio). Code-quality fixes in commit `76e16411`: dual-base64 error
+clarity (decoder confusion), expired-cap fail-fast (cap_token now
+returns `AnimaResult<String>` with cheap-path expiry check before
+issuing the request). 107 lib tests + 5 wiremock integration tests.
+
+**Stream T — `WebCryptoAnima` TypeScript browser backend (PR #1083,
+commit `93bf7687`):** Composes `PasskeyOracle` (WebAuthn-backed P-256
+auth via `navigator.credentials`) with `RemoteAnimaClient` (wallet
+half delegated to lifegw via fetch). DID multicodec `0x1200` →
+`did:key:zDn…` byte-identical to Rust; cross-language fixtures pin
+this. `SessionCap` lifecycle (15-min Tier-User cap, refresh-on-expiry,
+concurrent-mint coalescing). Spec compliance fix `be55b1f5`: route
+paths use `get_auth_pubkey` / `get_wallet_pubkey` (matches Stream R-1
+wiremock fixtures). Code-quality fixes in same commit: response body
+sanitization (`sanitizeErrorBody` truncates upstream errors to ≤200
+chars + ellipsis; structured `{ code, message }` JSON shapes
+preferred), `requestTimeoutMs` config (DEFAULT 30s, AbortSignal.timeout
+with manual fallback), `mapFetchFailure` distinguishing TimeoutError
+from generic transport, `cfg.indexedDB` doc-comment honesty fix.
+128 vitest tests + 5 cross-language DID vectors.
+
+**Stream R-2 — lifegw `/anima/custody/*` routes + `TierUserMinter` +
+WS bearer subprotocol (PR #1084, commit `b082ee52`):** 6 axum HTTP/JSON
+routes + `TierUserMinter` (sibling of `Tier2Minter`, same `KmsSigner`
+trait, `aud="anima.user-cap"`, 15-min default TTL). Each route
+verifies the bearer JWT (signature + audience + sub-binding via
+`JwksCache::verify_capability_token`), enforces per-route scope
+intersection (Tier-User cap with `anima.user.sign_auth` cannot call
+`/sign_wallet`), and binds `claims.sub == body.user_id`. Mint + enroll
+require Tier-2 audience exclusively. WS bearer subprotocol parses
+`Sec-WebSocket-Protocol: bearer.<jwt>` (Tier-1 only — closes M8.2 SDK
+gap for browser WS clients that can't set Authorization headers).
+Strict char validation. soma admin UDS connector via `service_fn`
+(per-request connect; pooling deferred). All upstream errors are
+sanitized (no `tonic::Status` leaked verbatim); per-RPC deadline 10s
+via `tokio::time::timeout`; `validate_user_id` rejects empty / >64
+chars / control chars at gateway boundary; request bodies use
+`deny_unknown_fields`. Two rounds of in-PR fixes:
+
+1. **Security review fixes (B1+B2+I1, commits `e825b541` + `bd8ec745`):**
+   The initial PR mounted the anima router OUTSIDE the AuthLayer with
+   `require_bearer` doing presence-only checks — auth bypass on 6
+   privileged routes. Spec-compliance review caught this as
+   BLOCKING. Fix: built `JwksCache::verify_capability_token` (new
+   multi-audience verifier in `auth/jwks.rs`), added `verify_bearer`
+   helper, added `check_scope_and_subject` enforcing per-route scope
+   + subject binding. 6 new negative integration tests
+   (unverified bearer rejected with 401, expired bearer rejected,
+   wrong audience rejected, scope-insufficient rejected with 403,
+   user_id mismatch rejected with 403, Tier-User cap rejected from
+   mint_session_cap).
+
+2. **Code-quality follow-up fixes (I-1 through I-7, commits
+   `d9e6f505` + `b9ad820b` + `24f5da36` + `fbd740f0` + `16fc91ff`):**
+   Sanitize upstream errors (`sanitize_upstream` maps
+   `tonic::Code` → `(StatusCode, &'static str)`; soma UDS path no
+   longer leaked in 502 body — log via `tracing::warn!`), per-RPC
+   deadline (10s), `deny_unknown_fields` on request bodies,
+   `validate_user_id` at gateway boundary, WS subprotocol bearer
+   strict char validation. 4 new tests (deny_unknown_fields rejection,
+   empty/oversized user_id rejection, WS bearer with whitespace
+   rejection).
+
+199 lifegw tests total (151 unit + 19 anima_custody integration + 29
+others). Graceful degradation: if `cfg.anima_custody = None` the
+routes return 501 with helpful message — lifegw still starts cleanly.
+
+**Cross-cutting integration (Wave 3):**
+
+- The 6 `/anima/custody/*` route shapes are now the canonical browser
+  custody contract. Stream R-1's wiremock fixtures and Stream T's
+  msw-mock-fetch tests pin both sides; Stream R-2 implements the
+  server-side handlers. Wire compatibility verified at every boundary.
+- Closes M8.2 SDK known-limitation (browser-auth via WS subprotocol
+  unsupported by gateway). M8.1 (Connect-vs-grpc-web mismatch)
+  remains open but is sidestepped for custody — the `/anima/custody/*`
+  routes are HTTP/JSON, NOT gRPC-web, so they're consumed via plain
+  `fetch` from chatOS without proto codegen.
+- The lago-auth `verify_jwt` multi-alg dispatcher (D-Sub-E) and the
+  new lifegw `JwksCache::verify_capability_token` (D-Sub-C R-2) both
+  implement multi-audience verification — they're sibling
+  implementations of the same canonical pattern. broomva.tech's
+  external AAP verifier should adopt the same shape.
+
+**Wave 3 summary:**
+- Spec D = **100% complete (6/6 sub-phases shipped)**. All 6
+  production custody backends ship: InProcessAnima, VaultTransitAnima,
+  TpmAnima, SomaCustody, HardwareWalletAnima, WebCryptoAnima +
+  RemoteAnima (paired).
+- M9 (apps/chat migration to AnimaCustody) is now unblocked.
+- M8.2 SDK known-limitation closed (subprotocol bearer auth).
+- Tests delta: ~3922 Rust + 50 TS → ~3922 + ~12 (R-1) + ~199 net
+  lifegw delta (R-2) + ~78 TS delta (T 50→128) = ~4133 Rust + 128 TS.
+- Code-quality discipline: 2 streams surfaced BLOCKING issues in
+  spec review (T's wire-shape divergence, R-2's auth bypass + scope
+  bypass). Both fixed in-PR via dispatched fix-agents. The two-stage
+  review pattern + parallel worktree dispatch + fix-in-PR discipline
+  is now well-tested across 9 PRs across 3 waves.
+- Critical-path next: M9 (apps/chat migration). chatOS settings UI
+  for passkey enrollment + custody status + rotation history lives
+  here; live USDC-transfer e2e on Base testnet validates the full
+  D-Sub-C → soma → Vault → Base path.
+
+PR #1082 + #1083 + #1084 merged 2026-05-02.
+
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |

--- a/docs/superpowers/plans/2026-05-02-m9-anima-custody-apps-migration.md
+++ b/docs/superpowers/plans/2026-05-02-m9-anima-custody-apps-migration.md
@@ -1,0 +1,132 @@
+# M9 — Anima Custody Apps Migration Plan
+
+**Date**: 2026-05-02
+**Status**: PLANNED (Spec D substrate shipped 2026-05-02; chatOS apps migration begins)
+**Owner**: Wave 4 (apps integration)
+**Critical-path predecessors**: ✅ Spec D 100% complete (Waves 1–3) — all 6 production custody backends shipped; ✅ M8 SDK v0.1.0-pre at `sdks/life-sdk-ts/` with WebCryptoAnima + RemoteAnimaClient + SessionCap; ✅ lifegw `/anima/custody/*` 6 routes + TierUserMinter + WS bearer subprotocol shipped.
+**Critical-path successors**: M10 (public launch).
+
+## What Wave 3 shipped (substrate ready for M9)
+
+- **AnimaCustody trait** locked at `crates/anima/anima-identity/src/custody.rs` with 6 backend variants (`InProcess`, `Vault`, `Tpm`, `Soma`, `HardwareWallet`, `WebCrypto`, `Remote`)
+- **Browser-side TS SDK** at `sdks/life-sdk-ts/src/anima/`:
+  - `WebCryptoAnima` composition wrapper (auth = passkey, wallet = remote)
+  - `PasskeyOracle` (WebAuthn `navigator.credentials.create/get` + COSE_Key parser + IndexedDB cache)
+  - `RemoteAnimaClient` (fetch wrapper for `/anima/custody/*`)
+  - `SessionCap` (15-min Tier-User cap lifecycle)
+  - `did:key:zDn…` derivation (multicodec `0x1200`, byte-identical to Rust)
+- **Rust-side bridge** at `crates/anima/anima-identity/src/remote.rs`:
+  - `RemoteAnima` for non-browser callers (CLIs, agents, native apps)
+- **Server-side gateway** at `crates/life-runtime/lifegw/src/services/anima_custody.rs`:
+  - 6 HTTP/JSON routes — `sign_auth`, `sign_wallet`, `get_auth_pubkey/{user_id}`, `get_wallet_pubkey/{user_id}`, `mint_session_cap`, `enroll_passkey`
+  - `TierUserMinter` — sibling of Tier2Minter, `aud="anima.user-cap"`, 15-min TTL
+  - `JwksCache::verify_capability_token` — multi-audience verifier with sub-binding + scope intersection
+  - WS bearer subprotocol (`Sec-WebSocket-Protocol: bearer.<jwt>`) — closes M8.2
+
+## M9 scope (this plan)
+
+Migrate `apps/chatOS` to use AnimaCustody for browser users + server-side anima daemon for wallet operations, settling on Base testnet via real Vault.
+
+### Sub-phases
+
+#### M9.1 — chatOS SDK integration (~3 days)
+- Add `@broomva/life-sdk` (npm name TBD or `file:../../core/life/sdks/life-sdk-ts` for monorepo dev) as dep in `apps/chatOS/apps/web` + `apps/chatOS/apps/bot`
+- Add `packages/anima` (or extend `packages/auth`) with chatOS-specific WebCryptoAnima factory + SessionCap factory
+- Wire `client = createLifeClient({ baseUrl, anima: { ... } })` from SDK index
+- Smoke test: instantiate WebCryptoAnima in jsdom + verify enrollment + signing flow ends in mocked lifegw
+
+#### M9.2 — Passkey enrollment UI (~4 days)
+- New `/account/security/passkey` settings page in `apps/chatOS/apps/web`
+- States: not-enrolled, enrolling (passkey prompt), enrolled (DID + wallet address), error
+- Use shadcn/ui dialog + form patterns
+- Hook into existing `packages/auth` Better Auth flow (passkey enrollment is a post-signin step; user must already be logged in)
+- Show DID + wallet address + custody backend kind in settings UI
+- Provide "view rotation history" link → reads journal events via lifegw `/v1/events/stream` (Lago anima.identity_rotated events)
+
+#### M9.3 — chatOS sign-in via Tier-User cap (~3 days)
+- After passkey enrollment, every sign-in mints a Tier-User cap via `mint_session_cap`
+- Pass the cap as `Authorization: Bearer <jwt>` on `/anima/custody/*` calls
+- Browser WS upgrades use `Sec-WebSocket-Protocol: bearer.<tier1-token>` (Tier-1 only — Tier-User caps are HTTP-only per Spec D)
+- Persist enrollment state via IndexedDB (already handled by PasskeyOracle); re-mint cap on tab open if cached cap expired
+
+#### M9.4 — server-side anima daemon (~5 days)
+- Stand up production lifegw with `anima_custody` config block enabled
+- Stand up production soma with `admin_plane` config block (custody-oracle UDS `/run/life/soma-admin.sock`)
+- Stand up production Vault with secp256k1 transit key sidecar (Vault v1.15 doesn't support secp256k1 natively; either patches or HSM sidecar required — see D-Sub-B follow-up)
+- Wire end-to-end: chatOS → lifegw → soma → Vault
+- Operational runbook: provisioning new users, rotating keys, revoking compromised caps
+
+#### M9.5 — Live USDC e2e on Base testnet (~3 days)
+- Test wallet pre-funded with Base testnet USDC via faucet
+- chatOS UI: "Send USDC" form with recipient + amount
+- Sign EIP-3009 TransferWithAuthorization via WebCryptoAnima → RemoteAnimaClient → lifegw → soma → Vault → returned signature
+- Broadcast to Base testnet RPC; assert receipt
+- Acceptance test (Playwright e2e against staged lifegw + Base testnet)
+
+#### M9.6 — Mission-control desktop pairing (optional, ~3 days)
+- Mission-control desktop: detect TPM availability + Ledger presence
+- If both present: pair `TpmAnima` (auth) + `HardwareWalletAnima` (wallet)
+- If TPM only: `TpmAnima` (auth) + `RemoteAnima` (wallet via lifegw)
+- If neither: `InProcessAnima` with file-based key (warn user)
+- Settings UI: "custody backends" panel showing active config
+
+#### M9.7 — broomva.tech AAP verifier coordination (cross-repo, ~2 days)
+- broomva.tech adopts `lago-auth::verify_jwt` shape (or thin HTTP wrapper)
+- Multi-curve verifier: ES256 (P-256) primary, EdDSA (Ed25519) legacy fallback
+- Walks rotation chain via JournalResolver
+- Acceptance: a JWT signed by an old (rotated) key is rejected for post-rotation timestamps; accepted for pre-rotation timestamps (matches the timestamp at the time of issuance)
+
+### Total estimated effort
+
+~21 days of implementation + integration + e2e validation. Parallelizable across:
+- M9.1 + M9.2 (frontend track)
+- M9.4 (infra track)
+- M9.5 (e2e validation track, after M9.4)
+- M9.6 (desktop track, parallel)
+- M9.7 (cross-repo track, parallel)
+
+## Acceptance criteria (M9 done)
+
+1. ✅ chatOS browser user can enroll a passkey and see their DID + wallet address in settings
+2. ✅ chatOS browser user can sign a JWS for the Agent Auth Protocol via passkey
+3. ✅ chatOS browser user can initiate a USDC transfer; signature comes from server-side Vault; receipt confirmed on Base testnet
+4. ✅ Mission-control desktop user can use TPM-auth + Ledger-wallet pairing for the strongest custody story
+5. ✅ broomva.tech accepts P-256 / ES256 JWTs via the canonical verifier path
+6. ✅ Rotation event end-to-end: rotate from old DID, journal event written, downstream verifier accepts new DID for new tokens, accepts old DID for pre-rotation tokens
+
+## Tracking
+
+- Linear epic: `BRO-XXX: M9 Anima Custody Apps Migration` (placeholder; user files when MCP re-auths)
+- Sub-tickets: M9.1 .. M9.7 mapped 1:1
+- Status will be tracked in `docs/STATUS.md` § "M9 progress"
+
+## Open questions
+
+1. **`@broomva/life-sdk` npm publish vs monorepo file: dep**: chatOS lives in a separate workspace. Do we publish `life-sdk-ts` to npm under `@broomva/life-sdk` (production-grade), or use a `file:../../core/life/sdks/life-sdk-ts` workspace dep (faster iteration, no publish dance)? Recommendation: file: dep during M9 dev; publish for M10 launch.
+
+2. **Passkey portability and recovery**: Spec D §"Browser path" §4 puts portability on the OS (iCloud Keychain, Google Password Manager, BitWarden). What's the user-facing message when they sign in from a fresh device with no passkey? Options: (a) require re-enrollment via existing-device-issued rotation event; (b) require account recovery via email + KYC; (c) cross-device passkey sync via FIDO2 conditional UI. Lock in a UX choice early.
+
+3. **Tier-User cap revocation under fresh device**: if a user signs in on a phone, then loses the phone, the active 15-min Tier-User cap is still valid until expiry. Should chatOS provide a "revoke active sessions" button that publishes `anima.identity_revoked` events? Yes — this should ship in M9.2.
+
+4. **Vault sidecar cost/operations**: secp256k1 transit isn't native to Vault v1.15. Operational options: (a) HashiCorp Vault Enterprise w/ pluggable transit (cost), (b) HSM sidecar via PKCS#11 (cost + complexity), (c) wait for upstream Vault support. Recommendation: spike on (b) with softhsm in dev; revisit for production.
+
+5. **chatOS / Sentinel / Life-Module-tenant deployment story**: M9 ships the chatOS path. How do Sentinel and Life-Module tenants get the same custody story without a chatOS-shaped UI? Likely via a shared `packages/anima-react` library and per-tenant theming. Filed as M10 work.
+
+## Out of scope for M9
+
+- Full FIDO2 attestation chain verification (D-Sub-C R-2 follow-up)
+- WebHID hardware wallet for browser (D-Sub-F follow-up)
+- Generic EIP-712 encoder (D-Sub-A/B/C/D/E/F shared follow-up)
+- Live softhsm CI fixture for D-Sub-D
+- Live Ledger e2e for D-Sub-F
+- Connection pooling for lifegw → soma admin UDS (D-Sub-C R-2 follow-up)
+
+## Dependencies on external infrastructure
+
+- Production lifegw (already running for Tier-1 Vercel auth; needs `anima_custody` config block enabled)
+- Production soma with admin plane (currently dev-only)
+- Production Vault with secp256k1 (gap — see open question 4)
+- Base testnet RPC endpoint (Coinbase / Alchemy / public)
+- USDC testnet faucet on Base
+- Ledger Live or Ledger device (for M9.6)
+- TPM-equipped Linux host (for M9.6)


### PR DESCRIPTION
## Summary

- Annotates Wave 3 in docs/STATUS.md (Spec D D-Sub-C closed via 3 parallel PRs #1082 + #1083 + #1084 merged 2026-05-02)
- Updates crates/anima/CLAUDE.md phasing table to reflect D-Sub-C shipped + adds full D-Sub-C handoff section across all 3 streams
- **Spec D = 100% complete (6/6 sub-phases shipped)** ✅

## Wave 3 highlights

- Stream R-1 (PR #1082): `RemoteAnima` Rust backend — HTTP/JSON bridge to lifegw `/anima/custody/*`
- Stream T (PR #1083): `WebCryptoAnima` TS browser custody — passkey auth + RemoteAnimaClient wallet delegation + SessionCap (15-min Tier-User cap lifecycle)
- Stream R-2 (PR #1084): lifegw 6 axum routes + TierUserMinter + WS bearer subprotocol (closes M8.2)
- 2 of 3 streams surfaced BLOCKING issues in 2-stage review (T's wire-shape divergence, R-2's auth bypass) — all fixed in-PR

## Test plan

- [x] No code changes — pure docs append
- [x] STATUS.md still readable (no broken markdown)
- [x] Wave 3 summary references the right PRs (#1082 + #1083 + #1084) and merge commits
- [x] Spec D progress (6/6 → 100%) accurate; all sub-phases shipped
- [x] D-Sub-C handoff section in crates/anima/CLAUDE.md follows the established pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Specification D backend marked 100% complete across all six sub-phases, unblocking the next milestone.
  * Documented completion of browser integration, bridge implementation, and custody functionality.
  * Recorded security improvements and identified follow-up hardening items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->