### PR TITLE
docs(architecture): canonical agent-harness layered runtime + correct §6/§10 of ergon spec (BRO-1001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+### Changed
+- **Architectural correction (docs only, no code)**: the framing in
+  `docs/superpowers/specs/2026-05-05-ergon-v0.1.md` §6 (Composition with
+  arcan) and §10 (Migration plan) was structurally wrong. Both sections
+  assumed ergon would replace `arcan-harness` as a parallel session-level
+  runtime via an `AgentKind` trait abstraction. Reality:
+  1. `arcan-harness` is a ~300 LOC tool/sandbox utility crate, not the
+     agent harness. The actual agent harness is a 7-layer runtime stack
+     across ~25 crates.
+  2. Ergon's `Workflow::execute()` is one async fn — it cannot replace
+     the long-horizon tick engine (`aios_runtime::KernelRuntime`)
+     without losing per-tick journal traceability that autonomic /
+     EGRI / branching depend on.
+  Corrected framing: ergon is **one shape of tick body** alongside the
+  existing direct-call tick body. Both compose with KernelRuntime; both
+  produce per-tick events; **neither replaces anything**. Documented
+  comprehensively in:
+  - `docs/architecture/agent-harness.md` — new canonical 7-layer
+    runtime architecture (didn't exist before)
+  - `docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` —
+    new corrected BRO-1001 design (supersedes §6 + §10 of the original
+    ergon spec)
+  - In-place SUPERSEDED markers on §6 and §10 of
+    `2026-05-05-ergon-v0.1.md`
+  - Updated `crates/ergon/ergon/CLAUDE.md` with the corrected
+    positioning
+  No ergon code changes. The trait surface, hook lifecycle, wire types,
+  auto-hooks, and stream sinks are all correct as-shipped — they're
+  precisely what a tick-body adapter needs. What changes is the
+  positioning of BRO-1001 (the integration adapter), which becomes
+  `arcan-ergon::run_workflow_as_tick(...)` rather than a session-level
+  `ErgonAgentKind`. (BRO-1001)
+
 ### Added
 - `ergon-life-hooks` — new sibling crate at `crates/ergon/ergon-life-hooks/`
   housing the four "Life-native" auto-registered hooks (spec §3.8):

--- a/crates/ergon/ergon/CLAUDE.md
+++ b/crates/ergon/ergon/CLAUDE.md
@@ -1,28 +1,49 @@
 # CLAUDE.md — `ergon` crate
 
 > Instructions for AI agents working in this crate.
-> Last updated: 2026-05-06.
+> Last updated: 2026-05-08.
 
 ## What this crate is
 
-**ergon** is Life's Layer-2 agent-harness primitive. The trait set that lets
-a Broomva developer write a `Workflow` in Rust whose deterministic outer body
-orchestrates autonomous inner LLM steps, integrated end-to-end with the Life
-substrate.
+**ergon** is the workflow primitive for Life's agent harness. It's a small
+trait crate (`Workflow`, `Step`, `StepCtx`, `Hook`, `StreamSink`,
+`InferenceRequest`) that a Broomva developer implements to express a
+**bounded multi-turn agent operation** as plain async Rust whose body
+delegates to autonomous model + tool calls.
 
-**Layered position** (locked):
+A workflow is **not a long-horizon agent**. It is **one shape of tick
+body** (see `docs/architecture/agent-harness.md`): the kernel runs it as
+the contents of a single tick. The kernel still owns the agent loop;
+ergon just supplies a richer alternative to the existing single-call
+tick body.
+
+**Position in the harness stack** (canonical):
 
 ```
-Layer 4 — Life (Agent OS substrate)
-Layer 3 — arcan (runtime daemon)
-Layer 2 — ergon (HARNESS — this crate)
-Layer 1 — arcan-provider (model wire connectors)
-Layer 0 — model
+L5 — Session orchestration (arcand::ConsciousnessActor)
+L4 — Tick engine (aios_runtime::KernelRuntime)
+L3.5 — Tick body — direct OR ergon::Workflow      ← THIS CRATE supplies the workflow shape
+L3 — Port traits (aios-runtime)
+L2 — Substrate adapters (incl. arcan-ergon)
+L1 — Substrate primitives (lago, praxis, anima, ...)
+L0 — Kernel contract (aios-protocol)
 ```
+
+See `docs/architecture/agent-harness.md` for the full 7-layer stack and
+the two scopes of the agent loop (outer / session vs inner / tick).
+
+**Critical invariant**: ergon does NOT replace `KernelRuntime`. It does
+NOT replace `arcan-harness` (which isn't the harness anyway — it's a
+~300 LOC utility crate). It does NOT compete with the tick engine.
+Workflows are **bounded operations that run inside one kernel tick**.
 
 ## Spec & tracker
 
 - Spec: `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md`
+  (§§0-5, 7-9, 11-13 valid; §6 + §10 superseded)
+- Adapter spec: `core/life/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md`
+  (the corrected §6 + §10 framing)
+- Architecture: `core/life/docs/architecture/agent-harness.md`
 - Linear umbrella: BRO-994 — https://linear.app/broomva/issue/BRO-994
 
 ## Status (2026-05-06)

--- a/docs/architecture/agent-harness.md
+++ b/docs/architecture/agent-harness.md
@@ -310,6 +310,140 @@ tick. Replay can choose:
 - Workflow-level granularity: re-stream every `TextDelta`,
   `ToolUseStart`, etc. (this is for inner-loop debugging)
 
+## Where evaluators live (nous metacognition)
+
+Nous evaluators come in two shapes that map cleanly onto the two scopes
+above. **Choosing the right shape per evaluator is an architectural
+decision, not a stylistic one** — it determines whether the evaluator
+gets per-tick traceability, autonomic gating, anima attestation, and
+spec-E silicon routing for free.
+
+### Scope A — Inline scoring (per-turn hook)
+
+For evaluators that score **a single model response** with cheap
+deterministic logic (token counts, structural checks) or with a single
+LLM-as-judge call: stay as a `nous_core::NousEvaluator` direct impl,
+invoked through the `NousScoreHook` (`crates/ergon/ergon-life-hooks/`)
+that fires on every `on_post_inference` event inside any workflow.
+
+```text
+inside Workflow::execute:
+  ctx.run_inference_streaming(req)
+    └── provider.stream(...)
+         ├── tokens stream out
+         └── on_post_inference fires
+               └── NousScoreHook
+                     └── adapter calls nous_core::NousEvaluator
+                           └── score recorded as tracing event +
+                               (future) lago Custom event
+```
+
+Failure semantics: **observe-only**. A failing scorer logs a warning
+and the workflow continues — score availability is not a precondition
+for the agent's progress.
+
+### Scope B — Block-level evaluation (workflow-bodied tick)
+
+For evaluators that need the **autonomous loop** — multi-step LLM
+reasoning, tool dispatch, structured output parsing, journal lookups —
+implement them as `ergon::Workflow` impls and run them as workflow
+ticks. They become first-class agents:
+
+| Evaluator profile | Right home |
+|---|---|
+| Pure heuristic (token count, regex, deterministic metric) | `nous_core::NousEvaluator` impl in `nous-heuristics` |
+| Single rule check ("did response cite ≥1 source?") | `nous_core::NousEvaluator` impl in `nous-judge` |
+| LLM-as-judge with structured verdict (novelty + specificity + relevance) | `ergon::Workflow` in `apps/<judge-name>/` |
+| Multi-step LLM evaluation with tool dispatch (read PR, run tests, score code) | `ergon::Workflow` |
+| Cross-session pattern detection over the journal | `ergon::Workflow` running in a `Verify` tick |
+
+The dividing line: **does the evaluator need the autonomous loop?**
+If yes, it's a workflow. If no, it's a direct `NousEvaluator` impl.
+
+### Verify-mode composition (deferred enhancement)
+
+The kernel's `OperatingMode::Verify` is the seam where post-execution
+evaluation runs. Today it dispatches via direct nous calls. Once
+workflow-bodied ticks ship (BRO-1001), Verify mode can dispatch
+naturally to a workflow tick body whose workflow is itself a nous
+evaluator:
+
+```text
+KernelRuntime in mode=Execute
+  └── tick N: workflow body produces a verdict, writes a file, etc.
+       └── TickCompleted{mode_after=Verify}
+KernelRuntime in mode=Verify
+  └── tick N+1: kind=Workflow{name="session.evaluator", input=<prior>}
+       └── arcan-ergon::run_workflow_as_tick(...)
+            └── nous-evaluator workflow runs as the tick body
+            └── produces score, decision
+       └── TickCompleted{output=score, mode_after=Sleep|Recover|Execute}
+```
+
+Verify mode becomes "run the verify-workflow." The evaluator is just
+another workflow. Everything composes:
+
+- The Verify tick produces kernel-typed `TickStarted{Verify}` /
+  `TickCompleted` events
+- The evaluator workflow's internal stream events nest under that
+  tick's `run_id`
+- `AnimaAttestHook` signs the start/end of the evaluator workflow
+- `AutonomicBudgetHook` gates model calls inside it
+- The outcome feeds back into `AgentStateVector` exactly as today's
+  Verify-mode evaluations do
+
+This is **not v0.1 scope**. v0.1 lands the workflow-tick mechanism
+(BRO-1001 + BRO-1001b) and the first concrete evaluator workflow
+(`bookkeeping-judge`, BRO-1003). Verify-mode dispatch becomes the
+natural next composition once those prove the pattern.
+
+### Optional `WorkflowAsNousEvaluator` adapter
+
+A future ~50 LOC adapter could wrap any `ergon::Workflow` as a
+`nous_core::NousEvaluator` so existing nous-routing code
+(`EvaluatorRegistry`, `NousJudge` selection) can dispatch to workflows
+through the existing trait surface:
+
+```rust
+// crates/nous/nous-ergon/ (potential, not committed)
+pub struct WorkflowAsNousEvaluator<W: ergon::Workflow> {
+    executor: ergon::WorkflowExecutor<W>,
+    // + adapter context for building StepCtx
+}
+
+impl<W: ergon::Workflow> nous_core::NousEvaluator for WorkflowAsNousEvaluator<W> {
+    async fn evaluate(&self, ctx: &EvalContext) -> NousResult<EvalResult> {
+        // marshal EvalContext → W::Input, call executor.run, marshal
+        // W::Output → EvalResult
+    }
+}
+```
+
+Cheap composition. Write it when the first workflow needs to be
+addressable through nous-routing. Not before.
+
+### What this gives us
+
+Three architectural wins land at once when nous metacognition runs as
+workflows:
+
+1. **Per-tick traceability for evaluations.** Replay shows "evaluated
+   session S1 at tick R7-T12; evaluator did 3 model calls; scored
+   7/9; decision=promote." Direct-call evaluators today don't get
+   this.
+2. **Composable evaluators.** A meta-evaluator workflow can call
+   sub-evaluator workflows. "Score this extract on novelty / specificity
+   / relevance" becomes three child workflows whose outputs an
+   aggregator workflow combines. No custom orchestration.
+3. **Substrate inheritance.** Evaluators automatically get anima
+   attestation, autonomic gating, lago durability, vigil tracing, and
+   (when Spec E ships) silicon routing — without writing any
+   integration code.
+
+The deeper truth: **nous evaluators that need to think (vs just
+compute) are themselves agents**. Treating them as workflows isn't a
+shoehorn — it's recognizing what they always were.
+
 ## Bottom-up dependency chain
 
 Each layer depends only on layers below it. **No backwards arrows. No

--- a/docs/architecture/agent-harness.md
+++ b/docs/architecture/agent-harness.md
@@ -1,0 +1,556 @@
+# Agent Harness — Layered Runtime Architecture
+
+**Date**: 2026-05-08
+**Status**: Canonical — supersedes the §6/§10 framing of `2026-05-05-ergon-v0.1.md`
+**Owner**: Life kernel + ergon teams jointly
+**Related specs**:
+- `docs/superpowers/specs/2026-05-05-ergon-v0.1.md` (workflow trait crate)
+- `docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` (corrected adapter design)
+- `docs/superpowers/specs/2026-05-07-spec-e-agent-loop-compute-contract.md` (silicon contract, BRO-1019)
+
+## Why this document exists
+
+"Agent harness" is overloaded terminology. There is a Rust crate literally
+named `arcan-harness` — it is ~300 LOC of tool / sandbox / hashline-edit
+utilities, not the harness. The actual agent harness is a **7-layer stack
+distributed across ~25 crates**.
+
+This document is the canonical map of that stack. Any future spec that
+mentions "the harness" should reference these layers by number.
+
+A previous spec (`2026-05-05-ergon-v0.1.md`) framed `ergon` as a
+session-level runtime that would replace `arcan-harness` over time.
+**That framing was wrong on two counts**: (a) `arcan-harness` was never
+the harness, and (b) ergon's workflow model can't replace the
+long-horizon tick engine without losing the per-tick journal traceability
+that autonomic / EGRI / branching depend on.
+
+The corrected framing — documented here, in the BRO-1001 design spec,
+and propagated through the ergon spec — is that **ergon supplies one
+shape of tick body alongside the existing direct-call tick body**. Both
+compose with the kernel; both produce per-tick events; neither replaces
+anything.
+
+## The 7-layer stack
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│ L6 — Process entry points                                          │
+│   arcan (binary)         lifed (facade-aggregator daemon)          │
+│   arcand (agent daemon)  lifegw (edge gateway)                     │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L5 — Session orchestration  ← OUTER LOOP scope                     │
+│   arcand::ConsciousnessActor                                       │
+│   - mailbox + queue + projection                                   │
+│   - decides WHEN to start/stop/interrupt agent cycles              │
+│   - drives KernelRuntime tick by tick                              │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L4 — Tick engine (long-horizon agent loop)                         │
+│   aios_runtime::KernelRuntime::tick_on_branch(...)                 │
+│   - one tick = one bounded operation                               │
+│   - mode FSM (Execute/Verify/Recover/AskHuman/Sleep)               │
+│   - emits kernel-typed EventKind events to journal                 │
+│   - persists AgentStateVector, branch state, run state             │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L3.5 — Tick body (what runs INSIDE one tick)  ← INNER LOOP scope   │
+│   Two shapes:                                                      │
+│   • Direct: one model call via ModelProviderPort (current)         │
+│   • Workflow: ergon::Workflow::execute (BRO-1001)                  │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L3 — Port traits (kernel ↔ substrate boundary)                     │
+│   ModelProviderPort, ToolHarnessPort, ApprovalPort,                │
+│   PolicyGatePort, EventStorePort                                   │
+│   + TurnMiddleware, ToolCallGuard for cross-cutting                │
+│   (aios-runtime owns the trait shapes)                             │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L2 — Substrate adapters (port impls over real backends)            │
+│   arcan-aios-adapters    (ArcanProviderAdapter → ModelProviderPort)│
+│   arcan-praxis           (PraxisToolHarness → ToolHarnessPort)     │
+│   arcan-lago             (LagoEventStore → EventStorePort)         │
+│   arcan-anima            (AgentSoul attestation hooks)             │
+│   ergon-life-hooks       (4 auto-hooks for ergon ticks)            │
+│   ergon-life-sinks       (3 stream sinks for ergon ticks)          │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L1.5 — Silicon contract  ← Spec E / BRO-1019 (in design)           │
+│   inference-core::InferenceBackend                                 │
+│   inference-mlx, inference-vllm, inference-tt, ...                 │
+│   KV cache, speculative decode, model swap, tool-await reconnect   │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L1 — Substrate primitives                                          │
+│   lago-core (event journal + blob store)                           │
+│   praxis-core (tool execution + sandbox)                           │
+│   anima-core (identity)                                            │
+│   autonomic-core (homeostasis)                                     │
+│   nous-core (evaluation)                                           │
+│   life-vigil (observability)                                       │
+└────────────────────────────────────────────────────────────────────┘
+                                   ↓
+┌────────────────────────────────────────────────────────────────────┐
+│ L0 — Kernel contract                                               │
+│   aios-protocol                                                    │
+│   - EventKind taxonomy                                             │
+│   - OperatingMode FSM                                              │
+│   - AgentStateVector, BudgetState, PolicySet                       │
+│   - SessionId, BranchId, RunId, ToolRunId                          │
+│   - Capability tokens, SoulProfile                                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**The harness** = layers L1.5 + L2 + L3 + L3.5 + L4 + L5. Below it: the
+kernel contract and substrate primitives. Above it: process daemons.
+
+## Layer-by-layer responsibilities
+
+### L0 — Kernel contract (`aios-protocol`)
+
+Owns the canonical types every layer above must agree on. No code that
+*does* anything; only types. Stability commitment: changes are major
+version bumps with migration notes.
+
+### L1 — Substrate primitives
+
+Each substrate (lago / praxis / anima / autonomic / nous / vigil) is its
+own crate cluster. Each provides typed Rust APIs over a domain (events,
+tools, identity, homeostasis, evaluation, observability). They depend on
+L0 and not on each other (some bridge crates exist; those are L2).
+
+### L1.5 — Silicon contract (Spec E, in design)
+
+The `InferenceBackend` trait + KV cache + speculative decoding + model
+swap + tool-await reconnect. Sits between the substrate primitives and
+the port adapters at L2/L3. **Lives in `inference-core` once shipped**;
+today this layer is occupied by `arcan-core/src/aisdk.rs` (single
+hard-coded path to Vercel AI SDK).
+
+### L2 — Substrate adapters
+
+The crates that implement port traits over real substrate. Naming
+convention is `arcan-<substrate>` for kernel-facing adapters:
+- `arcan-aios-adapters` — `ArcanProviderAdapter` implements
+  `ModelProviderPort` (also `AutonomicPolicyAdapter` for
+  `PolicyGatePort`)
+- `arcan-praxis` — implements `ToolHarnessPort`
+- `arcan-lago` — implements `EventStorePort`
+- `arcan-anima` — soul attestation hooks
+- `ergon-life-hooks` — the four auto-hooks for ergon-shaped ticks
+- `ergon-life-sinks` — the three stream sinks (Lago / Vigil / Lifegw)
+
+These are *adapter* crates: they translate between kernel/ergon-side
+abstractions (port traits, hook traits) and substrate-side concrete
+types (Journal, AutonomicGatingProfile, NousEvaluator, AgentSoul, etc.).
+
+### L3 — Port traits
+
+`aios-runtime` defines the kernel-facing trait shapes. These are the
+ABI between L4 (kernel) and L2 (adapters). Critically, L3 doesn't know
+which adapter is wired in — it sees only the trait. This is what lets
+us swap arcan-praxis for a different tool runtime without changing the
+kernel.
+
+### L3.5 — Tick body
+
+What runs inside one kernel tick. **This is the layer where ergon plugs
+in.** Two shapes today:
+
+- **Direct tick body**: one model call via `ModelProviderPort.complete`,
+  optional tool dispatch via `ToolHarnessPort.execute`. Existing
+  pattern, used by every tick in production today.
+- **Workflow tick body** (BRO-1001): one
+  `ergon::WorkflowExecutor::run` call that runs an entire bounded
+  multi-turn operation inside the tick's lifetime. Returns a typed
+  `Output` that becomes the tick's payload.
+
+Both produce kernel `EventKind` events at tick boundaries. Workflow
+bodies additionally produce `EventKind::Custom("ergon.stream", ...)`
+events nested under the parent tick's `run_id` for sub-event
+traceability.
+
+### L4 — Tick engine (`KernelRuntime::tick_on_branch`)
+
+The long-horizon loop. Each call to `tick_on_branch`:
+- Reads session state (AgentStateVector, queued approvals, mode)
+- Runs the appropriate tick body (direct or workflow)
+- Updates state
+- Persists events to the event journal via `EventStorePort`
+- Returns a `TickOutput` with the new mode
+
+The tick engine is *bounded per call but unbounded per session*. A
+single agent run is N ticks; a session can run for weeks.
+
+### L5 — Session orchestration (`arcand::ConsciousnessActor`)
+
+Decides *when* to tick. Owns:
+- The session's mailbox (incoming user messages, tool results, timer
+  fires)
+- The work queue (current run, pending follow-ups)
+- The interruption flag (for steering)
+- The cadence (re-tick while `mode == Execute`; pause on `Sleep` /
+  `AskHuman`)
+
+The consciousness actor is what makes long-horizon agents real —
+without it, there's no answer to "when does the next tick run?"
+
+### L6 — Process entry points
+
+The daemons and binaries that hold sessions in memory:
+- `arcand` — the agent daemon, hosts ConsciousnessActor instances
+- `lifed` — facade-aggregator routing requests to the right backend
+- `lifegw` — edge gateway with TLS, JWT, scope intersection
+- `arcan` — installable CLI binary
+
+## The two scopes of the agent loop
+
+This is the most important distinction in this document.
+
+### Outer loop — session scope
+
+**Owned by**: L5 + L4 (ConsciousnessActor + KernelRuntime).
+
+**Lifetime**: across days. Bounded only by user lifecycle / explicit
+session close.
+
+**Step granularity**: one tick (one call to `tick_on_branch`).
+
+```text
+ConsciousnessActor receives mailbox event
+  ↓
+decides to start/continue an agent cycle
+  ↓
+calls run_agent_cycle_inner
+  ↓
+loops: KernelRuntime::tick_on_branch(...)
+  - returns mode
+  - if mode == Execute: continue ticking
+  - if mode == Verify: nous evaluation pass
+  - if mode == Recover: error-handling tick
+  - if mode == AskHuman: pause, wait for input
+  - if mode == Sleep: stop until next mailbox event
+  ↓
+each tick produces:
+  TickStarted, TickCompleted, mode transitions, AgentStateVector
+  updates, RunStarted/Completed, ToolCallRequested/Completed,
+  ProviderResponded, Steered, Compacted, ... (kernel-typed
+  EventKind variants in lago journal)
+```
+
+This is the long-horizon agent. **It can run for weeks. Each tick is a
+checkpoint. Lago has every tick. Replay reconstructs the whole
+agent.**
+
+### Inner loop — tick scope
+
+**Owned by**: L3.5 (tick body).
+
+**Lifetime**: one tick (seconds for direct ticks, seconds-to-minutes
+for workflow ticks).
+
+**Step granularity**: model call + optional tool dispatch (direct), or
+multiple model + tool turns within `Workflow::execute` (workflow).
+
+**Direct tick body**:
+
+```text
+TickStarted (run_id = R, kind = Direct)
+  ↓
+  ModelProviderPort.complete(req)
+  ↓
+  optional: ToolHarnessPort.execute(call)
+  ↓
+  emit ProviderResponded / ToolCallCompleted
+  ↓
+TickCompleted (mode_after = ?)
+```
+
+**Workflow tick body** (BRO-1001):
+
+```text
+TickStarted (run_id = R, kind = Workflow{name, input})
+  ↓
+  arcan_ergon::run_workflow_as_tick(name, input, ctx)
+       ↓
+       ergon::WorkflowExecutor::run(ctx, input)
+            ↓
+            workflow.execute(ctx, input)  [user-written async fn]
+                 ↓
+                 ctx.run_inference_streaming(req)  [autonomous turn 1]
+                      ↓ each StreamEvent → LagoSink (tagged run_id=R)
+                      ↓                  → VigilSink (tracing)
+                      ↓                  → LifegwSink (user SSE)
+                 ↓
+                 ctx.tools.invoke(call)
+                 ↓
+                 ctx.run_inference_streaming(req)  [autonomous turn 2]
+                 ↓
+                 ...
+            ↓
+            return Workflow::Output
+  ↓
+TickCompleted (run_id = R, output = JSON, mode_after = ?)
+```
+
+**Crucially**: workflow stream events are appended to the journal
+*tagged with the parent tick's `run_id`*. They're sub-events under the
+tick. Replay can choose:
+- Tick-level granularity: just `TickStarted` / `TickCompleted`
+  boundaries (this is what autonomic / EGRI / branching consume)
+- Workflow-level granularity: re-stream every `TextDelta`,
+  `ToolUseStart`, etc. (this is for inner-loop debugging)
+
+## Bottom-up dependency chain
+
+Each layer depends only on layers below it. **No backwards arrows. No
+peer reaches up.**
+
+```text
+Step 0: aios-protocol             (zero deps; kernel contract)
+            ↓
+Step 1: lago-core, praxis-core, anima-core, autonomic-core,
+        nous-core, life-vigil    (substrate primitives)
+            ↓
+Step 2: aios-runtime              (KernelRuntime + port traits)
+            ↓
+Step 3: arcan-core                (legacy types: Provider/Tool/
+                                   Orchestrator; mostly used in
+                                   tests + some adapters)
+            ↓
+Step 4: ergon                     (workflow trait, autonomous loop;
+                                   ZERO substrate deps — the
+                                   architectural commitment)
+            ↓
+Step 5: substrate adapters
+        a) arcan-aios-adapters    (kernel ports)
+        b) arcan-praxis           (tool harness)
+        c) arcan-lago             (event store)
+        d) arcan-anima            (identity hooks)
+        e) ergon-life-hooks       (4 auto-hooks)
+        f) ergon-life-sinks       (3 stream sinks)
+            ↓
+Step 6: arcan-ergon (BRO-1001)
+        - implements ergon::Provider over ModelProviderPort
+        - implements ergon::ToolRegistry over ToolHarnessPort
+        - implements 4 ergon-life-hooks adapter traits
+        - exposes run_workflow_as_tick(name, input, tick_ctx)
+            ↓
+Step 7: arcand (kernel daemon)
+        - ConsciousnessActor (session orchestration)
+        - run_agent_cycle_inner (the outer-loop driver)
+        - dispatches each tick to the right body
+            ↓
+Step 8: process binaries
+        arcan binary, lifed, lifegw
+```
+
+The ordering is enforced at the Cargo level: each crate's `Cargo.toml`
+lists deps from layers below. Workspace-level CI (`cargo deny`,
+`verify_dependencies_*`) catches violations.
+
+## Top-down execution trace
+
+A real example, end-to-end. **Scenario**: long-running coding agent
+(kernel-shaped session) needs to score 5 research extracts as part of
+its work; uses bookkeeping-judge (ergon workflow) for each.
+
+```text
+1. User sends message via lifegw (L6)
+   ↓
+2. lifed routes to arcand (L6)
+   ↓
+3. ConsciousnessActor (L5) wakes up
+   - reads mailbox
+   - decides this is a continuation of session S1 (existing kernel agent)
+   - calls run_agent_cycle_inner(run_id=R7, session_id=S1, ...)
+   ↓
+4. run_agent_cycle_inner enters the outer loop
+   ↓
+5. tick #1: KernelRuntime::tick_on_branch(S1, "main", input) (L4)
+   - mode = Execute, kind = Direct
+   - goes through ModelProviderPort (L3)
+   - ArcanProviderAdapter (L2) calls aisdk (L1.5 today, future Spec E)
+   - model returns: "I need to score 5 extracts"
+   - kernel emits TickStarted/ProviderResponded/TickCompleted
+     (kernel-typed events)
+   - tick body decides next tick should be a Workflow tick
+   ↓
+6. tick #2: KernelRuntime::tick_on_branch(S1, "main", input) (L4)
+   - mode = Execute, kind = Workflow{
+       name="bookkeeping.promotion-judge",
+       input={"extract": "ext1.md"}
+     }
+   - emits TickStarted{run_id=R7-T2, kind=Workflow}
+   ↓
+7. tick body dispatches to arcan_ergon::run_workflow_as_tick (L3.5)
+   - looks up the workflow by name in WorkflowRegistry
+   - constructs StepCtx from TickCtx:
+     • provider: ergon::Provider impl wrapping ArcanProviderAdapter
+     • tools: ergon::ToolRegistry impl wrapping arcan-praxis
+     • hooks: HookRegistry pre-populated with 4 ergon-life-hooks (L2)
+     • sink: FanoutSink([LagoSink, VigilSink, LifegwSink])
+       from ergon-life-sinks (L2), each tagged with run_id=R7-T2
+     • runtime: arcan's TickHandle as RuntimeHandle
+   - calls WorkflowExecutor::run(ctx, input)
+   ↓
+8. WorkflowExecutor.run fires on_workflow_start hooks (L3.5)
+   - AnimaAttestHook signs SessionStart (sub-event under R7-T2)
+   - PraxisCapabilityHook (no-op for workflow_start)
+   - AutonomicBudgetHook (no-op for workflow_start)
+   - NousScoreHook (no-op for workflow_start)
+   ↓
+9. workflow.execute(ctx, input) runs (user's code, L3.5)
+   pseudo:
+   ```
+   let extract = ctx.tools.invoke("fs_read",
+                                  {"path": "ext1.md"}).await?;
+                 ↑ on_pre_tool_use → PraxisCapabilityHook
+                                     checks PolicySet (L2)
+                 ↑ tools.invoke → ergon::ToolRegistry impl
+                                  → arcan-praxis (L2)
+                                  → praxis-core::Tool (L1)
+                 ↑ on_post_tool_use
+   let req = InferenceRequest::new("claude-sonnet-4")
+                 .with_role(Role::agent("Score this extract..."));
+   let resp = ctx.run_inference_streaming(req).await?;
+                 ↑ on_pre_inference → AutonomicBudgetHook (L2)
+                                     → reads HomeostaticState
+                                     → may Continue/Deny
+                 ↑ provider.stream → ergon::Provider impl
+                                    → ArcanProviderAdapter (L2)
+                                    → ModelProviderPort (L3)
+                                    → aisdk → Anthropic API (L0)
+                 ↑ each StreamEvent → sink.emit
+                                      (LagoSink → journal,
+                                       VigilSink → tracing,
+                                       LifegwSink → user's SSE stream)
+                 ↑ on_post_inference → NousScoreHook scores response
+   Ok(parse_verdict(&resp))
+   ```
+   ↓
+10. WorkflowExecutor.run fires on_workflow_end hooks
+    - AnimaAttestHook signs SessionClose
+    ↓
+11. arcan_ergon::run_workflow_as_tick returns Output (PromotionVerdict)
+    ↓
+12. KernelRuntime emits TickCompleted{run_id=R7-T2, output=verdict,
+                                       mode_after=Execute}
+    ↓
+13. ConsciousnessActor sees the result
+    - decides to continue ticking (4 more extracts to score)
+    - back to step 6 with input={"extract": "ext2.md"}
+    ↓
+14. After all 5 extracts: tick #N has mode_after=Verify
+    - kernel runs evaluation tick (could be another workflow or direct)
+    ↓
+15. Eventually: mode_after=Sleep
+    - ConsciousnessActor stops the cycle
+    - session persists in lago
+    - waits for next mailbox event
+```
+
+**Two scoped agent loops in one execution**:
+- The outer loop ran 6+ ticks across the session. Each tick is durable,
+  replayable, autonomic-gated, branchable, traceable as kernel events.
+- The inner loop (steps 7–11) ran 5 times — one per extract — each as
+  a rich tick. Each was bounded, returned a typed Output, didn't have
+  to know about ticks.
+
+**Crucially**: workflow events from steps 7–11 are in the journal
+tagged with `run_id=R7-T2` etc. They nest under the parent tick.
+Replay at tick granularity sees only `TickStarted{Workflow} →
+TickCompleted{Output}`. Replay at workflow granularity also sees every
+TextDelta, ToolCall, score.
+
+## Where each layer lives in the workspace
+
+| Layer | Crates / paths |
+|---|---|
+| L0 | `crates/aios/aios-protocol` |
+| L1 | `crates/lago/*`, `crates/praxis/praxis-core`, `crates/anima/anima-core`, `crates/autonomic/autonomic-core`, `crates/nous/nous-core`, `crates/vigil/life-vigil` |
+| L1.5 | `crates/inference/*` (planned, BRO-1019); today `crates/arcan/arcan-core/src/aisdk.rs` |
+| L2 | `crates/arcan/arcan-aios-adapters`, `crates/arcan/arcan-praxis`, `crates/arcan/arcan-lago`, `crates/arcan/arcan-anima`, `crates/ergon/ergon-life-hooks`, `crates/ergon/ergon-life-sinks` |
+| L3 | `crates/aios/aios-runtime` (port traits) |
+| L3.5 | Direct: `arcan-aios-adapters` (existing). Workflow: `crates/arcan/arcan-ergon` (BRO-1001, planned) |
+| L4 | `crates/aios/aios-runtime` (KernelRuntime impl) |
+| L5 | `crates/arcan/arcand` (ConsciousnessActor) |
+| L6 | `crates/arcan/arcan` (binary), `crates/life-runtime/lifed`, `crates/life-runtime/lifegw` |
+
+## Built today vs pending
+
+**Built and on main:**
+- L0 aios-protocol
+- L1 all six substrate primitives
+- L2 substrate adapters (kernel side); ergon-life-hooks; ergon-life-sinks (after #1170)
+- L3 port traits in aios-runtime
+- L4 KernelRuntime
+- L5 ConsciousnessActor
+- L6 arcan, arcand, lifed, lifegw
+- ergon trait crate (workflow, hook, model, runtime, step modules)
+
+**Pending:**
+- L3.5 workflow tick body — `arcan-ergon` adapter (BRO-1001, with the
+  *corrected* design per
+  `2026-05-08-bro-1001-ergon-tick-body.md`)
+- arcand `TickKind` dispatch — small change to TickInput + the tick
+  body match in run_agent_cycle_inner (BRO-1001b, follow-up)
+- bookkeeping-judge port — the first real `Workflow` impl that runs
+  as a rich tick (BRO-1003)
+
+**Spec E future** (BRO-1019, parallel track):
+- L1.5 `inference-core` — silicon contract trait. When this lands,
+  `ergon::Provider` impls in `arcan-ergon` re-target through
+  `InferenceRouter` for KV reuse + speculative decode + multi-vendor
+  silicon.
+
+## Glossary
+
+| Term | Meaning in this document |
+|---|---|
+| **Agent** | A long-running entity bound to a session, ticked by KernelRuntime |
+| **Session** | A persistent identity-scoped run, identified by `SessionId` |
+| **Tick** | One bounded execution unit; a call to `tick_on_branch`; produces a `TickOutput` |
+| **Tick body** | What runs *inside* a tick — direct (one call) or workflow (multi-call) |
+| **Workflow** | A bounded multi-turn operation defined by `ergon::Workflow::execute`; runs *inside* one tick |
+| **Run** | A single agent cycle within a session, identified by `RunId`; spans multiple ticks |
+| **Branch** | A divergent path within a session, identified by `BranchId`; sessions can branch and merge |
+| **OperatingMode** | The FSM state of a session: Execute / Verify / Recover / AskHuman / Sleep |
+| **Outer loop** | The tick stream owned by ConsciousnessActor + KernelRuntime; long-horizon |
+| **Inner loop** | The model+tool loop within one tick body; bounded |
+
+## Stability commitments
+
+1. **The 7 layers above will not change without a versioned spec
+   amendment.** Layers may grow internal complexity; the layer
+   boundaries themselves are stable.
+2. **The dependency chain is bottom-up only.** Any PR that adds a
+   reverse arrow (e.g., aios-protocol depending on lago) is
+   architecturally invalid and must be rejected at review.
+3. **The two scopes of the agent loop are stable.** Outer loop is
+   tick-driven and lives across days. Inner loop is tick-bounded and
+   lives within seconds-to-minutes per tick. New tick body shapes
+   may be added without changing this contract.
+4. **Per-tick events in the journal are kernel-typed `EventKind`
+   variants.** Workflow stream events are sub-events nested under the
+   parent tick's `run_id`. Both granularities are replayable; neither
+   replaces the other.
+
+## References
+
+- `aios-protocol` source — kernel contract types
+- `aios-runtime/src/lib.rs` — `KernelRuntime`, port traits
+- `arcand/src/consciousness.rs` — ConsciousnessActor + outer loop driver
+- `crates/ergon/ergon/src/step.rs` — autonomous inner loop
+- `docs/superpowers/specs/2026-05-05-ergon-v0.1.md` — workflow trait spec (with §6/§10 corrections)
+- `docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` — corrected adapter design
+- `docs/superpowers/specs/2026-05-07-spec-e-agent-loop-compute-contract.md` — silicon contract

--- a/docs/superpowers/specs/2026-05-05-ergon-v0.1.md
+++ b/docs/superpowers/specs/2026-05-05-ergon-v0.1.md
@@ -1,15 +1,42 @@
 # Spec — Ergon v0.1
 
 **Date**: 2026-05-05
-**Status**: Ready to file (open questions §8 resolved during impl)
+**Status**: Active — §6 and §10 superseded by `2026-05-08-bro-1001-ergon-tick-body.md` (course-correction); other sections valid as-written
 **Owner**: harness layer (`crates/ergon/`) — new crate
 **Type**: design-spec
 **Target release**: life v0.6 / ergon v0.1
 **Linear**: project "Ergon — Agent Harness Primitive" (BRO-ergon-v0.1)
-**Supersedes**: nothing for v0.1; deprecates `arcan-harness` from v0.4 (separate spec at that time)
+**Supersedes**: nothing
 **Related**:
+- `core/life/docs/architecture/agent-harness.md` (canonical 7-layer runtime architecture)
+- `core/life/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` (corrected §6 / §10 framing — read this for current adapter design)
 - `core/life/docs/superpowers/specs/2026-04-25-soma-spec-c-m0.md`
 - `core/life/docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md`
+
+## Correction note (2026-05-08)
+
+§6 and §10 of this document were filed under the **incorrect assumption
+that ergon would replace `arcan-harness` as the agent runtime over
+time** (with arcan-harness being deprecated at ergon v0.4).
+
+That framing was wrong on two counts:
+1. `arcan-harness` is a ~300 LOC tool/sandbox/hashline-edit utility crate,
+   not the agent harness. The actual agent harness in Life is a 7-layer
+   runtime stack distributed across ~25 crates (see `docs/architecture/agent-harness.md`).
+2. Ergon's workflow model (`Workflow::execute()` as one async fn) cannot
+   replace the long-horizon tick engine without losing per-tick journal
+   traceability that autonomic / EGRI / branching depend on.
+
+**The corrected framing**: ergon supplies one shape of *tick body*
+(workflow-bodied ticks) alongside the existing direct-call tick body.
+Both compose with `aios_runtime::KernelRuntime`; both produce per-tick
+events; **neither replaces anything**.
+
+§§0–5, 7–9, 11–13 of this document are valid as written. §6 (Composition
+with arcan) and §10 (Migration plan) are SUPERSEDED by
+`docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md`.
+
+---
 
 ## 0. Purpose (one sentence — the whole spec is governed by this)
 
@@ -424,7 +451,14 @@ LOCKED:
 13. lifegw              close upstream stream; lago has full event sequence on disk
 ```
 
-## 6. Composition with arcan — the adapter
+## 6. Composition with arcan — the adapter [SUPERSEDED]
+
+> **SUPERSEDED 2026-05-08** — see
+> `docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` for the
+> corrected adapter design. The `ErgonAgentKind` / `AgentKind` trait
+> abstraction below assumed a structure that doesn't exist in arcan.
+> Reality: ergon is a tick body, not a session-level runtime. Adapter
+> lives in `crates/arcan/arcan-ergon/`, not `crates/arcan/arcan/src/agent_kind/`.
 
 LOCKED. New file `core/life/crates/arcan/src/agent_kind/ergon.rs`:
 
@@ -521,7 +555,16 @@ Within 2 weeks of v0.1 shipping, ergon must demonstrate:
 - A real session (e.g., a bookkeeping-judge run) is fully reconstructable from lago events alone (manual replay test).
 - No regression in arcan's existing 1077 tests.
 
-## 10. Migration plan — `arcan-harness` → `ergon`
+## 10. Migration plan — `arcan-harness` → `ergon` [SUPERSEDED]
+
+> **SUPERSEDED 2026-05-08** — there is no migration. `arcan-harness` is
+> not the agent harness; it's a tool/sandbox utility crate that stays as
+> it is. ergon does not deprecate any existing crate. The corrected
+> trajectory is in
+> `docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md` §10
+> ("Composition trajectory"): ergon is a new tick-body shape that
+> coexists with the existing direct-call tick body, indefinitely. Both
+> compose with `aios_runtime::KernelRuntime` and produce per-tick events.
 
 Out of scope for v0.1. Outline only:
 

--- a/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md
+++ b/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md
@@ -358,6 +358,34 @@ diff (~20 LOC) but it's the **seam** that makes ergon useful.
 This change is part of BRO-1001's scope. Not deferred to BRO-1001b
 (that's the *daemon*-side wiring; this is the *kernel*-side seam).
 
+## 6.1 Composition with `OperatingMode::Verify` (forward-compatible note)
+
+`TickKind::Workflow` is what enables a clean future composition where
+the kernel's `Verify` mode dispatches to evaluator workflows directly.
+That's not in v0.1 scope, but the `TickKind` enum is intentionally
+non-exhaustive so the kernel can grow:
+
+```rust
+#[non_exhaustive]
+pub enum TickKind {
+    Direct,
+    Workflow { name: String, input: serde_json::Value },
+    // Future variants (NOT in v0.1):
+    // VerifyWorkflow { evaluator: String, target: RunId }
+    // RecoverWorkflow { strategy: String, error_summary: String }
+}
+```
+
+When this composition lands (post-v0.1, post-BRO-1003 proves the
+pattern), evaluator workflows like `bookkeeping.promotion-judge` and
+`session.evaluator` can be invoked by the kernel automatically when
+`mode == Verify`. See `docs/architecture/agent-harness.md` § "Where
+evaluators live (nous metacognition)" for the detailed composition.
+
+This is mentioned here so future agents reading this spec understand
+that `TickKind`'s shape is anticipating evaluator-workflow dispatch
+without committing to it. v0.1 ships only `Direct` and `Workflow`.
+
 ## 7. Definition of done — v0.1 ships when
 
 ALL of the following are true:

--- a/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md
+++ b/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md
@@ -1,0 +1,505 @@
+# Spec — BRO-1001 — Ergon Tick-Body Adapter
+
+**Date**: 2026-05-08
+**Status**: Active — supersedes §6 and §10 of `2026-05-05-ergon-v0.1.md`
+**Owner**: arcan-ergon (`crates/arcan/arcan-ergon/`) — new crate
+**Type**: design-spec
+**Linear**: [BRO-1001](https://linear.app/broomva/issue/BRO-1001)
+**Related**:
+- `core/life/docs/architecture/agent-harness.md` (canonical layer cake)
+- `core/life/docs/superpowers/specs/2026-05-05-ergon-v0.1.md` (workflow trait crate; §6 + §10 superseded by this doc)
+- `core/life/docs/superpowers/specs/2026-05-07-spec-e-agent-loop-compute-contract.md` (silicon contract — composes with this)
+
+## 0. Purpose (one sentence — the whole spec is governed by this)
+
+**The arcan-ergon adapter (`crates/arcan/arcan-ergon/`) lets a kernel
+tick run an `ergon::Workflow` as its body — preserving per-tick
+journal traceability, autonomic gating, branch state, and the
+OperatingMode FSM exactly as the existing direct-call tick body does.**
+
+If a feature does not serve that sentence, it does not go in this spec.
+
+## 1. Why this spec replaces the §6 / §10 framing of the original ergon spec
+
+`2026-05-05-ergon-v0.1.md` proposed an `AgentKind` trait abstraction in
+which ergon would be **one of N runtimes** dispatched at the *session*
+level by arcand. The corrected understanding (see
+`docs/architecture/agent-harness.md`):
+
+1. The actual production agent loop is `aios_runtime::KernelRuntime`,
+   driven tick-by-tick by `arcand::ConsciousnessActor`. There is no
+   `AgentKind` trait in arcan.
+2. The agent harness is a **7-layer stack** (L0 kernel contract → L6
+   process daemons), not a single runtime crate.
+3. Ergon's `Workflow::execute()` is one async fn — it cannot suspend
+   mid-flight, cannot replay from event N>0, cannot survive a daemon
+   restart. It is structurally **not a long-horizon runtime**.
+4. Long-horizon agents need the tick engine: each tick is a checkpoint;
+   sessions live across days; replay reconstructs from kernel-typed
+   `EventKind` events.
+
+What ergon legitimately adds is a richer *tick body shape*: one tick
+runs an entire bounded workflow (multi-turn model+tool execution) and
+returns a typed Output. The kernel still owns the agent loop. Workflow
+events nest under the parent tick's `run_id` for sub-event
+traceability.
+
+This spec describes that integration.
+
+## 2. Scope
+
+### 2.1 In scope (v0.1)
+
+- New crate `crates/arcan/arcan-ergon/` (sibling of `arcan-praxis`,
+  `arcan-lago`, `arcan-anima`) with adapter impls of:
+  - `ergon::Provider` over `aios_runtime::ModelProviderPort`
+  - `ergon::ToolRegistry` over `aios_runtime::ToolHarnessPort` (with
+    `PolicyGatePort` consulted for capability enforcement)
+  - `ergon::RuntimeHandle` over a kernel `TickHandle`
+  - The four `ergon-life-hooks` adapter traits (`CapabilityResolver`,
+    `BudgetGate`, `ResponseScorer`, `SoulAttester`) over substrate
+    types (`PolicySet`, `AutonomicGatingProfile`, `NousEvaluator`,
+    `AgentSoul`)
+- `WorkflowRegistry` — name → workflow lookup, populated at daemon
+  startup
+- `run_workflow_as_tick(name, input, tick_ctx)` — the entry point the
+  kernel tick handler calls when a tick is workflow-bodied
+- Integration smoke test: register a workflow, run it as a rich tick
+  via a mock kernel, verify journal events are emitted at both tick
+  granularity (kernel events) and workflow granularity (Custom
+  ergon.stream events nested under run_id)
+
+### 2.2 Out of scope (deferred)
+
+- **arcand wiring** (BRO-1001b): the small change to `TickInput` and
+  `run_agent_cycle_inner` that lets a session *select* a workflow tick
+  body. This is its own ticket because it touches the daemon's hot
+  path; it should land after BRO-1001 with a feature flag.
+- **Workflow registry persistence**: v0.1 registers workflows in
+  process memory at daemon startup. Lago-backed workflow definitions
+  (so workflows can be deployed without redeploying arcand) are a v0.2
+  concern.
+- **Speculative execution / KV reuse across workflows**: that's Spec E
+  / BRO-1019's job. After Spec E ships, `arcan-ergon::ergon::Provider`
+  retargets through `InferenceRouter` and gets it for free.
+- **Workflow-level branching**: a workflow runs in one tick. Tick
+  branching (kernel-level) is unchanged. Workflows don't branch
+  internally in v0.1.
+- **bookkeeping-judge port** (BRO-1003): the first real workflow
+  exercising this adapter. Its own PR.
+
+## 3. Layered position
+
+LOCKED:
+
+```text
+L4 — KernelRuntime (tick engine, aios-runtime)
+        │
+        │ tick_on_branch returns mode; outer loop continues until Sleep
+        │
+        ↓
+L3.5 — Tick body
+        │
+        │ Two shapes:
+        │   - Direct (existing): ModelProviderPort.complete + ToolHarnessPort.execute
+        │   - Workflow (this spec): arcan_ergon::run_workflow_as_tick
+        │
+        ↓
+L3   — Port traits (aios-runtime)
+        │
+        │ ModelProviderPort, ToolHarnessPort, ApprovalPort,
+        │ PolicyGatePort, EventStorePort
+        │
+        ↓
+L2   — Substrate adapters
+        │
+        │ arcan-aios-adapters, arcan-praxis, arcan-lago, arcan-anima,
+        │ ergon-life-hooks, ergon-life-sinks, arcan-ergon (this spec)
+        │
+        ↓
+L1   — Substrate primitives
+```
+
+`arcan-ergon` is **at L3.5 but composed with L2 adapters**. It's the
+"bridge" between ergon (a vendor-neutral workflow primitive at the
+non-substrate layer) and arcan's port-trait stack.
+
+## 4. Public API — locked
+
+### 4.1 Crate manifest
+
+```toml
+[package]
+name        = "arcan-ergon"
+description = "Tick-body adapter — runs ergon Workflows as the body of a kernel tick."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+
+[dependencies]
+ergon              = { workspace = true }
+ergon-life-hooks   = { workspace = true }
+ergon-life-sinks   = { workspace = true }
+aios-protocol      = { workspace = true }
+aios-runtime       = { workspace = true }
+arcan-core         = { workspace = true }
+arcan-aios-adapters = { workspace = true }
+lago-core          = { workspace = true }
+praxis-core        = { workspace = true }
+anima-core         = { workspace = true }
+autonomic-core     = { workspace = true }
+nous-core          = { workspace = true }
+async-trait        = { workspace = true }
+serde              = { workspace = true, features = ["derive"] }
+serde_json         = { workspace = true }
+tokio              = { workspace = true, features = ["sync", "macros"] }
+tracing            = { workspace = true }
+```
+
+### 4.2 Module layout
+
+```text
+crates/arcan/arcan-ergon/src/
+├── lib.rs              # public API
+├── error.rs            # ArcanErgonError
+├── registry.rs         # WorkflowRegistry: name → DynWorkflowExecutor
+├── runner.rs           # run_workflow_as_tick(...) — the kernel's entry point
+├── provider.rs         # impl ergon::Provider over ModelProviderPort
+├── tools.rs            # impl ergon::ToolRegistry over ToolHarnessPort + PolicyGatePort
+├── runtime_handle.rs   # impl ergon::RuntimeHandle over kernel TickHandle
+└── auto_hooks/
+    ├── capability.rs   # impl CapabilityResolver over PolicySet
+    ├── budget.rs       # impl BudgetGate over AutonomicGatingProfile
+    ├── score.rs        # impl ResponseScorer over NousEvaluator
+    └── attestation.rs  # impl SoulAttester over AgentSoul
+```
+
+Eight active modules. ~700-900 LOC total.
+
+### 4.3 Entry point: `run_workflow_as_tick`
+
+```rust
+/// Run an ergon workflow as the body of one kernel tick.
+///
+/// Called by the kernel tick handler when `tick_input.kind ==
+/// TickKind::Workflow{name, input}`. Builds a `StepCtx` from the
+/// kernel's `TickCtx` (provider, tools, hooks, sinks all configured
+/// against substrate adapters), then calls
+/// `WorkflowExecutor::run(ctx, input)`. The workflow runs entirely
+/// within this function call.
+///
+/// All substrate sinks (Lago / Vigil / Lifegw) are tagged with the
+/// parent tick's `run_id`, so workflow stream events nest under the
+/// tick in the journal.
+pub async fn run_workflow_as_tick(
+    workflow_name: &str,
+    input: serde_json::Value,
+    tick_ctx: &TickBodyCtx<'_>,
+) -> Result<serde_json::Value, ArcanErgonError>;
+
+/// Per-tick context the kernel hands to the workflow body. Constructed
+/// inside the tick handler from kernel state.
+pub struct TickBodyCtx<'a> {
+    pub session_id: SessionId,
+    pub branch_id:  BranchId,
+    pub run_id:     RunId,
+    pub trace:      tracing::Span,
+
+    // L2 adapter handles — wired at daemon startup
+    pub provider_port:    Arc<dyn ModelProviderPort>,
+    pub tool_harness:     Arc<dyn ToolHarnessPort>,
+    pub policy_gate:      Arc<dyn PolicyGatePort>,
+    pub journal:          Arc<dyn lago_core::Journal>,
+    pub upstream_tx:      tokio::sync::mpsc::Sender<ergon::StreamEvent>,
+
+    // Substrate state for auto-hooks
+    pub policy_set:       Arc<aios_protocol::PolicySet>,
+    pub gating_profile:   Arc<autonomic_core::AutonomicGatingProfile>,
+    pub evaluator:        Arc<dyn nous_core::NousEvaluator>,
+    pub soul:             Arc<anima_core::AgentSoul>,
+
+    // Workflow registry (for sub-step lookup if a workflow composes others)
+    pub workflows:        Arc<WorkflowRegistry>,
+}
+```
+
+### 4.4 Workflow registry
+
+```rust
+pub struct WorkflowRegistry {
+    workflows: dashmap::DashMap<String, Arc<dyn DynWorkflowExecutor>>,
+}
+
+impl WorkflowRegistry {
+    pub fn new() -> Self;
+
+    /// Register a workflow under the given name (e.g.,
+    /// "bookkeeping.promotion-judge"). Typically called at daemon
+    /// startup from a config or feature-flag list.
+    pub fn register<W: ergon::Workflow>(&self, name: &str, workflow: Arc<W>);
+
+    /// Look up by name. Returns None if not registered.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn DynWorkflowExecutor>>;
+}
+
+/// Type-erased executor. Internally holds an `Arc<dyn Workflow>`-like
+/// thing plus the type-coercion machinery so `run_workflow_as_tick`
+/// can take `serde_json::Value` and dispatch generically.
+trait DynWorkflowExecutor: Send + Sync {
+    async fn run_dyn(
+        &self,
+        ctx: &mut ergon::StepCtx<'_>,
+        input: serde_json::Value,
+    ) -> Result<serde_json::Value, ergon::ErgonError>;
+}
+```
+
+`DynWorkflowExecutor` is the type-erasure trick that lets us hold
+arbitrary `Workflow<Input, Output>` impls in a single registry.
+Implementation detail: a wrapper struct `TypedExecutor<W>` does the
+`serde_json` round-trip at the boundary.
+
+## 5. Lifecycle — kernel tick → workflow execution
+
+LOCKED:
+
+```text
+arcand consciousness owns the outer loop.
+For each tick:
+
+1.  ConsciousnessActor decides a tick is needed
+2.  Builds TickInput { objective, kind, ... }
+       kind = TickKind::Direct      (today's path, unchanged)
+              | TickKind::Workflow { name, input }   (new, this spec)
+3.  Calls KernelRuntime::tick_on_branch(...)
+4.  Kernel emits TickStarted{run_id, kind}
+5.  Kernel dispatches based on kind:
+       Direct   → existing path (ModelProviderPort.complete + tool dispatch)
+       Workflow → arcan_ergon::run_workflow_as_tick(name, input, body_ctx)
+6.  arcan-ergon:
+       a) WorkflowRegistry.get(name) → executor
+       b) Build StepCtx<'_> from TickBodyCtx:
+          - provider:  ErgonProviderAdapter wrapping body_ctx.provider_port
+          - tools:     ErgonToolRegistryAdapter wrapping body_ctx.tool_harness
+                                                      + body_ctx.policy_gate
+          - hooks:     HookRegistry::default()
+                          .with(PraxisCapabilityHook::new(/* PolicySet adapter */))
+                          .with(AutonomicBudgetHook::new(/* gating-profile adapter */))
+                          .with(NousScoreHook::new(/* evaluator adapter */))
+                          .with(AnimaAttestHook::new(/* soul adapter */))
+          - sink:      Arc::new(FanoutSink::new(vec![
+                          Arc::new(LagoSink::new(body_ctx.journal,
+                                                 body_ctx.session_id.clone())),
+                          Arc::new(VigilSink::new()),
+                          Arc::new(LifegwSink::new(body_ctx.upstream_tx.clone())),
+                       ]))
+                      // All sinks already inherit body_ctx.run_id via session scope
+          - runtime:   ErgonRuntimeHandleAdapter
+       c) executor.run_dyn(&mut ctx, input).await
+            → fires on_workflow_start hooks
+            → calls workflow.execute(ctx, input)
+                  → user code runs ctx.run_inference_streaming / ctx.tools.invoke
+                  → each StreamEvent flows through FanoutSink
+                  → LagoSink appends EventKind::Custom{
+                        event_type: "ergon.stream",
+                        data: <event>
+                    } to journal under body_ctx.run_id
+            → fires on_workflow_end hooks
+            → returns Output
+       d) Output serialised to JSON, returned to kernel
+7.  Kernel emits TickCompleted{
+        run_id, kind: Workflow, output: Some(json),
+        mode_after, last_seq, ...
+    }
+8.  ConsciousnessActor reads TickOutput, decides next tick
+```
+
+**Result**: the workflow runs *inside* one kernel tick. Tick boundaries
+emit kernel-typed events. Workflow internals emit nested Custom events.
+Replay can choose granularity. Autonomic / EGRI / branching all see
+the kernel tick events normally.
+
+## 6. The TickKind extension (small aios-runtime change)
+
+`aios-runtime` needs a new field on `TickInput`:
+
+```rust
+pub struct TickInput {
+    pub objective: String,
+    pub proposed_tool: Option<ToolCall>,
+    pub system_prompt: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub kind: TickKind,            // NEW
+}
+
+#[non_exhaustive]
+pub enum TickKind {
+    Direct,
+    Workflow {
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+impl Default for TickKind {
+    fn default() -> Self { Self::Direct }    // backward-compatible
+}
+```
+
+`Default::default() == TickKind::Direct` keeps every existing call
+site working without modification. New call sites that want a workflow
+tick set `kind: TickKind::Workflow { ... }` explicitly.
+
+The kernel tick handler in `aios_runtime::KernelRuntime` matches on
+`tick_input.kind` and dispatches to the right body. This is a small
+diff (~20 LOC) but it's the **seam** that makes ergon useful.
+
+This change is part of BRO-1001's scope. Not deferred to BRO-1001b
+(that's the *daemon*-side wiring; this is the *kernel*-side seam).
+
+## 7. Definition of done — v0.1 ships when
+
+ALL of the following are true:
+
+1. `cargo check -p arcan-ergon` passes.
+2. `cargo test -p arcan-ergon --all-targets` passes (~25 unit tests +
+   1 integration test against an in-process kernel).
+3. `cargo clippy -p arcan-ergon --all-targets -- -D warnings` passes.
+4. `cargo fmt -p arcan-ergon -- --check` passes.
+5. `aios-runtime` has the `TickKind` extension; default behaviour is
+   unchanged for `TickKind::Direct` (every existing call site
+   compiles and runs without modification).
+6. The integration test drives the path end-to-end:
+   - Register a trivial workflow ("echo input")
+   - Build a `TickBodyCtx` over mock adapters
+   - Call `run_workflow_as_tick` with `kind=Workflow{name="echo", input=...}`
+   - Assert the kernel emits `TickStarted{Workflow}` and
+     `TickCompleted{output: ...}`
+   - Assert the journal contains nested `Custom("ergon.stream", ...)`
+     events tagged with the parent `run_id`
+   - Assert the four auto-hooks fired in order
+7. No regression in any existing arcan / aios-runtime / arcand test.
+8. CHANGELOG entry on the Life monorepo lists arcan-ergon v0.1.
+
+## 8. Open questions
+
+Five questions whose final answers fall out naturally during the first
+200 LOC of `runner.rs`. Proposals locked unless impl reveals a problem.
+
+1. **Q1.** Type erasure for the workflow registry — `Box<dyn DynWorkflowExecutor>`
+   with serde-Value boundaries, or generic `Workflow<I, O>` per-call?
+   *Resolution: erasure via `DynWorkflowExecutor` + JSON boundary.
+   Generic per-call breaks the "register once, dispatch by string"
+   pattern.*
+
+2. **Q2.** Where does the `WorkflowRegistry` live — owned by arcand,
+   or a static singleton?
+   *Resolution: owned by arcand at startup; passed via `TickBodyCtx`.
+   No statics.*
+
+3. **Q3.** How does `LifegwSink` get the right upstream `tx` for the
+   current session?
+   *Resolution: arcand's session state owns the tx; passes it into
+   `TickBodyCtx` per tick.*
+
+4. **Q4.** Should `RunId` for workflow stream events be the parent
+   tick's run_id, or a child run_id?
+   *Resolution: parent tick's run_id, per the architecture doc's
+   "sub-events nest under the tick" invariant. A workflow is one tick;
+   it does not start a new run.*
+
+5. **Q5.** Where does the model name come from — `InferenceRequest` or
+   tick-level config?
+   *Resolution: `InferenceRequest::model` (set by the workflow body).
+   The kernel tick handler doesn't impose a model.*
+
+## 9. Validation criteria (post-ship)
+
+Within 2 weeks of v0.1 shipping, the adapter must demonstrate:
+
+1. **Bookkeeping-judge parity** (BRO-1003): the same workflow that
+   shipped on Bellows produces verdicts identical to the Bellows
+   version when fed the same input. Behavior parity proves the adapter
+   layering is correct.
+
+2. **Journal traceability**: a real session running a workflow tick
+   can be:
+   - Replayed at tick granularity (autonomic / EGRI / branching see
+     only `TickStarted` / `TickCompleted` events, normally)
+   - Replayed at workflow granularity (debugger sees every
+     `StreamEvent` nested under the parent tick)
+
+3. **No regression**: arcan's existing test suite plus all
+   aios-runtime tests pass. KernelRuntime tick latency for a
+   `TickKind::Direct` tick is within 1% of pre-spec baseline.
+
+4. **Backward compatibility**: every existing arcand call site that
+   builds a `TickInput` without setting `kind` continues to work
+   (`Default::default() == TickKind::Direct`).
+
+## 10. Composition trajectory
+
+There is no "arcan-harness retirement." The original spec framed ergon
+as a successor to arcan-harness; that's wrong. arcan-harness is a
+small ~300 LOC tool/sandbox/hashline-edit utility crate that stays as
+it is.
+
+The actual agent harness is the kernel runtime stack
+(`aios_runtime::KernelRuntime` + port adapters + `arcand`
+consciousness). That stack is **augmented** by ergon, not replaced:
+
+| Phase | When | Action |
+|---|---|---|
+| v0.1 | now | ergon shipped; arcan-ergon adapter (this spec) lets workflows run as rich ticks; bookkeeping-judge (BRO-1003) is the proof-of-shape |
+| v0.2 | after Spec E (BRO-1019) ships | `ergon::Provider` re-targets `InferenceRouter`; KV reuse + speculative decode + multi-vendor silicon for free |
+| v0.3 | as workflows accumulate | more agents structure their tick bodies as workflows; direct-tick remains for simple per-turn flows |
+| ongoing | indefinite | both tick body shapes coexist; the choice is per-tick, not per-session |
+
+There is no migration to "everything on ergon." Ergon is one shape of
+tick body. Different tasks favor different shapes.
+
+## 11. Versioning & stability
+
+- arcan-ergon v0.x: pre-1.0; minor versions may break trait surfaces
+  with CHANGELOG migration notes.
+- arcan-ergon v1.0: trait surface frozen; `#[non_exhaustive]` on every
+  public enum/struct that may grow.
+- The `TickKind` enum is `#[non_exhaustive]` — new variants land in
+  any minor version without breakage.
+
+## 12. Implementation work — ordered
+
+1. Add `TickKind` enum + field to `aios_runtime::TickInput`. Verify
+   no test breaks (`cargo test -p aios-runtime --all-targets`).
+2. Add the kernel-side dispatch match in `KernelRuntime::tick_on_branch`
+   for `TickKind::Workflow{...}`. Initially returns
+   `Err(KernelError::NotImplemented(...))`. Verify default `Direct`
+   path unchanged.
+3. Create `crates/arcan/arcan-ergon/` with the locked Cargo.toml from
+   §4.1 and module skeleton from §4.2.
+4. Land `error.rs`, `registry.rs`, `runtime_handle.rs` (small, no
+   substrate complexity).
+5. Land `provider.rs` (translates `ergon::ModelRequest` ↔
+   `aios_runtime::ModelCompletionRequest`; this is the meatiest of the
+   adapters).
+6. Land `tools.rs` (translates `ergon::ToolCall` ↔
+   `aios_runtime::ToolHarnessPort` invocation; integrates
+   `PolicyGatePort` for capability checks).
+7. Land the four auto-hook adapter impls in `auto_hooks/`.
+8. Land `runner.rs` — `run_workflow_as_tick` ties everything together.
+9. Wire the kernel-side dispatch (step 2) to call
+   `arcan_ergon::run_workflow_as_tick`. Now the path is end-to-end.
+10. Integration test in `tests/end_to_end.rs` per §7 item 6.
+11. CHANGELOG entry.
+
+Estimated effort: 3-5 days focused work.
+
+## 13. Sign-off
+
+This spec is **ready to file**. It supersedes §6 and §10 of
+`2026-05-05-ergon-v0.1.md` and references the canonical layered
+architecture in `docs/architecture/agent-harness.md`.
+
+Filed at: `core/life/docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md`.
+Linear: BRO-1001 (description updated to point here).


### PR DESCRIPTION
## Summary

**Course correction PR. No code changes.** Documents what the agent harness actually is, and corrects two sections of the original ergon spec (§6 + §10) that assumed an architecture that doesn't exist in arcan.

## What was wrong

\`docs/superpowers/specs/2026-05-05-ergon-v0.1.md\` §6 and §10 framed ergon as a parallel session-level runtime that would replace \`arcan-harness\` over time via an \`AgentKind\` trait abstraction.

That's wrong on two counts:
1. **\`arcan-harness\` is not the agent harness.** It's a ~300 LOC tool/sandbox utility crate. The actual agent harness is a 7-layer runtime stack distributed across ~25 crates.
2. **Ergon's \`Workflow::execute()\` cannot replace the tick engine.** It's one async fn with no suspend/resume, no replay-from-event-N, no daemon-restart survival. KernelRuntime tick-by-tick is the actual long-horizon agent loop. Workflow-as-async-fn would lose per-tick journal traceability that autonomic / EGRI / branching depend on.

## Corrected framing

**Ergon supplies one shape of *tick body* alongside the existing direct-call tick body.** Both compose with \`aios_runtime::KernelRuntime\`. Both produce per-tick events. Neither replaces anything.

| | **Direct tick body** (existing) | **Workflow tick body** (BRO-1001) |
|---|---|---|
| Implementation | \`ModelProviderPort.complete\` + optional \`ToolHarnessPort.execute\` | \`ergon::WorkflowExecutor::run\` (multi-turn workflow) |
| Best for | Simple per-turn flows | Bounded multi-turn operations (judges, scorers, scrapers) |
| Per-tick events | Kernel-typed \`EventKind\` variants | Kernel events at boundary + \`Custom(\"ergon.stream\", ...)\` nested under \`run_id\` |
| Replay | At kernel granularity | At kernel + workflow granularity |

## What this PR ships

**Documentation only:**

- **NEW** \`docs/architecture/agent-harness.md\` — canonical 7-layer runtime architecture. Maps every layer (L0 kernel contract → L6 process daemons) to its owning crates, walks bottom-up dependency chain + top-down execution trace, defines the two scopes of the agent loop (outer/session vs inner/tick), enumerates built vs pending. **This is the doc any future spec should reference when it talks about \"the harness.\"**

- **NEW** \`docs/superpowers/specs/2026-05-08-bro-1001-ergon-tick-body.md\` — corrected BRO-1001 design. 13 sections covering: scope, layered position, public API (\`TickBodyCtx\`, \`run_workflow_as_tick\`, \`WorkflowRegistry\`), lifecycle, the small \`TickKind\` extension to aios-runtime, DoD, open questions, validation criteria, composition trajectory, versioning, ordered impl plan.

- **MODIFIED** \`docs/superpowers/specs/2026-05-05-ergon-v0.1.md\` — added top-level correction note pointing to the architecture doc + new BRO-1001 spec. §6 + §10 marked SUPERSEDED inline. §§0-5, 7-9, 11-13 valid as written.

- **MODIFIED** \`crates/ergon/ergon/CLAUDE.md\` — corrected positioning (\"ergon is one shape of tick body, not a parallel session runtime\") + canonical layer diagram.

- **MODIFIED** \`CHANGELOG.md\` — Changed entry documenting the correction.

## What does NOT change

The ergon trait surface (Workflow, Step, StepCtx, Hook, model wire types, runtime ports, stream sinks), ergon-life-hooks (4 auto-hooks + adapter traits), ergon-life-sinks (Lago / Vigil / Lifegw). All correct as shipped. They're precisely what a tick-body adapter needs.

## Why this is a doc-only PR

The course correction was caught **before** shipping the wrong adapter (BRO-1001 wasn't scaffolded yet). The trait crates already on main are substrate-free and framing-agnostic. The mismatched framing existed only in the spec text + the not-yet-written adapter design. By correcting the docs first, BRO-1001 will be scaffolded against the right design — no retracted code.

## Test plan

- [x] \`cargo check -p ergon -p ergon-life-hooks\` clean (no code regression)
- [x] All in-flight ergon work unaffected (#1170 doesn't touch any of these files)
- [ ] CI: format / lint / msrv / test-linux / test-macos / build-release green

## What's next after merge

1. Update Linear BRO-1001 description to point at the new spec
2. After #1170 (ergon-life-sinks rebased) merges, scaffold \`crates/arcan/arcan-ergon/\` per the corrected design
3. BRO-1001b (separate ticket): arcand wiring for \`TickKind\` dispatch (small change, feature-flagged)
4. BRO-1003: bookkeeping-judge port — first real workflow exercising the corrected adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added canonical agent-harness architecture documentation outlining the distributed runtime stack and execution scopes.
  * Clarified ErgON positioning: it is a workflow-bodied tick shape that composes with the kernel runtime and does not replace existing systems.
  * Added new specification for the ergon tick-body adapter and workflow execution contract.
  * Updated internal documentation to reflect current ErgON architecture and primitives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->