### PR TITLE
feat(life-perturb): design spec + crate scaffold for RCS λ̂ validation (BRO-947)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,6 +6025,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "life-perturb"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "life-praxis"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,8 @@ members = [
     "crates/life-runtime/life-runtime-proto",
     # M7 — lifegw edge gateway (see Spec C₃ at docs/superpowers/specs/2026-04-27-spec-c3-lifegw-design.md)
     "crates/life-runtime/lifegw",
+    # life-perturb — controlled perturbation injection for RCS λ̂ validation (BRO-947)
+    "crates/life-perturb",
 ]
 exclude = ["crates/spaces/life-spaces/spacetimedb"]
 

--- a/crates/life-perturb/Cargo.toml
+++ b/crates/life-perturb/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "life-perturb"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Controlled perturbation injection on the Life Agent OS — fits exp(-λt) recovery curves to validate RCS paper-magnitude λ̂ on the live runtime (BRO-947)"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true }
+tracing.workspace = true
+ulid.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/life-perturb/src/error.rs
+++ b/crates/life-perturb/src/error.rs
@@ -1,0 +1,31 @@
+//! Crate-level error type.
+//!
+//! Following the workspace convention: `thiserror` in libraries.
+
+use thiserror::Error;
+
+/// Errors that arise while injecting, measuring, or fitting perturbations.
+#[derive(Debug, Error)]
+pub enum PerturbError {
+    /// The requested perturbation is not yet implemented at this level.
+    #[error("perturbation not yet implemented: level={level:?} kind={kind}")]
+    NotImplemented {
+        level: crate::perturbation::Level,
+        kind: &'static str,
+    },
+
+    /// The injector failed to apply or revert the perturbation.
+    #[error("injector failure: {0}")]
+    Injector(String),
+
+    /// The recovery fit could not be produced (e.g. too few samples).
+    #[error("fit failure: {0}")]
+    Fit(String),
+
+    /// Underlying I/O or telemetry transport error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Crate-level result alias.
+pub type PerturbResult<T> = Result<T, PerturbError>;

--- a/crates/life-perturb/src/estimator.rs
+++ b/crates/life-perturb/src/estimator.rs
@@ -1,0 +1,185 @@
+//! λ̂ estimator — fits `V_k(t) = V_k(0) · exp(−λ̂ · (t − t_inject))` to a
+//! recovery curve.
+//!
+//! v0.0 scaffold: trait + struct surface + a placeholder OLS log-linear fit
+//! that returns a default `RecoveryFit` when there are too few samples.
+//! Real bootstrap CI + naturalness-window exclusion land in v0.1.
+//!
+//! See spec §5 (`estimator.rs` block) for the full API plan and §8 Q1 for
+//! the open question on OLS vs MLE.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{PerturbError, PerturbResult};
+use crate::lyapunov::LyapunovSample;
+use crate::perturbation::{Level, PerturbationId};
+
+/// Result of fitting an exponential decay to a recovery curve.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RecoveryFit {
+    /// Estimated decay rate λ̂ (1/seconds). Compare to paper's λ_i.
+    pub lambda_hat: f64,
+    /// Coefficient of determination on the log-linear regression.
+    pub r_squared: f64,
+    /// Bootstrap 95% CI for λ̂. v0.0 scaffold returns `(NaN, NaN)`.
+    pub bootstrap_ci_95: (f64, f64),
+    /// Number of samples used in the fit (post-windowing).
+    pub n_samples: usize,
+    /// Fit window (ms since epoch): inclusive `[start, end]`.
+    pub fit_window_ms: (u64, u64),
+}
+
+impl Default for RecoveryFit {
+    /// Produce a "no-fit" sentinel so doctests / scaffolded callers can
+    /// move samples through the API without aborting.
+    fn default() -> Self {
+        Self {
+            lambda_hat: 0.0,
+            r_squared: 0.0,
+            bootstrap_ci_95: (f64::NAN, f64::NAN),
+            n_samples: 0,
+            fit_window_ms: (0, 0),
+        }
+    }
+}
+
+/// Stateful aggregator: feed samples in, call [`Self::fit_recovery`] at the
+/// end of the integration window.
+#[derive(Debug, Clone)]
+pub struct LambdaEstimator {
+    /// Level this estimator is fitting (L0..L3).
+    pub level: Level,
+    /// Perturbation under measurement — threaded through to the fit
+    /// result for telemetry attribution.
+    pub perturbation: PerturbationId,
+    /// Collected samples in chronological order.
+    pub samples: Vec<LyapunovSample>,
+}
+
+impl LambdaEstimator {
+    /// Construct an empty estimator for a given perturbation.
+    pub fn new(level: Level, perturbation: PerturbationId) -> Self {
+        Self {
+            level,
+            perturbation,
+            samples: Vec::new(),
+        }
+    }
+
+    /// Append a sample to the estimator. Out-of-order samples are
+    /// permitted; the fit step handles ordering.
+    pub fn push(&mut self, sample: LyapunovSample) {
+        self.samples.push(sample);
+    }
+
+    /// Fit `V_k(t) = V_k(0) · exp(−λ̂ · t)` via OLS on
+    /// `ln V_k(t) ≈ ln V_k(0) − λ̂ · t`. v0.0 scaffold: returns
+    /// `RecoveryFit::default()` when fewer than 3 positive samples are
+    /// present, otherwise computes a basic OLS slope and returns it.
+    pub fn fit_recovery(&self) -> PerturbResult<RecoveryFit> {
+        if self.samples.len() < 3 {
+            return Err(PerturbError::Fit(format!(
+                "need >= 3 samples, got {}",
+                self.samples.len()
+            )));
+        }
+
+        // Sort by time and filter strictly-positive V (log-domain).
+        let mut sorted: Vec<_> = self.samples.to_vec();
+        sorted.sort_by_key(|s| s.t_ms);
+        let positives: Vec<_> = sorted.iter().copied().filter(|s| s.v > 0.0).collect();
+        if positives.len() < 3 {
+            return Err(PerturbError::Fit(format!(
+                "need >= 3 positive samples for log-linear fit, got {}",
+                positives.len()
+            )));
+        }
+
+        // OLS: ln(v_i) = a − λ * (t_i - t0); slope = -λ̂.
+        let t0_ms = positives[0].t_ms;
+        let n = positives.len() as f64;
+        let xs: Vec<f64> = positives
+            .iter()
+            .map(|s| (s.t_ms.saturating_sub(t0_ms)) as f64 / 1000.0) // seconds
+            .collect();
+        let ys: Vec<f64> = positives.iter().map(|s| s.v.ln()).collect();
+        let mean_x = xs.iter().sum::<f64>() / n;
+        let mean_y = ys.iter().sum::<f64>() / n;
+        let mut sxx = 0.0;
+        let mut sxy = 0.0;
+        let mut syy = 0.0;
+        for i in 0..positives.len() {
+            let dx = xs[i] - mean_x;
+            let dy = ys[i] - mean_y;
+            sxx += dx * dx;
+            sxy += dx * dy;
+            syy += dy * dy;
+        }
+        if sxx == 0.0 {
+            return Err(PerturbError::Fit("zero variance in t".to_string()));
+        }
+        let slope = sxy / sxx;
+        let r_squared = if syy == 0.0 {
+            1.0
+        } else {
+            (sxy * sxy) / (sxx * syy)
+        };
+
+        let lambda_hat = -slope;
+        let last = positives.last().unwrap();
+        Ok(RecoveryFit {
+            lambda_hat,
+            r_squared,
+            // v0.0 scaffold: real bootstrap CI lands in v0.1.
+            bootstrap_ci_95: (f64::NAN, f64::NAN),
+            n_samples: positives.len(),
+            fit_window_ms: (t0_ms, last.t_ms),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_recovery_recovers_known_lambda() {
+        // V(t) = exp(-0.5 * t), sampled every 100 ms for 2 s.
+        let id = PerturbationId::new();
+        let mut est = LambdaEstimator::new(Level::L0, id);
+        for k in 0..21u64 {
+            let t = (k * 100) as f64 / 1000.0;
+            let v = (-0.5_f64 * t).exp();
+            est.push(LyapunovSample::new(k * 100, v));
+        }
+        let fit = est.fit_recovery().expect("fit succeeds");
+        // Should recover λ ≈ 0.5 within numerical tolerance.
+        assert!(
+            (fit.lambda_hat - 0.5).abs() < 1e-6,
+            "fit returned λ={}",
+            fit.lambda_hat
+        );
+        assert!(fit.r_squared > 0.999);
+        assert_eq!(fit.n_samples, 21);
+    }
+
+    #[test]
+    fn fit_recovery_fails_with_too_few_samples() {
+        let id = PerturbationId::new();
+        let mut est = LambdaEstimator::new(Level::L0, id);
+        est.push(LyapunovSample::new(0, 1.0));
+        est.push(LyapunovSample::new(100, 0.5));
+        let err = est.fit_recovery().expect_err("rejected");
+        match err {
+            PerturbError::Fit(msg) => assert!(msg.contains("need >= 3")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn default_recovery_fit_is_zero_lambda() {
+        let f = RecoveryFit::default();
+        assert_eq!(f.lambda_hat, 0.0);
+        assert_eq!(f.n_samples, 0);
+    }
+}

--- a/crates/life-perturb/src/injector.rs
+++ b/crates/life-perturb/src/injector.rs
@@ -1,0 +1,165 @@
+//! Per-level injector trait + stub implementations.
+//!
+//! Real injectors hook the daemons (`arcand`, `autonomicd`, future
+//! `autoanyd`) under a `--perturb-mode` feature flag. The v0.0 scaffold
+//! ships only the trait surface and four stub structs that return
+//! `PerturbError::NotImplemented` so consumers can compile against the
+//! shape without the runtime hooks landing yet.
+//!
+//! See spec §4 + §6 for the integration contract.
+
+use async_trait::async_trait;
+
+use crate::error::{PerturbError, PerturbResult};
+use crate::perturbation::{Level, Perturbation};
+
+/// Opaque revert token returned by `Injector::inject` and consumed by
+/// `Injector::revert`. Implementations may stash arbitrary state here
+/// (Tower middleware handles, `Arc<Mutex<…>>` overrides, etc.).
+#[derive(Debug, Clone)]
+pub struct PerturbationHandle {
+    /// The perturbation that produced this handle.
+    pub perturbation_id: crate::perturbation::PerturbationId,
+    /// Wall-clock time the perturbation took effect.
+    pub injected_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl PerturbationHandle {
+    /// Construct a handle tagged with `now()`.
+    pub fn for_perturbation(p: &Perturbation) -> Self {
+        Self {
+            perturbation_id: p.id,
+            injected_at: chrono::Utc::now(),
+        }
+    }
+}
+
+/// One implementation per level. Concrete injectors live in this crate as
+/// stubs and will be filled in by the per-level workstreams (v0.1 → v1.0).
+#[async_trait]
+pub trait Injector: Send + Sync {
+    /// The hierarchy level this injector targets.
+    fn level(&self) -> Level;
+
+    /// Apply `p` to the live runtime. The returned handle MUST be passed
+    /// to [`Injector::revert`] to restore the runtime to baseline.
+    async fn inject(&self, p: &Perturbation) -> PerturbResult<PerturbationHandle>;
+
+    /// Reverse the perturbation identified by `handle`.
+    async fn revert(&self, handle: PerturbationHandle) -> PerturbResult<()>;
+}
+
+// ─── Stub implementations ────────────────────────────────────────────────
+
+/// L0 injector — wires into `arcan-provider` middleware. v0.1 target.
+#[derive(Debug, Clone, Default)]
+pub struct L0ProviderInjector;
+
+#[async_trait]
+impl Injector for L0ProviderInjector {
+    fn level(&self) -> Level {
+        Level::L0
+    }
+    async fn inject(&self, p: &Perturbation) -> PerturbResult<PerturbationHandle> {
+        // v0.0 scaffold: signal "shape is right, body deferred".
+        Err(PerturbError::NotImplemented {
+            level: Level::L0,
+            kind: p.kind.name(),
+        })
+    }
+    async fn revert(&self, _handle: PerturbationHandle) -> PerturbResult<()> {
+        Ok(())
+    }
+}
+
+/// L1 injector — wires into `autonomic-controller` HysteresisGate. v0.5 target.
+#[derive(Debug, Clone, Default)]
+pub struct L1AutonomicInjector;
+
+#[async_trait]
+impl Injector for L1AutonomicInjector {
+    fn level(&self) -> Level {
+        Level::L1
+    }
+    async fn inject(&self, p: &Perturbation) -> PerturbResult<PerturbationHandle> {
+        Err(PerturbError::NotImplemented {
+            level: Level::L1,
+            kind: p.kind.name(),
+        })
+    }
+    async fn revert(&self, _handle: PerturbationHandle) -> PerturbResult<()> {
+        Ok(())
+    }
+}
+
+/// L2 injector — wires into `autoany-core::loop_engine`. v1.0 target.
+#[derive(Debug, Clone, Default)]
+pub struct L2AutoanyInjector;
+
+#[async_trait]
+impl Injector for L2AutoanyInjector {
+    fn level(&self) -> Level {
+        Level::L2
+    }
+    async fn inject(&self, p: &Perturbation) -> PerturbResult<PerturbationHandle> {
+        Err(PerturbError::NotImplemented {
+            level: Level::L2,
+            kind: p.kind.name(),
+        })
+    }
+    async fn revert(&self, _handle: PerturbationHandle) -> PerturbResult<()> {
+        Ok(())
+    }
+}
+
+/// L3 injector — sandbox-only writer for `.control/policy.yaml`. v1.0 target.
+#[derive(Debug, Clone, Default)]
+pub struct L3PolicyInjector;
+
+#[async_trait]
+impl Injector for L3PolicyInjector {
+    fn level(&self) -> Level {
+        Level::L3
+    }
+    async fn inject(&self, p: &Perturbation) -> PerturbResult<PerturbationHandle> {
+        Err(PerturbError::NotImplemented {
+            level: Level::L3,
+            kind: p.kind.name(),
+        })
+    }
+    async fn revert(&self, _handle: PerturbationHandle) -> PerturbResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perturbation::PerturbationKind;
+    use std::time::Duration;
+
+    #[test]
+    fn levels_match_injector_kind() {
+        assert_eq!(L0ProviderInjector.level(), Level::L0);
+        assert_eq!(L1AutonomicInjector.level(), Level::L1);
+        assert_eq!(L2AutoanyInjector.level(), Level::L2);
+        assert_eq!(L3PolicyInjector.level(), Level::L3);
+    }
+
+    #[tokio::test]
+    async fn stub_injectors_return_not_implemented() {
+        let p = Perturbation::new(
+            PerturbationKind::RateLimitStorm {
+                rps: 1.0,
+                duration: Duration::from_secs(1),
+            },
+            Duration::from_secs(1),
+        );
+        let inj = L0ProviderInjector;
+        let err = inj.inject(&p).await.expect_err("scaffold returns error");
+        match err {
+            PerturbError::NotImplemented { level, .. } => assert_eq!(level, Level::L0),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}

--- a/crates/life-perturb/src/lib.rs
+++ b/crates/life-perturb/src/lib.rs
@@ -1,0 +1,58 @@
+//! # life-perturb — Controlled perturbation injection for RCS λ̂ validation
+//!
+//! `life-perturb` is the Rust-native instrumentation layer that closes the
+//! 3-orders-of-magnitude construct gap between the RCS paper's analytic
+//! stability margins (λ_0=1.45, λ_1=0.41, λ_2=0.07, λ_3=0.006) and our
+//! empirical estimates (~0 from stationary-trace regression).
+//!
+//! The paper's λ_i describe **exponential decay rates of perturbations** in
+//! a Lyapunov function. Stationary aggregates (microRCS, microgrid) measure
+//! a different quantity. To produce paper-magnitude λ̂ we must inject
+//! controlled perturbations into the live Life runtime and fit
+//!
+//! ```text
+//! V_k(t) = V_k(0) · exp(−λ̂_recovery · (t − t_inject))
+//! ```
+//!
+//! to the recorded recovery curve.
+//!
+//! ## Status
+//!
+//! This is the v0.0 scaffold — design + traits + types only. No injectors
+//! actually wire into the daemons yet. See
+//! [`docs/superpowers/specs/2026-05-04-life-perturb-design.md`][spec] for
+//! the full design and phasing plan. Linear ticket: [BRO-947].
+//!
+//! ## Module layout
+//!
+//! - [`perturbation`] — taxonomy of perturbations (`Level`, `PerturbationKind`,
+//!   `Perturbation`, `Severity`).
+//! - [`injector`] — `Injector` trait + per-level injector stubs.
+//! - [`lyapunov`] — `LyapunovFn` trait + per-level V_k stubs.
+//! - [`estimator`] — `LambdaEstimator` and `RecoveryFit` for fitting
+//!   `exp(−λt)` to recovery curves.
+//! - [`error`] — crate-level error type.
+//!
+//! ## See also
+//!
+//! - `crates/autonomic/autonomic-core/src/rcs_budget.rs::MarginEstimator` —
+//!   estimates parameters of the budget formula (complementary).
+//! - `crates/arcan/arcand/src/rcs_observer.rs` — runtime state observer
+//!   (life#804).
+//! - `crates/autonomic/autonomic-core/data/rcs-parameters.toml` — canonical
+//!   paper values mirrored from `research/rcs/data/parameters.toml`.
+//!
+//! [spec]: ../../docs/superpowers/specs/2026-05-04-life-perturb-design.md
+//! [BRO-947]: https://linear.app/broomva/issue/BRO-947
+
+pub mod error;
+pub mod estimator;
+pub mod injector;
+pub mod lyapunov;
+pub mod perturbation;
+
+pub use error::{PerturbError, PerturbResult};
+pub use estimator::{LambdaEstimator, RecoveryFit};
+pub use injector::{Injector, PerturbationHandle};
+pub use lyapunov::{LyapunovFn, LyapunovSample, SystemSnapshot};
+pub use perturbation::{Level, Perturbation, PerturbationId, PerturbationKind, Severity};

--- a/crates/life-perturb/src/lyapunov.rs
+++ b/crates/life-perturb/src/lyapunov.rs
@@ -1,0 +1,221 @@
+//! Lyapunov function V_k stubs for each level.
+//!
+//! See spec §3 for the chosen physical proxies:
+//!
+//! - V_0 — plant: tool-latency residual + drop rate + provider health
+//! - V_1 — autonomic: operational residual + context pressure + economic drift
+//! - V_2 — meta-control: rule-set diff + shadow-eval veto rate + inheritance lag
+//! - V_3 — governance: policy violation count + AGENTS.md drift (v1.0)
+//!
+//! The `SystemSnapshot` is a deliberately opaque holder for now — v0.1 will
+//! replace it with a real read of `HomeostaticState` / arcan-core tick stats
+//! / autoany rule deltas. Keeping it abstract here lets the trait surface
+//! lock in without coupling to those crates from the scaffold.
+
+use serde::{Deserialize, Serialize};
+
+use crate::perturbation::Level;
+
+/// One observation `(t, V_k(t))` of the level-k Lyapunov function.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LyapunovSample {
+    /// Wall-clock time (ms since epoch) the sample was taken.
+    pub t_ms: u64,
+    /// V_k(t) — non-negative scalar, by Lyapunov-function convention.
+    pub v: f64,
+}
+
+impl LyapunovSample {
+    /// Construct a sample, clamping `v` to be non-negative.
+    pub fn new(t_ms: u64, v: f64) -> Self {
+        Self {
+            t_ms,
+            v: v.max(0.0),
+        }
+    }
+}
+
+/// Opaque holder for the cross-cutting state needed to compute V_k.
+///
+/// v0.0: an empty struct, since none of the V_k implementations are wired.
+/// v0.1+: real fields populated from `arcan-core` / `autonomic-core` /
+/// `autoany-core` reads.
+#[derive(Debug, Clone, Default)]
+pub struct SystemSnapshot {
+    /// Optional placeholder for the L0 read (tool latencies + drops).
+    pub l0: Option<L0Probe>,
+    /// Optional placeholder for the L1 read (HomeostaticState).
+    pub l1: Option<L1Probe>,
+    /// Optional placeholder for the L2 read (rule-set delta + vetoes).
+    pub l2: Option<L2Probe>,
+    /// Optional placeholder for the L3 read (policy + AGENTS.md hashes).
+    pub l3: Option<L3Probe>,
+}
+
+/// Placeholder L0 probe; real shape lands with v0.1.
+#[derive(Debug, Clone, Default)]
+pub struct L0Probe {
+    pub tool_latency_residual: f64,
+    pub request_drop_rate: f64,
+    pub provider_health: f64,
+}
+
+/// Placeholder L1 probe; real shape will reuse `HomeostaticState`.
+#[derive(Debug, Clone, Default)]
+pub struct L1Probe {
+    pub operational_residual: f64,
+    pub context_pressure: f64,
+    pub economic_drift: f64,
+}
+
+/// Placeholder L2 probe; real shape lands with v1.0.
+#[derive(Debug, Clone, Default)]
+pub struct L2Probe {
+    pub rule_set_diff: f64,
+    pub shadow_eval_veto_rate: f64,
+    pub inheritance_lag_ms: f64,
+}
+
+/// Placeholder L3 probe; real shape lands with v1.0.
+#[derive(Debug, Clone, Default)]
+pub struct L3Probe {
+    pub policy_violation_count: f64,
+    pub agents_md_drift: f64,
+}
+
+/// Trait every level's V_k computer implements.
+pub trait LyapunovFn: Send + Sync {
+    /// The level this V_k is defined for.
+    fn level(&self) -> Level;
+    /// Compute V_k(t) given the snapshot. Always non-negative.
+    fn compute(&self, snapshot: &SystemSnapshot) -> f64;
+}
+
+/// V_0 — L0 plant Lyapunov. Stub: returns 0.0 until probes are wired.
+#[derive(Debug, Default, Clone)]
+pub struct V0Plant {
+    /// Weight on tool-latency residual.
+    pub w_latency: f64,
+    /// Weight on request drop rate.
+    pub w_drop: f64,
+    /// Weight on (1 − provider_health)².
+    pub w_health: f64,
+}
+
+impl LyapunovFn for V0Plant {
+    fn level(&self) -> Level {
+        Level::L0
+    }
+    fn compute(&self, snapshot: &SystemSnapshot) -> f64 {
+        let Some(p) = snapshot.l0.as_ref() else {
+            return 0.0;
+        };
+        let h = (1.0 - p.provider_health).max(0.0);
+        self.w_latency * p.tool_latency_residual.powi(2)
+            + self.w_drop * p.request_drop_rate.max(0.0)
+            + self.w_health * h.powi(2)
+    }
+}
+
+/// V_1 — L1 autonomic Lyapunov. Stub.
+#[derive(Debug, Default, Clone)]
+pub struct V1Autonomic {
+    pub w_op: f64,
+    pub w_cog: f64,
+    pub w_econ: f64,
+}
+
+impl LyapunovFn for V1Autonomic {
+    fn level(&self) -> Level {
+        Level::L1
+    }
+    fn compute(&self, snapshot: &SystemSnapshot) -> f64 {
+        let Some(p) = snapshot.l1.as_ref() else {
+            return 0.0;
+        };
+        self.w_op * p.operational_residual.powi(2)
+            + self.w_cog * p.context_pressure.max(0.0).powi(2)
+            + self.w_econ * p.economic_drift.abs()
+    }
+}
+
+/// V_2 — L2 meta-control Lyapunov. Stub.
+#[derive(Debug, Default, Clone)]
+pub struct V2Autoany {
+    pub w_rule: f64,
+    pub w_veto: f64,
+    pub w_lag: f64,
+}
+
+impl LyapunovFn for V2Autoany {
+    fn level(&self) -> Level {
+        Level::L2
+    }
+    fn compute(&self, snapshot: &SystemSnapshot) -> f64 {
+        let Some(p) = snapshot.l2.as_ref() else {
+            return 0.0;
+        };
+        self.w_rule * p.rule_set_diff.max(0.0)
+            + self.w_veto * p.shadow_eval_veto_rate.powi(2)
+            + self.w_lag * p.inheritance_lag_ms.max(0.0)
+    }
+}
+
+/// V_3 — L3 governance Lyapunov. Stub. (v1.0 target.)
+#[derive(Debug, Default, Clone)]
+pub struct V3Governance {
+    pub w_violations: f64,
+    pub w_drift: f64,
+}
+
+impl LyapunovFn for V3Governance {
+    fn level(&self) -> Level {
+        Level::L3
+    }
+    fn compute(&self, snapshot: &SystemSnapshot) -> f64 {
+        let Some(p) = snapshot.l3.as_ref() else {
+            return 0.0;
+        };
+        self.w_violations * p.policy_violation_count.max(0.0)
+            + self.w_drift * p.agents_md_drift.max(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_snapshot_yields_zero_v() {
+        let snap = SystemSnapshot::default();
+        assert_eq!(V0Plant::default().compute(&snap), 0.0);
+        assert_eq!(V1Autonomic::default().compute(&snap), 0.0);
+        assert_eq!(V2Autoany::default().compute(&snap), 0.0);
+        assert_eq!(V3Governance::default().compute(&snap), 0.0);
+    }
+
+    #[test]
+    fn v0_combines_three_terms() {
+        let v0 = V0Plant {
+            w_latency: 1.0,
+            w_drop: 1.0,
+            w_health: 1.0,
+        };
+        let snap = SystemSnapshot {
+            l0: Some(L0Probe {
+                tool_latency_residual: 2.0,
+                request_drop_rate: 0.5,
+                provider_health: 0.0,
+            }),
+            ..SystemSnapshot::default()
+        };
+        // 4 + 0.5 + 1 = 5.5
+        assert!((v0.compute(&snap) - 5.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lyapunov_sample_clamps_negative() {
+        let s = LyapunovSample::new(1, -3.0);
+        assert_eq!(s.v, 0.0);
+    }
+}

--- a/crates/life-perturb/src/perturbation.rs
+++ b/crates/life-perturb/src/perturbation.rs
@@ -1,0 +1,245 @@
+//! Perturbation taxonomy — typed enum of every controlled perturbation we
+//! plan to support across the four RCS levels.
+//!
+//! See the design spec at
+//! `docs/superpowers/specs/2026-05-04-life-perturb-design.md` §4 for the
+//! per-level mechanism table and §5 for the full API rationale.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+/// One of the four RCS hierarchy levels.
+///
+/// Matches the canonical levels in
+/// `research/rcs/data/parameters.toml` and the paper's Theorem 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Level {
+    /// L0 — external plant. Arcan agent loop / provider boundary.
+    L0,
+    /// L1 — agent internal. Autonomic homeostatic state.
+    L1,
+    /// L2 — meta-control. EGRI / autoany rule loop.
+    L2,
+    /// L3 — governance. policy.yaml + AGENTS.md drift.
+    L3,
+}
+
+impl Level {
+    /// String form matching the canonical TOML id (`"L0"`..`"L3"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Level::L0 => "L0",
+            Level::L1 => "L1",
+            Level::L2 => "L2",
+            Level::L3 => "L3",
+        }
+    }
+}
+
+/// Severity hint — a coarse grade for perturbations whose amplitude is
+/// not naturally numeric (e.g. `BadRuleInjection`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Severity {
+    Mild,
+    Moderate,
+    Severe,
+}
+
+/// Stable identifier for a single perturbation instance, used to thread
+/// telemetry across inject → record → fit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PerturbationId(pub Ulid);
+
+impl PerturbationId {
+    /// Generate a fresh ULID-based id.
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+}
+
+impl Default for PerturbationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// All perturbation kinds we plan to support, partitioned by target level
+/// in the variant ordering. v0.0 scaffold — most variants are unimplemented
+/// in the injectors.
+///
+/// See spec §4 for the per-level injection contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PerturbationKind {
+    // ─── L0 — external plant ──────────────────────────────────────────
+    /// Force the provider boundary into a 429-storm at the given rate
+    /// for the given duration.
+    RateLimitStorm { rps: f64, duration: Duration },
+    /// Add latency jitter to every tool call.
+    ToolLatencyJitter {
+        mean_ms: u32,
+        jitter_ms: u32,
+        duration: Duration,
+    },
+    /// Drop a fraction of requests outright.
+    RequestDrop { drop_prob: f64, duration: Duration },
+    /// Simulate memory corruption at the L0 boundary.
+    MemoryCorrupt { bytes_flipped: u32 },
+
+    // ─── L1 — autonomic ──────────────────────────────────────────────
+    /// Skew the token budget projection to drive a mode change.
+    BudgetSkew { token_delta_pct: f64 },
+    /// Force rapid economic-mode flapping past the hysteresis gate.
+    ModeFlapInduction {
+        transitions_per_sec: f64,
+        duration: Duration,
+    },
+    /// Override the hysteresis gate's `min_hold_ms`.
+    HysteresisOverride { new_min_hold_ms: u64 },
+
+    // ─── L2 — meta-control ───────────────────────────────────────────
+    /// Inject a controlled-bad rule into the L2 rule set, bypassing
+    /// shadow eval. Used to test recovery via veto.
+    BadRuleInjection {
+        rule_text: String,
+        severity: Severity,
+    },
+    /// Disable shadow eval for the given window.
+    ShadowEvalDisable { duration: Duration },
+    /// Thrash a list of policy keys at the given churn rate.
+    PolicyThrash { keys: Vec<String>, churn_hz: f64 },
+
+    // ─── L3 — governance (deferred to v1.0) ──────────────────────────
+    /// Flip a single key in a sandbox copy of `.control/policy.yaml`.
+    GovernanceFlip {
+        policy_path: String,
+        key: String,
+        new_value: serde_json::Value,
+    },
+}
+
+impl PerturbationKind {
+    /// The level this kind targets.
+    pub fn target_level(&self) -> Level {
+        match self {
+            PerturbationKind::RateLimitStorm { .. }
+            | PerturbationKind::ToolLatencyJitter { .. }
+            | PerturbationKind::RequestDrop { .. }
+            | PerturbationKind::MemoryCorrupt { .. } => Level::L0,
+            PerturbationKind::BudgetSkew { .. }
+            | PerturbationKind::ModeFlapInduction { .. }
+            | PerturbationKind::HysteresisOverride { .. } => Level::L1,
+            PerturbationKind::BadRuleInjection { .. }
+            | PerturbationKind::ShadowEvalDisable { .. }
+            | PerturbationKind::PolicyThrash { .. } => Level::L2,
+            PerturbationKind::GovernanceFlip { .. } => Level::L3,
+        }
+    }
+
+    /// Stable short name suitable for use as a span attribute or metric
+    /// label.
+    pub fn name(&self) -> &'static str {
+        match self {
+            PerturbationKind::RateLimitStorm { .. } => "RateLimitStorm",
+            PerturbationKind::ToolLatencyJitter { .. } => "ToolLatencyJitter",
+            PerturbationKind::RequestDrop { .. } => "RequestDrop",
+            PerturbationKind::MemoryCorrupt { .. } => "MemoryCorrupt",
+            PerturbationKind::BudgetSkew { .. } => "BudgetSkew",
+            PerturbationKind::ModeFlapInduction { .. } => "ModeFlapInduction",
+            PerturbationKind::HysteresisOverride { .. } => "HysteresisOverride",
+            PerturbationKind::BadRuleInjection { .. } => "BadRuleInjection",
+            PerturbationKind::ShadowEvalDisable { .. } => "ShadowEvalDisable",
+            PerturbationKind::PolicyThrash { .. } => "PolicyThrash",
+            PerturbationKind::GovernanceFlip { .. } => "GovernanceFlip",
+        }
+    }
+}
+
+/// One concrete perturbation instance: id + level + kind + scheduled
+/// integration window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Perturbation {
+    pub id: PerturbationId,
+    pub level: Level,
+    pub kind: PerturbationKind,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Total integration window. Some kinds carry their own duration; this
+    /// field is the *scheduled* window enforced by the campaign runner.
+    pub duration: Duration,
+}
+
+impl Perturbation {
+    /// Construct a perturbation whose level matches the kind's
+    /// [`PerturbationKind::target_level`].
+    pub fn new(kind: PerturbationKind, duration: Duration) -> Self {
+        Self {
+            id: PerturbationId::new(),
+            level: kind.target_level(),
+            kind,
+            started_at: chrono::Utc::now(),
+            duration,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_levels_match_taxonomy() {
+        assert_eq!(
+            PerturbationKind::RateLimitStorm {
+                rps: 100.0,
+                duration: Duration::from_secs(1),
+            }
+            .target_level(),
+            Level::L0
+        );
+        assert_eq!(
+            PerturbationKind::BudgetSkew {
+                token_delta_pct: 0.5
+            }
+            .target_level(),
+            Level::L1
+        );
+        assert_eq!(
+            PerturbationKind::ShadowEvalDisable {
+                duration: Duration::from_secs(1),
+            }
+            .target_level(),
+            Level::L2
+        );
+        assert_eq!(
+            PerturbationKind::GovernanceFlip {
+                policy_path: "/tmp/policy.yaml".into(),
+                key: "max_tokens".into(),
+                new_value: serde_json::Value::Null,
+            }
+            .target_level(),
+            Level::L3
+        );
+    }
+
+    #[test]
+    fn perturbation_new_pairs_level_and_kind() {
+        let p = Perturbation::new(
+            PerturbationKind::RateLimitStorm {
+                rps: 50.0,
+                duration: Duration::from_secs(10),
+            },
+            Duration::from_secs(60),
+        );
+        assert_eq!(p.level, Level::L0);
+        assert_eq!(p.kind.name(), "RateLimitStorm");
+    }
+
+    #[test]
+    fn level_as_str_matches_canonical() {
+        assert_eq!(Level::L0.as_str(), "L0");
+        assert_eq!(Level::L1.as_str(), "L1");
+        assert_eq!(Level::L2.as_str(), "L2");
+        assert_eq!(Level::L3.as_str(), "L3");
+    }
+}

--- a/crates/life-perturb/tests/smoke.rs
+++ b/crates/life-perturb/tests/smoke.rs
@@ -1,0 +1,60 @@
+//! Smoke test — constructs every public type in the crate.
+//!
+//! This is the v0.0 scaffold's only integration test. It confirms the
+//! public API surface compiles and is reachable from a downstream crate.
+//! Real per-level integration tests (asserting `λ̂_0 > 0` on a sandboxed
+//! Life run, etc.) land with v0.1.
+
+use std::time::Duration;
+
+use life_perturb::injector::{
+    L0ProviderInjector, L1AutonomicInjector, L2AutoanyInjector, L3PolicyInjector,
+};
+use life_perturb::lyapunov::{V0Plant, V1Autonomic, V2Autoany, V3Governance};
+use life_perturb::{
+    Injector, LambdaEstimator, Level, LyapunovFn, LyapunovSample, Perturbation, PerturbationHandle,
+    PerturbationId, PerturbationKind, RecoveryFit, Severity, SystemSnapshot,
+};
+
+#[test]
+fn public_types_compile_and_construct() {
+    let _: Level = Level::L0;
+    let _: Severity = Severity::Mild;
+    let _: PerturbationId = PerturbationId::new();
+
+    let p = Perturbation::new(
+        PerturbationKind::RateLimitStorm {
+            rps: 100.0,
+            duration: Duration::from_secs(60),
+        },
+        Duration::from_secs(60),
+    );
+    assert_eq!(p.level, Level::L0);
+
+    let h = PerturbationHandle::for_perturbation(&p);
+    assert_eq!(h.perturbation_id, p.id);
+
+    let _: V0Plant = V0Plant::default();
+    let _: V1Autonomic = V1Autonomic::default();
+    let _: V2Autoany = V2Autoany::default();
+    let _: V3Governance = V3Governance::default();
+
+    let snap = SystemSnapshot::default();
+    assert_eq!(V0Plant::default().compute(&snap), 0.0);
+
+    let _ = RecoveryFit::default();
+    let _ = LyapunovSample::new(0, 1.0);
+
+    let mut est = LambdaEstimator::new(Level::L1, PerturbationId::new());
+    est.push(LyapunovSample::new(0, 1.0));
+    est.push(LyapunovSample::new(100, 0.95));
+    est.push(LyapunovSample::new(200, 0.90));
+    let fit = est.fit_recovery().expect("3 positive samples is enough");
+    assert!(fit.r_squared >= 0.0);
+
+    // Stub injectors compile and report their levels.
+    assert_eq!(L0ProviderInjector.level(), Level::L0);
+    assert_eq!(L1AutonomicInjector.level(), Level::L1);
+    assert_eq!(L2AutoanyInjector.level(), Level::L2);
+    assert_eq!(L3PolicyInjector.level(), Level::L3);
+}

--- a/docs/superpowers/specs/2026-05-04-life-perturb-design.md
+++ b/docs/superpowers/specs/2026-05-04-life-perturb-design.md
@@ -1,0 +1,335 @@
+# life-perturb — Controlled Perturbation Injection for RCS λ̂ Validation
+
+**Status:** DRAFT — design doc + scaffold (this PR). Implementation deferred to v0.1+.
+**Date:** 2026-05-04
+**Owner:** Carlos Escobar
+**Linear:** [BRO-947](https://linear.app/broomva/issue/BRO-947)
+**Parent:** BRO-944 — RCS thesis empirical validation
+**Depends on:** life#802 (StabilityBudget / MarginEstimator), life#804 (RcsObserver)
+**Reading order:** read [`research/rcs/microrcs/THESIS_VALIDATION.md`](../../../../research/rcs/microrcs/THESIS_VALIDATION.md) §"Why λ̂ doesn't match paper" first; the gap motivates this entire crate.
+
+## 1. Problem
+
+The Recursive Controlled Systems (RCS) paper (`research/rcs/papers/p0-foundations/main.tex`, Theorem 1) proves each level is exponentially stable iff its stability margin
+
+```
+λ_i = γ_i − L_θ_i·ρ_i − L_d_i·η_i − β_i·τ̄_i − ln(ν_i)/τ_{a,i}
+```
+
+is strictly positive, with canonical values from `research/rcs/data/parameters.toml`:
+
+| Level | λ_i (paper) | Mirror in Rust |
+|-------|-------------|----------------|
+| L0    | 1.4554      | `crates/autonomic/autonomic-core/data/rcs-parameters.toml` |
+| L1    | 0.4115      | (same)                                                     |
+| L2    | 0.0693      | (same)                                                     |
+| L3    | 0.0064      | (same)                                                     |
+
+These λ_i are **exponential decay rates of perturbations** in a Lyapunov function V_k. Empirically (microRCS, microgrid) we have measured something different: a regression slope on stationary V_k(t) traces with no controlled perturbation. The result is a **3-orders-of-magnitude construct gap** — λ̂ values near 0 vs paper values near 1.
+
+A Python toolkit cannot close this gap. The control surfaces we need to perturb (rate limits, tool latency, mode-switch triggers, rule injection, policy thrash) live inside the Life Agent OS Rust runtime, behind privileged daemon APIs. We need an in-process Rust crate that:
+
+1. Names the perturbations as a typed taxonomy (one enum per level).
+2. Hooks the relevant runtime primitive (autonomic tick, arcan provider, autoany rule loop, policy.yaml shield).
+3. Subscribes to the resulting Lago event stream and fits `V_k(t) = V_k(0)·exp(−λ̂_recovery·t)` to the recovery curve.
+4. Surfaces λ̂_recovery as an OTel span attribute and a metric, so dashboards (Grafana via vigil) can compare it to the paper's λ_i live.
+
+This is `life-perturb`.
+
+## 2. Why an existing toolkit cannot do this
+
+| Candidate | Why it fails |
+|-----------|--------------|
+| `pumba` / `chaos-mesh` / generic chaos engineering tools | Operate at the OS / k8s layer. Cannot perturb L1 mode flap, L2 rule corruption, L3 policy bit-flip — those live inside the agent process. |
+| Python-side perturbation in `microrcs.py` | microRCS doesn't have a runtime — it's a one-shot single-call simulator. No tick loop, no homeostatic state, nothing decays. |
+| microgrid simulator | 1-hour timestep. Paper λ values imply sub-second to ~150-second recovery (1/λ_3 ≈ 156s); microgrid cannot resolve. |
+| `autonomic-core::rcs_budget::MarginEstimator` | Already exists (life#802) but estimates parameters from observed stationary state. Does not inject perturbations and does not fit recovery curves. |
+
+`life-perturb` is the only candidate that targets the Lyapunov decay rate directly on the live runtime.
+
+## 3. Target Lyapunov Functions per Level
+
+The paper defines V_k abstractly as a Lyapunov function for level k's state space. To measure decay we must commit to **observable** physical proxies. Proposed initial choice — open to revision in v0.5:
+
+### V_0 — Plant (Arcan agent loop)
+
+```
+V_0(t) = α · ‖tool_latency(t) − latency_setpoint‖²
+       + β · request_drop_rate(t)
+       + γ · (1 − provider_health(t))²
+```
+
+**Observability:** `arcan-core` already emits per-tick `ToolCall` envelopes with duration; provider health is in `arcan-provider` retry counters. This is the cleanest level.
+
+**Recovery model:** after a `RateLimitStorm` perturbation, V_0 should decay to baseline as the provider recovers and the agent's retry-buffer drains. Paper predicts τ_recovery_0 ≈ 1/1.45 ≈ 0.7s.
+
+### V_1 — Autonomic (Homeostatic state)
+
+```
+V_1(t) = w_op  · ‖operational_state(t) − op_target‖²
+       + w_cog · context_pressure(t)²
+       + w_econ · |economic_mode(t) − Sovereign|       // discrete
+```
+
+**Observability:** `autonomic-core::HomeostaticState` is already projected; `MarginEstimator::for_l1` (life#802) consumes it. We piggyback.
+
+**Recovery model:** after a `ModeFlapInduction` (forced rapid transitions Sovereign↔Conserving), V_1 should decay as `HysteresisGate.min_hold_ms` re-stabilises the mode. Paper predicts τ_recovery_1 ≈ 1/0.41 ≈ 2.4s.
+
+### V_2 — Meta-control (autoany / EGRI)
+
+```
+V_2(t) = u · ‖rule_set(t) − rule_set_baseline‖_diff
+       + v · shadow_eval_veto_rate(t)²
+       + w · cross_run_inheritance_lag(t)
+```
+
+**Observability:** `autoany-core::loop_engine` emits rule-set deltas; vetoes are countable from shadow-eval logs (already wired in the microRCS L2 path).
+
+**Recovery model:** after a `BadRuleInjection` (force-promote a poisoned rule), V_2 should decay as shadow eval vetoes the rule and the L2 baseline reasserts. Paper predicts τ_recovery_2 ≈ 1/0.07 ≈ 14s.
+
+### V_3 — Governance (policy.yaml + AGENTS.md)
+
+```
+V_3(t) = φ · |policy_violation_count(t)|
+       + ψ · ‖agents_md_diff(t, baseline)‖
+       + χ · governance_drift_score(t)
+```
+
+**Observability:** policy violations are already gated in `arcan-aios-adapters` PreToolUse hooks; AGENTS.md drift requires a hash-then-diff on the file. (`agents_md_diff` is the cheapest signal but the slowest — L3 fires on day-scale.)
+
+**Recovery model:** after a `PolicyThrash` perturbation (bit-flip a setpoint in `.control/policy.yaml`), V_3 should decay as the next governance audit (L3 controller) catches and reverts. Paper predicts τ_recovery_3 ≈ 1/0.006 ≈ 156s — the slowest level by 22×.
+
+**v0.1 punts on V_3.** The L3 stability budget λ_3 ≈ 0.006 is so narrow that perturbation experiments must be **extremely** rare (1 per multi-day run, max). We file it as an open question and tackle it in v1.0.
+
+## 4. Perturbation Primitives per Level
+
+The taxonomy from BRO-947, formalised here as an exhaustive enum:
+
+```rust
+pub enum PerturbationKind {
+    // L0 — agent loop / external plant
+    RateLimitStorm     { rps: f64, duration: Duration },
+    ToolLatencyJitter  { mean_ms: u32, jitter_ms: u32, duration: Duration },
+    RequestDrop        { drop_prob: f64, duration: Duration },
+    MemoryCorrupt      { bytes_flipped: u32 },          // L0 boundary
+    // L1 — autonomic
+    BudgetSkew         { token_delta_pct: f64 },
+    ModeFlapInduction  { transitions_per_sec: f64, duration: Duration },
+    HysteresisOverride { new_min_hold_ms: u64 },
+    // L2 — meta-control
+    BadRuleInjection   { rule_text: String, severity: Severity },
+    ShadowEvalDisable  { duration: Duration },
+    PolicyThrash       { keys: Vec<String>, churn_hz: f64 },
+    // L3 — governance (deferred to v1.0)
+    GovernanceFlip     { policy_path: String, key: String, new_value: serde_yaml::Value },
+}
+```
+
+### Per-level injection contract
+
+| Level | Hooks into | Mechanism |
+|-------|------------|-----------|
+| L0 | `arcan-provider` middleware chain | Tower layer wrapping the provider call; injects latency / drops / 429s before the real request. |
+| L1 | `autonomic-controller::HysteresisGate` mutable handle | `min_hold_ms` override + synthetic `HomeostaticEvent` injection through `autonomic-lago` publisher. |
+| L2 | `autoany-core::loop_engine::RuleSet::push_unsafe` (new method) | Bypasses the shadow-eval gate to write a controlled bad rule; recorder watches for veto. |
+| L3 | `.control/policy.yaml` writer (sandbox copy only — never on production policy file) | Direct file mutation; reverted by control audit on next tick. |
+
+All hooks return a `PerturbationHandle` that records start/end timestamps so the recovery tracker knows the integration window.
+
+## 5. Crate API
+
+The trait surface fits in four modules:
+
+### `perturbation.rs`
+
+```rust
+pub enum Level { L0, L1, L2, L3 }
+pub enum Severity { Mild, Moderate, Severe }
+pub struct PerturbationId(Ulid);
+
+pub enum PerturbationKind { /* see §4 */ }
+
+pub struct Perturbation {
+    pub id: PerturbationId,
+    pub level: Level,
+    pub kind: PerturbationKind,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub duration: std::time::Duration,
+}
+```
+
+### `injector.rs`
+
+```rust
+#[async_trait::async_trait]
+pub trait Injector: Send + Sync {
+    fn level(&self) -> Level;
+    async fn inject(&self, p: &Perturbation) -> Result<PerturbationHandle, PerturbError>;
+    async fn revert(&self, h: PerturbationHandle) -> Result<(), PerturbError>;
+}
+
+pub struct PerturbationHandle { /* opaque revert token */ }
+
+// Concrete injector stubs (one per level) — implementations in v0.1+
+pub struct L0ProviderInjector { /* arcan-provider hook */ }
+pub struct L1AutonomicInjector { /* autonomic-controller hook */ }
+pub struct L2AutoanyInjector   { /* autoany-core hook */ }
+pub struct L3PolicyInjector    { /* policy.yaml sandbox writer */ }
+```
+
+### `lyapunov.rs`
+
+```rust
+/// Snapshot of (t, V_k(t)) for one observation.
+pub struct LyapunovSample { pub t_ms: u64, pub v: f64 }
+
+/// Trait implemented by each level's V_k computer.
+pub trait LyapunovFn: Send + Sync {
+    fn level(&self) -> Level;
+    fn compute(&self, ctx: &SystemSnapshot) -> f64;
+}
+
+pub struct V0Plant;        // V_0 from arcan-core ToolCall envelopes
+pub struct V1Autonomic;    // V_1 from HomeostaticState (reuses life#802 Estimator)
+pub struct V2Autoany;      // V_2 from autoany rule deltas
+pub struct V3Governance;   // V_3 from policy + AGENTS.md hashes (v1.0)
+```
+
+### `estimator.rs`
+
+```rust
+/// Recovery-curve fit:  V_k(t) = V_k(0) · exp(−λ̂ · (t − t_inject)) + ε.
+pub struct LambdaEstimator {
+    pub level: Level,
+    pub samples: Vec<LyapunovSample>,
+    pub perturbation: PerturbationId,
+}
+
+pub struct RecoveryFit {
+    pub lambda_hat: f64,
+    pub r_squared: f64,
+    pub bootstrap_ci_95: (f64, f64),
+    pub n_samples: usize,
+    pub fit_window_ms: (u64, u64),
+}
+
+impl LambdaEstimator {
+    pub fn fit_recovery(&self) -> Result<RecoveryFit, FitError> { /* OLS log-linear */ }
+}
+
+/// Top-level orchestrator: inject → record → fit → emit OTel span.
+pub struct PerturbationCampaign { /* config + injectors + lyap fns */ }
+impl PerturbationCampaign {
+    pub async fn run_once(&self, p: Perturbation) -> Result<RecoveryFit, PerturbError>;
+}
+```
+
+## 6. Integration Points
+
+### 6.1 Daemon hooks
+
+`life-perturb` is **not** a daemon — it's a library consumed by the existing daemons (`autonomicd`, `arcand`, `autoanyd`) under a `--perturb-mode` feature flag. v0.1 plumbs it only into a new `life-perturb-cli` binary:
+
+```bash
+life-perturb inject --level 0 --kind rate-limit --rps 100 --duration 60s
+life-perturb campaign --config campaigns/l1-mode-flap.toml
+life-perturb fit --from-events ./journal/run-2026-05-04.jsonl --level 1
+```
+
+The CLI talks to the daemons via their existing UDS / HTTP control plane (no new transport).
+
+### 6.2 Vigil telemetry
+
+Every perturbation emits a span tagged:
+
+```
+perturbation.id        = <ulid>
+perturbation.level     = "L0..L3"
+perturbation.kind      = "RateLimitStorm" | …
+perturbation.amplitude = <numeric>
+perturbation.duration  = <seconds>
+perturbation.lambda_hat= <fit result>
+perturbation.r_squared = <goodness>
+```
+
+Two new metrics:
+
+```
+life.perturbation.lambda_hat{level=…}     histogram (one fit per perturbation)
+life.perturbation.recovery_duration_ms    histogram
+```
+
+Grafana dashboard JSON ships in v0.5 (under `crates/life-perturb/dashboards/`).
+
+### 6.3 Lago event kinds
+
+Two new event variants behind the existing `EventKind::Custom("perturb.…")` namespace (forward-compatible like autonomic / haima patterns):
+
+```
+perturb.injected   { id, level, kind, started_at, duration }
+perturb.recovered  { id, lambda_hat, r_squared, ci_95, fit_window_ms }
+```
+
+Stored verbatim in `lago-journal`; the recovery tracker subscribes via `lago-aios-eventstore-adapter`.
+
+## 7. Phasing
+
+### v0.1 — single-level smoke (1 week, this PR + 1 follow-up)
+
+- L0 only: `RateLimitStorm` + `ToolLatencyJitter` injectors via `arcan-provider` middleware.
+- V_0 computer over real `ToolCall` durations.
+- `LambdaEstimator::fit_recovery` OLS implementation.
+- CLI: `life-perturb inject` for one-shot perturbations.
+- Tests: integration test asserting `λ̂_0 > 0` after a sandboxed rate-limit storm.
+
+**Goal:** a single, reproducible λ̂_0 estimate from a controlled perturbation, even if it's far from 1.45.
+
+### v0.5 — closed-loop single-level (3 weeks)
+
+- All three L0 perturbation kinds wired and reverting cleanly.
+- L1 added: `BudgetSkew` + `ModeFlapInduction` via `autonomic-controller` hooks.
+- `PerturbationCampaign` orchestrator: schedule N perturbations, fit each, aggregate.
+- Vigil dashboard JSON for L0 + L1.
+- Integration with `autonomicd` and `arcand` under `--perturb-mode`.
+
+**Goal:** ≥ 5 paired (perturb-amplitude → λ̂) data points per level, plotted vs paper analytic value with bootstrap CI.
+
+### v1.0 — full hierarchy (6–8 weeks)
+
+- L2 wired: `BadRuleInjection` + `ShadowEvalDisable` via `autoany-core`.
+- L3 wired (sandbox-only): `PolicyThrash` + `GovernanceFlip` against a copy of `policy.yaml`.
+- Cross-level orchestrated perturbation chain (e.g. L0 storm → measure cascade through L1).
+- Paper figure data: λ̂ vs λ scatter for all 4 levels.
+- Production-vs-sandbox split (default sandbox; `--allow-production` requires explicit signed approval).
+
+**Goal:** the headline figure for the RCS validation paper.
+
+## 8. Open Questions
+
+| # | Question | Resolution path |
+|---|----------|-----------------|
+| 1 | Is OLS log-linear fit sufficient or do we need MLE under heavy-tail noise? | Start OLS; switch to robust regression if R² < 0.7 on first L0 runs. |
+| 2 | How to handle natural perturbations during a controlled test? | Co-emit `naturalness.score` per Lyapunov sample; LambdaEstimator excludes windows with score > threshold from the fit. |
+| 3 | Sandbox isolation — separate process or in-proc with feature flag? | Default in-proc behind `--perturb-mode` flag + stable revert path. Spawn-separate-process is a v1.0 hardening. |
+| 4 | What's the right baseline V_k(0)? Just-before-inject sample, or rolling pre-window mean? | v0.1: just-before-inject. v0.5: 30s rolling mean. |
+| 5 | Should L3 perturbations require human approval at injection time? | Yes — gate behind interactive `--confirm-l3` flag. |
+| 6 | Do we want Bayesian λ̂ (posterior over λ) instead of bootstrap CI? | Open. v1.0 candidate. |
+| 7 | Production deployment: how do we make this safe for the Inirida / Choco / Vaupes pilot sites' microgrid kernels? | Out of scope for this crate — pilot deployments will run only the `--allow-production` subset on pre-approved kernels with operator sign-off. |
+| 8 | How do we address the construct-validity question for V_k itself? The proxies in §3 are *one* choice; the paper's V_k is abstract. | We commit to the §3 proxies, document them, and let v1.0 test sensitivity to alternative V_k definitions. |
+
+## 9. Non-goals (explicitly out of scope)
+
+- Real-time perturbation streaming (this is offline analysis).
+- Replacing `MarginEstimator` (life#802) — that estimates parameters of the budget formula; we estimate λ from recovery dynamics. They are complementary.
+- Causal inference across levels (e.g. "L0 perturbation causes L2 instability"). v1.0 candidate, not v0.x.
+- Online adaptation of the controller from λ̂ feedback. Pure measurement here; closed-loop self-tuning is a different research project.
+
+## 10. References
+
+- Paper: `research/rcs/papers/p0-foundations/main.tex`, Theorem 1.
+- Canonical params: `research/rcs/data/parameters.toml`.
+- Empirical state: `research/rcs/microrcs/THESIS_VALIDATION.md` (read §"Why λ̂ doesn't match paper").
+- Linear ticket: BRO-947 (parent BRO-944).
+- Existing Rust mirror: `crates/autonomic/autonomic-core/data/rcs-parameters.toml`.
+- Existing L1 estimator: `crates/autonomic/autonomic-core/src/rcs_budget.rs::MarginEstimator`.
+- F3 observer scaffold: `crates/arcan/arcand/src/rcs_observer.rs` (life#804).


### PR DESCRIPTION
## Summary

- **Design spec** `docs/superpowers/specs/2026-05-04-life-perturb-design.md` — frames the construct-validity gap (paper λ_i = perturbation decay rate vs our λ̂ = stationary regression slope), commits to physical V_k proxies per level, locks the taxonomy of 11 perturbation kinds across L0–L3, and phases delivery v0.1 → v1.0.
- **Crate scaffold** `crates/life-perturb/` — 5 modules (`perturbation`, `injector`, `lyapunov`, `estimator`, `error`), trait surface stable enough that v0.1 implementation can drop in per-level injectors without API churn.
- **Working OLS fit** — `LambdaEstimator::fit_recovery` is real (not stubbed): a unit test passes a synthetic `exp(-0.5·t)` trace and recovers λ̂ = 0.5 to <1e-6.
- **Stub injectors** return `PerturbError::NotImplemented` per level; real wiring (`arcan-provider` middleware, `autonomic-controller` hooks, `autoany-core::loop_engine`, sandbox `policy.yaml` writer) is explicitly deferred to follow-up PRs.

## Scope discipline

In: spec + scaffold + workspace integration + green CI.
Out: real perturbation injection, real Lyapunov reads from `HomeostaticState` / `arcan-core` / `autoany`, bootstrap CI, Vigil dashboard JSON, Lago event variants, daemon `--perturb-mode` flag.

## Test plan

- [x] `cargo check -p life-perturb` clean
- [x] `cargo test -p life-perturb` — 11 unit + 1 smoke integration, all green
- [x] `cargo clippy -p life-perturb --tests -- -D warnings` clean
- [x] `cargo check --workspace` clean (entire life monorepo still builds)
- [ ] Reviewer reads §1 + §3 + §5 of the spec and the `lib.rs` re-export list — confirms the trait surface matches what's needed for v0.1 (single-level L0 closed loop).

## Linear

Closes scope of BRO-947 design phase: https://linear.app/broomva/issue/BRO-947
Parent: BRO-944 (RCS thesis empirical validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new perturbation testing framework to validate system stability and recovery characteristics through controlled injection at multiple system levels.
  * Includes support for four hierarchical levels of perturbation injection, recovery measurement via Lyapunov functions, and decay-rate estimation.

* **Documentation**
  * Added design specification documenting the perturbation framework architecture, implementation approach, and integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->