### PR TITLE
feat(ergon): Agent / AgentSpec / TypedAgent primitive (BRO-1005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@
   * **Sub-context isolation**: each agent invocation opens an isolated
     sub-scope via `StepCtx::swap_scope` — separate message history,
     chained tool registry, but shared provider/hooks/sink/runtime.
-    Parallel `try_join_all` over multiple agents from a workflow body
-    works correctly without history pollution.
+    This isolation is for **serial** reuse of one `StepCtx` so a
+    follow-up step doesn't inherit the previous agent's conversation.
+    Parallel fan-out over multiple agents (e.g. `try_join_all`)
+    requires the workflow author to clone the substrate Arcs and
+    construct independent `StepCtx` instances — one per branch.
   * **Forward-compat slot**: `AgentSpec.extensions: HashMap<String, Value>`
     plus `#[non_exhaustive]` lets future patterns (recursion configs,
     identity constraints, scheduling hints, remote refs, Spec E backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,69 @@
 ## Unreleased
 
 ### Added
+- `ergon::Agent` / `ergon::AgentSpec` / `ergon::TypedAgent` — first-class
+  typed-I/O agent primitive for the Life agent harness. (BRO-1005)
+  * **`AgentSpec`** is data: serializable, `JsonSchema`-derivable,
+    constructible at runtime, returnable as the typed `Output` of
+    another agent (the "factory" pattern that enables agent-emits-agent
+    composition without recursion machinery), and embeddable in
+    streams or lago events.
+  * **`Agent` trait** is the unifying contract: `fn spec()` + `async fn
+    run(ctx, input: Value) -> Output: Value`. Implemented for
+    `AgentSpec` directly (dynamic path) and auto-derived for any
+    `T: TypedAgent` (static path). Both lower to the same engine —
+    `ergon::run_spec`.
+  * **`TypedAgent` trait** is the static-typed convenience: declare
+    `Input` / `Output` as Rust types with `Serialize` + `Deserialize`
+    + `JsonSchema` bounds plus a few config methods, and the framework
+    auto-derives an `AgentSpec` (with sanitized JSON Schemas) and
+    auto-impls `Agent` over it.
+  * **`AgentStep<A>` / `TypedAgentStep<T>`** wrappers bridge agents
+    into `ergon::Step` so workflow bodies compose them via the standard
+    `ctx.step(&agent_step, input)` API. Explicit wrappers (rather than
+    a blanket `impl<A: Agent> Step for A`) preserve trait coherence
+    so future blanket Step impls remain possible.
+  * **The interpreter** (`ergon::run_spec`) drives the autonomous loop
+    with a synthetic `record_answer` tool injected into the workflow's
+    `ToolRegistry` (via `ChainedToolRegistry`). The model's final act
+    must be `record_answer({"answer": <typed value>})`; the interpreter
+    captures the args via a side channel, validates against the output
+    schema, deserializes, and returns. On schema violation a corrective
+    user message is appended and the loop retries up to `max_retries`;
+    exhausted retries surface as `AgentError::SchemaViolation`. Other
+    typed failures: `AgentError::AnswerNotEmitted` (model never
+    recorded), `AgentError::Refusal` (provider stop_reason=Refusal),
+    `AgentError::InvalidSpec` (pre-flight validation).
+  * **Sub-context isolation**: each agent invocation opens an isolated
+    sub-scope via `StepCtx::swap_scope` — separate message history,
+    chained tool registry, but shared provider/hooks/sink/runtime.
+    Parallel `try_join_all` over multiple agents from a workflow body
+    works correctly without history pollution.
+  * **Forward-compat slot**: `AgentSpec.extensions: HashMap<String, Value>`
+    plus `#[non_exhaustive]` lets future patterns (recursion configs,
+    identity constraints, scheduling hints, remote refs, Spec E backend
+    hints) land additively without breaking changes.
+  * Adds `schemars = "0.8"` dependency to ergon (already in workspace).
+  14 integration tests with `ScriptedProvider` covering: happy path
+  single-turn, multi-turn with workflow tool dispatch, schema-violation
+  retry success, retry exhaustion → typed error, refusal, answer-not-
+  emitted, dynamic `AgentSpec::run` parity with TypedAgent, agent-emits-
+  AgentSpec factory pattern, sub-context isolation, schema sanitization.
+
+  **Why this shape**: an agentic OS needs primitives for identity,
+  capability, state, budget, observability, trust, communication,
+  discovery, and lifecycle. The Agent primitive's job is small and
+  precise — only the typed-I/O contract + first-class spec value +
+  agent-loop discipline. Identity/capability/state/budget/observability
+  /trust are delegated to existing substrates (anima, autonomic, vigil,
+  lago, nous) via the existing hook + sink + port architecture.
+  Communication patterns (mailboxes, pub/sub, remote dispatch) compose
+  via `AgentSpec`'s serializability without primitive changes.
+  Discovery, recursion, and long-lived agents are deferred to follow-
+  up primitives that compose with — rather than mutate — the Agent
+  trait. The first workflow that genuinely needs in-loop spawning
+  will land that as a narrow follow-up.
+
 - `arcan-ergon` — new sibling crate at `crates/arcan/arcan-ergon/`
   delivering the kernel-side adapter that runs an `ergon::Workflow`
   as the body of a single `aios_runtime::KernelRuntime` tick. Resolves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "async-trait",
  "futures",
  "insta",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/ergon/ergon/CLAUDE.md
+++ b/crates/ergon/ergon/CLAUDE.md
@@ -59,8 +59,10 @@ crate:
 | `model.rs` (Message, ContentBlock, ToolCall, ToolResult, ToolDefinition, ModelRequest, ModelResponse, Usage) | BRO-997 | Done |
 | `hook.rs` (Hook trait, HookCtx, HookRegistry, outcome types) | BRO-997 | Done |
 | `runtime.rs` (Provider, ToolRegistry, RuntimeHandle traits — runtime extension points owned by ergon, translated by the arcan adapter) | BRO-998 | Done |
-| `step.rs` (Step, StepCtx, InferenceRequest, run_inference_streaming + autonomous loop body, dispatch_tool) | BRO-998 | Done |
+| `step.rs` (Step, StepCtx, InferenceRequest, run_inference_streaming + autonomous loop body, dispatch_tool, swap_scope) | BRO-998 / BRO-1005 | Done |
 | `workflow.rs` (Workflow trait, WorkflowExecutor, SkillSet/EmptySkillSet stub) | BRO-999 | Done |
+| `agent.rs` (Agent trait, AgentSpec, AgentError, run_spec interpreter, ChainedToolRegistry, AnswerRecorderTools) | BRO-1005 | Done |
+| `typed_agent.rs` (TypedAgent trait + auto-Agent impl, typed_schema sanitization, AgentStep/TypedAgentStep wrappers) | BRO-1005 | Done |
 
 **Sibling crates landed:**
 

--- a/crates/ergon/ergon/Cargo.toml
+++ b/crates/ergon/ergon/Cargo.toml
@@ -21,6 +21,7 @@ aios-protocol.workspace = true
 # Standard async + serialization.
 async-trait.workspace = true
 futures.workspace = true
+schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/ergon/ergon/src/agent.rs
+++ b/crates/ergon/ergon/src/agent.rs
@@ -693,34 +693,24 @@ fn validate_against_schema(value: &Value, schema: &Value) -> std::result::Result
                 }
             }
         }
-        "array" => {
-            if !value.is_array() {
-                return Err(format!("expected array, got {}", json_kind(value)));
-            }
+        "array" if !value.is_array() => {
+            return Err(format!("expected array, got {}", json_kind(value)));
         }
-        "string" => {
-            if !value.is_string() {
-                return Err(format!("expected string, got {}", json_kind(value)));
-            }
+        "string" if !value.is_string() => {
+            return Err(format!("expected string, got {}", json_kind(value)));
         }
-        "number" | "integer" => {
-            if !value.is_number() {
-                return Err(format!("expected number, got {}", json_kind(value)));
-            }
+        "number" | "integer" if !value.is_number() => {
+            return Err(format!("expected number, got {}", json_kind(value)));
         }
-        "boolean" => {
-            if !value.is_boolean() {
-                return Err(format!("expected boolean, got {}", json_kind(value)));
-            }
+        "boolean" if !value.is_boolean() => {
+            return Err(format!("expected boolean, got {}", json_kind(value)));
         }
-        "null" => {
-            if !value.is_null() {
-                return Err(format!("expected null, got {}", json_kind(value)));
-            }
+        "null" if !value.is_null() => {
+            return Err(format!("expected null, got {}", json_kind(value)));
         }
-        _ => {
-            // No type field or unknown — be permissive at v0.1.
-        }
+        // Matched type AND value passes that type check, OR no type
+        // field / unknown type — both pass through. Permissive at v0.1.
+        _ => {}
     }
     Ok(())
 }

--- a/crates/ergon/ergon/src/agent.rs
+++ b/crates/ergon/ergon/src/agent.rs
@@ -1,0 +1,737 @@
+//! Agent primitive — first-class typed-I/O bounded computation with
+//! structured output.
+//!
+//! ## Where this fits
+//!
+//! `Workflow` is the deterministic outer body. `Step` is any unit of
+//! work composed inside that body. `Agent` is **a Step that performs
+//! the agent loop** — a model call (possibly multi-turn with tool
+//! dispatch) whose final act produces a typed answer matching a
+//! pre-declared schema.
+//!
+//! The Agent primitive's job is small and precise:
+//!
+//! 1. Enforce a typed I/O contract at the boundary (input matches an
+//!    `input_schema`, output matches an `output_schema`).
+//! 2. Drive the autonomous loop ([`crate::StepCtx::run_inference_streaming`])
+//!    with a synthetic `record_answer` tool whose schema matches the
+//!    declared output type.
+//! 3. Capture the model's `record_answer` tool call, validate its
+//!    args against the schema, deserialize into the typed output.
+//! 4. Retry on schema violation with a corrective message; surface a
+//!    typed [`AgentError`] when retries are exhausted.
+//!
+//! Everything else — identity, capabilities, budgets, observability,
+//! trust, communication — is delegated to the substrates that already
+//! provide those primitives (anima, autonomic, vigil, lago, …) via
+//! the existing hook + sink + port architecture.
+//!
+//! ## Two paths into one engine
+//!
+//! - **Static-typed**: implement [`crate::TypedAgent`] in Rust with
+//!   compile-time `Input`/`Output` types. The framework auto-derives
+//!   an [`AgentSpec`] from your impl.
+//! - **Dynamic / data-driven**: construct an [`AgentSpec`] at runtime
+//!   (deserialized from JSON, returned by another agent, loaded from
+//!   lago, etc.) and call [`AgentSpec::run`] directly.
+//!
+//! Both lower to the same interpreter ([`run_spec`]). The framework's
+//! correctness guarantees (schema validation, retry semantics, hook
+//! firing, lifecycle events) are uniform across both paths.
+//!
+//! ## What this primitive does NOT do (and why that's a feature)
+//!
+//! Deliberately out of scope at v0.1:
+//!
+//! - **Recursion / spawn_agent**: agents calling agents from within
+//!   their loop. The primitive is shaped to absorb this without
+//!   breaking changes (see module-level note on [`AgentSpec.extensions`]),
+//!   but not shipped here. The first workflow that genuinely needs
+//!   in-loop recursive spawning will land that as a narrow follow-up.
+//! - **Async invocation / mailboxes**: agents-as-services. Future
+//!   `AgentInvoker` trait will wrap `Agent::run` with mailbox
+//!   semantics; the primitive's JSON-typed boundary makes that
+//!   trivial when the time comes.
+//! - **Discovery / registry**: name → agent lookup. Workflows compose
+//!   agents explicitly today; future `AgentRegistry` adds string-keyed
+//!   lookup once a workflow needs it.
+//! - **Long-lived / daemon agents**: reactive agents that don't
+//!   return a typed result. That's a SIBLING primitive (not a
+//!   subclass) — different shape, different lifecycle.
+//!
+//! Every deferred concern composes with the existing primitive
+//! without requiring it to change.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::error::{ErgonError, Result};
+use crate::model::{ContentBlock, ToolCall, ToolDefinition, ToolResult};
+use crate::role::Role;
+use crate::runtime::ToolRegistry;
+use crate::step::{InferenceRequest, StepCtx};
+
+// ─── AgentSpec ──────────────────────────────────────────────────────────
+
+/// First-class agent value.
+///
+/// `AgentSpec` is **data**, not just a trait. It can be:
+///
+/// - Constructed in Rust at compile time
+/// - Deserialized from JSON / a config file / a network message
+/// - Returned as the typed `Output` of another agent (the "factory"
+///   pattern that enables agent-emits-agent composition)
+/// - Embedded in a [`crate::stream::StreamEvent`] or lago event for
+///   full replay of an agent run
+/// - Passed through a transport (spaces channel, mailbox, RPC) without
+///   the framework caring
+///
+/// Marked `#[non_exhaustive]` so we can land additive fields (recursion
+/// configs, identity constraints, scheduling hints, remote refs)
+/// without a breaking change. Forward-compat values that haven't been
+/// promoted to first-class fields yet land in [`Self::extensions`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub struct AgentSpec {
+    /// Stable agent name, e.g. `"bookkeeping.score-extract"`.
+    /// Convention: dotted-path, kebab-case segments.
+    pub name: String,
+
+    /// Behavioral contract — becomes the agent-scope [`Role`] overlay.
+    /// Conventionally written as a system prompt: "You are X. Your
+    /// task is Y. You must finish by calling `record_answer` with …"
+    pub instructions: String,
+
+    /// Provider-specific model identifier.
+    pub model: String,
+
+    /// Maximum autonomous loop turns. Treat as the agent's compute
+    /// budget — high for genuine multi-turn agents (research,
+    /// planning), low for single-shot judges.
+    pub max_turns: u32,
+
+    /// Maximum retries on output schema validation failure.
+    pub max_retries: u8,
+
+    /// Optional whitelist of tool names the agent may invoke. `None`
+    /// means inherit the workflow's full registry. The framework
+    /// always synthesizes the agent's own `record_answer` tool;
+    /// `allowed_tools` filters everything ELSE.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+
+    /// JSON Schema for the input the agent accepts. Used at the
+    /// boundary to validate inbound JSON.
+    pub input_schema: Value,
+
+    /// JSON Schema for the typed output. The framework synthesizes a
+    /// `record_answer(answer: <output_schema>)` tool from this and
+    /// validates the model's tool-use args against it.
+    pub output_schema: Value,
+
+    /// Forward-compat slot. New patterns land here as agreed-upon
+    /// keys (e.g. `"max_depth": 8`, `"backend_hint": "mlx"`,
+    /// `"remote": {…}`) before being promoted to first-class fields.
+    /// Empty for v0.1 statically-constructed specs.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub extensions: HashMap<String, Value>,
+}
+
+impl AgentSpec {
+    /// Construct a new spec with the supplied required fields plus
+    /// sensible defaults for the rest.
+    ///
+    /// Defaults:
+    /// - `max_turns`: 16
+    /// - `max_retries`: 3
+    /// - `allowed_tools`: `None` (inherits the workflow's full registry)
+    /// - `extensions`: empty
+    ///
+    /// Builder methods (`with_max_turns`, `with_max_retries`,
+    /// `with_allowed_tools`, `with_extension`) refine the result.
+    pub fn new(
+        name: impl Into<String>,
+        model: impl Into<String>,
+        instructions: impl Into<String>,
+        input_schema: Value,
+        output_schema: Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            instructions: instructions.into(),
+            model: model.into(),
+            max_turns: 16,
+            max_retries: 3,
+            allowed_tools: None,
+            input_schema,
+            output_schema,
+            extensions: HashMap::new(),
+        }
+    }
+
+    /// Builder: set the autonomous loop turn budget.
+    #[must_use]
+    pub fn with_max_turns(mut self, n: u32) -> Self {
+        self.max_turns = n;
+        self
+    }
+
+    /// Builder: set the schema-violation retry budget.
+    #[must_use]
+    pub fn with_max_retries(mut self, n: u8) -> Self {
+        self.max_retries = n;
+        self
+    }
+
+    /// Builder: restrict the agent's tool access to a specific list.
+    #[must_use]
+    pub fn with_allowed_tools(mut self, tools: Vec<String>) -> Self {
+        self.allowed_tools = Some(tools);
+        self
+    }
+
+    /// Builder: add a forward-compat extension entry.
+    #[must_use]
+    pub fn with_extension(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.extensions.insert(key.into(), value);
+        self
+    }
+
+    /// Run this spec against a [`StepCtx`].
+    ///
+    /// Functionally equivalent to constructing a [`crate::TypedAgent`]
+    /// with matching types and calling its `run`. Both lower to the
+    /// same engine ([`run_spec`]).
+    pub async fn run(&self, ctx: &mut StepCtx<'_>, input: Value) -> Result<Value> {
+        run_spec(self, ctx, input).await
+    }
+
+    /// Validate that this spec is well-formed enough for the
+    /// interpreter to accept. Cheap structural checks only — no I/O.
+    /// Called automatically at the start of [`Self::run`].
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(ErgonError::internal("AgentSpec.name is empty"));
+        }
+        if self.model.is_empty() {
+            return Err(ErgonError::internal(format!(
+                "AgentSpec `{}`: model is empty",
+                self.name
+            )));
+        }
+        if self.max_turns == 0 {
+            return Err(ErgonError::internal(format!(
+                "AgentSpec `{}`: max_turns must be >= 1",
+                self.name
+            )));
+        }
+        if !self.input_schema.is_object() {
+            return Err(ErgonError::internal(format!(
+                "AgentSpec `{}`: input_schema must be a JSON object",
+                self.name
+            )));
+        }
+        if !self.output_schema.is_object() {
+            return Err(ErgonError::internal(format!(
+                "AgentSpec `{}`: output_schema must be a JSON object",
+                self.name
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ─── Agent trait ────────────────────────────────────────────────────────
+
+/// Anything runnable that conforms to the agent-loop discipline.
+///
+/// Implemented for:
+///
+/// - [`AgentSpec`] directly (dynamic / data-driven path)
+/// - Any `T: TypedAgent` via the auto-impl in `typed_agent.rs`
+///
+/// Both lower to [`run_spec`]. Custom `Agent` impls are unusual —
+/// prefer `TypedAgent` for static cases or `AgentSpec` for dynamic
+/// cases. Implementing `Agent` directly is reserved for advanced
+/// patterns like recording wrappers, remote-dispatch shims, etc.
+#[async_trait]
+pub trait Agent: Send + Sync {
+    /// The (possibly-derived) spec for this agent. Cheap to call —
+    /// implementations should memoize if the spec is expensive to
+    /// construct.
+    fn spec(&self) -> AgentSpec;
+
+    /// Run with JSON-typed boundaries. Default impl runs the spec
+    /// through the shared interpreter; override only if you have a
+    /// genuine reason to bypass it (e.g. remote dispatch).
+    async fn run(&self, ctx: &mut StepCtx<'_>, input: Value) -> Result<Value> {
+        run_spec(&self.spec(), ctx, input).await
+    }
+}
+
+#[async_trait]
+impl Agent for AgentSpec {
+    fn spec(&self) -> AgentSpec {
+        self.clone()
+    }
+    async fn run(&self, ctx: &mut StepCtx<'_>, input: Value) -> Result<Value> {
+        run_spec(self, ctx, input).await
+    }
+}
+
+// ─── AgentError (carried through ErgonError::Workflow / ::Internal) ─────
+
+/// Failures the interpreter can surface. Returned wrapped in
+/// [`ErgonError::Workflow`] for boundary callers; tests can downcast
+/// via [`AgentError::from_err`].
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AgentError {
+    /// The model never emitted a `record_answer` tool call within the
+    /// turn budget.
+    AnswerNotEmitted { agent: String, max_turns: u32 },
+    /// The model's `record_answer` args failed JSON-schema validation
+    /// across all retry attempts.
+    SchemaViolation {
+        agent: String,
+        attempts: u8,
+        last_error: String,
+    },
+    /// Provider returned a refusal stop reason on the final attempt.
+    Refusal { agent: String, message: String },
+    /// Spec validation failed before the loop even started.
+    InvalidSpec { agent: String, reason: String },
+}
+
+impl std::fmt::Display for AgentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AnswerNotEmitted { agent, max_turns } => {
+                write!(
+                    f,
+                    "agent `{agent}` never emitted record_answer within max_turns={max_turns}"
+                )
+            }
+            Self::SchemaViolation {
+                agent,
+                attempts,
+                last_error,
+            } => {
+                write!(
+                    f,
+                    "agent `{agent}`: record_answer args failed schema validation across \
+                     {attempts} attempt(s); last error: {last_error}"
+                )
+            }
+            Self::Refusal { agent, message } => {
+                write!(f, "agent `{agent}` refused: {message}")
+            }
+            Self::InvalidSpec { agent, reason } => {
+                write!(f, "agent `{agent}` spec invalid: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+impl From<AgentError> for ErgonError {
+    fn from(value: AgentError) -> Self {
+        ErgonError::Workflow(value.to_string())
+    }
+}
+
+// ─── The interpreter ────────────────────────────────────────────────────
+
+/// Name of the synthetic tool the interpreter injects to capture the
+/// agent's typed output. Stable string — agents must call this exactly.
+pub const RECORD_ANSWER_TOOL: &str = "record_answer";
+
+/// Run an [`AgentSpec`] against a [`StepCtx`].
+///
+/// This is the single execution engine for both static [`crate::TypedAgent`]
+/// and dynamic [`AgentSpec`] paths.
+///
+/// ## What it does
+///
+/// 1. Validate the spec.
+/// 2. Build a chained [`ToolRegistry`] that wraps the workflow's own
+///    registry and intercepts `record_answer` (filtering by
+///    `allowed_tools` if set).
+/// 3. Open a sub-context (isolated message history; same provider,
+///    hooks, sink, runtime).
+/// 4. Push the input as a `User` message.
+/// 5. Build an [`InferenceRequest`] with `model`, `max_turns`, and a
+///    [`Role`] overlay carrying the agent's instructions PLUS a
+///    standard suffix instructing the model to finish via `record_answer`.
+/// 6. Call [`crate::StepCtx::run_inference_streaming`].
+/// 7. After it returns, read the captured answer from the side
+///    channel. If absent → `AnswerNotEmitted`. If present but
+///    schema-invalid → either retry (with corrective message) up to
+///    `max_retries` or surface `SchemaViolation`.
+/// 8. Return the validated answer.
+///
+/// The retry loop uses a fresh `run_inference_streaming` call each
+/// time, with the corrective message appended to history. This gives
+/// hooks a chance to fire on each retry attempt.
+pub async fn run_spec(spec: &AgentSpec, ctx: &mut StepCtx<'_>, input: Value) -> Result<Value> {
+    spec.validate().map_err(|e| AgentError::InvalidSpec {
+        agent: spec.name.clone(),
+        reason: e.to_string(),
+    })?;
+
+    // Build the answer-capture sink + chained tool registry.
+    let answer_slot: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+    let recorder = Arc::new(AnswerRecorderTools::new(
+        spec.output_schema.clone(),
+        Arc::clone(&answer_slot),
+    ));
+    let chained: Arc<dyn ToolRegistry> = Arc::new(ChainedToolRegistry::new(
+        Arc::clone(&ctx.tools),
+        recorder,
+        spec.allowed_tools.clone(),
+    ));
+
+    // Open the sub-context with the chained registry. The Drop impl
+    // restores the parent's history + tools when this guard goes out
+    // of scope.
+    let sub = SubCtx::open(ctx, chained);
+
+    // Seed history with the input as a user message.
+    sub.ctx
+        .push_message(crate::model::Message::user_text(canonical_input_message(
+            spec, &input,
+        )));
+
+    // Compose the agent's role overlay. The agent-scope role carries
+    // the spec's instructions plus the framework's standard suffix
+    // (the record_answer contract). Workflow-scope and call-scope
+    // roles, if present, layer on top via the standard precedence rule.
+    let role = Role::agent("").with_instruction(compose_instructions(spec));
+    let request = InferenceRequest::new(spec.model.clone())
+        .with_role(role)
+        .with_max_turns(spec.max_turns);
+
+    // Drive the loop with retries on schema violation.
+    let mut attempts: u8 = 0;
+
+    loop {
+        attempts = attempts.saturating_add(1);
+
+        // Run the autonomous loop. The answer may be captured into
+        // the side channel even if the loop subsequently hits
+        // MaxTurns waiting for an EndTurn confirmation that never
+        // comes — so we check the slot regardless of whether
+        // `run_inference_streaming` returned Ok or Err(MaxTurns).
+        let response_result = sub.ctx.run_inference_streaming(&request).await;
+
+        // Read the captured answer (if any).
+        let captured = {
+            let mut guard = answer_slot.lock().await;
+            guard.take()
+        };
+
+        if let Some(answer) = captured {
+            // The answer was delivered. Validate against schema.
+            match validate_against_schema(&answer, &spec.output_schema) {
+                Ok(()) => return Ok(answer),
+                Err(err) => {
+                    if attempts >= spec.max_retries.max(1) {
+                        return Err(AgentError::SchemaViolation {
+                            agent: spec.name.clone(),
+                            attempts,
+                            last_error: err,
+                        }
+                        .into());
+                    }
+                    // Append a corrective user message for the next
+                    // attempt and continue the retry loop.
+                    sub.ctx
+                        .push_message(crate::model::Message::user_text(format!(
+                            "Your previous `{RECORD_ANSWER_TOOL}` call's arguments \
+                         failed schema validation: {err}. Please call \
+                         `{RECORD_ANSWER_TOOL}` again with a corrected payload."
+                        )));
+                    continue;
+                }
+            }
+        }
+
+        // No answer captured. The terminal state is what determines
+        // which typed error we surface.
+        return match response_result {
+            Ok(response) if matches!(response.stop_reason, crate::stream::StopReason::Refusal) => {
+                let text = response
+                    .content
+                    .iter()
+                    .find_map(|b| match b {
+                        ContentBlock::Text { text } => Some(text.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                Err(AgentError::Refusal {
+                    agent: spec.name.clone(),
+                    message: text,
+                }
+                .into())
+            }
+            Ok(_) => Err(AgentError::AnswerNotEmitted {
+                agent: spec.name.clone(),
+                max_turns: spec.max_turns,
+            }
+            .into()),
+            Err(ErgonError::MaxTurns(_)) => Err(AgentError::AnswerNotEmitted {
+                agent: spec.name.clone(),
+                max_turns: spec.max_turns,
+            }
+            .into()),
+            Err(other) => Err(other),
+        };
+    }
+}
+
+// ─── Sub-context (isolated history; shared everything else) ─────────────
+
+/// A scoped [`StepCtx`] whose message history is reset for the
+/// duration of an agent run, then restored on drop. The parent's
+/// history and tools registry are swapped back atomically.
+///
+/// Why isolated? Each agent invocation needs its own conversation —
+/// otherwise parallel `try_join_all` over multiple agents would
+/// braid their histories together. The other StepCtx fields
+/// (provider, hooks, sink, runtime, trace) are SHARED by reference
+/// since they're already `Arc`-based.
+struct SubCtx<'a, 'p> {
+    ctx: &'a mut StepCtx<'p>,
+    saved: Option<(Vec<crate::model::Message>, Arc<dyn ToolRegistry>)>,
+}
+
+impl<'a, 'p> SubCtx<'a, 'p> {
+    fn open(parent: &'a mut StepCtx<'p>, tools: Arc<dyn ToolRegistry>) -> Self {
+        let saved = parent.swap_scope(Vec::new(), tools);
+        Self {
+            ctx: parent,
+            saved: Some(saved),
+        }
+    }
+}
+
+impl<'a, 'p> Drop for SubCtx<'a, 'p> {
+    fn drop(&mut self) {
+        if let Some((history, tools)) = self.saved.take() {
+            self.ctx.swap_scope(history, tools);
+        }
+    }
+}
+
+// ─── Tool registry chaining ─────────────────────────────────────────────
+
+/// Wraps a user-supplied [`ToolRegistry`] with an
+/// [`AnswerRecorderTools`] so the synthetic `record_answer` tool is
+/// available to the agent. Optionally filters the user's tools by an
+/// allow-list (the `allowed_tools` field on [`AgentSpec`]).
+struct ChainedToolRegistry {
+    user: Arc<dyn ToolRegistry>,
+    recorder: Arc<AnswerRecorderTools>,
+    allow: Option<Vec<String>>,
+}
+
+impl ChainedToolRegistry {
+    fn new(
+        user: Arc<dyn ToolRegistry>,
+        recorder: Arc<AnswerRecorderTools>,
+        allow: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            user,
+            recorder,
+            allow,
+        }
+    }
+
+    fn user_tool_allowed(&self, name: &str) -> bool {
+        match &self.allow {
+            None => true,
+            Some(allow) => allow.iter().any(|n| n == name),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolRegistry for ChainedToolRegistry {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        let mut defs = self.recorder.definitions();
+        for d in self.user.definitions() {
+            if self.user_tool_allowed(&d.name) {
+                defs.push(d);
+            }
+        }
+        defs
+    }
+
+    async fn invoke(&self, call: ToolCall) -> Result<ToolResult> {
+        if call.name == RECORD_ANSWER_TOOL {
+            return self.recorder.invoke(call).await;
+        }
+        if !self.user_tool_allowed(&call.name) {
+            return Ok(ToolResult::model_error(
+                call.id,
+                serde_json::json!({
+                    "error": format!(
+                        "tool `{}` is not in the agent's allowed_tools list",
+                        call.name,
+                    )
+                }),
+            ));
+        }
+        self.user.invoke(call).await
+    }
+}
+
+/// One-tool registry exposing only `record_answer`. Captures the
+/// model's tool-use args into a side channel for the interpreter to
+/// read after the loop terminates.
+struct AnswerRecorderTools {
+    schema: Value,
+    slot: Arc<Mutex<Option<Value>>>,
+}
+
+impl AnswerRecorderTools {
+    fn new(schema: Value, slot: Arc<Mutex<Option<Value>>>) -> Self {
+        Self { schema, slot }
+    }
+}
+
+#[async_trait]
+impl ToolRegistry for AnswerRecorderTools {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        // Wrap output_schema as `{"type": "object", "properties":
+        // {"answer": <schema>}, "required": ["answer"]}` so the model
+        // emits `record_answer({"answer": …})`.
+        let wrapped = serde_json::json!({
+            "type": "object",
+            "properties": { "answer": self.schema.clone() },
+            "required": ["answer"],
+            "additionalProperties": false,
+        });
+        vec![ToolDefinition::new(
+            RECORD_ANSWER_TOOL,
+            "Record your final answer. Call this exactly once on your final turn \
+             to deliver the typed result. The framework reads the `answer` \
+             argument as the agent's output.",
+            wrapped,
+        )]
+    }
+
+    async fn invoke(&self, call: ToolCall) -> Result<ToolResult> {
+        let answer = call.input.get("answer").cloned().unwrap_or(Value::Null);
+        *self.slot.lock().await = Some(answer);
+        // Return synthetic success so the autonomous loop continues
+        // and the model gets a chance to terminate cleanly.
+        Ok(ToolResult::success(
+            call.id,
+            serde_json::json!({"ok": true, "recorded": true}),
+        ))
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+fn canonical_input_message(spec: &AgentSpec, input: &Value) -> String {
+    // Render the input as a JSON code block so the model can parse it
+    // unambiguously. Conventional shape; future agents could override.
+    format!(
+        "Input for `{}`:\n```json\n{}\n```",
+        spec.name,
+        serde_json::to_string_pretty(input).unwrap_or_else(|_| "<invalid JSON>".to_owned()),
+    )
+}
+
+fn compose_instructions(spec: &AgentSpec) -> String {
+    // The instructions block PLUS a standard suffix telling the model
+    // how to deliver its answer. The suffix is identical across all
+    // agents — it's the framework's contract with the model.
+    format!(
+        "{instructions}\n\n\
+         === Output Contract ===\n\
+         You must finish by calling the `{RECORD_ANSWER_TOOL}` tool exactly \
+         once with `{{\"answer\": <typed answer matching the declared output \
+         schema>}}`. Do not respond with text-only on your final turn — the \
+         framework reads your answer from the `{RECORD_ANSWER_TOOL}` tool \
+         arguments. After calling `{RECORD_ANSWER_TOOL}`, you may stop.",
+        instructions = spec.instructions,
+    )
+}
+
+/// Lightweight schema validation. We don't pull a full JSON-schema
+/// validator dep at v0.1 — we check structural fit (object vs array,
+/// required keys present, scalar types match). Strict validation is
+/// left to consumers that want it; the typed-output `serde::Deserialize`
+/// at the static-typed boundary is the real check there.
+fn validate_against_schema(value: &Value, schema: &Value) -> std::result::Result<(), String> {
+    let kind = schema.get("type").and_then(Value::as_str).unwrap_or("");
+    match kind {
+        "object" => {
+            if !value.is_object() {
+                return Err(format!("expected object, got {}", json_kind(value)));
+            }
+            if let (Some(Value::Array(required)), Some(obj)) =
+                (schema.get("required"), value.as_object())
+            {
+                for r in required {
+                    if let Some(key) = r.as_str()
+                        && !obj.contains_key(key)
+                    {
+                        return Err(format!("missing required key `{key}`"));
+                    }
+                }
+            }
+        }
+        "array" => {
+            if !value.is_array() {
+                return Err(format!("expected array, got {}", json_kind(value)));
+            }
+        }
+        "string" => {
+            if !value.is_string() {
+                return Err(format!("expected string, got {}", json_kind(value)));
+            }
+        }
+        "number" | "integer" => {
+            if !value.is_number() {
+                return Err(format!("expected number, got {}", json_kind(value)));
+            }
+        }
+        "boolean" => {
+            if !value.is_boolean() {
+                return Err(format!("expected boolean, got {}", json_kind(value)));
+            }
+        }
+        "null" => {
+            if !value.is_null() {
+                return Err(format!("expected null, got {}", json_kind(value)));
+            }
+        }
+        _ => {
+            // No type field or unknown — be permissive at v0.1.
+        }
+    }
+    Ok(())
+}
+
+fn json_kind(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/crates/ergon/ergon/src/agent.rs
+++ b/crates/ergon/ergon/src/agent.rs
@@ -116,7 +116,11 @@ pub struct AgentSpec {
     /// planning), low for single-shot judges.
     pub max_turns: u32,
 
-    /// Maximum retries on output schema validation failure.
+    /// Maximum *corrective retries* on output schema validation
+    /// failure (in addition to the initial attempt). A value of `3`
+    /// means up to `1 + 3 = 4` total attempts at producing a
+    /// schema-conformant answer before [`AgentError::SchemaViolation`]
+    /// is surfaced.
     pub max_retries: u8,
 
     /// Optional whitelist of tool names the agent may invoke. `None`
@@ -442,7 +446,11 @@ pub async fn run_spec(spec: &AgentSpec, ctx: &mut StepCtx<'_>, input: Value) -> 
             match validate_against_schema(&answer, &spec.output_schema) {
                 Ok(()) => return Ok(answer),
                 Err(err) => {
-                    if attempts >= spec.max_retries.max(1) {
+                    // `max_retries` is *corrective retries on top of
+                    // the initial attempt*, so we exhaust at
+                    // `attempts > max_retries` (e.g. max_retries=3
+                    // permits attempts 1, 2, 3, 4).
+                    if attempts > spec.max_retries.max(1) {
                         return Err(AgentError::SchemaViolation {
                             agent: spec.name.clone(),
                             attempts,
@@ -502,11 +510,19 @@ pub async fn run_spec(spec: &AgentSpec, ctx: &mut StepCtx<'_>, input: Value) -> 
 /// duration of an agent run, then restored on drop. The parent's
 /// history and tools registry are swapped back atomically.
 ///
-/// Why isolated? Each agent invocation needs its own conversation —
-/// otherwise parallel `try_join_all` over multiple agents would
-/// braid their histories together. The other StepCtx fields
-/// (provider, hooks, sink, runtime, trace) are SHARED by reference
-/// since they're already `Arc`-based.
+/// Why isolated? When a workflow body runs multiple agents *in
+/// sequence* against the same `StepCtx`, the sub-scope ensures the
+/// next agent doesn't inherit the previous agent's conversation. The
+/// `Agent::run` signature takes `&mut StepCtx`, so this isolation is
+/// for **serial** reuse of one ctx — concurrent invocations against
+/// the same ctx are precluded by the borrow checker.
+///
+/// For genuine parallel fan-out (e.g. running N agents over a
+/// `Vec<Item>` via `try_join_all`), the workflow author should clone
+/// the underlying `Provider`/`HookRegistry`/`StreamSink`/`RuntimeHandle`
+/// (all `Arc`-based already) and construct N independent
+/// `StepCtx` instances — one per branch. This mirrors how
+/// `arcan-ergon`'s runner builds a fresh ctx per workflow tick.
 struct SubCtx<'a, 'p> {
     ctx: &'a mut StepCtx<'p>,
     saved: Option<(Vec<crate::model::Message>, Arc<dyn ToolRegistry>)>,

--- a/crates/ergon/ergon/src/lib.rs
+++ b/crates/ergon/ergon/src/lib.rs
@@ -48,6 +48,7 @@
 
 #![doc(html_no_source)]
 
+pub mod agent;
 pub mod error;
 pub mod hook;
 pub mod model;
@@ -55,8 +56,10 @@ pub mod role;
 pub mod runtime;
 pub mod step;
 pub mod stream;
+pub mod typed_agent;
 pub mod workflow;
 
+pub use agent::{Agent, AgentError, AgentSpec, RECORD_ANSWER_TOOL, run_spec};
 pub use error::{ErgonError, Result};
 pub use hook::{Hook, HookCtx, HookOutcome, HookRegistry, InferenceHookOutcome, ToolHookOutcome};
 pub use model::{
@@ -67,6 +70,10 @@ pub use role::{Role, RoleScope};
 pub use runtime::{Provider, RuntimeHandle, ToolRegistry};
 pub use step::{DEFAULT_INFERENCE_MAX_TURNS, InferenceRequest, Step, StepCtx};
 pub use stream::{BufferSink, FanoutSink, StopReason, StreamEvent, StreamSink};
+pub use typed_agent::{
+    AgentStep, DEFAULT_TYPED_AGENT_MAX_RETRIES, DEFAULT_TYPED_AGENT_MAX_TURNS, TypedAgent,
+    TypedAgentStep, typed_schema,
+};
 pub use workflow::{EmptySkillSet, SkillSet, Workflow, WorkflowExecutor};
 
 /// Re-export of [`aios_protocol::ids::SessionId`] — the canonical session

--- a/crates/ergon/ergon/src/step.rs
+++ b/crates/ergon/ergon/src/step.rs
@@ -242,6 +242,25 @@ impl<'a> StepCtx<'a> {
         &self.history
     }
 
+    /// Atomically replace the conversation scope (message history + tool
+    /// registry) and return the previous values.
+    ///
+    /// Used by the [`crate::agent::run_spec`] interpreter to give each
+    /// agent invocation its own isolated conversation while sharing the
+    /// rest of the [`StepCtx`] (provider, hooks, sink, runtime, trace).
+    /// Most workflow authors should never call this directly; prefer
+    /// [`Self::step`] (with an `Agent` or any other `Step` impl), which
+    /// handles scope management for you.
+    pub fn swap_scope(
+        &mut self,
+        new_history: Vec<Message>,
+        new_tools: Arc<dyn ToolRegistry>,
+    ) -> (Vec<Message>, Arc<dyn ToolRegistry>) {
+        let prev_history = std::mem::replace(&mut self.history, new_history);
+        let prev_tools = std::mem::replace(&mut self.tools, new_tools);
+        (prev_history, prev_tools)
+    }
+
     /// Run a sub-step. Fires `on_step_start` / `on_step_end` hooks
     /// automatically.
     pub async fn step<S>(&mut self, s: &S, input: S::Input) -> Result<S::Output>

--- a/crates/ergon/ergon/src/typed_agent.rs
+++ b/crates/ergon/ergon/src/typed_agent.rs
@@ -1,0 +1,284 @@
+//! `TypedAgent` — static-typed convenience over [`crate::Agent`].
+//!
+//! Implementing [`TypedAgent`] in Rust is the **default path** for
+//! known-shape agents. The framework auto-derives an [`AgentSpec`]
+//! from your impl (using `schemars` for input/output schema
+//! synthesis) and auto-impls [`Agent`] over it. The impl's `run`
+//! body delegates to the same [`crate::agent::run_spec`] interpreter
+//! the dynamic [`AgentSpec`] path uses.
+//!
+//! ## Why two paths into one engine
+//!
+//! - `TypedAgent` (this module): static-typed, compile-time-checked,
+//!   serde-erased `Input`/`Output`. Use this for agents that ship as
+//!   part of your binary.
+//! - [`AgentSpec`] (data): runtime-constructed, JSON-typed. Use this
+//!   for dynamic patterns — agents that generate other agents,
+//!   agents loaded from a registry, agents flowing through a wire
+//!   transport.
+//!
+//! Both lower to the same engine. The framework's correctness
+//! guarantees (schema validation, retries, hook firing, lifecycle
+//! events) are uniform across both.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use schemars::schema_for;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::agent::{Agent, AgentSpec, run_spec};
+use crate::error::{ErgonError, Result};
+use crate::step::StepCtx;
+
+/// Default for [`TypedAgent::max_turns`]. Matches the autonomous
+/// loop's general-purpose default — high enough for genuine agents,
+/// low enough to fail fast on runaway behavior.
+pub const DEFAULT_TYPED_AGENT_MAX_TURNS: u32 = 16;
+
+/// Default for [`TypedAgent::max_retries`]. One initial attempt plus
+/// up to three corrective retries on schema-violation feedback.
+pub const DEFAULT_TYPED_AGENT_MAX_RETRIES: u8 = 3;
+
+/// Static-typed convenience trait for known-shape agents.
+///
+/// Implementers supply the `Input` / `Output` types (with `Serialize`,
+/// `Deserialize`, and `JsonSchema` bounds) and a small set of config
+/// methods describing the agent's behavior. The framework auto-derives
+/// an [`AgentSpec`] from your impl and auto-impls [`Agent`] over it.
+///
+/// ## Example
+///
+/// ```ignore
+/// use ergon::{TypedAgent, StepCtx};
+/// use std::borrow::Cow;
+/// use schemars::JsonSchema;
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Serialize, JsonSchema)] struct ScoreInput { text: String }
+/// #[derive(Deserialize, JsonSchema)] struct ScoreOutput { score: u8 }
+///
+/// struct Scorer;
+/// impl TypedAgent for Scorer {
+///     type Input = ScoreInput;
+///     type Output = ScoreOutput;
+///     fn name(&self) -> &str { "demo.scorer" }
+///     fn instructions(&self) -> Cow<'_, str> {
+///         Cow::Borrowed("Score the text 1-10. Higher is better.")
+///     }
+///     fn model(&self) -> &str { "claude-haiku-4-5" }
+///     fn max_turns(&self) -> u32 { 1 }  // single-shot judge
+/// }
+/// ```
+pub trait TypedAgent: Send + Sync + 'static {
+    /// Typed input. Must be JSON-serializable AND have a JSON Schema
+    /// (so the framework can declare the agent's input contract).
+    type Input: Serialize + JsonSchema + Send;
+
+    /// Typed output. Must be JSON-deserializable AND have a JSON
+    /// Schema (so the framework can synthesize the `record_answer`
+    /// tool's input schema and validate the model's response).
+    type Output: DeserializeOwned + JsonSchema + Send;
+
+    /// Stable agent name. Convention: dotted-path, e.g.
+    /// `"bookkeeping.score-extract"`.
+    fn name(&self) -> &str;
+
+    /// Behavioral contract — becomes the agent-scope [`crate::Role`]
+    /// overlay. Conventionally written as a system prompt.
+    fn instructions(&self) -> Cow<'_, str>;
+
+    /// Provider-specific model identifier, e.g.
+    /// `"claude-sonnet-4-5-20250929"`.
+    fn model(&self) -> &str;
+
+    /// Maximum autonomous loop turns. Default
+    /// [`DEFAULT_TYPED_AGENT_MAX_TURNS`]. Override low (1-2) for
+    /// single-shot judges, high (32+) for genuine agents that plan,
+    /// use tools, observe results, and iterate.
+    fn max_turns(&self) -> u32 {
+        DEFAULT_TYPED_AGENT_MAX_TURNS
+    }
+
+    /// Maximum retries on output schema validation failure. Default
+    /// [`DEFAULT_TYPED_AGENT_MAX_RETRIES`].
+    fn max_retries(&self) -> u8 {
+        DEFAULT_TYPED_AGENT_MAX_RETRIES
+    }
+
+    /// Optional whitelist of tool names the agent may invoke. `None`
+    /// (default) means inherit the workflow's full registry. The
+    /// framework always synthesizes the agent's own `record_answer`
+    /// tool; this filters everything else.
+    fn allowed_tools(&self) -> Option<&[String]> {
+        None
+    }
+}
+
+/// Bridge `TypedAgent` impls into `Agent` impls.
+///
+/// Auto-derives an [`AgentSpec`] from the impl's typed I/O and
+/// config, then runs through the shared [`run_spec`] interpreter.
+#[async_trait]
+impl<T: TypedAgent> Agent for T {
+    fn spec(&self) -> AgentSpec {
+        AgentSpec {
+            name: self.name().to_owned(),
+            instructions: self.instructions().to_string(),
+            model: self.model().to_owned(),
+            max_turns: self.max_turns(),
+            max_retries: self.max_retries(),
+            allowed_tools: self.allowed_tools().map(|s| s.to_vec()),
+            input_schema: typed_schema::<T::Input>(),
+            output_schema: typed_schema::<T::Output>(),
+            extensions: HashMap::new(),
+        }
+    }
+
+    async fn run(&self, ctx: &mut StepCtx<'_>, input: Value) -> Result<Value> {
+        run_spec(&self.spec(), ctx, input).await
+    }
+}
+
+/// Helper for `TypedAgent` impls: generate the JSON Schema for a type
+/// in the LLM-friendly form the interpreter expects.
+///
+/// The schema is post-processed to strip schemars metadata that
+/// confuses LLMs — `$schema`, `title` for primitives, `definitions`
+/// when there's only one definition. Inlines refs where possible.
+pub fn typed_schema<T: JsonSchema>() -> Value {
+    let raw = schema_for!(T);
+    let mut value = serde_json::to_value(&raw).unwrap_or(Value::Null);
+    sanitize_schema_for_llm(&mut value);
+    value
+}
+
+/// Strip / inline schemars-specific decoration that's noise to the
+/// model. Modifies in-place.
+fn sanitize_schema_for_llm(value: &mut Value) {
+    if let Value::Object(map) = value {
+        // Drop the top-level `$schema` URL — purely informational.
+        map.remove("$schema");
+
+        // If schemars emitted a `definitions` block with exactly one
+        // entry AND the top-level is a `$ref` to it, inline the
+        // definition. This is the common case for a single derived
+        // type and produces a flatter, more LLM-friendly schema.
+        if let (Some(Value::Object(defs)), Some(Value::String(reference))) =
+            (map.get("definitions").cloned(), map.get("$ref").cloned())
+            && let Some(name) = reference.strip_prefix("#/definitions/")
+            && defs.len() == 1
+            && let Some(def) = defs.get(name).cloned()
+        {
+            map.remove("definitions");
+            map.remove("$ref");
+            if let Value::Object(def_map) = def {
+                for (k, v) in def_map {
+                    map.insert(k, v);
+                }
+            }
+        }
+
+        // Recurse into nested objects/arrays. Avoid borrowing issues
+        // by collecting keys first.
+        let keys: Vec<String> = map.keys().cloned().collect();
+        for k in keys {
+            if let Some(child) = map.get_mut(&k) {
+                sanitize_schema_for_llm(child);
+            }
+        }
+    } else if let Value::Array(arr) = value {
+        for item in arr.iter_mut() {
+            sanitize_schema_for_llm(item);
+        }
+    }
+}
+
+// ─── Convenient bridge: any Agent runs as a Step via the AgentStep wrapper ─
+
+/// Wrap any [`Agent`] as a [`crate::Step`] so workflow bodies can
+/// compose agents through the standard `ctx.step(...)` API.
+///
+/// Why a wrapper rather than a blanket `impl<A: Agent> Step for A`?
+/// Trait coherence — a blanket impl would collide with future blanket
+/// `Step` impls and prevent users from writing their own
+/// non-LLM-Step types. The wrapper is explicit and intentional.
+pub struct AgentStep<A: Agent + 'static> {
+    inner: Arc<A>,
+}
+
+impl<A: Agent + 'static> AgentStep<A> {
+    /// Construct from an Arc-wrapped agent.
+    pub fn new(agent: Arc<A>) -> Self {
+        Self { inner: agent }
+    }
+
+    /// Convenience: construct from a boxed agent.
+    pub fn from_value(agent: A) -> Self {
+        Self::new(Arc::new(agent))
+    }
+
+    /// Read-only access to the wrapped agent.
+    pub fn agent(&self) -> &Arc<A> {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl<A: Agent + 'static> crate::Step for AgentStep<A> {
+    type Input = Value;
+    type Output = Value;
+
+    fn name(&self) -> &str {
+        // Borrow the AgentSpec name. We can't return a &str borrowed
+        // from a temporary, so we cache by deferring to the trait
+        // object's instance. This produces a `<agent>:<name>` label
+        // — descriptive and stable.
+        "agent"
+    }
+
+    async fn run(&self, ctx: &mut StepCtx<'_>, input: Self::Input) -> Result<Self::Output> {
+        self.inner.run(ctx, input).await
+    }
+}
+
+/// Convenience: convert any `TypedAgent` into a typed `Step` whose
+/// `Input`/`Output` are the agent's typed I/O. Hides the JSON
+/// boundary inside the wrapper so workflow bodies stay statically
+/// typed end-to-end.
+pub struct TypedAgentStep<T: TypedAgent> {
+    inner: Arc<T>,
+}
+
+impl<T: TypedAgent> TypedAgentStep<T> {
+    pub fn new(agent: Arc<T>) -> Self {
+        Self { inner: agent }
+    }
+    pub fn from_value(agent: T) -> Self {
+        Self::new(Arc::new(agent))
+    }
+    pub fn agent(&self) -> &Arc<T> {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl<T: TypedAgent> crate::Step for TypedAgentStep<T> {
+    type Input = T::Input;
+    type Output = T::Output;
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    async fn run(&self, ctx: &mut StepCtx<'_>, input: Self::Input) -> Result<Self::Output> {
+        let input_value = serde_json::to_value(&input).map_err(ErgonError::Codec)?;
+        let output_value = self.inner.run(ctx, input_value).await?;
+        serde_json::from_value(output_value).map_err(ErgonError::Codec)
+    }
+}

--- a/crates/ergon/ergon/src/typed_agent.rs
+++ b/crates/ergon/ergon/src/typed_agent.rs
@@ -208,14 +208,25 @@ fn sanitize_schema_for_llm(value: &mut Value) {
 /// Trait coherence — a blanket impl would collide with future blanket
 /// `Step` impls and prevent users from writing their own
 /// non-LLM-Step types. The wrapper is explicit and intentional.
+///
+/// The wrapped agent's `spec().name` is cached at construction so
+/// `Step::name()` produces per-agent telemetry rather than a
+/// collapsed `"agent"` literal — important for tracing, hook
+/// filtering, and lago provenance.
 pub struct AgentStep<A: Agent + 'static> {
     inner: Arc<A>,
+    cached_name: String,
 }
 
 impl<A: Agent + 'static> AgentStep<A> {
-    /// Construct from an Arc-wrapped agent.
+    /// Construct from an Arc-wrapped agent. The agent's
+    /// `spec().name` is read once and cached for `Step::name()`.
     pub fn new(agent: Arc<A>) -> Self {
-        Self { inner: agent }
+        let cached_name = agent.spec().name;
+        Self {
+            inner: agent,
+            cached_name,
+        }
     }
 
     /// Convenience: construct from a boxed agent.
@@ -235,11 +246,7 @@ impl<A: Agent + 'static> crate::Step for AgentStep<A> {
     type Output = Value;
 
     fn name(&self) -> &str {
-        // Borrow the AgentSpec name. We can't return a &str borrowed
-        // from a temporary, so we cache by deferring to the trait
-        // object's instance. This produces a `<agent>:<name>` label
-        // — descriptive and stable.
-        "agent"
+        &self.cached_name
     }
 
     async fn run(&self, ctx: &mut StepCtx<'_>, input: Self::Input) -> Result<Self::Output> {

--- a/crates/ergon/ergon/tests/agent_primitive.rs
+++ b/crates/ergon/ergon/tests/agent_primitive.rs
@@ -1,0 +1,687 @@
+//! Integration tests for the Agent / TypedAgent / AgentSpec primitive.
+//!
+//! All tests use a `ScriptedProvider` that returns pre-canned model
+//! responses — no real network. The point is to validate the
+//! interpreter's behavior against every distinct outcome path:
+//!
+//! 1. Static `TypedAgent` happy path (single turn, valid answer).
+//! 2. Multi-turn agent that uses workflow tools, then records answer.
+//! 3. Schema-violation retry path (first attempt fails validation,
+//!    second attempt succeeds with a corrective user message).
+//! 4. Retry exhaustion → typed `SchemaViolation` error.
+//! 5. Provider returns a refusal stop reason → typed `Refusal`.
+//! 6. Model never calls `record_answer` → typed `AnswerNotEmitted`.
+//! 7. Dynamic `AgentSpec::run` produces the same result as the
+//!    equivalent `TypedAgent`.
+//! 8. Agent emits an `AgentSpec` as its output (the factory pattern
+//!    that proves agent-emits-agent works without recursion machinery).
+//! 9. Sub-context isolation — running an agent does not pollute the
+//!    parent's message history.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use ergon::{
+    Agent, AgentError, AgentSpec, BufferSink, ContentBlock, ErgonError, HookRegistry, Message,
+    ModelRequest, ModelResponse, Provider, RuntimeHandle, StepCtx, StopReason, StreamSink,
+    ToolCall, ToolDefinition, ToolRegistry, ToolResult, TypedAgent, run_spec,
+};
+use ergon::{MessageRole, RECORD_ANSWER_TOOL};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// ── Test types ──────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, JsonSchema, PartialEq, Debug, Clone)]
+struct ScoreInput {
+    text: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, PartialEq, Debug, Clone)]
+struct Score {
+    novelty: u8,
+    specificity: u8,
+    relevance: u8,
+}
+
+struct StaticScorer {
+    name: &'static str,
+    instructions: &'static str,
+    model: &'static str,
+    max_turns: u32,
+    max_retries: u8,
+}
+
+impl Default for StaticScorer {
+    fn default() -> Self {
+        Self {
+            name: "test.scorer",
+            instructions: "You score the input on three axes (novelty, specificity, relevance) \
+                           each 0-3. Higher is better.",
+            model: "test-model",
+            max_turns: 1,
+            max_retries: 3,
+        }
+    }
+}
+
+impl TypedAgent for StaticScorer {
+    type Input = ScoreInput;
+    type Output = Score;
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn instructions(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.instructions)
+    }
+    fn model(&self) -> &str {
+        self.model
+    }
+    fn max_turns(&self) -> u32 {
+        self.max_turns
+    }
+    fn max_retries(&self) -> u8 {
+        self.max_retries
+    }
+}
+
+// ── ScriptedProvider ────────────────────────────────────────────────────
+
+/// Returns pre-canned `ModelResponse`s in order. Each call pops the
+/// front of the queue. Panics if the queue is empty (means the test
+/// expected fewer turns than we got).
+struct ScriptedProvider {
+    name: String,
+    queue: Mutex<Vec<ModelResponse>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: Vec<ModelResponse>) -> Self {
+        Self {
+            name: "scripted".to_owned(),
+            queue: Mutex::new(responses),
+        }
+    }
+
+    fn remaining(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn stream(
+        &self,
+        _req: ModelRequest,
+        _sink: Arc<dyn StreamSink>,
+    ) -> Result<ModelResponse, ErgonError> {
+        let mut q = self.queue.lock().unwrap();
+        if q.is_empty() {
+            panic!("ScriptedProvider queue exhausted — test asked for more turns than scripted");
+        }
+        Ok(q.remove(0))
+    }
+}
+
+// ── Helpers to build canned ModelResponses ──────────────────────────────
+
+fn record_answer_call(call_id: &str, answer: serde_json::Value) -> ModelResponse {
+    ModelResponse::new(
+        vec![ContentBlock::ToolUse {
+            id: call_id.to_owned(),
+            name: RECORD_ANSWER_TOOL.to_owned(),
+            input: serde_json::json!({"answer": answer}),
+        }],
+        StopReason::ToolUse,
+    )
+}
+
+fn end_turn_text(text: &str) -> ModelResponse {
+    ModelResponse::new(
+        vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        StopReason::EndTurn,
+    )
+}
+
+fn refusal(text: &str) -> ModelResponse {
+    ModelResponse::new(
+        vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        StopReason::Refusal,
+    )
+}
+
+// ── EmptyTools / NopRuntime fixtures ────────────────────────────────────
+
+#[derive(Default)]
+struct EmptyTools;
+
+#[async_trait]
+impl ToolRegistry for EmptyTools {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        Vec::new()
+    }
+    async fn invoke(&self, call: ToolCall) -> Result<ToolResult, ErgonError> {
+        Err(ErgonError::Tool(format!(
+            "EmptyTools cannot invoke `{}`",
+            call.name
+        )))
+    }
+}
+
+struct NopRuntime;
+impl RuntimeHandle for NopRuntime {
+    fn operating_mode(&self) -> aios_protocol::mode::OperatingMode {
+        aios_protocol::mode::OperatingMode::Execute
+    }
+}
+
+// Build a clean StepCtx for one test invocation.
+fn make_ctx<'a>(
+    workflow_name: &'a str,
+    provider: Arc<dyn Provider>,
+    sink: Arc<BufferSink>,
+) -> StepCtx<'a> {
+    StepCtx::new(
+        ergon::SessionId::default(),
+        workflow_name,
+        provider,
+        Arc::new(EmptyTools) as Arc<dyn ToolRegistry>,
+        Arc::new(HookRegistry::default()),
+        sink as Arc<dyn StreamSink>,
+        Arc::new(NopRuntime) as Arc<dyn RuntimeHandle>,
+        tracing::Span::current(),
+    )
+}
+
+// ── 1. Static TypedAgent happy path (single turn) ──────────────────────
+
+#[tokio::test]
+async fn typed_agent_records_valid_answer_in_one_turn() {
+    // With max_turns=1, the autonomous loop runs the model exactly
+    // once; the model's record_answer tool_use is dispatched in that
+    // turn (capturing the answer in the side channel) and the loop
+    // exits with MaxTurns. The interpreter sees the captured answer
+    // and returns success — the post-record EndTurn confirmation is
+    // not required when max_turns budget is already spent.
+    let provider = Arc::new(ScriptedProvider::new(vec![record_answer_call(
+        "tu-1",
+        serde_json::json!({"novelty": 2, "specificity": 3, "relevance": 3}),
+    )]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider.clone() as Arc<dyn Provider>, sink);
+
+    let agent = StaticScorer::default();
+    let input = serde_json::to_value(ScoreInput {
+        text: "demo".into(),
+    })
+    .unwrap();
+
+    let answer = agent.run(&mut ctx, input).await.expect("run ok");
+    let parsed: Score = serde_json::from_value(answer).expect("deserialize Score");
+    assert_eq!(
+        parsed,
+        Score {
+            novelty: 2,
+            specificity: 3,
+            relevance: 3
+        }
+    );
+    assert_eq!(provider.remaining(), 0);
+}
+
+// ── 2. Multi-turn: agent uses a workflow tool, then records answer ────
+
+#[derive(Default)]
+struct StaticGreeterTool;
+
+#[async_trait]
+impl ToolRegistry for StaticGreeterTool {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        vec![ToolDefinition::new(
+            "greet",
+            "Generate a greeting",
+            serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}}),
+        )]
+    }
+    async fn invoke(&self, call: ToolCall) -> Result<ToolResult, ErgonError> {
+        let name = call
+            .input
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("anon");
+        Ok(ToolResult::success(
+            call.id,
+            serde_json::json!({"greeting": format!("hello, {name}")}),
+        ))
+    }
+}
+
+struct GreetThenScore;
+impl TypedAgent for GreetThenScore {
+    type Input = ScoreInput;
+    type Output = Score;
+    fn name(&self) -> &str {
+        "test.greet-then-score"
+    }
+    fn instructions(&self) -> Cow<'_, str> {
+        Cow::Borrowed("Greet then score.")
+    }
+    fn model(&self) -> &str {
+        "test-model"
+    }
+    fn max_turns(&self) -> u32 {
+        4
+    }
+}
+
+#[tokio::test]
+async fn agent_uses_workflow_tool_then_records_answer() {
+    let provider = Arc::new(ScriptedProvider::new(vec![
+        // Turn 1: model calls workflow tool `greet`
+        ModelResponse::new(
+            vec![ContentBlock::ToolUse {
+                id: "tu-1".into(),
+                name: "greet".into(),
+                input: serde_json::json!({"name": "Daisy"}),
+            }],
+            StopReason::ToolUse,
+        ),
+        // Turn 2: model calls record_answer with the score
+        record_answer_call(
+            "tu-2",
+            serde_json::json!({"novelty": 1, "specificity": 2, "relevance": 3}),
+        ),
+        // Turn 3: model emits EndTurn after record_answer success
+        end_turn_text("done"),
+    ]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = StepCtx::new(
+        ergon::SessionId::default(),
+        "test-workflow",
+        provider.clone() as Arc<dyn Provider>,
+        Arc::new(StaticGreeterTool) as Arc<dyn ToolRegistry>,
+        Arc::new(HookRegistry::default()),
+        sink as Arc<dyn StreamSink>,
+        Arc::new(NopRuntime) as Arc<dyn RuntimeHandle>,
+        tracing::Span::current(),
+    );
+
+    let answer = GreetThenScore
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect("run ok");
+    let score: Score = serde_json::from_value(answer).unwrap();
+    assert_eq!(score.relevance, 3);
+}
+
+// ── 3. Schema-violation retry succeeds on attempt 2 ─────────────────────
+
+#[tokio::test]
+async fn schema_violation_then_retry_succeeds() {
+    // Each retry attempt is a fresh `run_inference_streaming` call.
+    // With max_turns=1 inside each attempt, exactly one provider
+    // response is consumed per attempt.
+    let provider = Arc::new(ScriptedProvider::new(vec![
+        // Attempt 1: missing required `relevance` key — schema violation
+        record_answer_call("tu-1", serde_json::json!({"novelty": 2, "specificity": 3})),
+        // Attempt 2: corrected
+        record_answer_call(
+            "tu-2",
+            serde_json::json!({"novelty": 2, "specificity": 3, "relevance": 1}),
+        ),
+    ]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    let answer = StaticScorer::default()
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect("run ok after retry");
+    let s: Score = serde_json::from_value(answer).unwrap();
+    assert_eq!(s.relevance, 1);
+}
+
+// ── 4. Retry exhaustion → SchemaViolation error ─────────────────────────
+
+#[tokio::test]
+async fn retry_exhaustion_surfaces_schema_violation() {
+    let agent = StaticScorer {
+        max_retries: 2,
+        ..Default::default()
+    };
+    let provider = Arc::new(ScriptedProvider::new(vec![
+        // Attempt 1 — invalid
+        record_answer_call("tu-1", serde_json::json!({"novelty": 2})),
+        // Attempt 2 — still invalid
+        record_answer_call("tu-2", serde_json::json!({})),
+    ]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    let err = agent
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect_err("must fail with SchemaViolation");
+    assert!(
+        format!("{err}").contains("schema validation"),
+        "expected SchemaViolation message, got: {err}"
+    );
+}
+
+// ── 5. Provider returns Refusal → typed Refusal ─────────────────────────
+
+#[tokio::test]
+async fn refusal_is_surfaced() {
+    let provider = Arc::new(ScriptedProvider::new(vec![refusal("I cannot comply.")]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    let err = StaticScorer::default()
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect_err("must surface refusal");
+    let msg = format!("{err}");
+    assert!(msg.contains("refused"), "expected refusal text, got: {msg}");
+    assert!(msg.contains("cannot comply"));
+}
+
+// ── 6. Model never emits record_answer → AnswerNotEmitted ──────────────
+
+#[tokio::test]
+async fn answer_not_emitted_surfaces_typed_error() {
+    let agent = StaticScorer {
+        max_turns: 2,
+        ..Default::default()
+    };
+    let provider = Arc::new(ScriptedProvider::new(vec![end_turn_text(
+        "I'd prefer not to.",
+    )]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    let err = agent
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect_err("must fail with AnswerNotEmitted");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("never emitted record_answer") || msg.contains("AnswerNotEmitted"),
+        "expected AnswerNotEmitted, got: {msg}"
+    );
+}
+
+// ── 7. Dynamic AgentSpec::run path produces same result as TypedAgent ──
+
+#[tokio::test]
+async fn dynamic_agentspec_produces_same_result_as_typed_agent() {
+    let provider = Arc::new(ScriptedProvider::new(vec![record_answer_call(
+        "tu-1",
+        serde_json::json!({"novelty": 1, "specificity": 1, "relevance": 1}),
+    )]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    // Construct an AgentSpec that mirrors what TypedAgent would
+    // auto-derive — but at runtime, from data.
+    let spec = AgentSpec::new(
+        "dynamic.scorer",
+        "test-model",
+        "Score the input.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"]
+        }),
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "novelty": {"type": "integer"},
+                "specificity": {"type": "integer"},
+                "relevance": {"type": "integer"}
+            },
+            "required": ["novelty", "specificity", "relevance"]
+        }),
+    )
+    .with_max_turns(1);
+
+    let input = serde_json::json!({"text": "x"});
+    let answer = run_spec(&spec, &mut ctx, input).await.expect("run ok");
+    assert_eq!(answer["novelty"], 1);
+    assert_eq!(answer["specificity"], 1);
+    assert_eq!(answer["relevance"], 1);
+}
+
+// ── 8. Agent that emits an AgentSpec — agent factory pattern ───────────
+
+#[derive(Serialize, Deserialize, JsonSchema, PartialEq, Debug, Clone)]
+struct DesignRequest {
+    problem: String,
+}
+
+struct AgentDesigner;
+impl TypedAgent for AgentDesigner {
+    type Input = DesignRequest;
+    type Output = AgentSpec; // ← outputs a spec for another agent
+    fn name(&self) -> &str {
+        "test.designer"
+    }
+    fn instructions(&self) -> Cow<'_, str> {
+        Cow::Borrowed("Design an agent for the problem.")
+    }
+    fn model(&self) -> &str {
+        "test-model"
+    }
+    fn max_turns(&self) -> u32 {
+        1
+    }
+}
+
+#[tokio::test]
+async fn agent_can_emit_an_agent_spec_as_its_output() {
+    // The designer's emitted spec — note we wrap it as the "answer".
+    let designed = serde_json::json!({
+        "name": "designed.specialist",
+        "instructions": "You are the specialist.",
+        "model": "specialist-model",
+        "max_turns": 1,
+        "max_retries": 1,
+        "input_schema": {"type": "object"},
+        "output_schema": {"type": "object", "properties": {"result": {"type": "string"}}, "required": ["result"]}
+    });
+    let provider = Arc::new(ScriptedProvider::new(vec![record_answer_call(
+        "tu-1",
+        designed.clone(),
+    )]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    let answer = AgentDesigner
+        .run(
+            &mut ctx,
+            serde_json::to_value(DesignRequest {
+                problem: "subroutine X".into(),
+            })
+            .unwrap(),
+        )
+        .await
+        .expect("designer ok");
+
+    // The output should deserialize back into an AgentSpec — that's
+    // the proof that "agent emits agent" composes through the typed
+    // I/O contract without any special framework support.
+    let produced: AgentSpec = serde_json::from_value(answer).expect("deserialize spec");
+    assert_eq!(produced.name, "designed.specialist");
+    assert_eq!(produced.model, "specialist-model");
+}
+
+// ── 9. Sub-context isolation ────────────────────────────────────────────
+
+#[tokio::test]
+async fn agent_run_does_not_pollute_parent_history() {
+    let provider = Arc::new(ScriptedProvider::new(vec![record_answer_call(
+        "tu-1",
+        serde_json::json!({"novelty": 0, "specificity": 0, "relevance": 0}),
+    )]));
+    let sink = Arc::new(BufferSink::new());
+    let mut ctx = make_ctx("test-workflow", provider as Arc<dyn Provider>, sink);
+
+    // Seed parent history with a marker message.
+    ctx.push_message(Message::user_text("PARENT-MARKER"));
+    assert_eq!(ctx.history().len(), 1);
+
+    StaticScorer::default()
+        .run(
+            &mut ctx,
+            serde_json::to_value(ScoreInput { text: "x".into() }).unwrap(),
+        )
+        .await
+        .expect("run ok");
+
+    // Parent history must be exactly what it was BEFORE the agent
+    // ran. The agent's user/assistant/tool messages should be confined
+    // to the sub-context and discarded on drop.
+    assert_eq!(
+        ctx.history().len(),
+        1,
+        "parent history must NOT include sub-agent's messages; got {:?}",
+        ctx.history()
+    );
+    let parent_first = &ctx.history()[0];
+    assert_eq!(parent_first.role, MessageRole::User);
+    assert!(
+        parent_first
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Text { text } if text == "PARENT-MARKER"))
+    );
+}
+
+// ── 10. AgentError variants render usefully ────────────────────────────
+
+#[test]
+fn agent_error_variants_have_useful_display() {
+    let e1 = AgentError::AnswerNotEmitted {
+        agent: "x".into(),
+        max_turns: 5,
+    };
+    assert!(format!("{e1}").contains("never emitted"));
+
+    let e2 = AgentError::SchemaViolation {
+        agent: "x".into(),
+        attempts: 3,
+        last_error: "missing key".into(),
+    };
+    assert!(format!("{e2}").contains("schema validation"));
+    assert!(format!("{e2}").contains("3 attempt"));
+
+    let e3 = AgentError::Refusal {
+        agent: "x".into(),
+        message: "no".into(),
+    };
+    assert!(format!("{e3}").contains("refused"));
+
+    let e4 = AgentError::InvalidSpec {
+        agent: "x".into(),
+        reason: "bad".into(),
+    };
+    assert!(format!("{e4}").contains("invalid"));
+}
+
+// ── 11. typed_schema sanitization works ─────────────────────────────────
+
+#[test]
+fn typed_schema_strips_dollar_schema_and_inlines_single_definition() {
+    let schema = ergon::typed_schema::<Score>();
+    let map = schema.as_object().expect("schema is object");
+    assert!(
+        !map.contains_key("$schema"),
+        "expected sanitization to strip $schema"
+    );
+    assert!(
+        !map.contains_key("$ref"),
+        "expected sanitization to inline $ref"
+    );
+    assert!(
+        !map.contains_key("definitions"),
+        "expected sanitization to drop definitions when inlined"
+    );
+    assert_eq!(
+        map.get("type").and_then(|v| v.as_str()),
+        Some("object"),
+        "schema must declare type=object after sanitization"
+    );
+}
+
+// ── 12. AgentSpec roundtrips through JSON cleanly ──────────────────────
+
+#[test]
+fn agentspec_roundtrips_through_json() {
+    let original = AgentSpec::new(
+        "demo",
+        "m1",
+        "do X",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+    )
+    .with_max_turns(4)
+    .with_max_retries(2)
+    .with_allowed_tools(vec!["a".into(), "b".into()]);
+
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: AgentSpec = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.name, original.name);
+    assert_eq!(back.allowed_tools, original.allowed_tools);
+    assert_eq!(back.max_turns, original.max_turns);
+}
+
+// ── 13. AgentSpec::validate catches bad shapes ─────────────────────────
+
+#[test]
+fn agentspec_validate_rejects_empty_name() {
+    let spec = AgentSpec::new(
+        "",
+        "m",
+        "x",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+    );
+    assert!(spec.validate().is_err());
+}
+
+#[test]
+fn agentspec_validate_rejects_zero_max_turns() {
+    let spec = AgentSpec::new(
+        "x",
+        "m",
+        "x",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+    )
+    .with_max_turns(0);
+    assert!(spec.validate().is_err());
+}

--- a/crates/ergon/ergon/tests/agent_primitive.rs
+++ b/crates/ergon/ergon/tests/agent_primitive.rs
@@ -361,14 +361,16 @@ async fn schema_violation_then_retry_succeeds() {
 
 #[tokio::test]
 async fn retry_exhaustion_surfaces_schema_violation() {
+    // max_retries=1 means "1 corrective retry on top of the initial
+    // attempt" — i.e., 2 attempts total. Both bad → SchemaViolation.
     let agent = StaticScorer {
-        max_retries: 2,
+        max_retries: 1,
         ..Default::default()
     };
     let provider = Arc::new(ScriptedProvider::new(vec![
-        // Attempt 1 — invalid
+        // Attempt 1 (initial) — invalid
         record_answer_call("tu-1", serde_json::json!({"novelty": 2})),
-        // Attempt 2 — still invalid
+        // Attempt 2 (1st corrective retry) — still invalid
         record_answer_call("tu-2", serde_json::json!({})),
     ]));
     let sink = Arc::new(BufferSink::new());


### PR DESCRIPTION
## Summary

The first-class typed-I/O bounded-computation primitive Life agents ride on. Three types in `ergon`, no new sibling crate, no substrate deps beyond `schemars`.

- **`AgentSpec`** is data: serializable, `JsonSchema`-derivable, constructible at runtime, returnable as the typed `Output` of another agent (the factory pattern that enables agent-emits-agent composition without recursion machinery), embeddable in stream / lago events / wire transports.
- **`Agent`** trait is the unifying contract. Implemented for `AgentSpec` directly (dynamic) and auto-derived for any `T: TypedAgent` (static). Both lower to one interpreter — `run_spec` — so correctness guarantees are uniform.
- **`TypedAgent`** is static-typed convenience. Declare `Input`/`Output` with serde + `JsonSchema` bounds plus a few config methods; the framework auto-derives an AgentSpec and auto-impls Agent.

## How it composes with the rest of Life (no inventions, no reshuffles)

| Concern | Provided by | Agent's role |
|---|---|---|
| Identity | anima | `AnimaAttestHook` fires per agent boundary |
| Capability | aios-protocol PolicySet | `KernelCapabilityResolver`; agent's `allowed_tools` filters |
| State | lago | Standard kernel events; AgentSpec embeddable for full replay |
| Budget | autonomic | `AutonomicBudgetHook` fires per inference call |
| Observability | vigil + lago | StreamSink + tracing spans uniformly |
| Trust | anima sign + nous score | Existing hooks fire per agent |
| Communication | spaces + lago + AgentSpec serializability | Future mailboxes / pub-sub / remote dispatch wrap `Agent::run` without changing the primitive |
| Discovery / recursion / daemon agents | (deferred) | Shape set up to accept them as composing primitives |

## What's in scope

- `crates/ergon/ergon/src/agent.rs` — AgentSpec, Agent trait, AgentError, run_spec interpreter, ChainedToolRegistry, AnswerRecorderTools
- `crates/ergon/ergon/src/typed_agent.rs` — TypedAgent, auto-Agent impl, typed_schema sanitization, AgentStep / TypedAgentStep wrappers
- `crates/ergon/ergon/src/step.rs` — StepCtx::swap_scope (extension)
- 14 integration tests with `ScriptedProvider`, no network

## What's deliberately deferred

- Recursion / `spawn_agent` builtin tool — first workflow that genuinely needs in-loop spawning will land it as a narrow follow-up, on top of the Agent primitive without breaking changes
- `AgentRegistry`, `AgentInvoker`, `AgentResolver` traits — added when 1st use case appears
- Daemon / long-lived agents — different shape, sibling primitive (not subclass)
- Cross-agent message passing — composes via AgentSpec serializability when needed

## Test plan

- [x] `cargo test -p ergon --all-targets` — 67 in-crate + 14 integration = 81 green
- [x] `cargo clippy -p ergon --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p ergon` — clean
- [x] `cargo check --workspace` — full workspace compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent execution primitive with schema-based specification and validation
  * Support for both dynamic and typed agent definitions
  * Built-in retry logic for schema validation failures with configurable budgets
  * Tool filtering and isolated execution contexts per agent

* **Dependencies**
  * Added schemars for JSON schema generation

* **Tests**
  * Added integration test suite covering core agent behaviors and schema handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1198)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->