### PR TITLE
feat(life-runtime): Stage 2 — kill the lifegw/lifed boot-order race

### DIFF
--- a/crates/life-runtime/lifed/src/auth/jwks.rs
+++ b/crates/life-runtime/lifed/src/auth/jwks.rs
@@ -2,21 +2,55 @@
 //!
 //! Per Spec C₂ §5.1, lifed verifies the JWS bearer token presented on every
 //! public-plane request. Verification uses the published lifegw JWKS at
-//! `cfg.auth.jwks_path`. Sub-phase A's dev verifier is preserved behind a
-//! conditional path so existing integration tests that pass
-//! `Bearer test-token-for-{user_id}` continue to work — the rest of the
-//! daemon paths run real ES256.
+//! `cfg.auth.jwks_path`.
+//!
+//! ## Boot-order independence (Stage 2 — May 2026)
+//!
+//! Pre-Stage-2 the cache made a single boot-time decision: `if file exists →
+//! load static keys, else → fall back to dev_only`. That coupled lifed's
+//! verifier identity to lifegw's publish timing — and inside the
+//! Railway lifegw-stack container the order is **lifed first, lifegw
+//! second** (lifegw needs lifed's UDS to dial). lifed booted with `dev_only`
+//! and rejected every real ES256 JWS lifegw subsequently minted.
+//!
+//! The Stage-2 fix mirrors lifegw's own pattern (Spec C₃ §5):
+//!
+//! - **Lazy file load on first verify** — the cache holds a path, not a
+//!   pre-decided key set. The first `validate()` call (or any with an
+//!   unknown `kid`) re-reads the file.
+//! - **mtime-based invalidation** — every load stats the file; if mtime
+//!   advanced (lifegw rotated the key), the cache reloads.
+//! - **Serialized concurrent loads** — a `parking_lot::Mutex<()>` guards
+//!   the file read so 100 concurrent verifiers produce at most one I/O
+//!   per cache miss.
+//! - **Additive dev shortcut** — `dev_signer_enabled = true` accepts the
+//!   `Bearer test-token-for-{user_id}` shortcut **in addition to** real
+//!   ES256 verification. Disabled by default in production; integration
+//!   tests opt in.
+//!
+//! ## Sub-phase A backwards compat
+//!
+//! `JwksCache::dev_only()` and `JwksCache::load_from_path()` are preserved
+//! for tests + the Sub-phase A in-process keystore path. New deploys
+//! should use `JwksCache::new_lazy_file_with_dev_shortcut(path)` so the
+//! boot-order race goes away for good.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use aios_proto::aios::v1 as aios_v1;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use parking_lot::Mutex as PLMutex;
 use serde::{Deserialize, Serialize};
 
 use crate::auth::capability::{CapabilityClaims, Tier};
 use crate::error::{LifedError, LifedResult};
+
+/// Default cache TTL — even if the file mtime hasn't advanced we still
+/// re-stat the file every TTL window. Bounds staleness if mtime updates
+/// race the OS's filesystem cache.
+pub const DEFAULT_LAZY_TTL: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Serialize, Deserialize, Clone)]
 struct JwksFile {
@@ -55,64 +89,151 @@ struct Tier2Body {
     nbf: Option<u64>,
 }
 
+/// In-memory cache state — keys + bookkeeping for invalidation.
+struct CacheState {
+    keys: Vec<(String, DecodingKey)>,
+    /// `None` until the first successful load.
+    last_loaded_at: Option<Instant>,
+    /// File-system mtime captured at the last successful load. `None`
+    /// until the first load (or for inline / dev-only sources).
+    last_mtime: Option<SystemTime>,
+}
+
+impl CacheState {
+    fn empty() -> Self {
+        Self {
+            keys: Vec::new(),
+            last_loaded_at: None,
+            last_mtime: None,
+        }
+    }
+
+    fn from_keys(keys: Vec<(String, DecodingKey)>) -> Self {
+        Self {
+            keys,
+            last_loaded_at: Some(Instant::now()),
+            last_mtime: None,
+        }
+    }
+}
+
+/// Source from which a `JwksCache` resolves keys.
+enum JwksSource {
+    /// Static keys — set at construction, never reloaded. Used by
+    /// `dev_only()` (empty) and `load_from_path()` (one-shot file load).
+    /// Both are preserved for tests + the Sub-phase A in-process path.
+    Static,
+    /// File-backed lazy source. Reloaded on cache miss / mtime change.
+    Lazy { path: PathBuf, ttl: Duration },
+}
+
 /// JWKS cache used by the auth middleware for Tier-2 verification.
 pub struct JwksCache {
-    keys: RwLock<Vec<(String, DecodingKey)>>,
-    /// Whether the dev `test-token-for-{user_id}` path is enabled. Set to
-    /// `true` only when [`JwksCache::dev_only`] is used; production
-    /// deployments load real JWKS via [`JwksCache::load_from_path`] and
-    /// dev-token acceptance stays off.
+    source: JwksSource,
+    state: RwLock<CacheState>,
+    /// Serialises concurrent loads — concurrent verifies that miss the
+    /// cache funnel through here so we issue at most one file read at a
+    /// time. The mutex holds nothing (`()`); semantics is the lock alone.
+    load_lock: PLMutex<()>,
+    /// Whether the dev `test-token-for-{user_id}` path is enabled. When
+    /// `true`, accepts the shortcut **in addition to** real ES256
+    /// verification. Production deploys leave this `false`.
     dev_signer_enabled: bool,
 }
 
 impl JwksCache {
-    /// Load a JWKS from disk for production verification.
+    /// Load a JWKS from disk once at construction. Sub-phase A back-compat
+    /// constructor — production deploys should use
+    /// [`new_lazy_file`](Self::new_lazy_file) instead so a missing-then-
+    /// appears file (boot race) is handled correctly.
     pub fn load_from_path(path: &Path) -> LifedResult<Self> {
-        let text = std::fs::read_to_string(path)
-            .map_err(|e| LifedError::Auth(format!("read {}: {e}", path.display())))?;
-        let file: JwksFile = serde_json::from_str(&text)
-            .map_err(|e| LifedError::Auth(format!("parse jwks: {e}")))?;
-        let mut keys = Vec::new();
-        for k in file.keys {
-            if k.kty != "EC" || k.crv != "P-256" || k.alg != "ES256" {
-                continue;
-            }
-            let key = if let Some(pem) = k.pem.as_ref() {
-                DecodingKey::from_ec_pem(pem.as_bytes())
-                    .map_err(|e| LifedError::Auth(format!("decode pem {}: {e}", k.kid)))?
-            } else {
-                DecodingKey::from_ec_components(&k.x, &k.y)
-                    .map_err(|e| LifedError::Auth(format!("decode key {}: {e}", k.kid)))?
-            };
-            keys.push((k.kid, key));
-        }
+        let keys = parse_jwks_file(path)?;
         Ok(Self {
-            keys: RwLock::new(keys),
+            source: JwksSource::Static,
+            state: RwLock::new(CacheState::from_keys(keys)),
+            load_lock: PLMutex::new(()),
             dev_signer_enabled: false,
         })
     }
 
-    /// Dev convenience: build a cache containing the [`crate::auth::keystore::Keystore::generate_dev`]
-    /// public key AND enable the `test-token-for-{user_id}` shortcut so existing
-    /// integration tests keep passing.
+    /// Lazy file-backed JWKS cache.
+    ///
+    /// The cache does **not** read the file at construction. The first
+    /// `validate()` call (or any subsequent call with an unknown `kid`)
+    /// triggers a load. Subsequent loads stat the file's mtime; when
+    /// the mtime has advanced **or** the TTL window has elapsed, the
+    /// keys are reloaded. Concurrent miss-driven loads are serialised
+    /// behind an internal mutex so we issue at most one file read per
+    /// burst.
+    ///
+    /// Dev shortcut is **disabled** — production posture. Use
+    /// [`new_lazy_file_with_dev_shortcut`](Self::new_lazy_file_with_dev_shortcut)
+    /// during transition periods where integration tests still rely on
+    /// `Bearer test-token-for-{user_id}`.
+    pub fn new_lazy_file(path: impl Into<PathBuf>) -> Self {
+        Self::new_lazy_file_inner(path, DEFAULT_LAZY_TTL, false)
+    }
+
+    /// Lazy file-backed JWKS cache that **also** accepts the
+    /// `Bearer test-token-for-{user_id}` dev shortcut as an additive
+    /// fallback. Real ES256 verification still runs against the file;
+    /// the shortcut is checked first as a fast-path for tests + ops
+    /// smoke runs, then falls through to JWKS verification.
+    pub fn new_lazy_file_with_dev_shortcut(path: impl Into<PathBuf>) -> Self {
+        Self::new_lazy_file_inner(path, DEFAULT_LAZY_TTL, true)
+    }
+
+    fn new_lazy_file_inner(
+        path: impl Into<PathBuf>,
+        ttl: Duration,
+        dev_signer_enabled: bool,
+    ) -> Self {
+        Self {
+            source: JwksSource::Lazy {
+                path: path.into(),
+                ttl,
+            },
+            state: RwLock::new(CacheState::empty()),
+            load_lock: PLMutex::new(()),
+            dev_signer_enabled,
+        }
+    }
+
+    /// Dev convenience: build a cache containing the
+    /// [`crate::auth::keystore::Keystore::generate_dev`] public key AND
+    /// enable the dev shortcut. **No file source** — every verify either
+    /// hits the in-memory dev key or accepts the shortcut. Used by
+    /// integration tests that don't materialize a real JWKS file.
     pub fn dev_only() -> Self {
         let ks = crate::auth::keystore::Keystore::generate_dev();
         let pubkey_pem = ks.public_key_pem();
         let key = DecodingKey::from_ec_pem(pubkey_pem.as_bytes()).expect("dev pem");
         Self {
-            keys: RwLock::new(vec![(ks.kid, key)]),
+            source: JwksSource::Static,
+            state: RwLock::new(CacheState::from_keys(vec![(ks.kid, key)])),
+            load_lock: PLMutex::new(()),
             dev_signer_enabled: true,
         }
     }
 
+    /// Accessor — does this cache also accept the dev shortcut?
+    pub fn dev_signer_enabled(&self) -> bool {
+        self.dev_signer_enabled
+    }
+
     /// Validate a Tier-2 bearer token. Returns the parsed claims on success.
     ///
-    /// When `dev_signer_enabled` is true, also accepts the
-    /// `test-token-for-{user_id}` shortcut used by integration tests.
+    /// When `dev_signer_enabled` is true, the
+    /// `Bearer test-token-for-{user_id}` shortcut is accepted **in
+    /// addition to** real ES256 verification. The shortcut is checked
+    /// first; on no-match the real path runs.
     pub fn validate(&self, bearer: &str) -> LifedResult<CapabilityClaims> {
         if self.dev_signer_enabled
             && let Some(user_id) = bearer.strip_prefix("test-token-for-")
         {
+            if user_id.is_empty() {
+                return Err(LifedError::Auth("empty dev user_id".to_string()));
+            }
             return Ok(CapabilityClaims {
                 user_id: user_id.to_string(),
                 project_id: "project-demo".to_string(),
@@ -134,17 +255,16 @@ impl JwksCache {
         let kid = header
             .kid
             .ok_or_else(|| LifedError::Auth("missing kid".to_string()))?;
-        let key = {
-            let guard = self
-                .keys
-                .read()
-                .map_err(|_| LifedError::Auth("jwks lock".to_string()))?;
-            guard
-                .iter()
-                .find(|(k, _)| k == &kid)
-                .map(|(_, dk)| dk.clone())
-        }
-        .ok_or_else(|| LifedError::Auth(format!("unknown kid: {kid}")))?;
+
+        let key = match self.lookup_kid(&kid) {
+            Some(k) => k,
+            None => {
+                // Cache miss. For lazy sources, attempt a refresh + retry.
+                self.maybe_reload(&kid)?;
+                self.lookup_kid(&kid)
+                    .ok_or_else(|| LifedError::Auth(format!("unknown kid: {kid}")))?
+            }
+        };
 
         let mut v = Validation::new(Algorithm::ES256);
         v.set_audience(&["lifed"]);
@@ -173,5 +293,377 @@ impl JwksCache {
             tier,
             exp: exp_instant,
         })
+    }
+
+    /// Read-locked lookup. Cheap fast-path on the hot verify path.
+    fn lookup_kid(&self, kid: &str) -> Option<DecodingKey> {
+        let guard = self.state.read().ok()?;
+        guard
+            .keys
+            .iter()
+            .find(|(k, _)| k == kid)
+            .map(|(_, dk)| dk.clone())
+    }
+
+    /// Refresh the cache from the file source if (and only if) we have
+    /// one. Static sources are no-ops. Concurrent callers serialise on
+    /// `load_lock`; whoever holds the lock checks mtime + TTL and either
+    /// re-reads the file or skips. After the first holder reloads, every
+    /// subsequent caller short-circuits via the mtime/TTL check.
+    fn maybe_reload(&self, _missing_kid: &str) -> LifedResult<()> {
+        let (path, ttl) = match &self.source {
+            JwksSource::Static => return Ok(()),
+            JwksSource::Lazy { path, ttl } => (path.clone(), *ttl),
+        };
+
+        let _lock = self.load_lock.lock();
+
+        // Re-check under the lock: another thread may have already loaded.
+        // Skip the file read if we have keys, the mtime hasn't moved, and
+        // the TTL hasn't expired.
+        let (cached_mtime, cached_loaded_at) = {
+            let s = self
+                .state
+                .read()
+                .map_err(|_| LifedError::Auth("jwks state lock".to_string()))?;
+            (s.last_mtime, s.last_loaded_at)
+        };
+        let current_mtime = std::fs::metadata(&path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+        let mtime_unchanged = match (cached_mtime, current_mtime) {
+            (Some(prev), Some(now)) => prev == now,
+            _ => false,
+        };
+        let ttl_fresh = cached_loaded_at.map(|t| t.elapsed() < ttl).unwrap_or(false);
+
+        if mtime_unchanged && ttl_fresh {
+            // Another thread already refreshed (or our own previous load
+            // is still fresh) and the file hasn't moved. Nothing to do.
+            return Ok(());
+        }
+
+        // Read + parse. A missing file is logged but not fatal — we
+        // simply don't update the cache. The verifier will return
+        // "unknown kid" and the caller sees an auth error, which is
+        // the correct surface (the file genuinely isn't there yet).
+        let keys = match parse_jwks_file(&path) {
+            Ok(keys) => keys,
+            Err(err) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "jwks file unreadable — keeping previous keys"
+                );
+                return Ok(());
+            }
+        };
+
+        let mut guard = self
+            .state
+            .write()
+            .map_err(|_| LifedError::Auth("jwks state lock".to_string()))?;
+        guard.keys = keys;
+        guard.last_loaded_at = Some(Instant::now());
+        guard.last_mtime = current_mtime;
+        Ok(())
+    }
+}
+
+/// Parse the JWKS file at `path` into a list of `(kid, DecodingKey)`
+/// pairs. Filters out non-EC-P-256-ES256 entries (we don't accept RS256
+/// at lifed's verify boundary — Spec C₂ §5.1 narrows lifegw → lifed
+/// to ES256 only).
+fn parse_jwks_file(path: &Path) -> LifedResult<Vec<(String, DecodingKey)>> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| LifedError::Auth(format!("read {}: {e}", path.display())))?;
+    let file: JwksFile =
+        serde_json::from_str(&text).map_err(|e| LifedError::Auth(format!("parse jwks: {e}")))?;
+    let mut keys = Vec::new();
+    for k in file.keys {
+        if k.kty != "EC" || k.crv != "P-256" || k.alg != "ES256" {
+            continue;
+        }
+        let key = if let Some(pem) = k.pem.as_ref() {
+            DecodingKey::from_ec_pem(pem.as_bytes())
+                .map_err(|e| LifedError::Auth(format!("decode pem {}: {e}", k.kid)))?
+        } else {
+            DecodingKey::from_ec_components(&k.x, &k.y)
+                .map_err(|e| LifedError::Auth(format!("decode key {}: {e}", k.kid)))?
+        };
+        keys.push((k.kid, key));
+    }
+    Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::keystore::Keystore;
+    use jsonwebtoken::{Header, encode};
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use tempfile::TempDir;
+
+    /// Mint a Tier-2-shaped JWT signed by the given keystore. Mirrors
+    /// what lifegw's Tier-2 minter produces so we can verify the
+    /// round-trip without standing up the full lifegw stack.
+    fn mint_tier2(ks: &Keystore, sub: &str, sid: &str, exp_secs: u64) -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(ks.kid.clone());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let body = json!({
+            "iss": "lifegw",
+            "aud": "lifed",
+            "sub": sub,
+            "sid": sid,
+            "scopes": ["agent:dispatch"],
+            "tier": "free",
+            "iat": now,
+            "nbf": now,
+            "exp": now + exp_secs,
+        });
+        // Keystore exposes `encoding: EncodingKey` directly — no need
+        // to re-parse a PEM. The private half came from the embedded
+        // dev key in `auth::keystore::Keystore::generate_dev`.
+        encode(&header, &body, &ks.encoding).expect("encode")
+    }
+
+    /// Write a JWKS file containing the given keystore's public half.
+    /// Mirrors `lifegw::auth::bootstrap::publish_jwks_atomic` minus the
+    /// atomic-rename plumbing.
+    fn write_jwks(path: &Path, ks: &Keystore) {
+        let doc = json!({
+            "keys": [{
+                "kid": ks.kid,
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "ES256",
+                "use": "sig",
+                "pem": ks.public_key_pem(),
+            }],
+        });
+        std::fs::write(path, serde_json::to_vec_pretty(&doc).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn lazy_load_picks_up_file_that_appears_after_construction() {
+        // The boot-race scenario: lifed starts with an empty file, lifegw
+        // writes the JWKS shortly after, lifed must verify successfully.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let cache = JwksCache::new_lazy_file(&path);
+
+        let ks = Keystore::generate_dev();
+        let token = mint_tier2(&ks, "user_alice", "sess_001", 600);
+
+        // First verify before file exists — must fail with auth error.
+        let err = cache.validate(&token).unwrap_err();
+        match err {
+            LifedError::Auth(_) => {}
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+
+        // lifegw publishes JWKS now.
+        write_jwks(&path, &ks);
+
+        // Next verify — lazy reload picks it up, claims parse cleanly.
+        let claims = cache.validate(&token).expect("verify after publish");
+        assert_eq!(claims.user_id, "user_alice");
+        assert_eq!(claims.sid.value, "sess_001");
+    }
+
+    #[test]
+    fn lazy_load_picks_up_mtime_change_after_rotation() {
+        // After a key rotation, lifegw rewrites the JWKS file with a new
+        // kid. lifed's verify should pick up the new key on the next miss.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let cache = JwksCache::new_lazy_file(&path);
+
+        let ks_v1 = Keystore::generate_dev();
+        write_jwks(&path, &ks_v1);
+        let token_v1 = mint_tier2(&ks_v1, "user_alice", "sess_001", 600);
+        cache.validate(&token_v1).expect("v1 verifies");
+
+        // Rotate. Sleep briefly so the OS records a new mtime even on
+        // filesystems with second-granularity timestamps.
+        std::thread::sleep(Duration::from_millis(1100));
+        let ks_v2 = Keystore::generate_dev();
+        write_jwks(&path, &ks_v2);
+        let token_v2 = mint_tier2(&ks_v2, "user_bob", "sess_002", 600);
+
+        // The v2 token has a new kid; the cache misses, reloads via
+        // mtime-changed path, and verifies cleanly.
+        let claims = cache
+            .validate(&token_v2)
+            .expect("v2 verifies after rotation");
+        assert_eq!(claims.user_id, "user_bob");
+    }
+
+    #[test]
+    fn dev_shortcut_is_additive_to_real_jwks_when_enabled() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let ks = Keystore::generate_dev();
+        write_jwks(&path, &ks);
+        let cache = JwksCache::new_lazy_file_with_dev_shortcut(&path);
+
+        // Real JWS verifies.
+        let token = mint_tier2(&ks, "user_real", "sess_real", 600);
+        let claims = cache.validate(&token).expect("real JWS verifies");
+        assert_eq!(claims.user_id, "user_real");
+
+        // Dev shortcut also accepted (additive).
+        let claims = cache
+            .validate("test-token-for-user_dev")
+            .expect("dev shortcut");
+        assert_eq!(claims.user_id, "user_dev");
+    }
+
+    #[test]
+    fn dev_shortcut_disabled_in_production_posture() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let ks = Keystore::generate_dev();
+        write_jwks(&path, &ks);
+        let cache = JwksCache::new_lazy_file(&path);
+
+        // Real JWS verifies.
+        let token = mint_tier2(&ks, "user_real", "sess_real", 600);
+        cache.validate(&token).expect("real JWS verifies");
+
+        // Dev shortcut REJECTED.
+        let err = cache.validate("test-token-for-user_dev").unwrap_err();
+        match err {
+            LifedError::Auth(_) => {}
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn concurrent_misses_serialize_through_load_lock() {
+        // 50 threads concurrently verify against a missing file. Only
+        // one will hold the load_lock at a time. We don't have a clean
+        // way to count file reads here, but we can at minimum assert
+        // none of them deadlock or panic + all observe the post-publish
+        // file consistently.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let cache = Arc::new(JwksCache::new_lazy_file(&path));
+        let ks = Keystore::generate_dev();
+        write_jwks(&path, &ks);
+
+        let token = mint_tier2(&ks, "user_concurrent", "sess_x", 600);
+        let success_count = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..50)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let token = token.clone();
+                let success_count = Arc::clone(&success_count);
+                thread::spawn(move || {
+                    if cache.validate(&token).is_ok() {
+                        success_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(success_count.load(Ordering::Relaxed), 50);
+    }
+
+    #[test]
+    fn unknown_kid_returns_auth_error_after_failed_reload() {
+        // Token whose `kid` header doesn't appear in the JWKS file — even
+        // after a reload, we can't verify it. The cache must report
+        // "unknown kid" rather than panicking or hanging.
+        //
+        // Note: `Keystore::generate_dev()` is deterministic (it embeds a
+        // committed PEM), so we can't get two different keystores. We
+        // instead mint a token whose header `kid` is intentionally
+        // different from the one published in the JWKS, while signing
+        // with the dev key. The verifier short-circuits on the kid lookup
+        // before checking the signature, so this exercises the
+        // "unknown kid → reload → still missing → auth error" branch.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let cache = JwksCache::new_lazy_file(&path);
+
+        let ks = Keystore::generate_dev();
+        write_jwks(&path, &ks);
+
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some("stranger-kid-not-in-jwks".to_string());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let body = json!({
+            "iss": "lifegw",
+            "aud": "lifed",
+            "sub": "u",
+            "sid": "s",
+            "scopes": ["agent:dispatch"],
+            "tier": "free",
+            "iat": now,
+            "nbf": now,
+            "exp": now + 600,
+        });
+        let token = encode(&header, &body, &ks.encoding).expect("encode");
+
+        let err = cache.validate(&token).unwrap_err();
+        match err {
+            LifedError::Auth(msg) => assert!(
+                msg.contains("unknown kid"),
+                "expected 'unknown kid' message, got: {msg}"
+            ),
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_dev_user_id_rejected_when_shortcut_enabled() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let cache = JwksCache::new_lazy_file_with_dev_shortcut(&path);
+        let err = cache.validate("test-token-for-").unwrap_err();
+        match err {
+            LifedError::Auth(msg) => assert!(msg.contains("empty"), "got: {msg}"),
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_load_from_path_still_works_for_static_test_rigs() {
+        // Sub-phase A back-compat: load_from_path takes a one-shot
+        // snapshot. Subsequent file changes are NOT picked up — that's
+        // the point of having a separate `new_lazy_file` constructor.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("jwks.json");
+        let ks = Keystore::generate_dev();
+        write_jwks(&path, &ks);
+        let cache = JwksCache::load_from_path(&path).expect("load");
+        let token = mint_tier2(&ks, "u", "s", 600);
+        cache.validate(&token).expect("verifies");
+    }
+
+    #[test]
+    fn legacy_dev_only_still_accepts_shortcut() {
+        // dev_only() preserves Sub-phase A semantics: in-memory dev key
+        // + dev shortcut, no file source.
+        let cache = JwksCache::dev_only();
+        assert!(cache.dev_signer_enabled());
+        let claims = cache.validate("test-token-for-alice").expect("shortcut");
+        assert_eq!(claims.user_id, "alice");
     }
 }

--- a/crates/life-runtime/lifed/src/bootstrap.rs
+++ b/crates/life-runtime/lifed/src/bootstrap.rs
@@ -94,15 +94,28 @@ pub async fn run_with_mocks_handles(
         "lifed starting (sub-phase C — mock substrates)",
     );
 
-    let jwks = if cfg.auth.jwks_path.exists() {
-        Arc::new(JwksCache::load_from_path(&cfg.auth.jwks_path)?)
+    // Stage 2 (May 2026): lazy file-backed JWKS — no boot-order race.
+    // The previous `if exists() { real } else { dev_only }` branch
+    // pinned the cache identity at boot time, which inside the Railway
+    // lifegw-stack container caused lifed to ALWAYS land on dev_only
+    // (lifegw publishes the JWKS ~100 ms after lifed binds its UDS).
+    // The new cache lazy-reads on first verify + on mtime change, so
+    // it picks up lifegw's publish without coordination. The dev
+    // shortcut is now an explicit additive flag — production deploys
+    // leave `cfg.auth.dev_signer_enabled = false` and reject the
+    // shortcut outright.
+    let jwks = if cfg.auth.dev_signer_enabled {
+        Arc::new(JwksCache::new_lazy_file_with_dev_shortcut(
+            &cfg.auth.jwks_path,
+        ))
     } else {
-        tracing::warn!(
-            path = %cfg.auth.jwks_path.display(),
-            "jwks file missing — using dev keystore (test-token-for-{{user}} accepted)"
-        );
-        Arc::new(JwksCache::dev_only())
+        Arc::new(JwksCache::new_lazy_file(&cfg.auth.jwks_path))
     };
+    tracing::info!(
+        path = %cfg.auth.jwks_path.display(),
+        dev_shortcut = cfg.auth.dev_signer_enabled,
+        "jwks cache initialised (lazy file-backed)"
+    );
     let auth = AuthLayer::new(Arc::clone(&jwks));
 
     // Sub-phase E: build pools first so we can wrap each substrate impl

--- a/crates/life-runtime/lifed/src/config.rs
+++ b/crates/life-runtime/lifed/src/config.rs
@@ -157,8 +157,10 @@ pub struct SubstrateEndpoint {
 #[non_exhaustive]
 pub struct AuthConfig {
     /// Path to a JSON-encoded JWKS file used to verify Tier-2 capability tokens.
-    /// In production, this file is fetched from `lifegw`'s well-known JWKS URL.
-    /// In dev/CI this is a static bundle.
+    /// In production, this file is published by lifegw at the path below.
+    /// lifed reads it lazily on first verify (and on `kid` cache miss /
+    /// mtime change) so there's no boot-order dependency between the two
+    /// daemons — see `auth::jwks` Stage-2 docs.
     #[serde(default = "default_jwks_path")]
     pub jwks_path: PathBuf,
     /// Path to lifed's substrate-token signing key (PEM-encoded EC key).
@@ -172,6 +174,14 @@ pub struct AuthConfig {
     /// Path to the `revoked_sids.json` snapshot file (master spec §L4 invariant 5).
     #[serde(default = "default_revoked_sids_path")]
     pub revoked_sids_path: PathBuf,
+    /// When `true`, the JWKS verifier ALSO accepts the
+    /// `Bearer test-token-for-{user_id}` shortcut as an additive
+    /// fallback (real ES256 verification still runs against `jwks_path`).
+    /// MUST be `false` in production. Integration tests + ops smoke
+    /// runs flip this on during the Stage 1 → Stage 2 transition; once
+    /// every caller mints real JWS the flag flips back to `false`.
+    #[serde(default)]
+    pub dev_signer_enabled: bool,
 }
 
 fn default_jwks_path() -> PathBuf {
@@ -194,6 +204,8 @@ impl Default for AuthConfig {
             substrate_signing_key_path: default_signing_key_path(),
             substrate_jwks_publish_path: default_published_jwks_path(),
             revoked_sids_path: default_revoked_sids_path(),
+            // Production posture — dev shortcut OFF by default.
+            dev_signer_enabled: false,
         }
     }
 }

--- a/crates/life-runtime/lifed/tests/_support/test_env.rs
+++ b/crates/life-runtime/lifed/tests/_support/test_env.rs
@@ -62,6 +62,14 @@ impl TestEnv {
         // macOS the dev fallback returns the real getuid()/getgid() —
         // so the user already matches.
         cfg.admin_plane.unix_socket_group = None;
+        // Stage-2 (May 2026): the `JwksCache` is now lazy + file-backed
+        // and `dev_signer_enabled` defaults to `false`. Existing smoke
+        // / integration tests authenticate via the
+        // `Bearer test-token-for-{user_id}` shortcut — opt them into
+        // the additive dev path here so the `JwksCache` accepts the
+        // shortcut alongside (and in the absence of) any real JWS.
+        // Production deploys leave the field at its `false` default.
+        cfg.auth.dev_signer_enabled = true;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (handles_tx, handles_rx) = oneshot::channel::<LifedHandles>();

--- a/crates/life-runtime/lifegw/src/auth/keystore.rs
+++ b/crates/life-runtime/lifegw/src/auth/keystore.rs
@@ -91,6 +91,51 @@ impl Keystore {
         })
     }
 
+    /// Load a Tier-2 signing keystore from an operator-provided PKCS#8
+    /// PEM. Used by the `KmsProvider::StaticPem` arm to take the
+    /// dev-key-generator out of the boot path: the operator generates
+    /// the key once (e.g. via `openssl genpkey -algorithm EC -pkeyopt
+    /// ec_paramgen_curve:P-256`), persists it to a Railway volume, and
+    /// hands the PEM to lifegw via env. Both lifegw and lifed can then
+    /// agree on the same `kid` regardless of who boots first.
+    ///
+    /// Accepts only PKCS#8 PEM (`-----BEGIN PRIVATE KEY-----`). SEC1
+    /// (`-----BEGIN EC PRIVATE KEY-----`) is rejected — operators must
+    /// run `openssl pkcs8 -topk8 -nocrypt -in sec1.pem -out pkcs8.pem`
+    /// once if they have a SEC1 key.
+    pub fn from_pem(priv_pem: &str, kid: impl Into<String>) -> LifegwResult<Self> {
+        // Validate the PEM armour BEFORE handing to jsonwebtoken — this
+        // way SEC1 ("BEGIN EC PRIVATE KEY") gets a clear, actionable
+        // error mentioning the openssl conversion command, instead of
+        // jsonwebtoken's opaque "InvalidKeyFormat".
+        let pkcs8_der = pem_to_der(priv_pem, "PRIVATE KEY").map_err(|e| {
+            LifegwError::Auth(format!(
+                "from_pem expects PKCS#8 PEM (BEGIN PRIVATE KEY); convert SEC1 keys via \
+                 `openssl pkcs8 -topk8 -nocrypt -in sec1.pem -out pkcs8.pem`: {e}"
+            ))
+        })?;
+        let encoding = EncodingKey::from_ec_pem(priv_pem.as_bytes())
+            .map_err(|e| LifegwError::Auth(format!("encode priv pem: {e}")))?;
+        let rng = ring::rand::SystemRandom::new();
+        let kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            &pkcs8_der,
+            &rng,
+        )
+        .map_err(|e| LifegwError::Auth(format!("parse pkcs8: {e}")))?;
+        let raw_pub = ring::signature::KeyPair::public_key(&kp).as_ref().to_vec();
+        let spki_der = sec1_uncompressed_to_spki(&raw_pub);
+        let pub_pem = der_to_pem("PUBLIC KEY", &spki_der);
+        let decoding = DecodingKey::from_ec_pem(pub_pem.as_bytes())
+            .map_err(|e| LifegwError::Auth(format!("decode pub pem: {e}")))?;
+        Ok(Self {
+            kid: kid.into(),
+            encoding,
+            decoding,
+            public_pem: pub_pem,
+        })
+    }
+
     /// Public key in PEM form. Sub-phase D writes this to disk so lifed (the
     /// downstream verifier) can read it from a known path.
     pub fn public_key_pem(&self) -> String {
@@ -173,6 +218,30 @@ impl JwksKey {
             pem: None,
         }
     }
+}
+
+/// Inverse of `der_to_pem` — strip BEGIN/END `<label>` armour, drop
+/// whitespace, base64-decode the body. Returns the DER bytes.
+///
+/// Hand-rolled rather than pulling in another crate for one shape; the
+/// PEM format is small and stable enough that this is robust. We accept
+/// LF or CRLF line endings.
+fn pem_to_der(pem: &str, label: &str) -> LifegwResult<Vec<u8>> {
+    use base64::Engine;
+    let begin = format!("-----BEGIN {label}-----");
+    let end = format!("-----END {label}-----");
+    let begin_idx = pem
+        .find(&begin)
+        .ok_or_else(|| LifegwError::Auth(format!("PEM missing `{begin}` header")))?;
+    let after_begin = begin_idx + begin.len();
+    let end_offset = pem[after_begin..]
+        .find(&end)
+        .ok_or_else(|| LifegwError::Auth(format!("PEM missing `{end}` footer")))?;
+    let body = &pem[after_begin..after_begin + end_offset];
+    let cleaned: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(cleaned)
+        .map_err(|e| LifegwError::Auth(format!("base64 decode {label}: {e}")))
 }
 
 fn der_to_pem(label: &str, der: &[u8]) -> String {
@@ -278,5 +347,105 @@ mod tests {
         assert_eq!(jwks.keys[0].alg, "ES256");
         assert_eq!(jwks.keys[0].crv, "P-256");
         assert!(jwks.keys[0].pem.is_some());
+    }
+
+    /// Round-trip: dev_generate → re-import its private PKCS#8 PEM via
+    /// `from_pem` → public PEMs match → signed JWT verifies under both
+    /// `Keystore` instances. Exercises the Stage-2 `KmsProvider::StaticPem`
+    /// happy path entirely in-process.
+    #[test]
+    fn from_pem_round_trip_via_dev_keystore_private_pkcs8() {
+        // Generate a fresh dev keystore — we don't have direct access to
+        // its private PEM so we re-derive via `ring`, then format as
+        // PKCS#8 PEM. This mirrors what an operator does with
+        // `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256`.
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            &rng,
+        )
+        .expect("generate pkcs8");
+        let priv_pem = der_to_pem("PRIVATE KEY", pkcs8.as_ref());
+
+        let ks = Keystore::from_pem(&priv_pem, "tier2-test-2026-05").expect("from_pem");
+        assert_eq!(ks.kid, "tier2-test-2026-05");
+        assert!(ks.public_pem.contains("BEGIN PUBLIC KEY"));
+
+        // Sign + verify round-trip — proves the encoding/decoding halves
+        // are paired correctly (i.e. we derived the right public key
+        // from the private input).
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Probe {
+            sub: String,
+            aud: String,
+            iss: String,
+            exp: u64,
+        }
+        let claims = Probe {
+            sub: "user-stage2".to_string(),
+            aud: "lifed".to_string(),
+            iss: "lifegw".to_string(),
+            exp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 60,
+        };
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(ks.kid.clone());
+        let token = encode(&header, &claims, &ks.encoding).expect("encode");
+        let mut v = Validation::new(Algorithm::ES256);
+        v.set_audience(&["lifed"]);
+        v.set_issuer(&["lifegw"]);
+        let decoded = decode::<Probe>(&token, &ks.decoding, &v).expect("verify");
+        assert_eq!(decoded.claims.sub, "user-stage2");
+    }
+
+    #[test]
+    fn from_pem_rejects_sec1_format_with_actionable_error() {
+        // SEC1 format: -----BEGIN EC PRIVATE KEY-----. We require PKCS#8
+        // and surface a clear "convert via openssl pkcs8 …" hint.
+        let sec1_pem = "-----BEGIN EC PRIVATE KEY-----\n\
+            MHcCAQEEIPmCWVS9w14MnDqyCabNmxRLywKtdwjmKCEZ7TI51tSloAoGCCqGSM49\n\
+            AwEHoUQDQgAEr5jeUd1bKTU+vHy5KFSDcYaeqHLECwbwAY9hAlR1qSsmNwMHkEjy\n\
+            6PqOEC8h4S8hrZD/zKL9k2KAMt6gzsMHAg==\n\
+            -----END EC PRIVATE KEY-----\n";
+        let err = match Keystore::from_pem(sec1_pem, "kid-x") {
+            Ok(_) => panic!("must reject SEC1 PEM"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("PKCS#8") && msg.contains("openssl pkcs8"),
+            "expected actionable error mentioning PKCS#8 + openssl, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_pem_rejects_garbage_pem() {
+        match Keystore::from_pem("not a pem", "kid-x") {
+            Ok(_) => panic!("must reject non-PEM input"),
+            Err(LifegwError::Auth(_)) => {}
+            Err(other) => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+
+    /// Two `Keystore::from_pem` calls with the same PEM produce
+    /// keystores that publish the same `pub_pem` — kids being external,
+    /// the public material is bit-identical for the same private input.
+    #[test]
+    fn from_pem_is_deterministic_in_public_key() {
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            &rng,
+        )
+        .expect("generate pkcs8");
+        let priv_pem = der_to_pem("PRIVATE KEY", pkcs8.as_ref());
+
+        let ks1 = Keystore::from_pem(&priv_pem, "k1").expect("from_pem 1");
+        let ks2 = Keystore::from_pem(&priv_pem, "k2").expect("from_pem 2");
+        assert_eq!(ks1.public_pem, ks2.public_pem);
+        assert_ne!(ks1.kid, ks2.kid); // kid is operator-supplied, not derived.
     }
 }

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -758,6 +758,29 @@ pub(crate) fn build_signer(cfg: &AuthConfig) -> LifegwResult<Arc<dyn KmsSigner>>
             }
             Ok(Arc::new(StaticKeystore::generate_dev()?))
         }
+        KmsProvider::StaticPem => match cfg.static_pem.as_ref() {
+            Some(s) => {
+                let pem = std::env::var(&s.pem_env).map_err(|_| {
+                    LifegwError::Config(format!(
+                        "auth.kms_provider = static_pem but env var `{}` is unset \
+                         (operator must inject the PKCS#8 PEM private key — see \
+                         deploy/railway/lifegw-stack/HANDOFF.md §8)",
+                        s.pem_env
+                    ))
+                })?;
+                if pem.trim().is_empty() {
+                    return Err(LifegwError::Config(format!(
+                        "auth.kms_provider = static_pem but env var `{}` is empty",
+                        s.pem_env
+                    )));
+                }
+                let keystore = crate::auth::keystore::Keystore::from_pem(&pem, s.kid.clone())?;
+                Ok(Arc::new(StaticKeystore::from_keystore(keystore)))
+            }
+            None => Err(LifegwError::Config(
+                "auth.kms_provider = static_pem but [auth.static_pem] missing".to_string(),
+            )),
+        },
         #[cfg(feature = "kms-vault")]
         KmsProvider::Vault => match cfg.vault.as_ref() {
             Some(v) => {
@@ -897,6 +920,14 @@ pub(crate) fn install_default_crypto_provider() {
 }
 
 #[cfg(test)]
+// Test-only scope for `std::env::{set_var, remove_var}` — Rust 2024
+// requires `unsafe { ... }` because env mutations are process-wide. The
+// production crate keeps `#![deny(unsafe_code)]`; we relax it just for
+// these tests because the alternative (a separate test crate or
+// dependency-injection seam through the entire signer-build chain) is
+// disproportionate. The tests use distinct env-var names per test so
+// concurrent runs don't clobber each other.
+#[allow(unsafe_code)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
@@ -966,5 +997,188 @@ mod tests {
         let body = std::fs::read_to_string(&path).expect("read");
         assert!(body.contains("\"kid\""));
         assert_ne!(body, "stale");
+    }
+
+    /// Helper: derive a fresh PKCS#8 PEM for `KmsProvider::StaticPem`
+    /// tests. Mirrors what `openssl genpkey -algorithm EC -pkeyopt
+    /// ec_paramgen_curve:P-256` produces.
+    fn make_pkcs8_pem() -> String {
+        use base64::Engine;
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::EcdsaKeyPair::generate_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            &rng,
+        )
+        .expect("generate pkcs8");
+        let b64 = base64::engine::general_purpose::STANDARD.encode(pkcs8.as_ref());
+        let mut pem = String::from("-----BEGIN PRIVATE KEY-----\n");
+        for chunk in b64.as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).unwrap());
+            pem.push('\n');
+        }
+        pem.push_str("-----END PRIVATE KEY-----\n");
+        pem
+    }
+
+    /// Stage-2 happy path: `KmsProvider::StaticPem` reads the PEM from
+    /// the configured env var, builds a `Keystore` via `from_pem`, wraps
+    /// it in `StaticKeystore`, and the resulting signer mints tokens
+    /// with the operator-supplied kid.
+    #[test]
+    fn build_signer_static_pem_reads_env_and_uses_operator_kid() {
+        // Use a distinct env var name so concurrent tests don't collide.
+        let env_var = "LIFEGW_TEST_TIER2_STATIC_PEM_OK";
+        let pem = make_pkcs8_pem();
+        // SAFETY: Rust 2024 edition requires `unsafe { ... }` around
+        // `set_var` because env mutations affect process-global state.
+        // Tests in this module run on a single tokio runtime; we don't
+        // spawn parallel signer-builds against the same env var.
+        unsafe {
+            std::env::set_var(env_var, &pem);
+        }
+        let cfg = AuthConfig {
+            kms_provider: KmsProvider::StaticPem,
+            static_pem: Some(crate::config::StaticPemConfig {
+                pem_env: env_var.to_string(),
+                kid: "tier2-test-may26".to_string(),
+            }),
+            ..AuthConfig::default()
+        };
+        let signer = build_signer(&cfg).expect("static_pem signer builds");
+        assert_eq!(signer.active_kid(), "tier2-test-may26");
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    /// `KmsProvider::StaticPem` without `[auth.static_pem]` config is a
+    /// hard error — operators must explicitly opt in to the new
+    /// provider via the config block.
+    #[test]
+    fn build_signer_static_pem_rejects_missing_config_block() {
+        let cfg = AuthConfig {
+            kms_provider: KmsProvider::StaticPem,
+            static_pem: None,
+            ..AuthConfig::default()
+        };
+        match build_signer(&cfg) {
+            Ok(_) => panic!("must reject StaticPem without config block"),
+            Err(LifegwError::Config(m)) => {
+                assert!(m.contains("static_pem"), "error mentions static_pem: {m}")
+            }
+            Err(other) => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    /// Missing env var → actionable error mentioning the env name.
+    #[test]
+    fn build_signer_static_pem_rejects_missing_env_with_actionable_error() {
+        let env_var = "LIFEGW_TEST_TIER2_STATIC_PEM_NEVER_SET";
+        // Defensive cleanup — set_var/remove_var are unsafe in Rust 2024.
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+        let cfg = AuthConfig {
+            kms_provider: KmsProvider::StaticPem,
+            static_pem: Some(crate::config::StaticPemConfig {
+                pem_env: env_var.to_string(),
+                kid: "kid-x".to_string(),
+            }),
+            ..AuthConfig::default()
+        };
+        match build_signer(&cfg) {
+            Ok(_) => panic!("must reject StaticPem with unset env"),
+            Err(LifegwError::Config(m)) => {
+                assert!(m.contains(env_var), "error mentions env var name: {m}");
+                assert!(m.contains("HANDOFF"), "error references HANDOFF doc: {m}");
+            }
+            Err(other) => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    /// Empty env var → also a hard error (operators sometimes set the
+    /// var to `""` thinking that "unsets" it).
+    #[test]
+    fn build_signer_static_pem_rejects_empty_env() {
+        let env_var = "LIFEGW_TEST_TIER2_STATIC_PEM_EMPTY";
+        unsafe {
+            std::env::set_var(env_var, "");
+        }
+        let cfg = AuthConfig {
+            kms_provider: KmsProvider::StaticPem,
+            static_pem: Some(crate::config::StaticPemConfig {
+                pem_env: env_var.to_string(),
+                kid: "kid-x".to_string(),
+            }),
+            ..AuthConfig::default()
+        };
+        match build_signer(&cfg) {
+            Ok(_) => panic!("must reject empty env value"),
+            Err(LifegwError::Config(m)) => {
+                assert!(
+                    m.contains("empty") || m.contains("unset"),
+                    "error mentions empty/unset: {m}"
+                );
+            }
+            Err(other) => panic!("expected Config error, got {other:?}"),
+        }
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    /// End-to-end: build StaticPem signer, sign a JWS, verify it
+    /// against the published JWKS. Proves the operator-key path mints
+    /// tokens that downstream verifiers (lifed) will accept.
+    #[test]
+    fn build_signer_static_pem_publishes_matching_jwks() {
+        use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+
+        let env_var = "LIFEGW_TEST_TIER2_STATIC_PEM_E2E";
+        let pem = make_pkcs8_pem();
+        unsafe {
+            std::env::set_var(env_var, &pem);
+        }
+        let cfg = AuthConfig {
+            kms_provider: KmsProvider::StaticPem,
+            static_pem: Some(crate::config::StaticPemConfig {
+                pem_env: env_var.to_string(),
+                kid: "tier2-e2e".to_string(),
+            }),
+            ..AuthConfig::default()
+        };
+        let signer = build_signer(&cfg).expect("signer builds");
+
+        // Mint a JWS via the signer.
+        let claims = serde_json::json!({
+            "iss": "lifegw",
+            "aud": "lifed",
+            "sub": "user-stage2",
+            "exp": std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() + 60,
+        });
+        let token = signer.sign_jws(&claims).expect("sign");
+
+        // Pull the public PEM from the published JWKS, build a
+        // DecodingKey from it, verify the JWS.
+        let jwks = signer.publish_jwks();
+        let entry = jwks
+            .keys
+            .iter()
+            .find(|k| k.kid == "tier2-e2e")
+            .expect("kid present in jwks");
+        let pub_pem = entry.pem.as_ref().expect("jwks entry has pem field");
+        let decoding =
+            DecodingKey::from_ec_pem(pub_pem.as_bytes()).expect("decoding key from jwks pem");
+        let mut v = Validation::new(Algorithm::ES256);
+        v.set_audience(&["lifed"]);
+        v.set_issuer(&["lifegw"]);
+        decode::<serde_json::Value>(&token, &decoding, &v).expect("verify");
+
+        unsafe {
+            std::env::remove_var(env_var);
+        }
     }
 }

--- a/crates/life-runtime/lifegw/src/config.rs
+++ b/crates/life-runtime/lifegw/src/config.rs
@@ -267,6 +267,13 @@ pub struct AuthConfig {
     /// Sub-phase E item #2.
     #[serde(default)]
     pub gcp: Option<GcpConfig>,
+    /// Operator-provided PKCS#8 PEM private key + kid (Stage 2). Used
+    /// when `kms_provider = "static_pem"`. The key material is read
+    /// from the env vars named in the config — keeps secrets out of
+    /// disk in container deployments where the operator injects via
+    /// the platform's secret manager.
+    #[serde(default)]
+    pub static_pem: Option<StaticPemConfig>,
     /// Path to which the gateway publishes its Tier-2 JWKS document.
     /// `None` disables publish (used by tests that share key material
     /// in-memory). Default `/run/life/lifegw-jwks.json`.
@@ -292,6 +299,44 @@ pub struct AuthConfig {
     /// 15 min is rejected at config-validate time.
     #[serde(default, with = "humantime_serde_opt")]
     pub tier_user_ttl: Option<Duration>,
+}
+
+/// Operator-provided PKCS#8 PEM signing-key configuration.
+///
+/// Used by the Stage-2 lifegw-stack Railway deploy to break the
+/// boot-order race between lifegw and lifed: the operator generates an
+/// ES256 P-256 keypair once at container start (or persists it on a
+/// Railway volume), pre-publishes the public JWKS to the path lifed
+/// reads, and hands the private PEM to lifegw via env. With this in
+/// place, lifegw + lifed can boot in either order — lifed reads the
+/// JWKS lazily on first verify, and the kid is stable because it
+/// originates from the operator-provided key, not a per-boot
+/// `StaticKeystore::generate_dev()` call.
+///
+/// The `pem_env` field names the env var that holds the actual PEM —
+/// lifegw refuses to embed the key material into the config TOML
+/// (which is committed to source control). Operators inject via
+/// `LIFEGW_TIER2_SIGNING_KEY_PEM` (recommended) or any other env var.
+///
+/// `kid` is stable across deploys — the JWKS publishes the same `kid`
+/// whatever the env's actual value, so verifiers see continuity.
+/// Rotation = generate a new key + bump `kid` + redeploy.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct StaticPemConfig {
+    /// Name of the env var that holds the PKCS#8 PEM private key.
+    /// Default `LIFEGW_TIER2_SIGNING_KEY_PEM`.
+    #[serde(default = "default_static_pem_env")]
+    pub pem_env: String,
+    /// JWS `kid` for tokens minted with this key. Convention: a short
+    /// stable string (e.g. `tier2-2026-05`). Substrates verify against
+    /// this kid in the published JWKS.
+    pub kid: String,
+}
+
+fn default_static_pem_env() -> String {
+    "LIFEGW_TIER2_SIGNING_KEY_PEM".to_string()
 }
 
 /// HashiCorp Vault Transit configuration (Sub-phase B production
@@ -418,6 +463,14 @@ pub enum KmsProvider {
     /// In-process dev signer. Sub-phase A default.
     #[default]
     Dev,
+    /// Operator-provided PKCS#8 PEM private key, loaded from env at
+    /// boot (Stage 2 — May 2026). Bridges the gap between `Dev`
+    /// (per-boot random) and the heavy KMS providers (Vault / AWS /
+    /// GCP). The key is operator-managed: rotation = re-issue + redeploy.
+    /// Used by `lifegw-stack` Railway deploys where the entrypoint
+    /// generates the key once + hands it to both lifegw + lifed via
+    /// shared `/run/life/` paths and an env var.
+    StaticPem,
     /// AWS KMS (Sub-phase E, behind feature flag `kms-aws`).
     Aws,
     /// GCP Cloud KMS (Sub-phase E, behind feature flag `kms-gcp`).
@@ -438,6 +491,7 @@ impl Default for AuthConfig {
             vault: None,
             aws: None,
             gcp: None,
+            static_pem: None,
             publish_jwks_path: default_publish_jwks_path(),
             dev_signer_enabled: false,
             tier2_audience: default_tier2_audience(),

--- a/deploy/railway/lifegw-stack/HANDOFF.md
+++ b/deploy/railway/lifegw-stack/HANDOFF.md
@@ -96,40 +96,89 @@ broomva.tech (Vercel)
 flip `dev_signer_enabled = false` once the KMS provider also moves off
 `Dev` (Spec C₃ Sub-phase E).
 
-## 7. Known Stage-1 limitation: Tier-2 audience chain (lifed side)
+## 7. Stage 2 — boot-order race fixed (May 2026)
 
-When lifegw forwards its freshly-minted Tier-2 JWS to lifed, lifed
-currently rejects it with
-`{"kind":"closing","reason":"policy_violation:token_expired"}`. This is
-**not** a Tier-1 problem (Tier-1 verification works end-to-end as of
-Stage 1.5 above). Root cause is the lifed-side startup race:
+Both fixes from §6's earlier draft (a + b) are now shipped together —
+because either alone would have been incomplete:
 
-- The entrypoint starts `lifed` before `lifegw` (lifegw needs lifed's UDS
-  to start, so the order is forced).
-- lifed's `auth.jwks_path = /run/life/lifegw-jwks.json` does not exist at
-  the moment lifed boots.
-- lifed falls back to `JwksCache::dev_only()` per `bootstrap.rs:97-105`,
-  which **only** accepts the literal `Bearer test-token-for-{user_id}`
-  shortcut — it does not verify real ES256 JWS.
-- A few hundred ms later lifegw publishes the JWKS to that exact path, but
-  lifed's cache is already pinned to dev-only.
+**Fix A — operator-provided Tier-2 key** (`KmsProvider::StaticPem`)
 
-Two clean fixes — pick one before declaring Stage 2:
+The container no longer calls `StaticKeystore::generate_dev()` on every
+boot. Instead, `entrypoint.sh` either:
 
-a. **Pre-publish a shared JWKS**: in `entrypoint.sh`, generate one
-   ES256 key, write its public half to `/run/life/lifegw-jwks.json`
-   *before* `lifed` starts, and pass the full PEM to lifegw via
-   `LIFEGW_TIER2_KEY_PEM`-style env (lifegw would need a config knob to
-   adopt that key instead of `StaticKeystore::generate_dev()`).
+- reads `LIFEGW_TIER2_SIGNING_KEY_PEM` from env (operator-injected via
+  Railway secrets / external KMS shim), or
+- reuses the persistent file at `/var/life-state/tier2-signing.pkcs8.pem`
+  (Railway volume mount — survives image redeploys), or
+- generates a fresh PKCS#8 PEM via `openssl genpkey -algorithm EC
+  -pkeyopt ec_paramgen_curve:P-256` on first boot and writes it to the
+  same path.
 
-b. **Hot-reload the JwksCache in lifed**: mirror the additive
-   `new_with_dev_shortcut` change applied to lifegw — make lifed's
-   `JwksCache::dev_only()` ALSO trigger a one-shot retry-poll for the
-   JWKS file at first verify, with a small bounded window. This is
-   closer to the production-shape eventually needed for KMS key
-   rotation anyway.
+That PEM is exported as `LIFEGW_TIER2_SIGNING_KEY_PEM` and lifegw's
+`KmsProvider::StaticPem` arm reads it via `Keystore::from_pem`, with
+the operator-pinned `kid` from `[auth.static_pem]`. **The kid stays
+stable across container reboots and image redeploys** — clients never
+see a kid roll except during an explicit operator rotation.
 
-The deploy is otherwise functional: TLS, WS upgrade, real Tier-1
-verify, gRPC-web fallback, `/anima/custody/*` axum routes, `/healthz` —
-all green from the public domain. The dev `Bearer dev-token-for-X`
-path also still works as an integration-test fallback.
+**Fix B — lazy file-backed JwksCache in lifed** (`JwksCache::new_lazy_file`)
+
+lifed no longer makes a one-shot boot-time decision about its verifier
+identity. The new cache:
+
+- holds a path, not a key set
+- reads `auth.jwks_path` lazily on first `validate()` call
+- re-stats the file on each subsequent verify; if mtime advanced (key
+  rotation) **or** the TTL window expired, the keys are reloaded
+- serialises concurrent miss-driven loads behind a `parking_lot::Mutex`
+  so a thundering herd of 100 verifiers produces at most one file read
+- accepts the `Bearer test-token-for-{user_id}` dev shortcut additively
+  when `auth.dev_signer_enabled = true`
+
+Both fixes mirror lifegw's own production patterns (Spec C₃ §5).
+
+### Verification
+
+```
+$ TOKEN=$(node mint-tier1.mjs)            # broomva.tech-keyed JWS
+$ wss://lifegw.../v1/agent/stream + Authorization: Bearer $TOKEN
+WS OK: subprotocol='life.v1.agent'
+first frame: {"kind":"closing","reason":"internal_error"}
+```
+
+The handshake completes, lifegw verifies the Tier-1 JWS via
+broomva.tech's `/api/auth/jwks.json`, mints a Tier-2 cap with the
+operator-pinned kid, and lifed accepts it. The trailing
+`internal_error` is a separate downstream issue (lifed's
+`Agent.StreamSession` against `MockSubstrates` can't run a real agent
+turn) — that's the §8 Stage 3 work, not auth.
+
+Volume persistence verified: a `railway redeploy` after first boot
+shows `[entrypoint] reusing existing Tier-2 key at
+/var/life-state/tier2-signing.pkcs8.pem` instead of regenerating, and
+the published JWKS keeps the same kid across deploys.
+
+## 8. Open work (Stage 3) — real substrates instead of mocks
+
+`internal_error` from lifed's `Agent.StreamSession` is the next thing
+to fix. Two paths:
+
+a. **Single-container substrate fan-out**: ship `arcand`, `lagod`,
+   `haimad`, `animad`, `soma` into the same Railway container (more
+   `runuser -- /usr/local/bin/<daemon> &` blocks in `entrypoint.sh`).
+   All UDS sockets stay on the shared `/run/life/` tmpfs. Heaviest
+   single-image bloat but keeps the existing UDS-only wire.
+
+b. **Multi-container topology with substrate-side TCP transport**: each
+   substrate becomes its own Railway service, lifed's substrate clients
+   speak TCP+TLS over Railway's private DNS. Requires touching each
+   substrate's listener (currently UDS-only) but separates concerns
+   cleanly.
+
+(b) is the production-grade answer; (a) is the pragmatic one for
+keeping the demo end-to-end stack inside one container. We'll pick one
+based on the next user-facing milestone.
+
+The dev `Bearer dev-token-for-X` and `Bearer test-token-for-X` paths
+both still work as integration-test fallbacks. Production posture
+flips `dev_signer_enabled = false` in both daemons once every caller
+mints real JWS — at that point the dev shortcut is rejected outright.

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 # lifegw-stack entrypoint — fan out lifed + lifegw + caddy in one container.
 #
-# Order matters:
-#   1. Generate self-signed cert at /etc/lifegw/tls/{fullchain,privkey}.pem
-#      so lifegw passes its TLS-bind step. The cert is regenerated on every
-#      container boot — Caddy proxies upstream with `tls_insecure_skip_verify`,
-#      so trust-chain validity is irrelevant.
-#   2. Start lifed in the background. It binds /run/life/life.sock + the
-#      admin socket. Wait for the public socket to appear before starting
-#      lifegw (which would otherwise race the UDS connect).
-#   3. Start lifegw in the background. It listens on 127.0.0.1:8443.
-#   4. Wait for 8443 to accept connections, then exec caddy in foreground.
-#      caddy becomes the supervisor — SIGTERM lands on caddy first, which
-#      tini propagates to the children.
+# Stage-2 ordering (May 2026 — addresses the lifegw/lifed boot-race
+# described in `HANDOFF.md` §6/§7):
+#
+#   1. Self-signed TLS cert for the lifegw → Caddy hop. Regenerated each
+#      boot — Caddy proxies upstream with `tls_insecure_skip_verify` so
+#      the cert chain is irrelevant.
+#   2. **Persist a Tier-2 signing keypair** (PKCS#8 PEM). Stored under
+#      `LIFE_STATE_DIR` (`/var/life-state` by default — mount a Railway
+#      volume there to survive image redeploys; otherwise the key
+#      survives container restarts within the same image). Generated
+#      once via `openssl genpkey`; reused on every subsequent boot.
+#      Operator can also pre-supply the key via the
+#      `LIFEGW_TIER2_SIGNING_KEY_PEM` env (e.g. injected by Railway
+#      secrets) — entrypoint skips generation in that case.
+#   3. Start `lifed`. Its `JwksCache` is lazy + file-backed (Stage 2
+#      change in `lifed::auth::jwks`): the first `validate()` call
+#      reads `/run/life/lifegw-jwks.json`, and subsequent calls watch
+#      mtime so a rotation is picked up without coordination.
+#   4. Start `lifegw` with `kms_provider = "static_pem"` reading the
+#      env-bound key. lifegw publishes its JWKS atomically to
+#      `/run/life/lifegw-jwks.json`; lifed picks it up on first verify.
+#   5. Caddy in foreground as PID 1 (via tini).
 
 set -euo pipefail
 
@@ -20,12 +30,20 @@ set -euo pipefail
 PORT="${PORT:-8080}"
 LIFE_RUNTIME_DIR="${LIFE_RUNTIME_DIR:-/run/life}"
 TLS_DIR="${TLS_DIR:-/etc/lifegw/tls}"
+# Persistent path for the Tier-2 keypair. If a Railway volume is mounted
+# at /var/life-state, the key survives container restarts; otherwise it
+# lives only for the lifetime of the container — which is still enough
+# because `lifed`'s lazy JwksCache picks up the lifegw publish on the
+# first verify within that container's lifetime.
+LIFE_STATE_DIR="${LIFE_STATE_DIR:-/var/life-state}"
+TIER2_PEM_PATH="${TIER2_PEM_PATH:-${LIFE_STATE_DIR}/tier2-signing.pkcs8.pem}"
 
-mkdir -p "${LIFE_RUNTIME_DIR}" "${TLS_DIR}"
+mkdir -p "${LIFE_RUNTIME_DIR}" "${TLS_DIR}" "${LIFE_STATE_DIR}"
 # `life-runtime` group owns /run/life so lifed + lifegw (running as `life`)
 # can both bind UDS sockets there with mode 0660.
-chown -R life:life-runtime "${LIFE_RUNTIME_DIR}"
+chown -R life:life-runtime "${LIFE_RUNTIME_DIR}" "${LIFE_STATE_DIR}"
 chmod 2775 "${LIFE_RUNTIME_DIR}"
+chmod 0750 "${LIFE_STATE_DIR}"
 
 # ── 1. Self-signed cert (regenerated on every boot) ─────────────────────────
 if [[ ! -s "${TLS_DIR}/fullchain.pem" || ! -s "${TLS_DIR}/privkey.pem" ]]; then
@@ -41,19 +59,45 @@ if [[ ! -s "${TLS_DIR}/fullchain.pem" || ! -s "${TLS_DIR}/privkey.pem" ]]; then
   chown life:life-runtime "${TLS_DIR}/fullchain.pem" "${TLS_DIR}/privkey.pem"
 fi
 
-# ── 2. Start lifed ──────────────────────────────────────────────────────────
-echo "[entrypoint] starting lifed (mock-fallback=${LIFED_ALLOW_MOCK_FALLBACK:-0})"
-# Run lifed under the `life` user so its UDS sockets land owned by life:life-runtime.
-# `setpriv` would be cleaner but isn't on slim — `runuser` is.
-runuser -u life -g life-runtime -- \
+# ── 2. Tier-2 signing key (persistent across container restarts) ────────────
+# Three sources, in order of precedence:
+#   a) `LIFEGW_TIER2_SIGNING_KEY_PEM` env already set (operator-injected
+#      via Railway secrets / external KMS shim) — entrypoint trusts it
+#      verbatim and writes it to disk so subsequent reads short-circuit.
+#   b) `${TIER2_PEM_PATH}` already exists on disk (typical: Railway
+#      volume mounted at /var/life-state — key persists across redeploys).
+#   c) Neither — entrypoint generates a fresh PKCS#8 PEM.
+if [[ -n "${LIFEGW_TIER2_SIGNING_KEY_PEM:-}" ]]; then
+  echo "[entrypoint] using operator-provided Tier-2 PEM from env"
+  printf '%s\n' "${LIFEGW_TIER2_SIGNING_KEY_PEM}" >"${TIER2_PEM_PATH}"
+  chmod 0600 "${TIER2_PEM_PATH}"
+  chown life:life-runtime "${TIER2_PEM_PATH}"
+elif [[ ! -s "${TIER2_PEM_PATH}" ]]; then
+  echo "[entrypoint] generating Tier-2 signing key at ${TIER2_PEM_PATH}"
+  openssl genpkey \
+    -algorithm EC \
+    -pkeyopt ec_paramgen_curve:P-256 \
+    -out "${TIER2_PEM_PATH}" \
+    >/dev/null 2>&1
+  chmod 0600 "${TIER2_PEM_PATH}"
+  chown life:life-runtime "${TIER2_PEM_PATH}"
+else
+  echo "[entrypoint] reusing existing Tier-2 key at ${TIER2_PEM_PATH}"
+fi
+
+# Export for lifegw's `KmsProvider::StaticPem` arm. lifegw reads the env
+# at signer-build time (see `lifegw::bootstrap::build_signer`).
+LIFEGW_TIER2_SIGNING_KEY_PEM="$(cat "${TIER2_PEM_PATH}")"
+export LIFEGW_TIER2_SIGNING_KEY_PEM
+
+# ── 3. Start lifed ──────────────────────────────────────────────────────────
+echo "[entrypoint] starting lifed (mock-fallback=${LIFED_ALLOW_MOCK_FALLBACK:-false})"
+runuser --preserve-environment -u life -g life-runtime -- \
   /usr/local/bin/lifed daemon \
     --config "${LIFED_CONFIG:-/etc/lifed/config.toml}" \
   &
 LIFED_PID=$!
 
-# Wait for /run/life/life.sock to exist (max 30s — bootstrap reads lago,
-# JWKS publish, etc.). Failure here is fatal: caddy + lifegw would never
-# come up healthy without lifed.
 echo "[entrypoint] waiting for lifed UDS at ${LIFE_RUNTIME_DIR}/life.sock"
 for i in $(seq 1 60); do
   if [[ -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
@@ -72,16 +116,18 @@ if [[ ! -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
   exit 1
 fi
 
-# ── 3. Start lifegw ─────────────────────────────────────────────────────────
-echo "[entrypoint] starting lifegw"
-runuser -u life -g life-runtime -- \
+# ── 4. Start lifegw ─────────────────────────────────────────────────────────
+# lifegw publishes /run/life/lifegw-jwks.json atomically (write-tmp +
+# rename) inside its bootstrap. lifed's lazy JwksCache reads it on the
+# first verify — no coordination needed because the file mtime always
+# advances when lifegw rewrites it.
+echo "[entrypoint] starting lifegw (kms_provider=static_pem)"
+runuser --preserve-environment -u life -g life-runtime -- \
   /usr/local/bin/lifegw daemon \
     --config "${LIFEGW_CONFIG:-/etc/lifegw/config.toml}" \
   &
 LIFEGW_PID=$!
 
-# Wait for 127.0.0.1:8443 to accept TCP. We don't need to handshake TLS;
-# a successful connect is enough proof the listener is live.
 echo "[entrypoint] waiting for lifegw on 127.0.0.1:8443"
 for i in $(seq 1 60); do
   if (echo > /dev/tcp/127.0.0.1/8443) 2>/dev/null; then
@@ -96,15 +142,11 @@ for i in $(seq 1 60); do
   sleep 0.5
 done
 
-# ── 4. Caddy as PID 1's foreground process ─────────────────────────────────
-# `caddy run` is the long-lived foreground process. SIGTERM from Railway
-# lands on caddy via tini; we trap it here to fan-out a graceful shutdown
-# to the background daemons before exiting.
+# ── 5. Caddy as PID 1's foreground process ─────────────────────────────────
 shutdown() {
   echo "[entrypoint] SIGTERM received — draining"
   if kill -0 "${LIFEGW_PID}" 2>/dev/null; then kill -TERM "${LIFEGW_PID}" || true; fi
   if kill -0 "${LIFED_PID}"  2>/dev/null; then kill -TERM "${LIFED_PID}"  || true; fi
-  # Caddy itself is signaled by tini; nothing else to do.
 }
 trap shutdown TERM INT
 

--- a/deploy/railway/lifegw-stack/lifed.toml
+++ b/deploy/railway/lifegw-stack/lifed.toml
@@ -1,22 +1,14 @@
-# lifed config — Railway lifegw-stack deploy.
+# lifed config — Railway lifegw-stack deploy (Stage 2, May 2026).
 #
-# Stage 1: real lifed binary, mock substrates. lifed boots without any of
-# the per-substrate UDS sockets present (arcand / lagod / haimad / animad /
-# soma); the `LIFED_ALLOW_MOCK_FALLBACK=1` env var (set on the Railway
-# service) flips substrates to canned mocks at boot. The wire path
-# (Caddy → lifegw → lifed) runs end-to-end against real code; substrate
-# behaviour is mocked.
+# JwksCache is now lazy + file-backed (see `lifed::auth::jwks` Stage 2
+# notes): `validate()` reads `auth.jwks_path` on first miss and on
+# mtime change, so there's no boot-order race with lifegw. The dev
+# shortcut is additive — controlled by `auth.dev_signer_enabled`.
 #
-# Dev signer: lifed's bootstrap auto-falls-back to
-# `JwksCache::dev_only()` when `auth.jwks_path` does not exist, so the
-# `Bearer test-token-for-{user_id}` shortcut works without an explicit
-# config flag. Production swaps this by pre-publishing a real JWKS at
-# `auth.jwks_path` (which lifegw also writes to in this image).
-#
+# Substrates still run as in-process mocks (LIFED_ALLOW_MOCK_FALLBACK=true).
 # Production swap-in: drop `LIFED_ALLOW_MOCK_FALLBACK`, ship arcand +
-# lagod + haimad + animad + soma into the same container (or a successor
-# multi-container topology once tonic gets a TCP-only transport push),
-# and let lifed fail-fast on missing UDS sockets.
+# lagod + haimad + animad + soma into the same container (or move to a
+# multi-container topology), and let lifed fail-fast on missing UDS.
 
 [public_plane]
 unix_socket       = "/run/life/life.sock"
@@ -47,14 +39,17 @@ unix_socket = "/run/life/anima.sock"
 unix_socket = "/run/life/soma-admin.sock"
 
 [auth]
-# JWKS path is shared with lifegw — both daemons use the same key. lifegw
-# writes the JWKS to /run/life/lifegw-jwks.json on boot; lifed reads it.
-# Until lifegw publishes (couple-second race at startup), lifed runs in
-# dev-keystore mode (`Bearer test-token-for-{user_id}` accepted).
+# Stage 2: lifed reads `jwks_path` lazily on first verify (and on
+# mtime change for rotation). lifegw writes to the same path
+# atomically; the boot order between the two daemons no longer matters.
+# `dev_signer_enabled = true` keeps the test-token shortcut additive
+# during the Stage 1 → Stage 2 transition; flip to `false` once
+# every caller uses real JWS.
 jwks_path                   = "/run/life/lifegw-jwks.json"
 substrate_signing_key_path  = "/etc/life/lifed-signing-key.pem"
 substrate_jwks_publish_path = "/run/life/lifed-jwks.json"
 revoked_sids_path           = "/run/life/revoked_sids.json"
+dev_signer_enabled          = true
 
 [routing]
 idle_threshold_secs    = 3600

--- a/deploy/railway/lifegw-stack/lifegw.toml
+++ b/deploy/railway/lifegw-stack/lifegw.toml
@@ -1,10 +1,16 @@
-# lifegw config — Railway lifegw-stack deploy.
+# lifegw config — Railway lifegw-stack deploy (Stage 2, May 2026).
 #
-# This is a Stage-1 deploy: dev signer + Dev KMS. The gateway accepts the
-# `Bearer dev-token-for-{user_id}` Tier-1 shortcut and mints Tier-2 caps
-# from an in-process key. Production swap-in (Vault / AWS / GCP KMS, real
-# Vercel JWKS) is future work tracked in the canonical spec at
-# `apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md`.
+# Tier-2 mint runs against an operator-provided PKCS#8 PEM private key
+# (KmsProvider::StaticPem) — `entrypoint.sh` persists it under
+# `/var/life-state/tier2-signing.pkcs8.pem` and exports the contents
+# via `LIFEGW_TIER2_SIGNING_KEY_PEM` so this config can stay in source
+# control. Mount a Railway volume at /var/life-state to keep the key
+# stable across image redeploys (kid stays valid → in-flight tokens
+# survive rolling deploys).
+#
+# Tier-1 verification still uses real ES256 + broomva.tech's
+# `/api/auth/jwks.json`, with the dev shortcut additive (controlled
+# by `dev_signer_enabled = true`).
 #
 # `[upstream] lifed_uds_path` — path is shared with `lifed.toml`. Keep
 # both files in sync if you change the socket location.
@@ -31,27 +37,42 @@ unix_socket_group = "life-runtime"
 unix_socket_mode  = 0o660
 
 [auth]
+# Stage 2: Tier-2 mint is operator-key-backed via
+# `KmsProvider::StaticPem` (see `[auth.static_pem]` below). The kid is
+# stable across container restarts; the public half is published
+# atomically to `publish_jwks_path` on boot.
+#
 # Tier-1 verification accepts BOTH real ES256 JWS (verified against
 # broomva.tech's `/api/auth/jwks.json`) AND the dev shortcut
 # `Bearer dev-token-for-{user_id}`. lifegw's
-# `JwksCache::new_with_dev_shortcut` makes the two additive: real JWS
-# tokens are validated against the upstream JWKS, and the dev shortcut
-# is also accepted for ops smoke tests.
-#
-# `dev_signer_enabled = true` is also required by lifegw's Sub-phase C
-# hardening guard which couples the Dev `kms_provider` to this flag.
-# When we swap Tier-2 mint to Vault/AWS/GCP KMS (Spec C₃ Sub-phase E)
-# we flip this to `false` so the dev shortcut is rejected outright.
+# `JwksCache::new_with_dev_shortcut` makes the two additive — real JWS
+# tokens get JWKS verification, and the dev shortcut still works for
+# ops smoke tests during the Stage 1 → Stage 2 transition. Flip
+# `dev_signer_enabled` to `false` once every caller mints real JWS.
 jwks_url            = "https://broomva.tech/api/auth/jwks.json"
 tier1_audience      = "lifegw"
 tier1_issuer        = "https://broomva.tech"
-kms_provider        = "dev"
+kms_provider        = "static_pem"
 dev_signer_enabled  = true
 publish_jwks_path   = "/run/life/lifegw-jwks.json"
 tier2_audience      = "lifed"
 tier2_issuer        = "lifegw"
 tier2_ttl           = "900s"
 tier_user_ttl       = "900s"
+
+# ── Tier-2 signing key (Stage 2) ──────────────────────────────────────────
+# `pem_env` names the env var that holds the PKCS#8 PEM private key
+# (default `LIFEGW_TIER2_SIGNING_KEY_PEM`). entrypoint.sh exports it by
+# reading the persistent file at /var/life-state/tier2-signing.pkcs8.pem
+# (auto-generated once if absent), or by accepting an operator-pre-set
+# value (Railway secrets / external KMS shim).
+#
+# `kid` is operator-pinned. Rotation = bump kid + redeploy. The kid is
+# echoed into the published JWKS so substrates verify against the same
+# value lifegw signs with.
+[auth.static_pem]
+pem_env = "LIFEGW_TIER2_SIGNING_KEY_PEM"
+kid     = "tier2-railway-may26"
 
 [rate_limit]
 per_user_capacity        = 60


### PR DESCRIPTION
## Summary

Two complementary changes that together remove the boot-order dependency between lifegw and lifed inside the Railway lifegw-stack container.

### Fix 1 — \`lifed::auth::jwks::JwksCache\` lazy file-backed source
Drops the boot-time \`if file exists { real } else { dev_only }\` branch. New \`JwksCache::new_lazy_file(path)\` lazy-reads on first verify + on kid cache miss / mtime change, serialises concurrent miss-driven loads behind a \`parking_lot::Mutex\`, supports the dev shortcut **additively** when \`auth.dev_signer_enabled = true\`. Mirrors lifegw's own pattern (Spec C₃ §5).

### Fix 2 — \`lifegw\` operator-provided Tier-2 key (\`KmsProvider::StaticPem\`)
Container no longer calls \`StaticKeystore::generate_dev()\` per boot. New \`Keystore::from_pem\` + \`KmsProvider::StaticPem\` arm read a PKCS#8 PEM from the env var named in \`[auth.static_pem] pem_env\`. The kid is operator-pinned and stable across container reboots and image redeploys (Railway volume mount at \`/var/life-state\`).

### Stage-2 entrypoint coordination
\`entrypoint.sh\` persists the Tier-2 PKCS#8 PEM under \`/var/life-state/\`, exports \`LIFEGW_TIER2_SIGNING_KEY_PEM\` for lifegw's signer-build, tolerates operator-pre-set env (Railway secrets / external KMS). \`lifegw.toml\` flips \`kms_provider = \"static_pem\"\` + adds \`[auth.static_pem]\`; \`lifed.toml\` adds \`auth.dev_signer_enabled = true\` (additive transition flag).

## Verification on \`lifegw-production.up.railway.app\`

- Real Tier-1 JWS minted by broomva.tech (kid \`d03b6c2fc003b54f\`) — WS handshake completes (101), lifegw verifies, mints Tier-2, forwards to lifed, lifed verifies via lazy JwksCache.
- **\`policy_violation:token_expired\` — gone**. Replaced by \`internal_error\` (downstream mock-substrate, tracked separately in HANDOFF.md §8).
- Volume persistence confirmed: post-redeploy entrypoint logs \`reusing existing Tier-2 key at /var/life-state/...\` and kid stays stable across deploys.

## Test plan

- [x] \`cargo build --release -p lifegw -p lifed\` clean
- [x] \`cargo test -p lifed --lib\` — 52/52 pass (9 new jwks tests)
- [x] \`cargo test -p lifegw --lib\` — 160/160 pass (9 new keystore + bootstrap tests)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy -p lifegw -p lifed --all-targets -- -D warnings\` clean
- [x] Live deploy on Railway: real Tier-1 JWS verifies end-to-end through Tier-2 → lifed
- [x] Dev shortcut still works (\`Bearer dev-token-for-...\`) — additive path
- [x] Volume persistence: redeploy reuses key, no kid roll
- [ ] Stage 3 follow-up: \`internal_error\` from mock substrates → fix by either single-container substrate fan-out or multi-container TCP transport (HANDOFF.md §8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy-loaded JWKS caching with automatic file change detection and TTL-based reloading.
  * Introduced support for operator-provided static signing keys with persistent key management across deployments.

* **Improvements**
  * Boot process is now resilient to missing JWKS files at startup.
  * Concurrent key reload operations are properly serialized.

* **Documentation**
  * Updated deployment documentation describing Stage 2 auth setup and operational workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->