### PR TITLE
feat(ergon-life-hooks): four Life-native auto-hooks via adapter-trait pattern (BRO-1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 ## Unreleased
 
 ### Added
+- `ergon-life-hooks` — new sibling crate at `crates/ergon/ergon-life-hooks/`
+  housing the four "Life-native" auto-registered hooks (spec §3.8):
+  `PraxisCapabilityHook` (`on_pre_tool_use`),
+  `AutonomicBudgetHook` (`on_pre_inference`),
+  `NousScoreHook` (`on_post_inference`),
+  `AnimaAttestHook` (`on_workflow_start` / `on_workflow_end`).
+  Each hook is paired with a small **adapter trait**
+  (`CapabilityResolver`, `BudgetGate`, `ResponseScorer`, `SoulAttester`)
+  the hook consumes via `Arc<dyn _>` at construction. The arcan
+  adapter (BRO-1001) implements those traits against `aios_protocol::PolicySet`,
+  `autonomic::AutonomicGatingProfile`, `nous_core::NousEvaluator`,
+  and `anima_core::AgentSoul`.
+  Architectural win: the crate has **zero substrate dependencies** —
+  Cargo.toml lists only `ergon` + standard async/serde. Substrate dep
+  lives in BRO-1001's adapter, where it belongs. 15 unit tests across
+  the four modules (mocked adapters); `ergon` itself unchanged.
+  Failure semantics differ by hook: capability and budget denials are
+  hard veto (`Deny` outcome); score and attestation failures are
+  observe-only (`tracing::warn!` + `Continue`) — design rationale
+  documented in `crates/ergon/ergon-life-hooks/CLAUDE.md`.
+  Spec deviation: this crate replaces the spec's "auto-hooks live in
+  ergon itself" placement (§3.8). Reason: ergon stays vendor-neutral;
+  Life-specific governance hooks belong in their own crate so a future
+  ergon consumer (TS port, alternate agent OS) can ship its own
+  governance set without forking. (BRO-1000)
 - `ergon` — Layer-2 agent-harness primitive: hook lifecycle + wire types.
   Ships the second slice per spec §12: `model` module (provider-agnostic
   wire types — `Message` with block-structured content, `ContentBlock`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ergon-life-hooks"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "ergon",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "crates/praxis/praxis-tools",
     # Ergon — agent harness primitive
     "crates/ergon/ergon",
+    "crates/ergon/ergon-life-hooks",
     # Haima — finance
     "crates/haima/haima-api-schema",
     "crates/haima/haima-api",
@@ -225,6 +226,7 @@ praxis-skills = { path = "crates/praxis/praxis-skills", version = "0.3.0" }
 praxis-tools = { path = "crates/praxis/praxis-tools", version = "0.3.0" }
 # Ergon — agent harness primitive
 ergon = { path = "crates/ergon/ergon", version = "0.3.0" }
+ergon-life-hooks = { path = "crates/ergon/ergon-life-hooks", version = "0.3.0" }
 # Facade crates
 life-aios = { path = "crates/aios/life-aios", version = "0.3.0" }
 life-arcan = { path = "crates/arcan/life-arcan", version = "0.3.0", default-features = false }

--- a/crates/ergon/ergon-life-hooks/CLAUDE.md
+++ b/crates/ergon/ergon-life-hooks/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md — `ergon-life-hooks` crate
+
+> Instructions for AI agents working in this crate.
+> Last updated: 2026-05-06.
+
+## What this crate is
+
+**ergon-life-hooks** is the home of the four "Life-native" auto-registered
+hooks the spec (§3.8) calls for: `PraxisCapabilityHook`,
+`AutonomicBudgetHook`, `NousScoreHook`, and `AnimaAttestHook`. They're
+the bridge between Life's governance substrate (anima / autonomic /
+nous / aios capabilities) and ergon's harness loop.
+
+## Spec & tracker
+
+- Spec: `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md` §3.8
+- Linear: [BRO-1000](https://linear.app/broomva/issue/BRO-1000)
+- Umbrella: [BRO-994](https://linear.app/broomva/issue/BRO-994)
+
+## Core design — adapter-trait pattern
+
+Each hook has a paired **adapter trait** in the same module:
+
+| Hook | Adapter trait |
+|---|---|
+| `PraxisCapabilityHook` | `CapabilityResolver` |
+| `AutonomicBudgetHook`  | `BudgetGate` |
+| `NousScoreHook`        | `ResponseScorer` |
+| `AnimaAttestHook`      | `SoulAttester` |
+
+The hook takes `Arc<dyn AdapterTrait>` at construction. It uses **only
+the trait** in its body — never substrate types directly.
+
+The arcan adapter (BRO-1001) implements each adapter trait against the
+real substrate (`PolicySet`, `AutonomicGatingProfile`, `NousEvaluator`,
+`AgentSoul`). That keeps substrate dependencies confined to the
+adapter — this crate stays substrate-free.
+
+## Why this pattern
+
+- **Zero substrate deps in this crate.** The Cargo.toml depends on
+  `ergon` and standard async/serde — that's it. No `anima-core`, no
+  `autonomic-core`, no `nous-core`, no `aios-protocol-extension`.
+- **Full mockability.** Tests for each hook construct a small mock
+  adapter — no substrate ceremony required.
+- **Substrate API churn doesn't cascade.** When `anima-core` or
+  `autonomic-core` evolves, only the arcan adapter's adapter-trait
+  impls move. The hooks, their tests, ergon, and workflow authors are
+  all insulated.
+
+## Why a separate crate (not in `ergon`)?
+
+`ergon` is the vendor-neutral harness primitive. These four hooks
+encode **Life's** specific governance: which substrates exist, how
+they should fire, what failure semantics to use. A future consumer of
+`ergon` (e.g., a TS port, a different agent OS) would reasonably want
+its own auto-hook set.
+
+Keeping this in its own crate makes that boundary clean.
+
+## Failure semantics — three tiers
+
+Different hooks treat substrate errors differently:
+
+| Hook | Failure mode | Rationale |
+|---|---|---|
+| `PraxisCapabilityHook` | `Err(reason)` from resolver → `ToolHookOutcome::Deny` | Capability denial is policy; surface to model |
+| `AutonomicBudgetHook`  | `Err(reason)` from gate → `InferenceHookOutcome::Deny` | Budget exhaustion is a hard stop |
+| `NousScoreHook`        | `Err(reason)` from scorer → `tracing::warn!` + `Continue` | Scoring is observe-only in v0.1; failure is non-fatal |
+| `AnimaAttestHook`      | `Err(reason)` from attester → `tracing::warn!` + `Continue` | Attestation infrastructure unavailable shouldn't abort the workflow; observable via telemetry |
+
+If a deployment needs hard-fail-on-attestation, a custom hook can wrap
+`SoulAttester` and return `HookOutcome::Deny` on error. The
+crate-shipped `AnimaAttestHook` stays tolerant.
+
+## Hook event coverage
+
+All four hooks fire on **exactly one** lifecycle event:
+
+| Hook | Fires on |
+|---|---|
+| `PraxisCapabilityHook` | `on_pre_tool_use` |
+| `AutonomicBudgetHook`  | `on_pre_inference` |
+| `NousScoreHook`        | `on_post_inference` |
+| `AnimaAttestHook`      | `on_workflow_start` AND `on_workflow_end` |
+
+The other 7 events on each hook default to `Continue`. Each is wired
+explicitly (not via the trait's defaults) so the implementer's intent
+is visible in the source.
+
+## What this crate does NOT do
+
+- **Construct the hook registry**: that's the arcan adapter's job
+  (BRO-1001), since registry construction needs substrate handles.
+- **Implement the adapter traits**: again, BRO-1001.
+- **Define ordering**: the spec's "auto-hooks fire before user hooks"
+  constraint is enforced by the arcan adapter when it appends user
+  hooks to the registry it built from these four.
+
+## Useful commands
+
+```bash
+cargo check -p ergon-life-hooks
+cargo test  -p ergon-life-hooks --all-targets
+cargo clippy -p ergon-life-hooks --all-targets -- -D warnings
+cargo fmt -p ergon-life-hooks
+```
+
+## Don't
+
+- Do not pull in `anima-*` / `autonomic-*` / `nous-*` / `aios-*`
+  substrate crate deps. The whole point of the adapter-trait pattern
+  is to keep those out. If you need a new piece of substrate behaviour,
+  add it as a method on the relevant adapter trait.
+- Do not expand a hook to fire on multiple lifecycle events without
+  updating the table in the spec deviations section.
+- Do not change a hook's failure tier (e.g., make NousScoreHook
+  hard-fail) without updating the failure semantics table above and
+  the CHANGELOG.

--- a/crates/ergon/ergon-life-hooks/Cargo.toml
+++ b/crates/ergon/ergon-life-hooks/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ergon-life-hooks"
+description = "Life-native auto-registered hooks for the ergon harness — capability gating, budget enforcement, response scoring, soul attestation"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ergon.workspace = true
+async-trait.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }

--- a/crates/ergon/ergon-life-hooks/src/attestation.rs
+++ b/crates/ergon/ergon-life-hooks/src/attestation.rs
@@ -1,0 +1,238 @@
+//! Soul-attestation hook — signs `SessionStart` / `SessionEnd` events
+//! with the agent's identity material.
+//!
+//! Production wiring: the arcan adapter (BRO-1001) implements
+//! [`SoulAttester`] against `anima_core::AgentSoul` (or the
+//! anima-events sibling crate that owns the keypair). The signed events
+//! flow into lago via the journal.
+//!
+//! ## v0.1 scope: best-effort attestation
+//!
+//! Failures from the attester are logged (via `tracing::warn`) but do
+//! NOT abort the workflow. Rationale: a failed attestation should be
+//! observable via telemetry; refusing to run the workflow because
+//! attestation infrastructure is unavailable is a worse outcome than
+//! running it without a signature.
+//!
+//! If a deployment's threat model demands hard-failure on attestation
+//! errors, a custom hook can be added that wraps `SoulAttester` and
+//! returns `HookOutcome::Deny` on error. The default crate-shipped
+//! `AnimaAttestHook` stays tolerant.
+
+use async_trait::async_trait;
+use ergon::{
+    Hook, HookCtx, HookOutcome, InferenceHookOutcome, ModelRequest, ModelResponse, Result,
+    SessionId, ToolCall, ToolHookOutcome, ToolResult,
+};
+use std::sync::Arc;
+
+/// Adapter trait — implementer signs session-boundary events.
+///
+/// In production: implemented in the arcan adapter against
+/// `anima_core::AgentSoul`. The implementation owns the keypair and
+/// emits the signed event onto the lago journal.
+///
+/// Errors are non-fatal — see module docs.
+#[async_trait]
+pub trait SoulAttester: Send + Sync {
+    /// Sign a `SessionStart`-equivalent event for the given session.
+    async fn sign_session_start(
+        &self,
+        session_id: &SessionId,
+        workflow_name: &str,
+    ) -> std::result::Result<(), String>;
+
+    /// Sign a `SessionEnd`-equivalent event. `ok` indicates whether the
+    /// workflow completed successfully.
+    async fn sign_session_end(
+        &self,
+        session_id: &SessionId,
+        workflow_name: &str,
+        ok: bool,
+    ) -> std::result::Result<(), String>;
+}
+
+/// Hook that fires `on_workflow_start` and `on_workflow_end`, attesting
+/// each boundary via a [`SoulAttester`].
+pub struct AnimaAttestHook {
+    attester: Arc<dyn SoulAttester>,
+}
+
+impl AnimaAttestHook {
+    /// Construct from any [`SoulAttester`].
+    pub fn new(attester: Arc<dyn SoulAttester>) -> Self {
+        Self { attester }
+    }
+}
+
+#[async_trait]
+impl Hook for AnimaAttestHook {
+    fn name(&self) -> &str {
+        "anima-attest"
+    }
+
+    async fn on_workflow_start(&self, ctx: &HookCtx<'_>) -> Result<HookOutcome> {
+        if let Err(reason) = self
+            .attester
+            .sign_session_start(&ctx.session_id, ctx.workflow_name)
+            .await
+        {
+            tracing::warn!(
+                parent: ctx.trace,
+                workflow = ctx.workflow_name,
+                error = %reason,
+                "anima-attest sign_session_start failed (non-fatal)",
+            );
+        }
+        Ok(HookOutcome::Continue)
+    }
+
+    async fn on_workflow_end(&self, ctx: &HookCtx<'_>, ok: bool) -> Result<HookOutcome> {
+        if let Err(reason) = self
+            .attester
+            .sign_session_end(&ctx.session_id, ctx.workflow_name, ok)
+            .await
+        {
+            tracing::warn!(
+                parent: ctx.trace,
+                workflow = ctx.workflow_name,
+                ok,
+                error = %reason,
+                "anima-attest sign_session_end failed (non-fatal)",
+            );
+        }
+        Ok(HookOutcome::Continue)
+    }
+
+    async fn on_step_start(&self, _: &HookCtx<'_>, _: &str) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_end(&self, _: &HookCtx<'_>, _: &str, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_pre_inference(
+        &self,
+        _: &HookCtx<'_>,
+        _: &mut ModelRequest,
+    ) -> Result<InferenceHookOutcome> {
+        Ok(InferenceHookOutcome::Continue)
+    }
+    async fn on_post_inference(&self, _: &HookCtx<'_>, _: &ModelResponse) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_pre_tool_use(&self, _: &HookCtx<'_>, _: &mut ToolCall) -> Result<ToolHookOutcome> {
+        Ok(ToolHookOutcome::Continue)
+    }
+    async fn on_post_tool_use(
+        &self,
+        _: &HookCtx<'_>,
+        _: &ToolCall,
+        _: &mut ToolResult,
+    ) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct AttestRecorder {
+        events: Mutex<Vec<String>>,
+        fail_start: bool,
+        fail_end: bool,
+    }
+
+    #[async_trait]
+    impl SoulAttester for AttestRecorder {
+        async fn sign_session_start(
+            &self,
+            session_id: &SessionId,
+            workflow_name: &str,
+        ) -> std::result::Result<(), String> {
+            self.events
+                .lock()
+                .expect("lock")
+                .push(format!("start:{workflow_name}:{}", session_id.as_str()));
+            if self.fail_start {
+                Err("kms unreachable".into())
+            } else {
+                Ok(())
+            }
+        }
+        async fn sign_session_end(
+            &self,
+            session_id: &SessionId,
+            workflow_name: &str,
+            ok: bool,
+        ) -> std::result::Result<(), String> {
+            self.events
+                .lock()
+                .expect("lock")
+                .push(format!("end:{workflow_name}:{}:{ok}", session_id.as_str()));
+            if self.fail_end {
+                Err("kms unreachable".into())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
+        HookCtx::new(
+            SessionId::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            "wf",
+            span,
+        )
+    }
+
+    #[tokio::test]
+    async fn workflow_start_attests_via_adapter() {
+        let attester = Arc::new(AttestRecorder::default());
+        let hook = AnimaAttestHook::new(attester.clone() as Arc<dyn SoulAttester>);
+        let span = tracing::Span::current();
+        let outcome = hook.on_workflow_start(&ctx(&span)).await.unwrap();
+        assert!(matches!(outcome, HookOutcome::Continue));
+        let events = attester.events.lock().expect("lock").clone();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].starts_with("start:wf:"));
+    }
+
+    #[tokio::test]
+    async fn workflow_end_attests_with_success_flag() {
+        let attester = Arc::new(AttestRecorder::default());
+        let hook = AnimaAttestHook::new(attester.clone() as Arc<dyn SoulAttester>);
+        let span = tracing::Span::current();
+        let _ = hook.on_workflow_end(&ctx(&span), true).await.unwrap();
+        let _ = hook.on_workflow_end(&ctx(&span), false).await.unwrap();
+        let events = attester.events.lock().expect("lock").clone();
+        assert_eq!(events.len(), 2);
+        assert!(events[0].ends_with(":true"));
+        assert!(events[1].ends_with(":false"));
+    }
+
+    #[tokio::test]
+    async fn attester_failure_is_non_fatal() {
+        let attester = Arc::new(AttestRecorder {
+            fail_start: true,
+            fail_end: true,
+            ..Default::default()
+        });
+        let hook = AnimaAttestHook::new(attester as Arc<dyn SoulAttester>);
+        let span = tracing::Span::current();
+        // Both start and end MUST return Continue even when attestation fails.
+        let start = hook.on_workflow_start(&ctx(&span)).await.unwrap();
+        let end = hook.on_workflow_end(&ctx(&span), true).await.unwrap();
+        assert!(matches!(start, HookOutcome::Continue));
+        assert!(matches!(end, HookOutcome::Continue));
+    }
+
+    #[test]
+    fn name_is_kebab_case() {
+        let hook =
+            AnimaAttestHook::new(Arc::new(AttestRecorder::default()) as Arc<dyn SoulAttester>);
+        assert_eq!(hook.name(), "anima-attest");
+    }
+}

--- a/crates/ergon/ergon-life-hooks/src/budget.rs
+++ b/crates/ergon/ergon-life-hooks/src/budget.rs
@@ -1,0 +1,199 @@
+//! Budget-gating hook — vetoes inference calls when the agent's economic /
+//! cognitive / operational budget is exhausted.
+//!
+//! Production wiring: the arcan adapter (BRO-1001) implements
+//! [`BudgetGate`] against `autonomic::AutonomicGatingProfile`. The
+//! `economic` substate carries `allow_expensive_tools` and
+//! `max_tokens_next_turn`; `operational` and `cognitive` substates
+//! contribute mode-based gates.
+
+use async_trait::async_trait;
+use ergon::{
+    Hook, HookCtx, HookOutcome, InferenceHookOutcome, ModelRequest, ModelResponse, Result,
+    ToolCall, ToolHookOutcome, ToolResult,
+};
+use std::sync::Arc;
+
+/// Adapter trait — implementer answers "may this inference call proceed?".
+///
+/// In production: implemented in the arcan adapter against
+/// `autonomic::AutonomicGatingProfile`, surfacing budget rationale so
+/// the model can see *why* the call was denied.
+///
+/// The trait deliberately operates on a [`ModelRequest`] (not just a
+/// boolean) so a future implementation can also *narrow* the request —
+/// for example, downgrading `max_tokens` when the budget is tight, or
+/// stripping expensive tools — and return `Continue`. The hook re-checks
+/// after potential mutation.
+#[async_trait]
+pub trait BudgetGate: Send + Sync {
+    /// Decide whether the given inference call is allowed.
+    ///
+    /// Implementers **may mutate `req`** to narrow the call (e.g., reduce
+    /// `max_tokens`, filter `tools`) and return `Ok(())` to continue.
+    /// They may also return `Err(reason)` to deny outright; the reason is
+    /// surfaced as the [`InferenceHookOutcome::Deny`] message.
+    async fn allow_inference(&self, req: &mut ModelRequest) -> std::result::Result<(), String>;
+}
+
+/// Hook that fires `on_pre_inference` and consults a [`BudgetGate`]
+/// before allowing the provider call.
+pub struct AutonomicBudgetHook {
+    gate: Arc<dyn BudgetGate>,
+}
+
+impl AutonomicBudgetHook {
+    /// Construct from any [`BudgetGate`].
+    pub fn new(gate: Arc<dyn BudgetGate>) -> Self {
+        Self { gate }
+    }
+}
+
+#[async_trait]
+impl Hook for AutonomicBudgetHook {
+    fn name(&self) -> &str {
+        "autonomic-budget"
+    }
+
+    async fn on_pre_inference(
+        &self,
+        _ctx: &HookCtx<'_>,
+        req: &mut ModelRequest,
+    ) -> Result<InferenceHookOutcome> {
+        match self.gate.allow_inference(req).await {
+            Ok(()) => Ok(InferenceHookOutcome::Continue),
+            Err(reason) => Ok(InferenceHookOutcome::Deny(format!(
+                "budget exhausted: {reason}"
+            ))),
+        }
+    }
+
+    async fn on_workflow_start(&self, _: &HookCtx<'_>) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_workflow_end(&self, _: &HookCtx<'_>, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_start(&self, _: &HookCtx<'_>, _: &str) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_end(&self, _: &HookCtx<'_>, _: &str, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_post_inference(&self, _: &HookCtx<'_>, _: &ModelResponse) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_pre_tool_use(&self, _: &HookCtx<'_>, _: &mut ToolCall) -> Result<ToolHookOutcome> {
+        Ok(ToolHookOutcome::Continue)
+    }
+    async fn on_post_tool_use(
+        &self,
+        _: &HookCtx<'_>,
+        _: &ToolCall,
+        _: &mut ToolResult,
+    ) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ergon::{Message, SessionId};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Mock gate that toggles between allow/deny per the atomic flag.
+    struct ToggleGate {
+        deny: AtomicBool,
+        invocations: Mutex<u32>,
+    }
+
+    impl ToggleGate {
+        fn new(deny: bool) -> Self {
+            Self {
+                deny: AtomicBool::new(deny),
+                invocations: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BudgetGate for ToggleGate {
+        async fn allow_inference(
+            &self,
+            _req: &mut ModelRequest,
+        ) -> std::result::Result<(), String> {
+            *self.invocations.lock().expect("lock") += 1;
+            if self.deny.load(Ordering::Relaxed) {
+                Err("balance < 0".into())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Mutating gate that narrows max_tokens.
+    struct NarrowGate;
+
+    #[async_trait]
+    impl BudgetGate for NarrowGate {
+        async fn allow_inference(&self, req: &mut ModelRequest) -> std::result::Result<(), String> {
+            req.max_tokens = Some(256);
+            Ok(())
+        }
+    }
+
+    fn ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
+        HookCtx::new(
+            SessionId::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            "wf",
+            span,
+        )
+    }
+
+    #[tokio::test]
+    async fn allowed_inference_continues() {
+        let gate = Arc::new(ToggleGate::new(false));
+        let hook = AutonomicBudgetHook::new(gate.clone() as Arc<dyn BudgetGate>);
+        let span = tracing::Span::current();
+        let mut req = ModelRequest::new("m", vec![Message::user_text("hi")]);
+        let outcome = hook.on_pre_inference(&ctx(&span), &mut req).await.unwrap();
+        assert!(matches!(outcome, InferenceHookOutcome::Continue));
+        assert_eq!(*gate.invocations.lock().expect("lock"), 1);
+    }
+
+    #[tokio::test]
+    async fn exhausted_budget_returns_deny_with_reason() {
+        let gate = Arc::new(ToggleGate::new(true));
+        let hook = AutonomicBudgetHook::new(gate as Arc<dyn BudgetGate>);
+        let span = tracing::Span::current();
+        let mut req = ModelRequest::new("m", vec![Message::user_text("hi")]);
+        let outcome = hook.on_pre_inference(&ctx(&span), &mut req).await.unwrap();
+        match outcome {
+            InferenceHookOutcome::Deny(reason) => {
+                assert!(reason.contains("budget exhausted"));
+                assert!(reason.contains("balance"));
+            }
+            _ => panic!("expected Deny"),
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_can_mutate_request_in_place() {
+        let hook = AutonomicBudgetHook::new(Arc::new(NarrowGate) as Arc<dyn BudgetGate>);
+        let span = tracing::Span::current();
+        let mut req = ModelRequest::new("m", vec![Message::user_text("hi")]);
+        assert_eq!(req.max_tokens, None);
+        let outcome = hook.on_pre_inference(&ctx(&span), &mut req).await.unwrap();
+        assert!(matches!(outcome, InferenceHookOutcome::Continue));
+        assert_eq!(req.max_tokens, Some(256));
+    }
+
+    #[test]
+    fn name_is_kebab_case() {
+        let hook =
+            AutonomicBudgetHook::new(Arc::new(ToggleGate::new(false)) as Arc<dyn BudgetGate>);
+        assert_eq!(hook.name(), "autonomic-budget");
+    }
+}

--- a/crates/ergon/ergon-life-hooks/src/capability.rs
+++ b/crates/ergon/ergon-life-hooks/src/capability.rs
@@ -1,0 +1,193 @@
+//! Capability-gating hook — vetoes tool calls that exceed the agent's
+//! granted capabilities.
+//!
+//! Production wiring: the arcan adapter (BRO-1001) implements
+//! [`CapabilityResolver`] against `aios_protocol::PolicySet`, evaluating
+//! the call's required capability against the session's granted set.
+
+use async_trait::async_trait;
+use ergon::{
+    Hook, HookCtx, HookOutcome, InferenceHookOutcome, ModelRequest, ModelResponse, Result,
+    ToolCall, ToolHookOutcome, ToolResult,
+};
+use std::sync::Arc;
+
+/// Adapter trait — implementer answers "may this tool call proceed?".
+///
+/// In production: implemented in the arcan adapter against
+/// `aios_protocol::PolicySet`, walking `gate_capabilities` and matching
+/// the tool name plus its arguments to known capability patterns.
+///
+/// The trait is **deliberately small** — one async method. Substrate
+/// integration (PolicySet evaluation, capability glob matching, etc.)
+/// happens behind this seam, not in this crate.
+#[async_trait]
+pub trait CapabilityResolver: Send + Sync {
+    /// Decide whether the given tool invocation is allowed.
+    ///
+    /// - `Ok(())` ⇒ allow the call to dispatch.
+    /// - `Err(reason)` ⇒ deny; the reason is surfaced as the
+    ///   [`ToolHookOutcome::Deny`] message.
+    async fn can_invoke(
+        &self,
+        tool_name: &str,
+        input: &serde_json::Value,
+    ) -> std::result::Result<(), String>;
+}
+
+/// Hook that fires `on_pre_tool_use` and consults a [`CapabilityResolver`]
+/// before allowing dispatch.
+///
+/// On `Deny`, the autonomous loop synthesizes a model-visible error
+/// `ToolResult` (per `step.rs::dispatch_tool`), so the model sees the
+/// denial reason and can recover on the next turn rather than the
+/// workflow aborting.
+pub struct PraxisCapabilityHook {
+    resolver: Arc<dyn CapabilityResolver>,
+}
+
+impl PraxisCapabilityHook {
+    /// Construct from any [`CapabilityResolver`].
+    pub fn new(resolver: Arc<dyn CapabilityResolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl Hook for PraxisCapabilityHook {
+    fn name(&self) -> &str {
+        "praxis-capability"
+    }
+
+    async fn on_pre_tool_use(
+        &self,
+        _ctx: &HookCtx<'_>,
+        call: &mut ToolCall,
+    ) -> Result<ToolHookOutcome> {
+        match self.resolver.can_invoke(&call.name, &call.input).await {
+            Ok(()) => Ok(ToolHookOutcome::Continue),
+            Err(reason) => Ok(ToolHookOutcome::Deny(format!(
+                "capability denied for `{}`: {reason}",
+                call.name
+            ))),
+        }
+    }
+
+    // Other 7 events default to Continue.
+    async fn on_workflow_start(&self, _: &HookCtx<'_>) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_workflow_end(&self, _: &HookCtx<'_>, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_start(&self, _: &HookCtx<'_>, _: &str) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_end(&self, _: &HookCtx<'_>, _: &str, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_pre_inference(
+        &self,
+        _: &HookCtx<'_>,
+        _: &mut ModelRequest,
+    ) -> Result<InferenceHookOutcome> {
+        Ok(InferenceHookOutcome::Continue)
+    }
+    async fn on_post_inference(&self, _: &HookCtx<'_>, _: &ModelResponse) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_post_tool_use(
+        &self,
+        _: &HookCtx<'_>,
+        _: &ToolCall,
+        _: &mut ToolResult,
+    ) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ergon::SessionId;
+
+    /// Mock resolver that allows everything except the listed names.
+    struct DenyList(Vec<&'static str>);
+
+    #[async_trait]
+    impl CapabilityResolver for DenyList {
+        async fn can_invoke(
+            &self,
+            tool_name: &str,
+            _input: &serde_json::Value,
+        ) -> std::result::Result<(), String> {
+            if self.0.contains(&tool_name) {
+                Err(format!("`{tool_name}` is on the deny list"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
+        HookCtx::new(
+            SessionId::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            "wf",
+            span,
+        )
+    }
+
+    #[tokio::test]
+    async fn allowed_tool_continues() {
+        let hook = PraxisCapabilityHook::new(
+            Arc::new(DenyList(vec!["shell"])) as Arc<dyn CapabilityResolver>
+        );
+        let span = tracing::Span::current();
+        let hook_ctx = ctx(&span);
+        let mut call = ToolCall::new("c1", "fs_read", serde_json::json!({"path": "/x"}));
+        let outcome = hook.on_pre_tool_use(&hook_ctx, &mut call).await.unwrap();
+        assert!(matches!(outcome, ToolHookOutcome::Continue));
+    }
+
+    #[tokio::test]
+    async fn denied_tool_returns_deny_with_reason() {
+        let hook = PraxisCapabilityHook::new(
+            Arc::new(DenyList(vec!["shell"])) as Arc<dyn CapabilityResolver>
+        );
+        let span = tracing::Span::current();
+        let hook_ctx = ctx(&span);
+        let mut call = ToolCall::new("c1", "shell", serde_json::json!({"cmd": "rm -rf /"}));
+        let outcome = hook.on_pre_tool_use(&hook_ctx, &mut call).await.unwrap();
+        match outcome {
+            ToolHookOutcome::Deny(reason) => {
+                assert!(reason.contains("shell"));
+                assert!(reason.contains("deny list"));
+            }
+            _ => panic!("expected Deny"),
+        }
+    }
+
+    #[tokio::test]
+    async fn other_events_default_continue() {
+        let hook =
+            PraxisCapabilityHook::new(Arc::new(DenyList(vec![])) as Arc<dyn CapabilityResolver>);
+        let span = tracing::Span::current();
+        let hook_ctx = ctx(&span);
+        // Spot-check a few — exhaustive coverage is in ergon::hook tests.
+        assert!(matches!(
+            hook.on_workflow_start(&hook_ctx).await.unwrap(),
+            HookOutcome::Continue
+        ));
+        assert!(matches!(
+            hook.on_step_start(&hook_ctx, "s").await.unwrap(),
+            HookOutcome::Continue
+        ));
+    }
+
+    #[test]
+    fn name_is_kebab_case() {
+        let hook =
+            PraxisCapabilityHook::new(Arc::new(DenyList(vec![])) as Arc<dyn CapabilityResolver>);
+        assert_eq!(hook.name(), "praxis-capability");
+    }
+}

--- a/crates/ergon/ergon-life-hooks/src/lib.rs
+++ b/crates/ergon/ergon-life-hooks/src/lib.rs
@@ -1,0 +1,64 @@
+//! # ergon-life-hooks — Life-native auto-registered hooks
+//!
+//! This crate ships the four hooks the spec calls "auto-registered":
+//!
+//! | Hook | Event | Adapter trait | Implemented in |
+//! |---|---|---|---|
+//! | [`PraxisCapabilityHook`] | `on_pre_tool_use` | [`CapabilityResolver`] | arcan adapter (BRO-1001) against `aios_protocol::PolicySet` |
+//! | [`AutonomicBudgetHook`] | `on_pre_inference` | [`BudgetGate`]           | arcan adapter against `autonomic::AutonomicGatingProfile` |
+//! | [`NousScoreHook`]        | `on_post_inference`| [`ResponseScorer`]       | arcan adapter against `nous_core::NousEvaluator` |
+//! | [`AnimaAttestHook`]      | `on_workflow_start` / `on_workflow_end` | [`SoulAttester`] | arcan adapter against `anima_core::AgentSoul` (or its event-store sibling) |
+//!
+//! ## Design — the adapter-trait pattern
+//!
+//! Each hook takes an `Arc<dyn <Adapter>Trait>` injected at construction
+//! time. The adapter trait is **owned by this crate**, not by the substrate
+//! crate. This gives us:
+//!
+//! 1. **Zero substrate deps in this crate.** ergon-life-hooks compiles
+//!    against `ergon` only. It pulls in no `anima-core`, no
+//!    `autonomic-core`, no `nous-core`, no `aios-protocol-extension`
+//!    machinery. The substrate dep lives in BRO-1001 (the arcan adapter)
+//!    where it belongs.
+//!
+//! 2. **Full mockability.** Each hook is unit-testable with a tiny
+//!    `Adapter` mock. No substrate ceremony.
+//!
+//! 3. **Substrate API swaps don't cascade.** When `anima-core` changes its
+//!    signing API, only the arcan adapter's `SoulAttester` impl moves —
+//!    not the hook, not its tests, not ergon, not the workflow author.
+//!
+//! ## Why a separate crate (not in ergon)?
+//!
+//! `ergon` is the vendor-neutral harness primitive. These four hooks
+//! encode **Life's** specific governance choices: capability gating,
+//! budget enforcement, metacognitive scoring, soul attestation. A future
+//! consumer of ergon (e.g., a TS port, a different agent OS) would
+//! plausibly want a different set of auto-hooks. Keeping them in their
+//! own crate makes that clean.
+//!
+//! ## Status
+//!
+//! Linear: [BRO-1000](https://linear.app/broomva/issue/BRO-1000).
+//! Spec: `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md` §3.8.
+//!
+//! ## What this crate does NOT do
+//!
+//! - **Construct the auto-hook registry**: that's the arcan adapter's job
+//!   (BRO-1001), since registry construction needs substrate handles.
+//! - **Implement the adapter traits**: again, BRO-1001.
+//! - **Wire ordering**: the spec's "auto-hooks fire before user hooks"
+//!   ordering is enforced by the arcan adapter when it appends user
+//!   hooks to the registry it built from the auto-hooks here.
+
+#![doc(html_no_source)]
+
+pub mod attestation;
+pub mod budget;
+pub mod capability;
+pub mod score;
+
+pub use attestation::{AnimaAttestHook, SoulAttester};
+pub use budget::{AutonomicBudgetHook, BudgetGate};
+pub use capability::{CapabilityResolver, PraxisCapabilityHook};
+pub use score::{NousScoreHook, ResponseScorer};

--- a/crates/ergon/ergon-life-hooks/src/score.rs
+++ b/crates/ergon/ergon-life-hooks/src/score.rs
@@ -1,0 +1,201 @@
+//! Response-scoring hook — observes model output and records a score
+//! against the metacognitive evaluator.
+//!
+//! Production wiring: the arcan adapter (BRO-1001) implements
+//! [`ResponseScorer`] against `nous_core::NousEvaluator`, scoring each
+//! turn's response and persisting the result via lago events.
+//!
+//! ## v0.1 scope: observe-only
+//!
+//! `NousScoreHook` does **not** veto inference. It only observes. The
+//! response is scored, the score is recorded, and the outcome is always
+//! [`HookOutcome::Continue`]. Score-based denial is a v0.2 capability —
+//! it would require a richer return type from [`ResponseScorer`] (e.g.,
+//! a threshold + reason).
+
+use async_trait::async_trait;
+use ergon::{
+    Hook, HookCtx, HookOutcome, InferenceHookOutcome, ModelRequest, ModelResponse, Result,
+    ToolCall, ToolHookOutcome, ToolResult,
+};
+use std::sync::Arc;
+
+/// Adapter trait — implementer scores a model response.
+///
+/// In production: implemented in the arcan adapter against
+/// `nous_core::NousEvaluator`. The returned JSON value is the canonical
+/// score representation (e.g. `{"novelty": 2, "specificity": 3,
+/// "relevance": 3, "total": 8}`); ergon does not impose a schema.
+#[async_trait]
+pub trait ResponseScorer: Send + Sync {
+    /// Score the response. Errors are non-fatal; the hook records the
+    /// failure on the trace span and returns [`HookOutcome::Continue`].
+    async fn score(
+        &self,
+        response: &ModelResponse,
+    ) -> std::result::Result<serde_json::Value, String>;
+}
+
+/// Hook that fires `on_post_inference` and records a metacognitive
+/// score for the response.
+pub struct NousScoreHook {
+    scorer: Arc<dyn ResponseScorer>,
+}
+
+impl NousScoreHook {
+    /// Construct from any [`ResponseScorer`].
+    pub fn new(scorer: Arc<dyn ResponseScorer>) -> Self {
+        Self { scorer }
+    }
+}
+
+#[async_trait]
+impl Hook for NousScoreHook {
+    fn name(&self) -> &str {
+        "nous-score"
+    }
+
+    async fn on_post_inference(
+        &self,
+        ctx: &HookCtx<'_>,
+        response: &ModelResponse,
+    ) -> Result<HookOutcome> {
+        match self.scorer.score(response).await {
+            Ok(score) => {
+                tracing::info!(
+                    parent: ctx.trace,
+                    workflow = ctx.workflow_name,
+                    score = ?score,
+                    "nous-score recorded",
+                );
+            }
+            Err(reason) => {
+                tracing::warn!(
+                    parent: ctx.trace,
+                    workflow = ctx.workflow_name,
+                    error = %reason,
+                    "nous-score failed (non-fatal)",
+                );
+            }
+        }
+        Ok(HookOutcome::Continue)
+    }
+
+    async fn on_workflow_start(&self, _: &HookCtx<'_>) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_workflow_end(&self, _: &HookCtx<'_>, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_start(&self, _: &HookCtx<'_>, _: &str) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_step_end(&self, _: &HookCtx<'_>, _: &str, _: bool) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+    async fn on_pre_inference(
+        &self,
+        _: &HookCtx<'_>,
+        _: &mut ModelRequest,
+    ) -> Result<InferenceHookOutcome> {
+        Ok(InferenceHookOutcome::Continue)
+    }
+    async fn on_pre_tool_use(&self, _: &HookCtx<'_>, _: &mut ToolCall) -> Result<ToolHookOutcome> {
+        Ok(ToolHookOutcome::Continue)
+    }
+    async fn on_post_tool_use(
+        &self,
+        _: &HookCtx<'_>,
+        _: &ToolCall,
+        _: &mut ToolResult,
+    ) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ergon::{ContentBlock, SessionId, StopReason};
+    use std::sync::Mutex;
+
+    /// Mock scorer that records every call and returns a canned score.
+    struct RecorderScorer {
+        score: serde_json::Value,
+        calls: Mutex<u32>,
+    }
+
+    #[async_trait]
+    impl ResponseScorer for RecorderScorer {
+        async fn score(
+            &self,
+            _response: &ModelResponse,
+        ) -> std::result::Result<serde_json::Value, String> {
+            *self.calls.lock().expect("lock") += 1;
+            Ok(self.score.clone())
+        }
+    }
+
+    /// Mock scorer that always errors.
+    struct FailingScorer;
+
+    #[async_trait]
+    impl ResponseScorer for FailingScorer {
+        async fn score(
+            &self,
+            _response: &ModelResponse,
+        ) -> std::result::Result<serde_json::Value, String> {
+            Err("evaluator offline".into())
+        }
+    }
+
+    fn ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
+        HookCtx::new(
+            SessionId::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            "wf",
+            span,
+        )
+    }
+
+    fn sample_response() -> ModelResponse {
+        ModelResponse::new(vec![ContentBlock::text("hi")], StopReason::EndTurn)
+    }
+
+    #[tokio::test]
+    async fn successful_score_continues_and_invokes_scorer() {
+        let scorer = Arc::new(RecorderScorer {
+            score: serde_json::json!({"total": 8}),
+            calls: Mutex::new(0),
+        });
+        let hook = NousScoreHook::new(scorer.clone() as Arc<dyn ResponseScorer>);
+        let span = tracing::Span::current();
+        let outcome = hook
+            .on_post_inference(&ctx(&span), &sample_response())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, HookOutcome::Continue));
+        assert_eq!(*scorer.calls.lock().expect("lock"), 1);
+    }
+
+    #[tokio::test]
+    async fn scorer_failure_is_non_fatal_and_continues() {
+        let hook = NousScoreHook::new(Arc::new(FailingScorer) as Arc<dyn ResponseScorer>);
+        let span = tracing::Span::current();
+        let outcome = hook
+            .on_post_inference(&ctx(&span), &sample_response())
+            .await
+            .unwrap();
+        // Even when the scorer errors, the hook MUST return Continue —
+        // observability is observe-only in v0.1.
+        assert!(matches!(outcome, HookOutcome::Continue));
+    }
+
+    #[test]
+    fn name_is_kebab_case() {
+        let hook = NousScoreHook::new(Arc::new(RecorderScorer {
+            score: serde_json::json!(null),
+            calls: Mutex::new(0),
+        }) as Arc<dyn ResponseScorer>);
+        assert_eq!(hook.name(), "nous-score");
+    }
+}

--- a/crates/ergon/ergon/src/model.rs
+++ b/crates/ergon/ergon/src/model.rs
@@ -115,6 +115,11 @@ pub struct Message {
 }
 
 impl Message {
+    /// Construct a message with the given role and content blocks.
+    pub fn new(role: MessageRole, content: Vec<ContentBlock>) -> Self {
+        Self { role, content }
+    }
+
     /// Helper: a user message with a single text block.
     pub fn user_text(text: impl Into<String>) -> Self {
         Self {
@@ -323,6 +328,24 @@ pub struct ModelResponse {
 }
 
 impl ModelResponse {
+    /// Construct a response with the given content blocks and stop
+    /// reason. Defaults [`Usage`] to zeros — populate it via
+    /// [`Self::with_usage`] if needed.
+    pub fn new(content: Vec<ContentBlock>, stop_reason: StopReason) -> Self {
+        Self {
+            content,
+            stop_reason,
+            usage: Usage::default(),
+        }
+    }
+
+    /// Builder: attach token / cost accounting.
+    #[must_use]
+    pub fn with_usage(mut self, usage: Usage) -> Self {
+        self.usage = usage;
+        self
+    }
+
     /// Iterate over the response's tool-use blocks.
     pub fn tool_uses(&self) -> impl Iterator<Item = &ContentBlock> {
         self.content.iter().filter(|b| b.is_tool_use())


### PR DESCRIPTION
## Summary

New sibling crate \`crates/ergon/ergon-life-hooks/\` housing the four \"auto-registered\" hooks per spec §3.8. **Independent of #1165** (branches off main, no overlap).

- **`PraxisCapabilityHook`** + `CapabilityResolver` — gates tool calls
- **`AutonomicBudgetHook`** + `BudgetGate` — gates inference; gate can also narrow the request
- **`NousScoreHook`** + `ResponseScorer` — observe-only metacognitive scoring
- **`AnimaAttestHook`** + `SoulAttester` — signs `on_workflow_start` and `on_workflow_end`

15 new unit tests across the four modules. **Zero substrate dependencies in this crate** — adapter-trait pattern keeps anima/autonomic/nous/aios bindings in BRO-1001 (the arcan adapter).

Spec: \`core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md\` §3.8
Linear: [BRO-1000](https://linear.app/broomva/issue/BRO-1000). Umbrella: [BRO-994](https://linear.app/broomva/issue/BRO-994).

## Architectural decisions worth highlighting

### 1. Hooks live in their own crate, not in ergon

`ergon` is the vendor-neutral harness primitive. These four hooks encode **Life's** specific governance choices: which substrates exist (anima, autonomic, nous, aios caps), how they fire, what failure semantics they use. A future consumer of `ergon` (TS port, alternate agent OS) would reasonably want a different governance set. Splitting keeps that boundary clean.

### 2. Adapter-trait pattern keeps substrate deps in BRO-1001

Each hook takes \`Arc<dyn AdapterTrait>\` at construction. The adapter trait is **owned by ergon-life-hooks**, not by the substrate crates. The arcan adapter (BRO-1001) implements each adapter trait against the actual substrate type:

| Adapter trait | Implemented against (in BRO-1001) |
|---|---|
| \`CapabilityResolver\` | \`aios_protocol::PolicySet\` (gate_capabilities matching) |
| \`BudgetGate\`         | \`autonomic::AutonomicGatingProfile\` |
| \`ResponseScorer\`     | \`nous_core::NousEvaluator\` |
| \`SoulAttester\`       | \`anima_core::AgentSoul\` (or anima-events sibling that owns keypair) |

ergon-life-hooks's Cargo.toml lists ONLY \`ergon\` + standard async/serde. No substrate deps. Compiles, tests, and ships independently.

### 3. Failure tiers differ by hook

| Hook | Failure mode | Why |
|---|---|---|
| \`PraxisCapabilityHook\` | \`ToolHookOutcome::Deny\` | Capability denial is policy; surface to model |
| \`AutonomicBudgetHook\`  | \`InferenceHookOutcome::Deny\` | Budget exhaustion is hard stop |
| \`NousScoreHook\`        | \`tracing::warn!\` + \`Continue\` | Scoring is observe-only in v0.1 |
| \`AnimaAttestHook\`      | \`tracing::warn!\` + \`Continue\` | Attestation infra unavailable shouldn't abort workflow |

Documented at length in \`crates/ergon/ergon-life-hooks/CLAUDE.md\`.

## Bonus: ergon constructors

Adds \`ergon::Message::new(role, content)\` and \`ergon::ModelResponse::new(content, stop_reason)\` (+ \`with_usage\`) constructors. Both types are \`#[non_exhaustive]\` (set in BRO-997), so external crates couldn't construct them. ergon-life-hooks tests need to construct response values; the missing constructors were an oversight in BRO-997. Purely additive; ergon's 43 tests still pass.

## Why now (parallel to BRO-998 #1165)

Genuine independence — ergon-life-hooks uses only \`ergon::Hook\` + wire types from #1152 (already in main). It does NOT touch \`Step\` / \`StepCtx\` / \`Workflow\` from BRO-998 / BRO-999. Two PRs can ship in any order.

This is the canonical \"use parallel agents only when it improves throughput without creating coordination debt\" case — zero shared files between #1165 and this PR.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy -p ergon-life-hooks --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments\` clean
- [x] \`cargo test -p ergon-life-hooks --all-targets\` — **15 passed; 0 failed**
- [x] \`cargo test -p ergon --all-targets\` — 43 passed (no regression)
- [ ] CI: format / lint / msrv / test-linux / test-macos / build-release green

## What's next

| BRO | What | When |
|---|---|---|
| BRO-999 | \`workflow.rs\` (Workflow + WorkflowExecutor) + 3 substrate sinks | After #1165 merges |
| BRO-1001 | \`arcan/agent_kind/ergon.rs\` adapter — implements all four adapter traits + builds HookRegistry | After 999 + this |
| BRO-1002 | \`lifed/route/ergon.rs\` — Agent.StreamSession route | After 1001 |
| BRO-1003 | bookkeeping-judge port (parity test) | After 1002 |
| BRO-1004 | CI gates + docs/architecture/ergon.md | Final |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced ergon-life-hooks crate with four new lifecycle hooks: soul attestation for workflow events, budget enforcement for inference limits, capability resolution for tool access control, and response scoring for model outputs.
  * Enhanced model object creation with new constructors and builder methods for messages and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->