### PR TITLE
feat(life-runtime): Railway lifegw-stack deploy + additive dev-signer JwksCache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Docker build context exclusions for Railway / docker-buildx.
+#
+# Mirror .gitignore for the obvious caches, then prune workspace-level
+# artifacts that are huge but never needed inside any container build:
+# documentation, archived snapshots, evaluation harnesses, MLflow stores,
+# IDE caches, etc.
+
+# Rust build artifacts
+target/
+.target/
+**/target/
+**/.target/
+
+# Node + JS workspace artifacts
+node_modules/
+**/node_modules/
+.next/
+.bun/
+.cache/
+
+# Editor / OS noise
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*~
+
+# Local agent runtime data + secrets
+.arcan/
+.lago/
+.aios/
+.aios-*/
+.life/
+.env
+.env.*
+!.env.example
+
+# Git metadata is unnecessary at build time
+.git/
+.gitignore
+.githooks/
+
+# Heavy non-build paths
+docs/
+evals/
+archive/
+mlflow.db
+**/dev-tls/
+**/test-fixtures/
+
+# Tooling caches
+.pre-commit-cache/
+.pytest_cache/
+.ruff_cache/
+.cache/
+playwright-report/
+test-results/

--- a/crates/life-runtime/lifegw/src/auth/jwks.rs
+++ b/crates/life-runtime/lifegw/src/auth/jwks.rs
@@ -445,6 +445,20 @@ impl JwksCache {
         }
     }
 
+    /// Build a real JWKS cache that ALSO accepts the dev shortcut.
+    ///
+    /// Used by deploys that want to flip on Tier-1 verification of
+    /// real JWS tokens (issued by an apps/chat JWKS server) WITHOUT
+    /// killing the existing `Bearer dev-token-for-{user_id}` path
+    /// integration tests + ops smoke tests rely on. Production deploys
+    /// pass `dev_signer_enabled = false` and use [`JwksCache::new`]
+    /// directly to forbid the shortcut.
+    pub fn new_with_dev_shortcut(cfg: JwksCacheConfig) -> Self {
+        let mut cache = Self::new(cfg);
+        cache.dev_signer_enabled = true;
+        cache
+    }
+
     /// Dev convenience: build a cache that ALSO accepts the
     /// `dev-token-for-{user_id}` shortcut so existing integration tests
     /// keep passing without standing up an apps/chat JWKS server.

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -821,22 +821,37 @@ pub(crate) fn build_signer(cfg: &AuthConfig) -> LifegwResult<Arc<dyn KmsSigner>>
 /// installing this into the deprecated process-global; instead the
 /// returned `Arc<JwksCache>` is threaded into `AuthLayer::with_jwks`
 /// so each `AuthService<S>` instance owns its own handle.
+///
+/// `dev_signer_enabled` is **additive** to real JWKS verification:
+///
+///   - `dev_signer_enabled = false` → only real JWS tokens are
+///     accepted (production posture).
+///   - `dev_signer_enabled = true`  → real JWS tokens AND the
+///     `Bearer dev-token-for-{user_id}` shortcut are accepted.
+///
+/// Pre-fix the dev path returned a cache with an empty inline JWKS
+/// (`JwksCache::dev_only()`), so flipping the dev flag effectively
+/// disabled the real-JWS path. Deploys that wanted both — the apps/chat
+/// JWKS-issued production tokens AND the local-test dev shortcut — had
+/// to choose one or the other. The new
+/// `JwksCache::new_with_dev_shortcut` constructor combines both: real
+/// JWKS fetch + dev shortcut.
 fn build_jwks_cache(cfg: &AuthConfig) -> LifegwResult<Arc<JwksCache>> {
+    let mut jwks_cfg = JwksCacheConfig::new(
+        JwksSource::Url(cfg.jwks_url.clone()),
+        cfg.tier1_audience.clone(),
+        cfg.tier1_issuer.clone(),
+    );
+    jwks_cfg.ttl = cfg.jwks_cache_ttl;
+    jwks_cfg.rotation_grace = cfg.jwks_rotation_grace;
     let cache = if cfg.dev_signer_enabled {
-        // Dev path — accept the magic Bearer shortcut for tests / CI.
-        Arc::new(JwksCache::dev_only())
+        // Dev shortcut + real JWKS verification both active.
+        JwksCache::new_with_dev_shortcut(jwks_cfg)
     } else {
-        // Production path — fetch JWKS from the configured URL.
-        let mut jwks_cfg = JwksCacheConfig::new(
-            JwksSource::Url(cfg.jwks_url.clone()),
-            cfg.tier1_audience.clone(),
-            cfg.tier1_issuer.clone(),
-        );
-        jwks_cfg.ttl = cfg.jwks_cache_ttl;
-        jwks_cfg.rotation_grace = cfg.jwks_rotation_grace;
-        Arc::new(JwksCache::new(jwks_cfg))
+        // Production: real JWS only. Dev shortcut rejected.
+        JwksCache::new(jwks_cfg)
     };
-    Ok(cache)
+    Ok(Arc::new(cache))
 }
 
 /// Atomic JWKS publish — write to a temporary file then rename into

--- a/deploy/railway/lifegw-stack/Caddyfile
+++ b/deploy/railway/lifegw-stack/Caddyfile
@@ -1,0 +1,73 @@
+# lifegw-stack — Caddy reverse-proxy frontage.
+#
+# Public side : binds :$PORT cleartext (Railway edge already terminated TLS).
+# Upstream    : 127.0.0.1:8443 lifegw self-signed (tls_insecure_skip_verify).
+#
+# Caddy passes through:
+#   - HTTP/1.1 + HTTP/2 → upstream (auto-detected by hyper auto-Builder).
+#   - WebSocket Upgrade for `/v1/agent/stream`.
+#   - tonic-web (`application/grpc-web`) framing — Caddy is byte-transparent.
+#   - `/anima/custody/*` axum HTTP/JSON routes (Spec D D-Sub-C).
+#
+# Health probe: `/healthz` is served by lifegw directly; Caddy proxies it.
+
+{
+	auto_https off
+	# Inherit container log level via env so RUST_LOG-style toggles align.
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+}
+
+:{$PORT} {
+	# Operator visibility — every request line lands in the container log.
+	log {
+		output stdout
+		format console
+	}
+
+	# Quick liveness — Caddy answers if it is up; lifegw `/healthz` answers
+	# if the upstream is up. Railway hits the latter via the public domain.
+	handle /caddy/healthz {
+		respond "ok" 200
+	}
+
+	# WebSocket-upgrade matcher.
+	#
+	# Railway's edge proxy strips the `Connection: Upgrade` and
+	# `Upgrade: websocket` HTTP/1.1 hop-by-hop headers when fronting
+	# WebSocket traffic — only `Sec-WebSocket-Key`/`-Version`/`-Protocol`
+	# survive the hand-off to the origin. Caddy then sees a request that
+	# does NOT look like a WS upgrade, falls through to its plain HTTP
+	# proxy, and lifegw rejects the request as a malformed gRPC call.
+	#
+	# Workaround: detect WS by `Sec-WebSocket-Key` (which Railway DOES
+	# preserve), then re-inject the missing upgrade headers before the
+	# upstream call. lifegw's `is_ws_upgrade` then correctly dispatches
+	# the request to the bidi-pump handler.
+	@websocket {
+		path /v1/agent/stream
+		header Sec-WebSocket-Key *
+	}
+	reverse_proxy @websocket https://127.0.0.1:8443 {
+		header_up Connection Upgrade
+		header_up Upgrade websocket
+		transport http {
+			tls_insecure_skip_verify
+			versions 1.1
+		}
+	}
+
+	# Everything else (gRPC, gRPC-web, /healthz, /anima/custody/*) flows
+	# through the standard reverse-proxy path. `versions 1.1` pins HTTP/1.1
+	# to upstream so tonic-web's HTTP/1.1 trailer encoding works cleanly;
+	# native HTTP/2 gRPC isn't used by any client of this gateway today.
+	reverse_proxy https://127.0.0.1:8443 {
+		transport http {
+			tls_insecure_skip_verify
+			versions 1.1
+		}
+	}
+}

--- a/deploy/railway/lifegw-stack/Dockerfile
+++ b/deploy/railway/lifegw-stack/Dockerfile
@@ -1,0 +1,99 @@
+# lifegw-stack — Railway-shaped multi-process container.
+#
+# What runs inside:
+#   - lifed          (UDS at /run/life/life.sock + /run/life/life-admin.sock)
+#   - lifegw         (HTTPS on 127.0.0.1:8443, self-signed cert, dev signer)
+#   - caddy          (binds :$PORT cleartext, reverse-proxies to https://127.0.0.1:8443
+#                     with tls_insecure_skip_verify; preserves WS upgrade + h2c → h2 hop)
+#
+# Why this shape:
+#   - Spec C wires lifegw → lifed via UDS (`/run/life/life.sock`). Railway services
+#     are TCP-only across containers, so co-locating both daemons in one container
+#     keeps the canonical wire shape intact.
+#   - Railway terminates TLS at its edge and forwards plaintext HTTP to `:$PORT`,
+#     while lifegw is HTTPS-only by design. Caddy bridges the two: cleartext on
+#     the public side (Railway-edge already terminated TLS) and self-signed TLS
+#     on the lifegw side. The detour exists purely to avoid forking lifegw with
+#     a "behind-proxy cleartext" mode for one deploy target — see
+#     `apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md` §M.
+#
+# Build context: the `core/life` workspace root (so the Cargo workspace is
+# resolvable). Build command:
+#   docker build -f deploy/railway/lifegw-stack/Dockerfile -t lifegw-stack .
+
+# ── Stage 1 — Rust builder ──────────────────────────────────────────────────
+FROM rust:1.93-bookworm AS builder
+WORKDIR /build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        protobuf-compiler libprotobuf-dev \
+        clang lld pkg-config libssl-dev ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# `prost-build` invokes protoc and looks up well-known protos
+# (`google/protobuf/timestamp.proto` etc.) via an include path. The
+# `libprotobuf-dev` package places them at `/usr/include/google/protobuf`
+# on Debian; `PROTOC_INCLUDE` makes prost-build pass them as `-I` to protoc.
+ENV PROTOC=/usr/bin/protoc
+ENV PROTOC_INCLUDE=/usr/include
+
+COPY . .
+
+# Build both daemons in one pass. Default features pull in `kms-vault`
+# (compiled but unused — runtime config selects `KmsProvider::Dev`) and
+# `tokio-tungstenite/handshake` so the WS upgrade path is live.
+RUN cargo build --release \
+        --manifest-path Cargo.toml \
+        -p lifegw \
+        -p lifed \
+ && strip ./.target/release/lifegw ./.target/release/lifed
+
+# ── Stage 2 — runtime image ─────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Caddy via the official .deb (small, current). openssl for self-signed cert
+# generation at boot. tini reaps zombies cleanly when caddy is PID 1.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg debian-keyring debian-archive-keyring \
+        apt-transport-https openssl tini \
+ && curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+      | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
+ && curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
+      > /etc/apt/sources.list.d/caddy-stable.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends caddy \
+ && apt-get purge -y --auto-remove curl gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+# Runtime layout — every UDS lifegw + lifed touches lives under /run/life/.
+RUN groupadd --system life-runtime \
+ && useradd  --system --gid life-runtime --home-dir /var/lib/life --create-home life \
+ && mkdir -p /run/life /etc/lifegw/tls /etc/lifegw /etc/lifed \
+ && chown -R life:life-runtime /run/life /etc/lifegw /etc/lifed
+
+WORKDIR /opt/life
+
+COPY --from=builder /build/.target/release/lifegw /usr/local/bin/lifegw
+COPY --from=builder /build/.target/release/lifed  /usr/local/bin/lifed
+
+COPY deploy/railway/lifegw-stack/lifegw.toml    /etc/lifegw/config.toml
+COPY deploy/railway/lifegw-stack/lifed.toml     /etc/lifed/config.toml
+COPY deploy/railway/lifegw-stack/Caddyfile      /etc/caddy/Caddyfile
+COPY deploy/railway/lifegw-stack/entrypoint.sh  /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Railway sets PORT at runtime; default for local docker run.
+ENV PORT=8080 \
+    LIFEGW_CONFIG=/etc/lifegw/config.toml \
+    LIFED_CONFIG=/etc/lifed/config.toml \
+    LIFED_ALLOW_MOCK_FALLBACK=true \
+    RUST_LOG=info,lifegw=info,lifed=info \
+    RUST_BACKTRACE=1
+
+EXPOSE 8080
+
+# tini guards against caddy → lifegw → lifed orphan reaping; entrypoint.sh
+# fans out the three processes and execs caddy in fg so SIGTERM propagates.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/deploy/railway/lifegw-stack/HANDOFF.md
+++ b/deploy/railway/lifegw-stack/HANDOFF.md
@@ -73,11 +73,36 @@ vercel env rm LIFED_GATEWAY_URL production
 The factory falls back to `InProcessAgentSessionClient` — the old in-process
 agent loop — without redeploying anything else.
 
-## 6. Known Stage-1 limitation: Tier-2 audience chain
+## 6. Stage 1.5 — Tier-1 verification is REAL now (May 2026)
 
-When the WS handshake completes and lifegw forwards a freshly-minted Tier-2
-JWS to lifed, lifed currently rejects it with
-`{"kind":"closing","reason":"policy_violation:token_expired"}`. Root cause:
+The Tier-1 chain runs against broomva.tech's real Better Auth-bridged
+ES256 keypair:
+
+```
+broomva.tech (Vercel)
+  ─▶ /api/auth/jwks.json publishes the public ES256 key
+     (private half lives in `LIFEGW_TIER1_SIGNING_JWK` Vercel env)
+  ─▶ /api/life/run/.../prosopon mints a fresh Tier-1 JWT per turn
+     (audience=lifegw, issuer=https://broomva.tech, exp = now + 15min)
+     ─▶ wss://lifegw.../v1/agent/stream  (Bearer / subprotocol)
+        ─▶ lifegw fetches the JWKS, verifies the JWS via the fetched key
+           ─▶ mints Tier-2 cap, opens upstream lifed Agent.StreamSession
+```
+
+`lifegw.toml` keeps `dev_signer_enabled = true` so the dev shortcut
+(`Bearer dev-token-for-{user_id}`) **also** still works — lifegw's
+`JwksCache::new_with_dev_shortcut(cfg)` makes the two paths additive
+(real JWS preferred, dev shortcut as fallback). Production deploys
+flip `dev_signer_enabled = false` once the KMS provider also moves off
+`Dev` (Spec C₃ Sub-phase E).
+
+## 7. Known Stage-1 limitation: Tier-2 audience chain (lifed side)
+
+When lifegw forwards its freshly-minted Tier-2 JWS to lifed, lifed
+currently rejects it with
+`{"kind":"closing","reason":"policy_violation:token_expired"}`. This is
+**not** a Tier-1 problem (Tier-1 verification works end-to-end as of
+Stage 1.5 above). Root cause is the lifed-side startup race:
 
 - The entrypoint starts `lifed` before `lifegw` (lifegw needs lifed's UDS
   to start, so the order is forced).
@@ -97,11 +122,14 @@ a. **Pre-publish a shared JWKS**: in `entrypoint.sh`, generate one
    `LIFEGW_TIER2_KEY_PEM`-style env (lifegw would need a config knob to
    adopt that key instead of `StaticKeystore::generate_dev()`).
 
-b. **Hot-reload the JwksCache in lifed**: add a periodic reload (e.g. on
-   verify miss, refetch from `cfg.auth.jwks_path` if the mtime moved).
-   This is closer to the production-shape eventually needed for KMS key
-   rotation.
+b. **Hot-reload the JwksCache in lifed**: mirror the additive
+   `new_with_dev_shortcut` change applied to lifegw — make lifed's
+   `JwksCache::dev_only()` ALSO trigger a one-shot retry-poll for the
+   JWKS file at first verify, with a small bounded window. This is
+   closer to the production-shape eventually needed for KMS key
+   rotation anyway.
 
-The deploy is otherwise functional: TLS, WS upgrade, Tier-1 dev-signer,
-gRPC-web fallback, `/anima/custody/*` axum routes, `/healthz` — all
-green from the public domain.
+The deploy is otherwise functional: TLS, WS upgrade, real Tier-1
+verify, gRPC-web fallback, `/anima/custody/*` axum routes, `/healthz` —
+all green from the public domain. The dev `Bearer dev-token-for-X`
+path also still works as an integration-test fallback.

--- a/deploy/railway/lifegw-stack/HANDOFF.md
+++ b/deploy/railway/lifegw-stack/HANDOFF.md
@@ -1,0 +1,107 @@
+# Vercel handoff — `LIFED_GATEWAY_URL`
+
+After `lifegw-stack` is healthy on Railway, broomva.tech needs one Vercel
+env-var flip to route agent traffic through the canonical wire.
+
+## 1. Verify lifegw is healthy
+
+```bash
+curl -sf https://lifegw-production.up.railway.app/healthz
+# expected: HTTP 200 (lifegw replies cleartext through Caddy)
+
+curl -sf https://lifegw-production.up.railway.app/caddy/healthz
+# expected: HTTP 200 ("ok")
+
+# WS upgrade smoke test (uses websocat):
+websocat -H "Sec-WebSocket-Protocol: bearer.dev-token-for-smoke" \
+  "wss://lifegw-production.up.railway.app/v1/agent/stream?sid=smoke"
+# expected: connects, server replies with one or more frames before
+# closing on a missing session
+```
+
+## 2. Set the Vercel production env var
+
+```bash
+cd ~/broomva/broomva.tech/apps/chat
+vercel env add LIFED_GATEWAY_URL production
+# paste:  https://lifegw-production.up.railway.app
+```
+
+Or, if a custom domain is later wired (`gw.broomva.tech` etc.), use that
+domain instead — broomva.tech doesn't care which DNS name resolves the
+gateway, only that `LIFED_GATEWAY_URL` is reachable.
+
+## 3. What flips on the broomva.tech side
+
+```
+apps/chat/lib/life-runtime/agent-session/factory.ts:
+  if (env.LIFED_GATEWAY_URL) {
+    return new LifedWsAgentSessionClient({ baseUrl: env.LIFED_GATEWAY_URL });
+  }
+  return new InProcessAgentSessionClient(...);
+```
+
+So with the env set:
+- `/api/life/run/[project]/prosopon` opens a WS to lifegw instead of running
+  `RealAgentRunner` inline.
+- `/api/life/health` reports `lifed: live` and `arcan: live (via lifegw)`.
+- The Dock badges flip from SIM to LIVE on next refresh (data-driven from
+  `/api/life/health`).
+
+## 4. Tier-User cap shape
+
+The `LifedWsAgentSessionClient` opens the WS with:
+
+```
+Sec-WebSocket-Protocol: bearer.<jwt>
+```
+
+Stage 1 (this deploy) accepts the dev shortcut: `dev-token-for-{user_id}`.
+broomva.tech's session client mints this synthetic token by default in
+non-production environments. Production cap minting (real ES256 JWS via
+the lifegw KMS, audience `anima.user-cap`, 15-min TTL) is tracked in the
+spec at `apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md`
+§F (Future Stage).
+
+## 5. Rollback path
+
+```bash
+cd ~/broomva/broomva.tech/apps/chat
+vercel env rm LIFED_GATEWAY_URL production
+```
+
+The factory falls back to `InProcessAgentSessionClient` — the old in-process
+agent loop — without redeploying anything else.
+
+## 6. Known Stage-1 limitation: Tier-2 audience chain
+
+When the WS handshake completes and lifegw forwards a freshly-minted Tier-2
+JWS to lifed, lifed currently rejects it with
+`{"kind":"closing","reason":"policy_violation:token_expired"}`. Root cause:
+
+- The entrypoint starts `lifed` before `lifegw` (lifegw needs lifed's UDS
+  to start, so the order is forced).
+- lifed's `auth.jwks_path = /run/life/lifegw-jwks.json` does not exist at
+  the moment lifed boots.
+- lifed falls back to `JwksCache::dev_only()` per `bootstrap.rs:97-105`,
+  which **only** accepts the literal `Bearer test-token-for-{user_id}`
+  shortcut — it does not verify real ES256 JWS.
+- A few hundred ms later lifegw publishes the JWKS to that exact path, but
+  lifed's cache is already pinned to dev-only.
+
+Two clean fixes — pick one before declaring Stage 2:
+
+a. **Pre-publish a shared JWKS**: in `entrypoint.sh`, generate one
+   ES256 key, write its public half to `/run/life/lifegw-jwks.json`
+   *before* `lifed` starts, and pass the full PEM to lifegw via
+   `LIFEGW_TIER2_KEY_PEM`-style env (lifegw would need a config knob to
+   adopt that key instead of `StaticKeystore::generate_dev()`).
+
+b. **Hot-reload the JwksCache in lifed**: add a periodic reload (e.g. on
+   verify miss, refetch from `cfg.auth.jwks_path` if the mtime moved).
+   This is closer to the production-shape eventually needed for KMS key
+   rotation.
+
+The deploy is otherwise functional: TLS, WS upgrade, Tier-1 dev-signer,
+gRPC-web fallback, `/anima/custody/*` axum routes, `/healthz` — all
+green from the public domain.

--- a/deploy/railway/lifegw-stack/README.md
+++ b/deploy/railway/lifegw-stack/README.md
@@ -1,0 +1,100 @@
+# lifegw-stack — Railway deploy
+
+A multi-process container that ships `lifegw` + `lifed` together, fronted by
+Caddy, behind Railway's TLS-terminating edge. This is the **Stage-1** deploy
+profile referenced by the canonical Life runtime spec at
+`apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md` §M.
+
+## Topology
+
+```
+broomva.tech (Vercel)
+       │  wss://<railway-domain>/v1/agent/stream  (TLS at Railway edge)
+       ▼
++──────────────────── Railway service "lifegw" ──────────────────────+
+│                                                                    │
+│   :$PORT (cleartext)                                               │
+│      │                                                             │
+│      ▼                                                             │
+│   caddy ── reverse_proxy ──► https://127.0.0.1:8443 (self-signed)  │
+│                                       │                            │
+│                                       ▼                            │
+│                                    lifegw                          │
+│                                       │                            │
+│                                       ▼ /run/life/life.sock        │
+│                                    lifed (mock-fallback)           │
+│                                                                    │
++────────────────────────────────────────────────────────────────────+
+```
+
+## What runs in this image
+
+| Process | Role | Listens on |
+|---|---|---|
+| `caddy` | reverse-proxy / TLS-terminated bridge | `:$PORT` (cleartext) |
+| `lifegw` | edge gateway — Tier-1/Tier-2 mint, WS bidi pump, `/anima/custody/*` | `127.0.0.1:8443` (self-signed TLS) |
+| `lifed` | facade aggregator — `life.v1.{Agent,Events,Wallet,Identity}` | `/run/life/life.sock` (UDS) |
+
+`lifed` boots with `LIFED_ALLOW_MOCK_FALLBACK=1`, which substitutes mock substrates
+for arcand / lagod / haimad / animad / soma. The wire path through Caddy → lifegw →
+lifed runs against real code; substrate behaviour is mocked.
+
+## Stage 1 vs production
+
+| | Stage 1 (this image) | Production |
+|---|---|---|
+| Tier-1 verification | dev signer (`Bearer dev-token-for-{user_id}`) | real Vercel JWKS |
+| Tier-2 / Tier-User mint | in-process keystore | Vault / AWS / GCP KMS |
+| Substrates | mock fallback | arcand + lagod + haimad + animad + soma sharing `/run/life/` |
+| TLS | self-signed (loopback only) | real cert via Vault PKI / Let's Encrypt |
+| Rate limit | defaults (60/min/user, 10 WS/user) | tuned per tenant |
+
+## Build
+
+From the `core/life` workspace root:
+
+```bash
+docker build -f deploy/railway/lifegw-stack/Dockerfile -t lifegw-stack .
+```
+
+Railway picks the Dockerfile via the service's deploy config — see
+the railway service variables for `RAILWAY_DOCKERFILE_PATH`.
+
+## Local smoke test
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e PORT=8080 \
+  -e LIFED_ALLOW_MOCK_FALLBACK=1 \
+  -e RUST_LOG=info,lifegw=debug,lifed=debug \
+  lifegw-stack
+
+# In another shell:
+curl -sf http://127.0.0.1:8080/healthz
+curl -sf http://127.0.0.1:8080/caddy/healthz   # caddy-side liveness
+```
+
+## Vercel handoff
+
+Once the Railway service is up and a public domain is wired:
+
+```
+LIFED_GATEWAY_URL=https://<railway-domain-or-custom>
+```
+
+Set this in the broomva.tech Vercel project's production env. The
+`createAgentSessionClient()` factory at
+`apps/chat/lib/life-runtime/agent-session/factory.ts` reads the env var and
+flips the backend from `InProcessAgentSessionClient` to
+`LifedWsAgentSessionClient`. The `/api/life/health` endpoint reflects the
+flip via `health.ts`, and the Dock SIM/LIVE/COMING badges follow.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `Dockerfile` | multi-stage builder + runtime image |
+| `Caddyfile` | reverse-proxy config (`:$PORT` → `https://127.0.0.1:8443`) |
+| `lifegw.toml` | lifegw config — dev signer, dev KMS, loopback bind |
+| `lifed.toml` | lifed config — dev signer, mock substrate fallback |
+| `entrypoint.sh` | fan-out script (cert gen → lifed → lifegw → caddy fg) |

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# lifegw-stack entrypoint — fan out lifed + lifegw + caddy in one container.
+#
+# Order matters:
+#   1. Generate self-signed cert at /etc/lifegw/tls/{fullchain,privkey}.pem
+#      so lifegw passes its TLS-bind step. The cert is regenerated on every
+#      container boot — Caddy proxies upstream with `tls_insecure_skip_verify`,
+#      so trust-chain validity is irrelevant.
+#   2. Start lifed in the background. It binds /run/life/life.sock + the
+#      admin socket. Wait for the public socket to appear before starting
+#      lifegw (which would otherwise race the UDS connect).
+#   3. Start lifegw in the background. It listens on 127.0.0.1:8443.
+#   4. Wait for 8443 to accept connections, then exec caddy in foreground.
+#      caddy becomes the supervisor — SIGTERM lands on caddy first, which
+#      tini propagates to the children.
+
+set -euo pipefail
+
+# ── 0. Sanity ───────────────────────────────────────────────────────────────
+PORT="${PORT:-8080}"
+LIFE_RUNTIME_DIR="${LIFE_RUNTIME_DIR:-/run/life}"
+TLS_DIR="${TLS_DIR:-/etc/lifegw/tls}"
+
+mkdir -p "${LIFE_RUNTIME_DIR}" "${TLS_DIR}"
+# `life-runtime` group owns /run/life so lifed + lifegw (running as `life`)
+# can both bind UDS sockets there with mode 0660.
+chown -R life:life-runtime "${LIFE_RUNTIME_DIR}"
+chmod 2775 "${LIFE_RUNTIME_DIR}"
+
+# ── 1. Self-signed cert (regenerated on every boot) ─────────────────────────
+if [[ ! -s "${TLS_DIR}/fullchain.pem" || ! -s "${TLS_DIR}/privkey.pem" ]]; then
+  echo "[entrypoint] generating self-signed cert in ${TLS_DIR}"
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "${TLS_DIR}/privkey.pem" \
+    -out    "${TLS_DIR}/fullchain.pem" \
+    -days 365 \
+    -subj "/CN=lifegw.local" \
+    -addext "subjectAltName=DNS:localhost,DNS:lifegw.local,IP:127.0.0.1" \
+    >/dev/null 2>&1
+  chmod 0640 "${TLS_DIR}/fullchain.pem" "${TLS_DIR}/privkey.pem"
+  chown life:life-runtime "${TLS_DIR}/fullchain.pem" "${TLS_DIR}/privkey.pem"
+fi
+
+# ── 2. Start lifed ──────────────────────────────────────────────────────────
+echo "[entrypoint] starting lifed (mock-fallback=${LIFED_ALLOW_MOCK_FALLBACK:-0})"
+# Run lifed under the `life` user so its UDS sockets land owned by life:life-runtime.
+# `setpriv` would be cleaner but isn't on slim — `runuser` is.
+runuser -u life -g life-runtime -- \
+  /usr/local/bin/lifed daemon \
+    --config "${LIFED_CONFIG:-/etc/lifed/config.toml}" \
+  &
+LIFED_PID=$!
+
+# Wait for /run/life/life.sock to exist (max 30s — bootstrap reads lago,
+# JWKS publish, etc.). Failure here is fatal: caddy + lifegw would never
+# come up healthy without lifed.
+echo "[entrypoint] waiting for lifed UDS at ${LIFE_RUNTIME_DIR}/life.sock"
+for i in $(seq 1 60); do
+  if [[ -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
+    echo "[entrypoint] lifed UDS ready (after ${i} half-seconds)"
+    break
+  fi
+  if ! kill -0 "${LIFED_PID}" 2>/dev/null; then
+    echo "[entrypoint] FATAL: lifed exited before binding UDS" >&2
+    wait "${LIFED_PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+if [[ ! -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
+  echo "[entrypoint] FATAL: lifed did not bind UDS within 30s" >&2
+  exit 1
+fi
+
+# ── 3. Start lifegw ─────────────────────────────────────────────────────────
+echo "[entrypoint] starting lifegw"
+runuser -u life -g life-runtime -- \
+  /usr/local/bin/lifegw daemon \
+    --config "${LIFEGW_CONFIG:-/etc/lifegw/config.toml}" \
+  &
+LIFEGW_PID=$!
+
+# Wait for 127.0.0.1:8443 to accept TCP. We don't need to handshake TLS;
+# a successful connect is enough proof the listener is live.
+echo "[entrypoint] waiting for lifegw on 127.0.0.1:8443"
+for i in $(seq 1 60); do
+  if (echo > /dev/tcp/127.0.0.1/8443) 2>/dev/null; then
+    echo "[entrypoint] lifegw listening (after ${i} half-seconds)"
+    break
+  fi
+  if ! kill -0 "${LIFEGW_PID}" 2>/dev/null; then
+    echo "[entrypoint] FATAL: lifegw exited before binding 127.0.0.1:8443" >&2
+    wait "${LIFEGW_PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+
+# ── 4. Caddy as PID 1's foreground process ─────────────────────────────────
+# `caddy run` is the long-lived foreground process. SIGTERM from Railway
+# lands on caddy via tini; we trap it here to fan-out a graceful shutdown
+# to the background daemons before exiting.
+shutdown() {
+  echo "[entrypoint] SIGTERM received — draining"
+  if kill -0 "${LIFEGW_PID}" 2>/dev/null; then kill -TERM "${LIFEGW_PID}" || true; fi
+  if kill -0 "${LIFED_PID}"  2>/dev/null; then kill -TERM "${LIFED_PID}"  || true; fi
+  # Caddy itself is signaled by tini; nothing else to do.
+}
+trap shutdown TERM INT
+
+echo "[entrypoint] starting caddy on :${PORT}"
+exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/deploy/railway/lifegw-stack/lifed.toml
+++ b/deploy/railway/lifegw-stack/lifed.toml
@@ -1,0 +1,81 @@
+# lifed config — Railway lifegw-stack deploy.
+#
+# Stage 1: real lifed binary, mock substrates. lifed boots without any of
+# the per-substrate UDS sockets present (arcand / lagod / haimad / animad /
+# soma); the `LIFED_ALLOW_MOCK_FALLBACK=1` env var (set on the Railway
+# service) flips substrates to canned mocks at boot. The wire path
+# (Caddy → lifegw → lifed) runs end-to-end against real code; substrate
+# behaviour is mocked.
+#
+# Dev signer: lifed's bootstrap auto-falls-back to
+# `JwksCache::dev_only()` when `auth.jwks_path` does not exist, so the
+# `Bearer test-token-for-{user_id}` shortcut works without an explicit
+# config flag. Production swaps this by pre-publishing a real JWKS at
+# `auth.jwks_path` (which lifegw also writes to in this image).
+#
+# Production swap-in: drop `LIFED_ALLOW_MOCK_FALLBACK`, ship arcand +
+# lagod + haimad + animad + soma into the same container (or a successor
+# multi-container topology once tonic gets a TCP-only transport push),
+# and let lifed fail-fast on missing UDS sockets.
+
+[public_plane]
+unix_socket       = "/run/life/life.sock"
+unix_socket_mode  = 0o660
+unix_socket_group = "life-runtime"
+
+[admin_plane]
+unix_socket       = "/run/life/life-admin.sock"
+unix_socket_mode  = 0o660
+unix_socket_group = "life-runtime"
+
+# Per-substrate UDS endpoints — paths the bootstrap tries to connect to.
+# When LIFED_ALLOW_MOCK_FALLBACK=1 the missing sockets degrade to the
+# in-process mock; without the flag, lifed fails fast (production posture).
+[substrates.arcan]
+unix_socket = "/run/life/arcan.sock"
+
+[substrates.lago]
+unix_socket = "/run/life/lago.sock"
+
+[substrates.haima]
+unix_socket = "/run/life/haima.sock"
+
+[substrates.anima]
+unix_socket = "/run/life/anima.sock"
+
+[substrates.soma]
+unix_socket = "/run/life/soma-admin.sock"
+
+[auth]
+# JWKS path is shared with lifegw — both daemons use the same key. lifegw
+# writes the JWKS to /run/life/lifegw-jwks.json on boot; lifed reads it.
+# Until lifegw publishes (couple-second race at startup), lifed runs in
+# dev-keystore mode (`Bearer test-token-for-{user_id}` accepted).
+jwks_path                   = "/run/life/lifegw-jwks.json"
+substrate_signing_key_path  = "/etc/life/lifed-signing-key.pem"
+substrate_jwks_publish_path = "/run/life/lifed-jwks.json"
+revoked_sids_path           = "/run/life/revoked_sids.json"
+
+[routing]
+idle_threshold_secs    = 3600
+hard_cap               = 100000
+eviction_interval_secs = 300
+
+[pools]
+arcan_capacity = 32
+lago_capacity  = 64
+haima_capacity = 16
+anima_capacity = 16
+soma_capacity  = 8
+
+[idempotency]
+backend  = "in_memory"
+ttl_secs = 86400
+
+[vigil]
+otlp_endpoint        = ""
+trace_sample_ratio   = 0.05
+metric_interval_secs = 60
+
+[shutdown]
+drain_secs = 30

--- a/deploy/railway/lifegw-stack/lifegw.toml
+++ b/deploy/railway/lifegw-stack/lifegw.toml
@@ -1,0 +1,65 @@
+# lifegw config — Railway lifegw-stack deploy.
+#
+# This is a Stage-1 deploy: dev signer + Dev KMS. The gateway accepts the
+# `Bearer dev-token-for-{user_id}` Tier-1 shortcut and mints Tier-2 caps
+# from an in-process key. Production swap-in (Vault / AWS / GCP KMS, real
+# Vercel JWKS) is future work tracked in the canonical spec at
+# `apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md`.
+#
+# `[upstream] lifed_uds_path` — path is shared with `lifed.toml`. Keep
+# both files in sync if you change the socket location.
+
+[tls]
+cert_path = "/etc/lifegw/tls/fullchain.pem"
+key_path  = "/etc/lifegw/tls/privkey.pem"
+acme_enabled = false
+
+[listen]
+# Bind only on loopback — Caddy is the only client. Public traffic lands
+# on `:$PORT` which Caddy proxies in. The default http_redirect_addr is
+# `[::]:80` but the daemon does not actually bind it in Sub-phase D, so
+# we leave it at default. (Setting it explicitly to a value we don't
+# want bound would just reserve the field; omitting is the cleanest.)
+https_addr = "127.0.0.1:8443"
+
+[upstream]
+lifed_uds_path = "/run/life/life.sock"
+
+[admin_plane]
+unix_socket       = "/run/life/lifegw-admin.sock"
+unix_socket_group = "life-runtime"
+unix_socket_mode  = 0o660
+
+[auth]
+# Tier-1 verification accepts BOTH real ES256 JWS (verified against
+# broomva.tech's `/api/auth/jwks.json`) AND the dev shortcut
+# `Bearer dev-token-for-{user_id}`. lifegw's
+# `JwksCache::new_with_dev_shortcut` makes the two additive: real JWS
+# tokens are validated against the upstream JWKS, and the dev shortcut
+# is also accepted for ops smoke tests.
+#
+# `dev_signer_enabled = true` is also required by lifegw's Sub-phase C
+# hardening guard which couples the Dev `kms_provider` to this flag.
+# When we swap Tier-2 mint to Vault/AWS/GCP KMS (Spec C₃ Sub-phase E)
+# we flip this to `false` so the dev shortcut is rejected outright.
+jwks_url            = "https://broomva.tech/api/auth/jwks.json"
+tier1_audience      = "lifegw"
+tier1_issuer        = "https://broomva.tech"
+kms_provider        = "dev"
+dev_signer_enabled  = true
+publish_jwks_path   = "/run/life/lifegw-jwks.json"
+tier2_audience      = "lifed"
+tier2_issuer        = "lifegw"
+tier2_ttl           = "900s"
+tier_user_ttl       = "900s"
+
+[rate_limit]
+per_user_capacity        = 60
+per_user_refill_per_sec  = 60
+per_ip_capacity          = 60
+per_ip_refill_per_min    = 60
+concurrent_ws_per_user   = 10
+
+[observability]
+trace_sample_ratio = 0.05
+metric_interval    = "60s"


### PR DESCRIPTION
## Summary

Two related changes shipped together because the deploy artifacts test the JwksCache change end-to-end.

### 1. \`deploy/railway/lifegw-stack/\` — multi-process Railway service

\`Caddy (:\$PORT cleartext) → lifegw HTTPS on 127.0.0.1:8443 (self-signed) → lifed via /run/life/life.sock UDS\`. lifed boots with \`LIFED_ALLOW_MOCK_FALLBACK=true\`. Caddy re-injects the \`Connection: Upgrade\` + \`Upgrade: websocket\` headers Railway's edge strips, restoring WS upgrade for \`/v1/agent/stream\`.

Service deployed at \`https://lifegw-production.up.railway.app\` (Broomva Tech / Life project). \`/healthz\` and the WS handshake both verified end-to-end against a real ES256 JWT minted by broomva.tech.

### 2. \`JwksCache::new_with_dev_shortcut(cfg)\` — additive Tier-1 verifier

The previous \`JwksCache::dev_only()\` short-circuited the real-JWKS path entirely (empty inline JWKS), so deploys that wanted both apps/chat-issued production tokens AND the local-test dev shortcut had to choose one.

The new constructor wraps a real \`JwksCacheConfig\` (URL fetch) and flips \`dev_signer_enabled = true\` so \`verify()\` accepts both:
- real ES256 JWS verified via the upstream JWKS
- \`Bearer dev-token-for-{user_id}\` shortcut

\`bootstrap::build_jwks_cache\` uses this constructor when \`cfg.auth.dev_signer_enabled = true\`, and falls through to the strict \`JwksCache::new()\` (production posture) when false.

Pairs with broomva.tech's new \`/api/auth/jwks.json\` endpoint and the \`LIFEGW_TIER1_SIGNING_JWK\`-driven mint at \`apps/chat/lib/auth/lifegw-jwt.ts\` (broomva.tech PR #139 + #140, both merged).

## Verification

```bash
# Real Tier-1 JWT minted with the same key broomva.tech publishes:
$ python3 ws_smoke.py
OK: WS connected (subprotocol='life.v1.agent')
first frame: len=60
preview: {"kind":"closing","reason":"policy_violation:token_expired"}
```

The 101 Switching Protocols + first frame confirms lifegw verified the real JWS via broomva.tech's JWKS. The downstream \`policy_violation:token_expired\` is a separate, pre-existing Tier-2 startup race documented in \`HANDOFF.md\` §7 (lifed boots before lifegw publishes its own JWKS, so it can't verify lifegw's Tier-2 JWS yet — fix path: hot-reload in lifed).

## Test plan

- [x] \`cargo build --release -p lifegw\` clean
- [x] \`cargo test -p lifegw --lib\` 151/151 pass
- [x] \`/healthz\` returns 200 from public domain
- [x] WS handshake completes (status 101) with real broomva.tech-minted JWT
- [x] WS handshake still completes with dev-shortcut bearer (additive path)
- [ ] Tier-2 chain pending lifed-side fix (tracked in HANDOFF §7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)