### PR TITLE
feat(ergon): scaffold Layer-2 harness primitive — error/role/stream foundation (BRO-995, BRO-996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## Unreleased
 
 ### Added
+- `ergon` — new Layer-2 agent-harness primitive crate. First slice ships
+  the foundational trait surface with no Life-substrate dependencies:
+  `ErgonError` + `Result` (`error`), `Role` + `RoleScope` with
+  call > session > agent precedence (`role`), and `StreamEvent` canonical
+  taxonomy + `StreamSink` trait + `BufferSink` + `FanoutSink` (`stream`).
+  25 unit tests pass. Spec at
+  `docs/superpowers/specs/2026-05-05-ergon-v0.1.md`. Tracker BRO-994.
+  Note: spec lists `license = "Apache-2.0"`; the crate uses
+  `license.workspace = true` (MIT) for monorepo coherence — life is
+  MIT-licensed throughout. (BRO-995, BRO-996)
 - `arcan-prosopon` — Pneuma<L0ToExternal> bridge. Subscribes to KernelRuntime
   events, translates to ProsoponEvents, publishes to prosopon-daemon fanout.
   Opt-in via `cargo run -p arcan --features prosopon --prosopon-port <addr>`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,6 +3390,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "ergon"
+version = "0.3.0"
+dependencies = [
+ "aios-protocol",
+ "async-trait",
+ "futures",
+ "insta",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "tracing",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,6 +4742,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "serde",
  "similar",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ members = [
     "crates/praxis/praxis-mcp-bridge",
     "crates/praxis/praxis-skills",
     "crates/praxis/praxis-tools",
+    # Ergon — agent harness primitive
+    "crates/ergon/ergon",
     # Haima — finance
     "crates/haima/haima-api-schema",
     "crates/haima/haima-api",
@@ -221,6 +223,8 @@ praxis-core = { path = "crates/praxis/praxis-core", version = "0.3.0" }
 praxis-mcp-bridge = { path = "crates/praxis/praxis-mcp-bridge", version = "0.3.0" }
 praxis-skills = { path = "crates/praxis/praxis-skills", version = "0.3.0" }
 praxis-tools = { path = "crates/praxis/praxis-tools", version = "0.3.0" }
+# Ergon — agent harness primitive
+ergon = { path = "crates/ergon/ergon", version = "0.3.0" }
 # Facade crates
 life-aios = { path = "crates/aios/life-aios", version = "0.3.0" }
 life-arcan = { path = "crates/arcan/life-arcan", version = "0.3.0", default-features = false }

--- a/crates/ergon/ergon/CLAUDE.md
+++ b/crates/ergon/ergon/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — `ergon` crate
+
+> Instructions for AI agents working in this crate.
+> Last updated: 2026-05-06.
+
+## What this crate is
+
+**ergon** is Life's Layer-2 agent-harness primitive. The trait set that lets
+a Broomva developer write a `Workflow` in Rust whose deterministic outer body
+orchestrates autonomous inner LLM steps, integrated end-to-end with the Life
+substrate.
+
+**Layered position** (locked):
+
+```
+Layer 4 — Life (Agent OS substrate)
+Layer 3 — arcan (runtime daemon)
+Layer 2 — ergon (HARNESS — this crate)
+Layer 1 — arcan-provider (model wire connectors)
+Layer 0 — model
+```
+
+## Spec & tracker
+
+- Spec: `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md`
+- Linear umbrella: BRO-994 — https://linear.app/broomva/issue/BRO-994
+
+## Status (2026-05-06)
+
+Shipping incrementally per spec §12 work order. **Currently landed** in this
+crate:
+
+| File | BRO ticket | State |
+|---|---|---|
+| `error.rs` | BRO-996 | Done |
+| `role.rs` | BRO-996 | Done |
+| `stream.rs` (StreamEvent, StreamSink, BufferSink, FanoutSink) | BRO-996 | Done |
+
+**Not yet landed** (follow-up PRs):
+
+| File | BRO ticket | Notes |
+|---|---|---|
+| `hook.rs` | BRO-997 | Depends on praxis_core::Message, ToolCall, ToolResult — wire types in BRO-998's PR |
+| `step.rs` | BRO-998 | Step + StepCtx + InferenceRequest + RuntimeHandle |
+| `workflow.rs` | BRO-999 | Workflow + WorkflowExecutor |
+| `attestation.rs`, `budget.rs`, `score.rs`, `capability.rs` | BRO-1000 | Auto-registered hooks (anima / autonomic / nous / praxis) |
+| `LagoSink`, `VigilSink`, `LifegwSink` | BRO-998 | Default substrate sinks (deferred — pull in lago-journal / life-vigil / mpsc deps) |
+
+## Invariants (DO NOT VIOLATE)
+
+1. **Roles are NEVER persisted in session history.** `Role::merge` produces a
+   transient overlay applied only at `ModelRequest` build time. Inserting a
+   role into history breaks the call > session > agent precedence rule.
+
+2. **`StreamEvent` variants are append-only after v1.0.** Never remove,
+   never reorder semantically. New variants land in any minor version;
+   consumers MUST handle `StreamEvent::VendorEvent` for forward compat.
+
+3. **No `unwrap()` / `expect()` / `panic!()` in non-test code.** Workspace
+   clippy lints catch these. Use `ErgonError::*` variants.
+
+4. **No emojis in source files.** LLM-friendly diffs.
+
+5. **`async_trait` for now.** When Rust's native `async fn in trait` is
+   stable enough for our MSRV (currently 1.93), we'll migrate workspace-wide.
+
+6. **No Life-runtime deps in this crate's foundational layer.** This crate
+   currently has zero dependencies on `lago-journal`, `life-vigil`,
+   `praxis-*`, `arcan-*`, `anima-*`, `autonomic-*`, or `nous-*`. Those land
+   incrementally as their consuming modules ship (per the work-order in
+   spec §12).
+
+## License deviation from spec
+
+The spec lists `license = "Apache-2.0"`. This crate uses
+`license.workspace = true` (= MIT) for monorepo coherence — life's overall
+license is MIT. Documented in `core/life/CHANGELOG.md`.
+
+## Useful commands
+
+```bash
+cargo check -p ergon
+cargo test  -p ergon --all-targets
+cargo clippy -p ergon --all-targets -- -D warnings
+cargo fmt -p ergon
+```
+
+## Don't
+
+- Do not pull in Life-substrate crate deps speculatively — wire them only
+  when the consuming module needs them.
+- Do not bypass the role-merge precedence rule.
+- Do not introduce `unwrap()` / `expect()` to "fix" a clippy warning.
+- Do not rename `StreamEvent` variants after v1.0.

--- a/crates/ergon/ergon/Cargo.toml
+++ b/crates/ergon/ergon/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ergon"
+description = "Life's agent-harness primitive: deterministic workflows orchestrating autonomous LLM steps"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Substrate contracts (no I/O — minimal surface).
+aios-protocol.workspace = true
+
+# Standard async + serialization.
+async-trait.workspace = true
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+tracing.workspace = true
+
+[dev-dependencies]
+insta = { version = "1", features = ["yaml"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio-test = "0.4"

--- a/crates/ergon/ergon/src/error.rs
+++ b/crates/ergon/ergon/src/error.rs
@@ -1,0 +1,118 @@
+//! Error type and result alias for the ergon harness.
+//!
+//! Ergon is a Layer-2 trait crate; its errors are flat, structural, and never
+//! leak substrate detail. Each variant maps to a category of failure visible
+//! to the workflow author. Wire-level errors (transport, KMS, network)
+//! surface as [`ErgonError::Provider`] or substrate-specific variants in
+//! downstream impls.
+
+use std::fmt;
+
+/// Canonical error type for ergon workflows, steps, and hooks.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ErgonError {
+    /// A workflow-level error — usually surfaced from
+    /// [`crate::Workflow::execute`] (once that surface lands).
+    #[error("workflow error: {0}")]
+    Workflow(String),
+
+    /// A step-level error — surfaced from `Step::run`.
+    #[error("step error: {0}")]
+    Step(String),
+
+    /// A hook denied a lifecycle event (`Hook::on_*` returned `Deny(reason)`).
+    #[error("hook error: {0}")]
+    Hook(String),
+
+    /// A model-provider transport error.
+    #[error("provider error: {0}")]
+    Provider(String),
+
+    /// A tool invocation failed.
+    #[error("tool error: {0}")]
+    Tool(String),
+
+    /// The autonomic budget gate denied inference.
+    #[error("budget exhausted: {0}")]
+    Budget(String),
+
+    /// A capability check denied a tool call.
+    #[error("capability denied: {0}")]
+    CapabilityDenied(String),
+
+    /// The autonomous loop exceeded its `max_turns` budget.
+    #[error("max turns ({0}) exceeded")]
+    MaxTurns(u32),
+
+    /// Backpressure: the upstream stream was closed before the autonomous
+    /// loop completed (e.g., client disconnect propagated to LifegwSink).
+    #[error("stream closed by consumer")]
+    StreamClosed,
+
+    /// JSON serialization / deserialization failure.
+    #[error("ser/de: {0}")]
+    Codec(#[from] serde_json::Error),
+
+    /// Catch-all for invariant violations or implementation bugs. Prefer a
+    /// more specific variant when one fits.
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+/// The result type used throughout the ergon crate.
+pub type Result<T> = std::result::Result<T, ErgonError>;
+
+impl ErgonError {
+    /// Build a [`ErgonError::Workflow`] from any displayable.
+    pub fn workflow(msg: impl fmt::Display) -> Self {
+        Self::Workflow(msg.to_string())
+    }
+
+    /// Build a [`ErgonError::Step`] from any displayable.
+    pub fn step(msg: impl fmt::Display) -> Self {
+        Self::Step(msg.to_string())
+    }
+
+    /// Build a [`ErgonError::Internal`] from any displayable.
+    pub fn internal(msg: impl fmt::Display) -> Self {
+        Self::Internal(msg.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_includes_inner_message() {
+        let e = ErgonError::workflow("missing input");
+        assert_eq!(e.to_string(), "workflow error: missing input");
+    }
+
+    #[test]
+    fn max_turns_displays_count() {
+        let e = ErgonError::MaxTurns(16);
+        assert_eq!(e.to_string(), "max turns (16) exceeded");
+    }
+
+    #[test]
+    fn codec_from_serde_json_works() {
+        let bad: std::result::Result<serde_json::Value, _> =
+            serde_json::from_str("{not valid json");
+        let err: ErgonError = bad.unwrap_err().into();
+        assert!(matches!(err, ErgonError::Codec(_)));
+    }
+
+    #[test]
+    fn stream_closed_is_distinct_variant() {
+        let e = ErgonError::StreamClosed;
+        assert_eq!(e.to_string(), "stream closed by consumer");
+    }
+
+    #[test]
+    fn capability_denied_carries_reason() {
+        let e = ErgonError::CapabilityDenied("fs_write".into());
+        assert!(e.to_string().contains("fs_write"));
+    }
+}

--- a/crates/ergon/ergon/src/lib.rs
+++ b/crates/ergon/ergon/src/lib.rs
@@ -1,0 +1,54 @@
+//! # ergon — Life's agent-harness primitive
+//!
+//! Ergon is Life's Layer-2 agent-harness: the trait set that lets a Broomva
+//! developer write a [`Workflow`] in Rust whose deterministic outer body
+//! orchestrates autonomous inner LLM steps, integrated end-to-end with the
+//! Life substrate (praxis tools, lago events, anima identity, autonomic
+//! budgets, nous scoring, vigil traces, lifegw delivery).
+//!
+//! ## Naming
+//!
+//! `ergon` (Greek *ἔργον*, work / function / characteristic activity). Pairs
+//! philosophically with `praxis` (Greek *πρᾶξις*, doing) and `nous` (Greek
+//! *νοῦς*, mind). Three-way semantic fit: nous selects → praxis does → ergon
+//! is the work performed.
+//!
+//! ## Layered position
+//!
+//! ```text
+//! Layer 4 — Life (Agent OS substrate)
+//! Layer 3 — arcan (runtime daemon, OperatingMode FSM, capability gating)
+//! Layer 2 — ergon (HARNESS — owned by this crate)
+//! Layer 1 — arcan-provider (model wire connectors, multi-vendor)
+//! Layer 0 — model (Anthropic / OpenAI / Bedrock / etc.)
+//! ```
+//!
+//! ## Status — v0.1 (in progress)
+//!
+//! This crate is shipping incrementally per
+//! `docs/superpowers/specs/2026-05-05-ergon-v0.1.md` (spec §12 work order):
+//!
+//! - **Landed in this slice**: [`error`], [`role`], [`stream`] — pure data
+//!   shapes with no Life-substrate dependencies (the foundation layer).
+//! - **Coming next**: [`hook`] (trait + registry), [`step`] (`Step` +
+//!   `StepCtx` + `RuntimeHandle`), [`workflow`] (`Workflow` +
+//!   `WorkflowExecutor`), four auto-hooks (capability / budget / score /
+//!   attestation), arcan adapter, lifed route, bookkeeping-judge port.
+//!
+//! See [Linear project BRO-994](https://linear.app/broomva/project/ergon-agent-harness-primitive-ca2a51a0fba1)
+//! for the implementation tracker.
+
+#![doc(html_no_source)]
+
+pub mod error;
+pub mod role;
+pub mod stream;
+
+pub use error::{ErgonError, Result};
+pub use role::{Role, RoleScope};
+pub use stream::{BufferSink, FanoutSink, StopReason, StreamEvent, StreamSink};
+
+/// Re-export of [`aios_protocol::ids::SessionId`] — the canonical session
+/// identifier used throughout the Life substrate. Ergon does not define its
+/// own session type; it borrows the kernel-contract one.
+pub use aios_protocol::ids::SessionId;

--- a/crates/ergon/ergon/src/role.rs
+++ b/crates/ergon/ergon/src/role.rs
@@ -1,0 +1,277 @@
+//! Role overlays — call/session/agent precedence, never persisted.
+//!
+//! A [`Role`] is a lightweight system-prompt overlay. Three scopes exist
+//! ([`RoleScope::Call`], [`RoleScope::Session`], [`RoleScope::Agent`]) with
+//! strict precedence: **call > session > agent**.
+//!
+//! ## Critical invariant
+//!
+//! Roles are NEVER inserted into [`crate::SessionId`]-keyed history. They are
+//! applied at `ModelRequest` build time (in step.rs's autonomous loop, when
+//! that lands). Inserting a role into history is a bug — the precedence rule
+//! becomes meaningless if roles get baked in.
+//!
+//! ## Merge semantics
+//!
+//! Roles compose cumulatively for `instructions` (concatenated in
+//! agent → session → call order so call-scope instructions appear *last*
+//! and dominate the model's most-recent attention) and override-style for
+//! `identity` (highest scope wins outright).
+
+use serde::{Deserialize, Serialize};
+
+/// Precedence scope for a [`Role`] overlay.
+///
+/// **Order**: [`Self::Call`] > [`Self::Session`] > [`Self::Agent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RoleScope {
+    /// Workflow / agent default. Lowest precedence.
+    Agent,
+    /// Bound for the lifetime of a session. Middle precedence.
+    Session,
+    /// Bound for a single call. Highest precedence.
+    Call,
+}
+
+impl RoleScope {
+    /// Numeric precedence for ordering — higher value dominates.
+    pub fn precedence(self) -> u8 {
+        match self {
+            Self::Agent => 0,
+            Self::Session => 1,
+            Self::Call => 2,
+        }
+    }
+}
+
+/// A role overlay — a system-prompt fragment scoped to a specific lifetime.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Role {
+    /// Optional identity assertion (e.g., `"You are the bookkeeping judge."`).
+    pub identity: Option<String>,
+    /// Ordered list of instruction fragments. Merged cumulatively across
+    /// scopes in the order agent → session → call.
+    pub instructions: Vec<String>,
+    /// Which scope this overlay binds to.
+    pub scope: RoleScope,
+}
+
+impl Default for Role {
+    /// Default role: no identity, no instructions, agent-scope.
+    fn default() -> Self {
+        Self {
+            identity: None,
+            instructions: Vec::new(),
+            scope: RoleScope::Agent,
+        }
+    }
+}
+
+impl Role {
+    /// Construct a new agent-scope role with the given identity assertion.
+    pub fn agent(identity: impl Into<String>) -> Self {
+        Self {
+            identity: Some(identity.into()),
+            instructions: Vec::new(),
+            scope: RoleScope::Agent,
+        }
+    }
+
+    /// Append an instruction fragment.
+    pub fn with_instruction(mut self, line: impl Into<String>) -> Self {
+        self.instructions.push(line.into());
+        self
+    }
+
+    /// Set the scope of this role.
+    pub fn with_scope(mut self, scope: RoleScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    /// Merge agent / session / call roles per the **call > session > agent**
+    /// precedence rule.
+    ///
+    /// - `identity`: highest-precedence non-None wins.
+    /// - `instructions`: agent first, then session, then call (so the model
+    ///   sees the most-specific instruction last and weights it most).
+    /// - `scope`: the result has [`RoleScope::Call`] if any call-scope
+    ///   override was provided, otherwise [`RoleScope::Session`] if a
+    ///   session role was provided, otherwise [`RoleScope::Agent`].
+    pub fn merge(agent: &Self, session: Option<&Self>, call: Option<&Self>) -> Self {
+        let identity = call
+            .and_then(|r| r.identity.clone())
+            .or_else(|| session.and_then(|r| r.identity.clone()))
+            .or_else(|| agent.identity.clone());
+
+        let mut instructions = Vec::with_capacity(
+            agent.instructions.len()
+                + session.map_or(0, |r| r.instructions.len())
+                + call.map_or(0, |r| r.instructions.len()),
+        );
+        instructions.extend(agent.instructions.iter().cloned());
+        if let Some(s) = session {
+            instructions.extend(s.instructions.iter().cloned());
+        }
+        if let Some(c) = call {
+            instructions.extend(c.instructions.iter().cloned());
+        }
+
+        let scope = if call.is_some() {
+            RoleScope::Call
+        } else if session.is_some() {
+            RoleScope::Session
+        } else {
+            RoleScope::Agent
+        };
+
+        Self {
+            identity,
+            instructions,
+            scope,
+        }
+    }
+
+    /// Render the merged role into a single system-prompt string.
+    ///
+    /// Returns `None` if the role contributes no content (no identity and
+    /// no instructions). The exact text format is:
+    ///
+    /// ```text
+    /// <identity>
+    ///
+    /// <instruction 1>
+    /// <instruction 2>
+    /// ...
+    /// ```
+    ///
+    /// with the blank line elided when either section is empty.
+    pub fn render(&self) -> Option<String> {
+        let has_identity = self.identity.as_ref().is_some_and(|s| !s.is_empty());
+        let has_instructions = !self.instructions.is_empty();
+        if !has_identity && !has_instructions {
+            return None;
+        }
+        let mut out = String::new();
+        if let Some(id) = &self.identity {
+            out.push_str(id);
+        }
+        if has_identity && has_instructions {
+            out.push_str("\n\n");
+        }
+        for (i, line) in self.instructions.iter().enumerate() {
+            if i > 0 {
+                out.push('\n');
+            }
+            out.push_str(line);
+        }
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precedence_order_is_call_session_agent() {
+        assert!(RoleScope::Call.precedence() > RoleScope::Session.precedence());
+        assert!(RoleScope::Session.precedence() > RoleScope::Agent.precedence());
+    }
+
+    #[test]
+    fn default_role_renders_to_none() {
+        assert!(Role::default().render().is_none());
+    }
+
+    #[test]
+    fn merge_with_only_agent_returns_agent_scope() {
+        let agent = Role::agent("be helpful");
+        let merged = Role::merge(&agent, None, None);
+        assert_eq!(merged.scope, RoleScope::Agent);
+        assert_eq!(merged.identity.as_deref(), Some("be helpful"));
+    }
+
+    #[test]
+    fn merge_call_overrides_identity() {
+        let agent = Role::agent("agent persona");
+        let call = Role::agent("call persona").with_scope(RoleScope::Call);
+        let merged = Role::merge(&agent, None, Some(&call));
+        assert_eq!(merged.identity.as_deref(), Some("call persona"));
+        assert_eq!(merged.scope, RoleScope::Call);
+    }
+
+    #[test]
+    fn merge_session_overrides_agent_when_no_call() {
+        let agent = Role::agent("agent persona");
+        let session = Role::agent("session persona").with_scope(RoleScope::Session);
+        let merged = Role::merge(&agent, Some(&session), None);
+        assert_eq!(merged.identity.as_deref(), Some("session persona"));
+        assert_eq!(merged.scope, RoleScope::Session);
+    }
+
+    #[test]
+    fn merge_concatenates_instructions_agent_session_call() {
+        let agent = Role::default()
+            .with_instruction("agent-1")
+            .with_instruction("agent-2");
+        let session = Role::default()
+            .with_scope(RoleScope::Session)
+            .with_instruction("session-1");
+        let call = Role::default()
+            .with_scope(RoleScope::Call)
+            .with_instruction("call-1");
+        let merged = Role::merge(&agent, Some(&session), Some(&call));
+        assert_eq!(
+            merged.instructions,
+            vec!["agent-1", "agent-2", "session-1", "call-1"]
+        );
+    }
+
+    #[test]
+    fn render_includes_identity_then_instructions() {
+        let role = Role::agent("You are the judge.")
+            .with_instruction("Be terse.")
+            .with_instruction("Cite sources.");
+        let rendered = role.render().expect("non-empty");
+        assert_eq!(rendered, "You are the judge.\n\nBe terse.\nCite sources.");
+    }
+
+    #[test]
+    fn render_with_only_instructions_omits_blank_line() {
+        let role = Role::default().with_instruction("be brief");
+        assert_eq!(role.render().as_deref(), Some("be brief"));
+    }
+
+    #[test]
+    fn render_empty_identity_treated_as_absent() {
+        let role = Role {
+            identity: Some(String::new()),
+            instructions: vec!["hello".into()],
+            scope: RoleScope::Agent,
+        };
+        assert_eq!(role.render().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn merge_higher_precedence_identity_dominates_when_lower_is_some() {
+        let agent = Role::agent("agent");
+        let session = Role::agent("session").with_scope(RoleScope::Session);
+        let call = Role::agent("call").with_scope(RoleScope::Call);
+        let merged = Role::merge(&agent, Some(&session), Some(&call));
+        assert_eq!(merged.identity.as_deref(), Some("call"));
+    }
+
+    #[test]
+    fn merge_falls_back_when_higher_scope_has_none_identity() {
+        let agent = Role::agent("agent persona");
+        let call = Role::default().with_scope(RoleScope::Call); // identity=None
+        let merged = Role::merge(&agent, None, Some(&call));
+        // call has no identity → falls back to agent's
+        assert_eq!(merged.identity.as_deref(), Some("agent persona"));
+        // but scope still tracks the highest-supplied scope
+        assert_eq!(merged.scope, RoleScope::Call);
+    }
+}

--- a/crates/ergon/ergon/src/stream.rs
+++ b/crates/ergon/ergon/src/stream.rs
@@ -1,0 +1,426 @@
+//! Canonical stream-event taxonomy and sink trait.
+//!
+//! [`StreamEvent`] is ergon's wire-shape contract for what flows out of the
+//! autonomous loop. Every observable signal from a model + tool run lands as
+//! one of these variants. The taxonomy is **append-only after v1.0** —
+//! never removed, never reordered semantically.
+//!
+//! [`StreamSink`] is the consumer side: anything that wants to observe a
+//! workflow run (durable replay, OTel traces, end-user SSE) implements it.
+//!
+//! ## Default sinks landing in this module
+//!
+//! - [`BufferSink`] — accumulates every event in memory; for tests.
+//! - [`FanoutSink`] — broadcasts to N child sinks.
+//!
+//! ## Default sinks **deferred** to follow-up PRs (substrate integration)
+//!
+//! - `LagoSink` — durable replay via `lago_journal::Journal`.
+//! - `VigilSink` — OTel spans via `life_vigil::Tracer`.
+//! - `LifegwSink` — bounded mpsc towards lifegw upstream stream.
+//!
+//! Those three pull in Life-substrate crate dependencies that this PR
+//! intentionally keeps out of ergon's foundational layer.
+
+use crate::SessionId;
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Reason a stream terminated. Mirrors the upstream-provider taxonomy
+/// (Anthropic/OpenAI/Bedrock all converge on these four high-level cases).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    /// Model finished its turn voluntarily.
+    EndTurn,
+    /// Provider hit the configured max-tokens / max-output cap.
+    MaxTokens,
+    /// Model emitted a `tool_use` block; outer loop should dispatch and
+    /// re-enter `run_inference_streaming`.
+    ToolUse,
+    /// Provider matched a stop sequence supplied in the request.
+    StopSequence,
+    /// Refusal / safety termination (vendor-classified).
+    Refusal,
+    /// Provider error or unexpected termination.
+    Error,
+}
+
+/// Canonical event taxonomy emitted from the autonomous loop.
+///
+/// **Stability contract**: variants are append-only after v1.0. New variants
+/// may land in any minor version; existing variants are never removed and
+/// never have their semantics altered. Consumers MUST handle the
+/// [`Self::VendorEvent`] variant to gracefully accept future or
+/// vendor-specific events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum StreamEvent {
+    /// Session bookkeeping — emitted once at the start of every workflow run.
+    SessionStart {
+        session_id: SessionId,
+        model: String,
+        provider: String,
+    },
+
+    /// Begin of a top-level text block.
+    TextStart { id: String },
+    /// Streamed text token / chunk.
+    TextDelta { id: String, delta: String },
+    /// End of the text block whose `id` matches.
+    TextEnd { id: String },
+
+    /// Begin of an extended-thinking / reasoning block.
+    ReasoningStart { id: String, signed: bool },
+    /// Streamed reasoning chunk.
+    ReasoningDelta { id: String, delta: String },
+    /// End of the reasoning block.
+    ReasoningEnd { id: String, redacted: bool },
+
+    /// Model has decided to invoke a tool.
+    ToolUseStart { id: String, name: String },
+    /// Streamed JSON-encoded args for an in-progress tool invocation.
+    ToolUseInputDelta { id: String, partial_args: String },
+    /// End of a tool invocation. `denied` is true when a hook rejected the
+    /// call (capability gate, approval flow). `error` carries the message
+    /// when the underlying tool failed.
+    ToolUseEnd {
+        id: String,
+        ok: bool,
+        denied: bool,
+        error: Option<String>,
+    },
+
+    /// Begin of a structured-output block (e.g. JSON-schema constrained
+    /// generation).
+    StructuredStart { id: String, schema_name: String },
+    /// Streamed partial JSON for a structured-output block.
+    StructuredDelta { id: String, partial_json: String },
+    /// End of a structured-output block.
+    StructuredEnd { id: String },
+
+    /// A citation reference into a previously streamed source.
+    Citation {
+        id: String,
+        source_id: String,
+        span: (usize, usize),
+    },
+    /// A source reference (URL / title) attached to the response.
+    Source {
+        id: String,
+        url: Option<String>,
+        title: Option<String>,
+    },
+
+    /// Token / cost accounting for the upstream call.
+    Usage {
+        input: u32,
+        output: u32,
+        cached_input: Option<u32>,
+        reasoning: Option<u32>,
+    },
+
+    /// Stream terminated.
+    Done { stop_reason: StopReason },
+
+    /// Stream surfaced a recoverable error (the loop may retry).
+    Error { message: String },
+
+    /// Vendor-specific or future event ergon doesn't yet understand. Sinks
+    /// MUST accept and forward this variant unchanged.
+    VendorEvent {
+        vendor: String,
+        kind: String,
+        payload: serde_json::Value,
+    },
+}
+
+/// Consumer of a [`StreamEvent`] flow.
+///
+/// Implementations receive every event from the autonomous loop in
+/// emission order. Sinks may persist (Lago), trace (Vigil), forward to a
+/// client (Lifegw), or fan out to multiple downstream sinks.
+///
+/// ## Backpressure
+///
+/// Sinks that buffer (mpsc-style) propagate backpressure by awaiting on
+/// their internal channel. The autonomous loop awaits each `emit` call
+/// in turn, so a slow sink throttles the upstream provider naturally.
+#[async_trait]
+pub trait StreamSink: Send + Sync {
+    /// Forward a single stream event. Returns an error if the sink can no
+    /// longer accept events (e.g. the consumer has disconnected).
+    async fn emit(&self, event: StreamEvent) -> Result<()>;
+}
+
+/// In-memory sink that captures every event in emission order. Intended
+/// for unit tests and integration assertions.
+#[derive(Debug, Default)]
+pub struct BufferSink {
+    events: Mutex<Vec<StreamEvent>>,
+}
+
+impl BufferSink {
+    /// Create a new empty buffer sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the current event buffer, leaving the sink usable.
+    pub async fn snapshot(&self) -> Vec<StreamEvent> {
+        self.events.lock().await.clone()
+    }
+
+    /// Drain and return all events captured so far.
+    pub async fn drain(&self) -> Vec<StreamEvent> {
+        std::mem::take(&mut *self.events.lock().await)
+    }
+
+    /// Number of events captured so far.
+    pub async fn len(&self) -> usize {
+        self.events.lock().await.len()
+    }
+
+    /// True iff [`Self::len`] is zero.
+    pub async fn is_empty(&self) -> bool {
+        self.events.lock().await.is_empty()
+    }
+}
+
+#[async_trait]
+impl StreamSink for BufferSink {
+    async fn emit(&self, event: StreamEvent) -> Result<()> {
+        self.events.lock().await.push(event);
+        Ok(())
+    }
+}
+
+/// Broadcast a stream to N child sinks. Each `emit` call awaits every
+/// child sequentially in registration order. If any child returns an
+/// error, [`FanoutSink::emit`] short-circuits and returns that error;
+/// remaining children for the current event are skipped (they will see
+/// subsequent events normally).
+///
+/// This sequential semantics is intentional: it preserves backpressure
+/// (a slow durable sink throttles the loop) and yields deterministic
+/// failure ordering.
+pub struct FanoutSink {
+    sinks: Vec<Arc<dyn StreamSink>>,
+}
+
+impl FanoutSink {
+    /// Build a fanout from an explicit list of sinks.
+    pub fn new(sinks: Vec<Arc<dyn StreamSink>>) -> Self {
+        Self { sinks }
+    }
+
+    /// Number of registered child sinks.
+    pub fn len(&self) -> usize {
+        self.sinks.len()
+    }
+
+    /// True iff there are no registered child sinks.
+    pub fn is_empty(&self) -> bool {
+        self.sinks.is_empty()
+    }
+}
+
+impl std::fmt::Debug for FanoutSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FanoutSink")
+            .field("sinks", &self.sinks.len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl StreamSink for FanoutSink {
+    async fn emit(&self, event: StreamEvent) -> Result<()> {
+        for sink in &self.sinks {
+            sink.emit(event.clone()).await?;
+        }
+        Ok(())
+    }
+}
+
+/// A sink that always fails — used to assert error-propagation semantics
+/// from [`FanoutSink`] in tests.
+#[doc(hidden)]
+#[cfg(test)]
+struct FailingSink {
+    msg: String,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl StreamSink for FailingSink {
+    async fn emit(&self, _event: StreamEvent) -> Result<()> {
+        Err(crate::ErgonError::Internal(self.msg.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_text_delta(id: &str, delta: &str) -> StreamEvent {
+        StreamEvent::TextDelta {
+            id: id.to_string(),
+            delta: delta.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn buffer_sink_captures_events_in_order() {
+        let sink = BufferSink::new();
+        sink.emit(sample_text_delta("t1", "hello "))
+            .await
+            .expect("emit ok");
+        sink.emit(sample_text_delta("t1", "world"))
+            .await
+            .expect("emit ok");
+        assert_eq!(sink.len().await, 2);
+        let events = sink.snapshot().await;
+        match (&events[0], &events[1]) {
+            (StreamEvent::TextDelta { delta: a, .. }, StreamEvent::TextDelta { delta: b, .. }) => {
+                assert_eq!(a, "hello ");
+                assert_eq!(b, "world");
+            }
+            _ => panic!("unexpected event shape"),
+        }
+    }
+
+    #[tokio::test]
+    async fn buffer_sink_drain_clears_state() {
+        let sink = BufferSink::new();
+        sink.emit(sample_text_delta("t1", "x"))
+            .await
+            .expect("emit ok");
+        let drained = sink.drain().await;
+        assert_eq!(drained.len(), 1);
+        assert!(sink.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn fanout_emits_to_all_children_in_order() {
+        let a = Arc::new(BufferSink::new());
+        let b = Arc::new(BufferSink::new());
+        let fanout = FanoutSink::new(vec![a.clone(), b.clone()]);
+        assert_eq!(fanout.len(), 2);
+        assert!(!fanout.is_empty());
+
+        fanout
+            .emit(sample_text_delta("t1", "alpha"))
+            .await
+            .expect("emit ok");
+        fanout
+            .emit(sample_text_delta("t1", "beta"))
+            .await
+            .expect("emit ok");
+
+        assert_eq!(a.len().await, 2);
+        assert_eq!(b.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn fanout_short_circuits_on_first_error() {
+        let good = Arc::new(BufferSink::new());
+        let failing: Arc<dyn StreamSink> = Arc::new(FailingSink {
+            msg: "boom".to_string(),
+        });
+        let fanout = FanoutSink::new(vec![good.clone(), failing]);
+
+        let err = fanout
+            .emit(sample_text_delta("t1", "x"))
+            .await
+            .expect_err("should fail");
+        assert!(err.to_string().contains("boom"));
+        // good sink received the event before the failing sink errored
+        assert_eq!(good.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn empty_fanout_is_a_no_op() {
+        let fanout = FanoutSink::new(vec![]);
+        assert!(fanout.is_empty());
+        fanout
+            .emit(sample_text_delta("t1", "x"))
+            .await
+            .expect("empty fanout emits ok");
+    }
+
+    #[test]
+    fn stream_event_round_trips_through_json() {
+        // Snapshot the canonical JSON shape for a representative variant
+        // — this catches accidental rename / serde-rule changes.
+        let evt = StreamEvent::TextDelta {
+            id: "t1".into(),
+            delta: "hi".into(),
+        };
+        let json = serde_json::to_string(&evt).expect("serializable");
+        assert!(json.contains("\"event\":\"text_delta\""));
+        let back: StreamEvent = serde_json::from_str(&json).expect("deserializable");
+        match back {
+            StreamEvent::TextDelta { id, delta } => {
+                assert_eq!(id, "t1");
+                assert_eq!(delta, "hi");
+            }
+            _ => panic!("variant mismatch"),
+        }
+    }
+
+    #[test]
+    fn done_serializes_with_stop_reason() {
+        let evt = StreamEvent::Done {
+            stop_reason: StopReason::EndTurn,
+        };
+        let json = serde_json::to_string(&evt).expect("serializable");
+        assert!(json.contains("\"event\":\"done\""));
+        assert!(json.contains("end_turn"));
+    }
+
+    #[test]
+    fn vendor_event_round_trips_with_payload() {
+        let evt = StreamEvent::VendorEvent {
+            vendor: "anthropic".into(),
+            kind: "message_start".into(),
+            payload: serde_json::json!({ "id": "m_1" }),
+        };
+        let json = serde_json::to_string(&evt).expect("serializable");
+        let back: StreamEvent = serde_json::from_str(&json).expect("deserializable");
+        match back {
+            StreamEvent::VendorEvent {
+                vendor,
+                kind,
+                payload,
+            } => {
+                assert_eq!(vendor, "anthropic");
+                assert_eq!(kind, "message_start");
+                assert_eq!(payload["id"], "m_1");
+            }
+            _ => panic!("variant mismatch"),
+        }
+    }
+
+    #[test]
+    fn stop_reason_variants_are_distinguishable() {
+        let reasons = [
+            StopReason::EndTurn,
+            StopReason::MaxTokens,
+            StopReason::ToolUse,
+            StopReason::StopSequence,
+            StopReason::Refusal,
+            StopReason::Error,
+        ];
+        for r in reasons {
+            let json = serde_json::to_string(&r).expect("serializable");
+            let back: StopReason = serde_json::from_str(&json).expect("deserializable");
+            assert_eq!(r, back);
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-05-05-ergon-v0.1.md
+++ b/docs/superpowers/specs/2026-05-05-ergon-v0.1.md
@@ -1,0 +1,564 @@
+# Spec — Ergon v0.1
+
+**Date**: 2026-05-05
+**Status**: Ready to file (open questions §8 resolved during impl)
+**Owner**: harness layer (`crates/ergon/`) — new crate
+**Type**: design-spec
+**Target release**: life v0.6 / ergon v0.1
+**Linear**: project "Ergon — Agent Harness Primitive" (BRO-ergon-v0.1)
+**Supersedes**: nothing for v0.1; deprecates `arcan-harness` from v0.4 (separate spec at that time)
+**Related**:
+- `core/life/docs/superpowers/specs/2026-04-25-soma-spec-c-m0.md`
+- `core/life/docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md`
+
+## 0. Purpose (one sentence — the whole spec is governed by this)
+
+**Ergon is Life's agent-harness primitive: the trait set that lets a Broomva developer write a `Workflow` in Rust whose deterministic outer body orchestrates autonomous inner LLM steps, integrated end-to-end with the Life substrate (praxis tools, lago events, anima identity, autonomic budgets, nous scoring, vigil traces, lifegw delivery).**
+
+If a feature does not serve that sentence, it does not go in this spec.
+
+## 1. Scope
+
+### 1.1 In scope (v0.1)
+
+- New crate `core/life/crates/ergon/` with the public traits and types listed in §3.
+- Adapter inside `core/life/crates/arcan/src/agent_kind/ergon.rs` (~60 LOC) registering `ErgonAgentKind<W>` as an arcan `AgentKind`.
+- Route inside `core/life/crates/lifed/src/route/ergon.rs` (~200 LOC) exposing `Agent.StreamSession` for ergon workflows.
+- Migration of `examples/bookkeeping-judge` from `core/bellows/` to `core/life/apps/bookkeeping-judge/` re-implemented on ergon. Validates the surface against a real production workflow (it's already shipped on Bellows scoring the latest `research/notes/*-raw.md` files correctly).
+
+### 1.2 Out of scope (deferred)
+
+- `ergon-macros` (proc-macros for `#[workflow]`, `#[step]`, `#[tool]`). Defer until ≥3 workflows in production prove the boilerplate is worth eliminating.
+- Subagent / handoff (`ctx.subagent(workflow, input)`). Defer to v0.2; pneuma will likely be the right home anyway.
+- Reconstruct API (`WorkflowExecutor::resume_from_event(seq_no)`). Surface stays clean, impl deferred to v0.2.
+- Hashline editing as a higher-level primitive. v0.1 exposes `StepCtx::runtime` for direct delegation; no abstraction.
+- Vendor-builtin tools (Anthropic web_search, OpenAI code_interpreter). v0.1 supports only praxis-defined tools.
+- Approval / human-in-the-loop hook UI. The hook surface supports it; the UI is lifegw's concern, not ergon's.
+- arcan-harness retirement. Ergon v0.1 ships **alongside** arcan-harness; deprecation is a separate spec at v0.4.
+
+## 2. Layered position
+
+LOCKED:
+
+```
+Layer 4 — Life (Agent OS substrate)
+Layer 3 — arcan (runtime daemon, OperatingMode FSM, capability gating, soul attestation)
+Layer 2 — ergon (HARNESS — owned by this spec)
+Layer 1 — arcan-provider (model wire connectors, multi-vendor)
+Layer 0 — model (Anthropic / OpenAI / Bedrock / etc.)
+```
+
+Ergon is Layer 2. It is the harness. `arcan-harness` (the existing Life crate) is also at Layer 2 today; ergon supersedes it gradually per §10.
+
+**Naming rationale**: `ergon` (Greek *ἔργον*, work / function / characteristic activity). Pairs philosophically with `praxis` (Greek *πρᾶξις*, doing) and `nous` (Greek *νοῦς*, mind). Three-way semantic fit: nous selects → praxis does → ergon is the work performed. Short (5 letters), distinctive, no namespace collision in Rust crates land. Backup name: `hexis` (Greek *ἕξις*, disposition).
+
+## 3. Public API — locked
+
+### 3.1 Crate manifest
+
+```toml
+[package]
+name        = "ergon"
+description = "Life's agent-harness primitive: deterministic workflows orchestrating autonomous LLM steps."
+version      = { workspace = true }
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = "Apache-2.0"
+
+[dependencies]
+aios-protocol     = { workspace = true }
+praxis-core       = { workspace = true }
+praxis-skills     = { workspace = true }
+arcan-core        = { workspace = true }
+arcan-provider    = { workspace = true }
+anima             = { workspace = true }
+autonomic         = { workspace = true }
+nous              = { workspace = true }
+vigil             = { workspace = true }
+lago-journal      = { workspace = true }
+async-trait       = { workspace = true }
+serde             = { workspace = true }
+serde_json        = { workspace = true }
+thiserror         = { workspace = true }
+tokio             = { workspace = true, features = ["sync", "macros"] }
+tracing           = { workspace = true }
+ulid              = { workspace = true, features = ["serde"] }
+futures           = { workspace = true }
+blake3            = { workspace = true }   # for hashline integration
+
+[dev-dependencies]
+insta             = { workspace = true }
+wiremock          = { workspace = true }
+tokio-test        = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+### 3.2 Module layout
+
+```
+core/life/crates/ergon/src/
+├── lib.rs              # re-exports
+├── error.rs            # ErgonError, Result
+├── workflow.rs         # Workflow trait, WorkflowExecutor
+├── step.rs             # Step trait, StepCtx struct, InferenceRequest
+├── hook.rs             # Hook trait, HookCtx, outcomes, HookRegistry
+├── role.rs             # Role, RoleScope, Role::merge
+├── stream.rs           # StreamEvent, StreamSink, default sinks
+├── attestation.rs      # AnimaAttestHook (auto-registered)
+├── budget.rs           # AutonomicBudgetHook (auto-registered)
+├── score.rs            # NousScoreHook (auto-registered)
+└── capability.rs       # PraxisCapabilityHook (auto-registered)
+```
+
+Eight active modules (plus lib.rs and error.rs). ~1500 LOC total in one crate.
+
+### 3.3 Workflow trait (the user-implementation surface)
+
+```rust
+#[async_trait]
+pub trait Workflow: Send + Sync + 'static {
+    type Input: for<'de> serde::Deserialize<'de> + Send;
+    type Output: serde::Serialize + Send;
+
+    fn name(&self) -> &str;
+
+    /// Workflow-default role overlay. Lowest precedence; merged with
+    /// session and call roles via Role::merge.
+    fn role(&self) -> Role { Role::default() }
+
+    /// Skills the workflow may consult. Default: empty.
+    /// Reuses `praxis_skills::SkillSet` directly — no new abstraction.
+    fn skills(&self) -> &dyn praxis_skills::SkillSet {
+        &praxis_skills::EmptySkillSet
+    }
+
+    /// Tools the workflow exposes to the inner model loop.
+    /// Reuses `praxis_core::Tool` directly.
+    fn tools(&self) -> Vec<std::sync::Arc<dyn praxis_core::Tool>> { vec![] }
+
+    /// Sandbox policy for tool execution. Reuses praxis::SandboxPolicy.
+    fn sandbox_policy(&self) -> std::sync::Arc<praxis_core::SandboxPolicy>;
+
+    /// The deterministic orchestration body. Inside, the user calls
+    /// `ctx.step(...)` or `ctx.run_inference_streaming(...)` to delegate
+    /// autonomous work.
+    async fn execute(
+        &self,
+        ctx: &mut StepCtx<'_>,
+        input: Self::Input,
+    ) -> Result<Self::Output>;
+}
+```
+
+### 3.4 StepCtx (the autonomous-step boundary)
+
+```rust
+pub struct StepCtx<'a> {
+    pub session_id:    SessionId,                              // ULID
+    pub workflow_name: &'a str,
+    pub provider:      Arc<dyn arcan_provider::Provider>,
+    pub tools:         Arc<dyn praxis_core::ToolRegistry>,
+    pub sandbox:       Arc<praxis_core::SandboxPolicy>,
+    pub journal:       Arc<dyn lago_journal::Journal>,
+    pub homeostasis:   Arc<autonomic::HomeostaticState>,
+    pub soul:          Arc<anima::SoulProfile>,
+    pub skills:        &'a dyn praxis_skills::SkillSet,
+    pub hooks:         Arc<HookRegistry>,
+    pub sink:          Arc<dyn StreamSink>,
+    pub trace:         tracing::Span,
+
+    /// Direct handle to the underlying runtime (today: arcan) for
+    /// primitives ergon doesn't abstract (hashline editing,
+    /// OperatingMode introspection, etc.). Future runtimes implement
+    /// the same handle trait.
+    pub runtime:       Arc<dyn ergon::RuntimeHandle>,
+}
+
+impl StepCtx<'_> {
+    pub async fn step<S: Step + ?Sized>(
+        &mut self,
+        s: &S,
+        input: S::Input,
+    ) -> Result<S::Output>;
+
+    /// Drive the autonomous loop with native Life integration.
+    /// - Each token streamed → `self.sink` (which fans to lago + vigil + lifegw)
+    /// - Each tool call → praxis ToolRegistry + capability check
+    /// - Each turn → autonomic budget gate + nous scoring
+    /// - Workflow start/end → anima attestation
+    pub async fn run_inference_streaming(
+        &mut self,
+        req: &InferenceRequest,
+    ) -> Result<praxis_core::Message>;
+}
+```
+
+### 3.5 Step trait
+
+```rust
+#[async_trait]
+pub trait Step: Send + Sync {
+    type Input: Send;
+    type Output: Send;
+    fn name(&self) -> &str;
+    async fn run(
+        &self,
+        ctx: &mut StepCtx<'_>,
+        input: Self::Input,
+    ) -> Result<Self::Output>;
+}
+```
+
+### 3.6 InferenceRequest builder
+
+```rust
+#[derive(Debug, Clone)]
+pub struct InferenceRequest {
+    pub model:        String,
+    pub role:         Option<Role>,
+    pub max_tokens:   Option<u32>,
+    pub temperature:  Option<f32>,
+    pub stop:         Vec<String>,
+    pub max_turns:    u32,
+}
+
+pub const DEFAULT_INFERENCE_MAX_TURNS: u32 = 16;
+```
+
+Builder methods: `new(model)`, `with_role`, `with_max_tokens`, `with_temperature`, `with_max_turns`, `with_stop`.
+
+### 3.7 Hook (lifecycle extension)
+
+Same shape as Bellows' hook trait — 8 events × 3 outcome types. Borrowed unchanged.
+
+```rust
+#[async_trait]
+pub trait Hook: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn on_workflow_start(&self, _ctx: &HookCtx<'_>) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_workflow_end(&self, _ctx: &HookCtx<'_>, _ok: bool) -> Result<HookOutcome>;
+    async fn on_step_start   (&self, _ctx: &HookCtx<'_>, _name: &str) -> Result<HookOutcome>;
+    async fn on_step_end     (&self, _ctx: &HookCtx<'_>, _name: &str, _ok: bool) -> Result<HookOutcome>;
+    async fn on_pre_inference(&self, _ctx: &HookCtx<'_>, _req: &mut ModelRequest) -> Result<InferenceHookOutcome>;
+    async fn on_post_inference(&self, _ctx: &HookCtx<'_>, _resp: &ModelResponse) -> Result<HookOutcome>;
+    async fn on_pre_tool_use (&self, _ctx: &HookCtx<'_>, _call: &mut ToolCall) -> Result<ToolHookOutcome>;
+    async fn on_post_tool_use(&self, _ctx: &HookCtx<'_>, _call: &ToolCall, _result: &mut ToolResult) -> Result<HookOutcome>;
+}
+
+pub enum HookOutcome           { Continue, Deny(String) }
+pub enum ToolHookOutcome       { Continue, Deny(String), Stub(serde_json::Value) }
+pub enum InferenceHookOutcome  { Continue, Deny(String), Stub(praxis_core::Message) }
+```
+
+### 3.8 Auto-registered hooks (the Life-native superpowers)
+
+LOCKED: every `WorkflowExecutor::run` registers these in this order BEFORE any user-supplied hooks:
+
+```rust
+HookRegistry::default()
+    .with(PraxisCapabilityHook::new(runtime.aios_caps()))   // pre-tool: aiOS Capability check
+    .with(AutonomicBudgetHook::new(autonomic))              // pre-inference: budget gate
+    .with(NousScoreHook::new(nous))                         // post-inference: metacognitive score
+    .with(AnimaAttestHook::new(anima))                      // workflow-start/end: SoulProfile attest
+    // user hooks appended after
+```
+
+**Ordering rule**: auto-registered hooks fire FIRST. If a user hook denies after an auto-hook approved, the deny still wins. Auto-hooks fire first to short-circuit Life-policy-violating runs as cheaply as possible.
+
+**Opt-out**: `WorkflowExecutor::without_default_hooks()` for cheap/low-stakes workflows (per §8 Q3).
+
+### 3.9 StreamEvent canonical taxonomy
+
+LOCKED — borrowed from the Bellows wire-design spec, unchanged. `#[non_exhaustive]`.
+
+```rust
+pub enum StreamEvent {
+    SessionStart      { session_id: SessionId, model: String, provider: String },
+    TextStart         { id: String },
+    TextDelta         { id: String, delta: String },
+    TextEnd           { id: String },
+    ReasoningStart    { id: String, signed: bool },
+    ReasoningDelta    { id: String, delta: String },
+    ReasoningEnd      { id: String, redacted: bool },
+    ToolUseStart      { id: String, name: String },
+    ToolUseInputDelta { id: String, partial_args: String },
+    ToolUseEnd        { id: String, ok: bool, denied: bool, error: Option<String> },
+    StructuredStart   { id: String, schema_name: String },
+    StructuredDelta   { id: String, partial_json: String },
+    StructuredEnd     { id: String },
+    Citation          { id: String, source_id: String, span: (usize, usize) },
+    Source            { id: String, url: Option<String>, title: Option<String> },
+    Usage             { input: u32, output: u32, cached_input: Option<u32>, reasoning: Option<u32> },
+    Done              { stop_reason: StopReason },
+    Error             { message: String },
+    VendorEvent       { vendor: String, kind: String, payload: serde_json::Value },
+}
+```
+
+Variants are append-only after v1.0; never removed, never reordered semantically.
+
+### 3.10 StreamSink default impls
+
+LOCKED:
+
+```rust
+pub struct LagoSink   { journal: Arc<dyn lago_journal::Journal>, session_id: SessionId }
+pub struct VigilSink  { tracer: vigil::Tracer }
+pub struct LifegwSink { tx: tokio::sync::mpsc::Sender<StreamEvent> }
+pub struct FanoutSink { sinks: Vec<Arc<dyn StreamSink>> }
+pub struct BufferSink { events: Mutex<Vec<StreamEvent>> }   // for tests
+```
+
+Default sink for `WorkflowExecutor::run` invoked by arcan is:
+
+```rust
+FanoutSink::new(vec![
+    Arc::new(LagoSink::new(journal, session_id)),     // durable replay
+    Arc::new(VigilSink::new(tracer)),                  // OTel spans
+    Arc::new(LifegwSink::new(upstream_tx)),            // user-facing stream
+])
+```
+
+**Backpressure**: `LifegwSink` is bounded mpsc (capacity 64). Backpressure propagates: when the lifegw consumer is slow, the channel fills, the runtime stops emitting, the autonomous loop pauses on its next `sink.emit().await`. Upstream provider SSE call cancels via `tokio::select!` when the lifegw stream closes (client disconnect propagates back).
+
+### 3.11 Role
+
+Same as Bellows — call/session/agent precedence merged via `Role::merge`. Borrowed unchanged.
+
+```rust
+pub enum RoleScope { Call, Session, Agent }   // call > session > agent
+
+pub struct Role {
+    pub identity:     Option<String>,
+    pub instructions: Vec<String>,
+    pub scope:        RoleScope,
+}
+
+impl Role {
+    pub fn merge(agent: &Self, session: Option<&Self>, call: Option<&Self>) -> Self;
+    pub fn render(&self) -> Option<String>;   // produces the system-prompt string
+}
+```
+
+### 3.12 RuntimeHandle trait (per §8 Q2 + Q5)
+
+```rust
+/// The runtime handle ergon needs to talk to the layer below it.
+/// Today: implemented by arcan-core. Future: any other runtime.
+/// Narrowed projection of arcan-core::TickHandle exposing only what
+/// ergon-running workflows should call.
+pub trait RuntimeHandle: Send + Sync {
+    fn aios_caps(&self) -> Arc<dyn aios_protocol::CapabilityResolver>;
+    fn span(&self) -> &tracing::Span;
+    /// Edit a file via content-hash-addressed line replacement.
+    /// Multiple agents can edit the same file without stepping on each
+    /// other if they target distinct hashes.
+    async fn edit_hashline(
+        &self,
+        path: &str,
+        target_hash: blake3::Hash,
+        new_content: &str,
+    ) -> std::result::Result<HashlineEdit, RuntimeError>;
+    /// Workflow may inspect the operating mode it's running in.
+    fn operating_mode(&self) -> arcan_core::OperatingMode;
+}
+```
+
+This narrows the surface (per §8 Q2) so future non-arcan runtimes can implement it without exposing arcan internals.
+
+## 4. Delegation map (LOCKED — what ergon does NOT own)
+
+| Concern | Owned by | ergon's reference |
+|---|---|---|
+| Tool definition shape | `praxis-core::Tool` | `Workflow::tools()` returns `Vec<Arc<dyn praxis_core::Tool>>` directly |
+| Tool execution + sandboxing | `praxis::ToolRegistry` + `SandboxPolicy` + `FsPolicy` | `StepCtx::tools` is `Arc<dyn praxis_core::ToolRegistry>` |
+| Skill loading (Markdown frontmatter + body) | `praxis-skills` | `Workflow::skills()` returns `&dyn praxis_skills::SkillSet` |
+| Model providers (Anthropic, OpenAI, Bedrock, etc.) | `arcan-provider` | `StepCtx::provider` is `Arc<dyn arcan_provider::Provider>` |
+| Session persistence | `lago-journal` | sessions ARE event sequences; no separate `SessionStore` trait |
+| Identity / SoulProfile attestation | `anima` | `AnimaAttestHook` auto-registered |
+| Budget / homeostasis | `autonomic` | `AutonomicBudgetHook` auto-registered |
+| Metacognitive scoring | `nous` | `NousScoreHook` auto-registered |
+| OTel observability | `vigil` | `VigilSink` part of default fanout |
+| Capability tokens | `aios-protocol` | `PraxisCapabilityHook` auto-registered |
+| Hashline editing | `arcan-core` | `RuntimeHandle::edit_hashline` delegates |
+| Tick FSM / OperatingMode | `arcan-core` | arcan calls `WorkflowExecutor::run` inside Execute tick |
+| Multi-agent coordination / fields | `pneuma` / `plexus` | not ergon's concern |
+| Edge gateway (TLS, JWT, scope intersection) | `lifegw` | ergon emits typed events; lifegw owns wire bytes |
+| Facade / RPC routing | `lifed` | lifed routes `Agent.StreamSession` into ergon |
+| Wire format / SSE encoding | `lifegw` | not ergon's concern |
+| Input parsing / vendor compat | `lifegw` / `lifed` | not ergon's concern |
+| Reconstruct from journal | `lago-journal` | impl deferred to v0.2 — surface stays clean |
+| Payment / billing | `haima` | not ergon's concern |
+
+## 5. Lifecycle — request to response
+
+LOCKED:
+
+```text
+1.  Client → lifegw     TLS handshake; JWT mint w/ {agent:invoke, agent:stream}
+2.  lifegw → lifed      tonic-web Agent.StreamSession({agent: "X", input: {...}})
+3.  lifed → arcan       UDS RPC; arcan opens session
+4.  arcan               session_start: anima signs EventKind::SessionStart;
+                        lago appends; soma confirms durability
+5.  arcan               tick(Execute) — dispatches to ErgonAgentKind<W>::execute_tick
+6.  ergon adapter       builds StepCtx (60 LOC of glue per §6)
+7.  ergon adapter       calls workflow.execute(&mut ctx, typed_input)
+8.  workflow body       ctx.step(&MyStep, input) or ctx.run_inference_streaming(...)
+9.  ergon (in step.rs)  autonomous loop:
+                        for turn in 0..max_turns:
+                          - on_pre_inference hooks (auto: budget gate)
+                          - provider.stream(req) → consume StreamEvents
+                          - sink.emit(event) → fanout to lago/vigil/lifegw
+                          - on_post_inference hooks (auto: nous score)
+                          - if ToolUse: dispatch via praxis registry
+                                        with on_pre_tool_use / on_post_tool_use hooks
+                          - else: break
+10. ergon → arcan       return TickResult::Done { output }
+11. arcan               tick(Verify) → run nous evaluator; update AgentStateVector
+12. arcan               tick(Sleep)  → release session; anima signs SessionClose
+13. lifegw              close upstream stream; lago has full event sequence on disk
+```
+
+## 6. Composition with arcan — the adapter
+
+LOCKED. New file `core/life/crates/arcan/src/agent_kind/ergon.rs`:
+
+```rust
+pub struct ErgonAgentKind<W: ergon::Workflow> {
+    workflow: Arc<W>,
+}
+
+#[async_trait]
+impl<W: ergon::Workflow> arcan_core::AgentKind for ErgonAgentKind<W> {
+    async fn execute_tick(
+        &self,
+        tick: &mut arcan_core::TickCtx,
+        input: serde_json::Value,
+    ) -> arcan_core::Result<arcan_core::TickResult> {
+        let typed: W::Input = serde_json::from_value(input)
+            .map_err(arcan_core::Error::InvalidInput)?;
+
+        let mut ctx = ergon::StepCtx {
+            session_id:    tick.session_id(),
+            workflow_name: self.workflow.name(),
+            provider:      tick.provider(),
+            tools:         tick.tool_registry(),
+            sandbox:       self.workflow.sandbox_policy(),
+            journal:       tick.journal(),
+            homeostasis:   tick.autonomic_state(),
+            soul:          tick.soul_profile(),
+            skills:        self.workflow.skills(),
+            hooks:         ergon::HookRegistry::default()
+                              .with(ergon::PraxisCapabilityHook::new(tick.aios_caps()))
+                              .with(ergon::AutonomicBudgetHook::new(tick.autonomic()))
+                              .with(ergon::NousScoreHook::new(tick.nous()))
+                              .with(ergon::AnimaAttestHook::new(tick.anima())),
+            sink:          Arc::new(ergon::FanoutSink::new(vec![
+                              Arc::new(ergon::LagoSink::new(tick.journal(), tick.session_id())),
+                              Arc::new(ergon::VigilSink::new(tick.tracer())),
+                              Arc::new(ergon::LifegwSink::new(tick.upstream_tx())),
+                           ])),
+            trace:         tick.span(),
+            runtime:       tick.as_runtime_handle(),
+        };
+
+        let output = self.workflow.execute(&mut ctx, typed).await
+            .map_err(|e| arcan_core::Error::Workflow(e.to_string()))?;
+
+        Ok(arcan_core::TickResult::Done {
+            output: serde_json::to_value(output).map_err(arcan_core::Error::SerOutput)?,
+        })
+    }
+}
+```
+
+~60 LOC. Single file. Registers via arcan's existing `AgentKind` registry.
+
+## 7. Definition of done — v0.1 ships when
+
+ALL of the following are true:
+
+1. `cargo check -p ergon` passes.
+2. `cargo test -p ergon --all-targets` passes (~40 unit tests + 4 integration tests against an in-process arcan + lago).
+3. `cargo clippy -p ergon --all-targets -- -D warnings` passes.
+4. `cargo fmt -p ergon -- --check` passes.
+5. `core/life/apps/bookkeeping-judge/` exists, compiles, ships as a real ergon `Workflow` impl, scores ≥3 raw extracts correctly with reasoning that cites source content (matches the validation done against `2026-05-03-flue-research-raw.md`).
+6. arcan registers `ErgonAgentKind<W>` and the existing arcan integration tests still pass.
+7. lifed routes `Agent.StreamSession({agent: "bookkeeping.promotion-judge", ...})` through ergon end-to-end; SSE frames arrive at the test client matching the StreamEvent canonical taxonomy.
+8. `core/life/docs/architecture/ergon.md` exists and matches this spec verbatim (created during impl).
+9. CHANGELOG entry on the Life monorepo lists ergon v0.1.
+
+## 8. Open questions — proposed resolutions inline
+
+Five questions whose final answers fall out naturally during the first 200 LOC of `step.rs`. Proposals locked unless impl reveals a problem.
+
+1. **Q1.** Does `Workflow::sandbox_policy` return `Arc<praxis_core::SandboxPolicy>` or a builder closure that takes the session_id?
+   *Resolution: ship simpler `Arc<SandboxPolicy>` for v0.1; add per-session variant in v0.2 if needed.*
+
+2. **Q2.** `StepCtx::runtime` exposes a typed `RuntimeHandle` — narrow projection of arcan-core's `TickHandle`.
+   *Resolution: per §3.12 — define `ergon::RuntimeHandle` trait that exposes only what ergon-running workflows should call.*
+
+3. **Q3.** Should auto-registered hooks be configurable?
+   *Resolution: yes — add `WorkflowExecutor::without_default_hooks()` for explicit opt-out. Default is all-on.*
+
+4. **Q4.** Hook ordering between auto-registered and user-registered hooks — strictly auto-first?
+   *Resolution: strictly auto-first. Document the rule in the `Hook` trait docstring.*
+
+5. **Q5.** Naming the `StepCtx` field for runtime access.
+   *Resolution: `runtime` (abstract), since ergon shouldn't know it's specifically arcan in the trait surface (future runtimes might exist).*
+
+## 9. Validation criteria (post-ship)
+
+Within 2 weeks of v0.1 shipping, ergon must demonstrate:
+
+- The bookkeeping-judge port produces verdicts identical to the Bellows-shipped version when fed the same input. Behavior parity proves the abstraction is correct.
+- Streaming latency from upstream provider SSE → lifegw client SSE adds <50 ms p99 overhead (measured via vigil OTel spans).
+- A real session (e.g., a bookkeeping-judge run) is fully reconstructable from lago events alone (manual replay test).
+- No regression in arcan's existing 1077 tests.
+
+## 10. Migration plan — `arcan-harness` → `ergon`
+
+Out of scope for v0.1. Outline only:
+
+| Phase | Time | Action |
+|---|---|---|
+| ergon v0.1 | now | Ergon ships alongside arcan-harness. New agents on ergon, existing agents stay. |
+| ergon v0.2 | +1 month | Reconstruct API + hashline-editing helper land. Migrate 2–3 simpler arcan agents to ergon. |
+| ergon v0.3 | +2 months | OperatingMode-aware execution + cross-pollinate remaining arcan-harness primitives. Migrate complex agents. |
+| ergon v0.4 | +3 months | arcan-harness deprecation spec filed. arcan-core depends on ergon. |
+| ergon v1.0 / arcan-harness retired | +6 months | All Life agents on ergon. arcan-harness sunset. |
+
+Separate spec documents each phase transition.
+
+## 11. Versioning & stability
+
+- ergon v0.x: pre-1.0; minor versions may break trait surfaces with CHANGELOG migration notes.
+- ergon v1.0: trait surface frozen; `#[non_exhaustive]` on every public enum/struct that may grow.
+- StreamEvent variants are append-only after v1.0; never removed, never reordered semantically.
+
+## 12. Implementation work — ordered
+
+1. Create `core/life/crates/ergon/` with the locked Cargo.toml from §3.1 and module skeleton from §3.2.
+2. Land `error.rs`, `role.rs`, `stream.rs` first (no dependencies on the rest).
+3. Land `hook.rs` (depends on `stream.rs` for events the hooks observe).
+4. Land `step.rs` (depends on hook.rs and stream.rs; biggest single file, includes `RuntimeHandle` trait).
+5. Land `workflow.rs` + `WorkflowExecutor` (depends on step + hook).
+6. Land the four auto-hook impls in `attestation.rs`, `budget.rs`, `score.rs`, `capability.rs`.
+7. Land `core/life/crates/arcan/src/agent_kind/ergon.rs` adapter.
+8. Land `core/life/crates/lifed/src/route/ergon.rs`.
+9. Port bookkeeping-judge to `core/life/apps/bookkeeping-judge/` on ergon.
+10. CI gates + CHANGELOG + `core/life/docs/architecture/ergon.md`.
+
+Estimated effort: 2-3 weeks of focused work. Could be parallelized into 2 streams (core ergon trait surface vs. arcan/lifed integration) if dispatched as parallel teams once §8 questions are resolved.
+
+## 13. Sign-off
+
+Spec is **ready to file**. Five open questions in §8 have proposed resolutions; impl team can override any of them with a CHANGELOG note if implementation reveals a better answer.
+
+Filed at: `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md`.
+Linear project: "Ergon — Agent Harness Primitive" (Broomva team).


### PR DESCRIPTION
## Summary

First slice of **ergon** — Life's new Layer-2 agent-harness primitive. Lands the foundational layer (modules with no Life-substrate dependencies) per spec §12 work order, so the trait surface can stabilize before pulling in praxis / lago / vigil / anima / autonomic / nous / arcan deps in follow-up PRs.

- New crate `crates/ergon/ergon/` (Layer 2, between `arcan-provider` and `arcan` runtime)
- `error.rs` — `ErgonError` (10 variants, `#[non_exhaustive]`) + `Result` alias
- `role.rs` — `Role` + `RoleScope` with strict **call > session > agent** precedence, never persisted
- `stream.rs` — `StreamEvent` canonical taxonomy (18 variants, append-only after v1.0) + `StreamSink` trait + `BufferSink` + `FanoutSink`
- 25 unit tests pass, clippy clean, fmt clean

Spec: `docs/superpowers/specs/2026-05-05-ergon-v0.1.md` (also checked in this PR)
Linear umbrella: [BRO-994](https://linear.app/broomva/issue/BRO-994/ergon-v01-implementation-tracker)
Tickets closed by this PR: [BRO-995](https://linear.app/broomva/issue/BRO-995), [BRO-996](https://linear.app/broomva/issue/BRO-996)

## Why this slice scope

The full v0.1 is 10 spec-§12 tickets totaling ~1500 LOC + arcan adapter + lifed route + bookkeeping-judge port. This PR is intentionally the smallest reviewable slice: **modules with zero Life-substrate dependencies**. That keeps the foundational trait shape (Role precedence, StreamEvent taxonomy, error variants) reviewable in isolation before deeper integration work pulls in heavier deps.

## What is deliberately deferred (follow-up PRs)

Per spec §12:

- **BRO-997** `hook.rs` — depends on `praxis_core::Message`, `ToolCall`, `ToolResult`; type wiring lands alongside `step.rs` in BRO-998's PR.
- **BRO-998** `step.rs` (Step + StepCtx + InferenceRequest + RuntimeHandle) — the autonomous-loop body.
- **BRO-999** `workflow.rs` (Workflow + WorkflowExecutor)
- **BRO-1000** auto-hooks (`attestation.rs`, `budget.rs`, `score.rs`, `capability.rs`)
- **BRO-1001** arcan adapter at `crates/arcan/arcan/src/agent_kind/ergon.rs`
- **BRO-1002** lifed route at `crates/life-runtime/lifed/src/route/ergon.rs`
- **BRO-1003** bookkeeping-judge port to `apps/bookkeeping-judge/`
- **BRO-1004** CI gates + `docs/architecture/ergon.md`
- `LagoSink`, `VigilSink`, `LifegwSink` default sinks — pull in `lago-journal`, `life-vigil`, mpsc deps; deferred to BRO-998's PR.

## License deviation from spec

Spec §3.1 lists `license = "Apache-2.0"`. This crate uses `license.workspace = true` (= MIT) for monorepo coherence — life is MIT throughout. Documented in CHANGELOG.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p ergon --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments` — clean
- [x] `cargo test -p ergon --all-targets` — **25 passed; 0 failed**
- [x] No regression in workspace `cargo check`
- [ ] CI: format / lint / test-linux / test-macos / msrv all green

## Architecture (locked, spec §2)

```
Layer 4 — Life (Agent OS substrate)
Layer 3 — arcan (runtime daemon)
Layer 2 — ergon (HARNESS — this crate)
Layer 1 — arcan-provider (model wire connectors)
Layer 0 — model
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ergon crate as a foundational Layer-2 agent-harness primitive with error handling infrastructure, role/scope system for system prompt management, and stream event taxonomy with sink implementations.

* **Documentation**
  * Added comprehensive developer documentation and design specification for ergon crate.

* **Tests**
  * Included extensive test coverage with 25+ unit tests validating core functionality across error handling, role merging, and stream behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->