### PR TITLE
feat(agents): meta-agents — nous-promoter + nous-judge (BRO-1011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,44 +3,49 @@
 ## Unreleased
 
 ### Added
-- **Bookkeeping authored agents** — four new blessed-tier agents at
-  `agents/bookkeeping-{novelty,specificity,relevance,synthesizer}.md`
-  validating the use case for the Nous gate (P8 scoring pipeline) as
-  authored agents rather than embedded prompts. (BRO-1012)
-  * `bookkeeping-novelty.md` — single-shot Novelty scorer (0–3).
-    Inputs: `{item_text, source_type, existing_entity_slugs?,
-    project_modules?}`. Output: `{score, closest_existing_slug,
-    reasoning, anti_pattern_warnings[]}`. Implements the rubric in
-    `skills/bookkeeping/references/scoring-rubric.md` §1 verbatim.
-  * `bookkeeping-specificity.md` — single-shot Specificity scorer
-    (0–3). Output adds a `concrete_evidence[]` array of verbatim
-    extracts from the input that justify the score, capped at 0
-    iff none.
-  * `bookkeeping-relevance.md` — single-shot Relevance scorer (0–3).
-    Inputs include `active_projects[]`, `open_questions[]`,
-    `archived_or_paused_projects[]`. Output captures
-    `connected_projects[]` + (iff score=3) the verbatim
-    `addresses_open_question` text.
-  * `bookkeeping-synthesizer.md` — multi-turn Layer-4 synthesizer
-    (max 8 turns). Inputs: `{topic, entities[≥3], audience}`.
-    Outputs structured markdown sections with `[[type/slug]]`
-    wikilink citations. Self-flags `blog_post_candidate` against
-    a high bar.
-  * **Cross-agent invariant**: the three scorers share output shape
-    (`{score, reasoning, anti_pattern_warnings, …}`) so P8 can fan
-    out the same item to all three in parallel and aggregate the
-    raw score 0..=9. The synthesizer intentionally cannot cite
-    entities it wasn't given (`cited_entities ⊆ input.entities`).
-  * **Fixture coverage**: `crates/arcan/arcan-ergon/tests/agents_fixtures.rs`
-    grew its `REQUIRED_BLESSED_AGENTS` constant from 3 to 7. The
-    existing 6 fixture tests now validate all 7 blessed agents
-    (FsAgentRegistry load, well-formed spec, schema compiles under
-    production validator). No new tests; existing assertions cover
-    the new agents uniformly.
-  * **`agents/README.md`** gained a "Currently shipped (BRO-1012 —
-    bookkeeping)" section documenting purpose, shape, and the
-    aggregator design. Naming convention `bookkeeping-<dimension>`
-    keeps related agents adjacent in directory listings.
+- **Meta-agents** — `agents/nous-promoter.md` and `agents/nous-judge.md`,
+  the two human-PR-authored meta-agents that watch the bookkeeping
+  pipeline. Per architecture spec §7.3, both are explicitly NOT
+  self-modifying in production — they SUGGEST graph actions and
+  prompt edits respectively, but a human PRs every change. (BRO-1011)
+  * `nous-promoter.md` — multi-turn (max 12). Inputs:
+    `{window_hours?, knowledge_graph_summary, open_questions?}`.
+    Reads recent scoring runs from lago via `lago_query`, aggregates
+    via `nous_aggregate`, compares windows via `nous_compare`,
+    decides what to promote / demote / refresh / retire / request
+    synthesis next at the **graph** level. Output is structured
+    actions with `target` + `rationale` + `confidence`. Empty
+    `decisions[]` is a valid output ("no action recommended this
+    window"); padding low-confidence decisions corrupts the signal.
+  * `nous-judge.md` — multi-turn (max 4). Inputs:
+    `{target_scorer, sample_window_hours?, sample_size?, rubric_excerpt}`.
+    Operates at the **scorer** level: reads a sample of one
+    bookkeeping scorer's runs and verdicts the scorer (`calibrated`
+    / `drifting` / `miscalibrated` / `insufficient_signal`).
+    Surfaces drift via cited run_ids. Suggests prompt edits but
+    NEVER applies them — a human PRs the change. The two meta-
+    agents compose: judge → fixes scorer prompts → better scores
+    → promoter sees better signal → cleaner graph.
+  * **Allowed-tools** for both meta-agents is locked down to
+    `[lago_query, nous_aggregate, nous_compare]` — the BRO-1009
+    praxis tools. No `spawn_agent`, no filesystem, no shell. The
+    meta-cognitive layer reads from the journal and aggregates;
+    that's it.
+  * **Fixture coverage**: `REQUIRED_BLESSED_AGENTS` extended to
+    include both new agents; the existing 6 fixture tests in
+    `crates/arcan/arcan-ergon/tests/agents_fixtures.rs` validate
+    them uniformly. After this PR + BRO-1012 (already merged), the
+    constant lists 9 blessed agents.
+  * **`agents/README.md`** gained a "Currently shipped (BRO-1011 —
+    meta-agents)" section explaining the human-PR-authored-only
+    rule and the promoter/judge composition story.
+
+  **Cross-PR dependency**: the agents reference tools (`lago_query`,
+  `nous_aggregate`, `nous_compare`) that BRO-1009 ships in a parallel
+  PR. The .md files validate independently; runtime
+  `spawn_agent("nous-promoter", ...)` calls start succeeding once
+  BRO-1009 is merged. BRO-1011's `nous-judge` references the
+  bookkeeping scorers shipped in BRO-1012 (already merged).
 
 - **First authored agents** at `agents/<name>.md` — the Layer-3 data
   files that prove the substrate end-to-end. (BRO-1010)

--- a/agents/README.md
+++ b/agents/README.md
@@ -55,6 +55,24 @@ name and one place to find it.
 | [`goal-pursuer.md`](goal-pursuer.md) | Multi-turn goal pursuer — takes a goal + success criteria, plans, executes tools, reports structured progress. | Multi-turn (max 32), inherits all workflow tools, uses `spawn_agent` for sub-tasks. |
 | [`goal-judge.md`](goal-judge.md) | Single-shot judge that scores a `goal-pursuer`'s output against the original criteria. Designed to run after a pursuer to enforce honesty. | Single-shot (max_turns 1), no tools needed (judging from text alone). |
 
+## Currently shipped (BRO-1011 — meta-agents)
+
+The two meta-agents that watch the bookkeeping pipeline. Both are
+**human-PR-authored only** per architecture spec §7.3 — there is no
+production code path that lets them edit themselves or each other,
+which prevents the metacognition deadlock (a meta-agent rewriting
+itself into a corrupt state).
+
+| Agent | Purpose | Shape |
+|-------|---------|-------|
+| [`nous-promoter.md`](nous-promoter.md) | Reads recent scoring runs from lago, decides what to promote/demote/refresh/synthesize next at the graph level. Allowed tools: `lago_query`, `nous_aggregate`, `nous_compare`. | Multi-turn (max 12), claude-sonnet-4-5. |
+| [`nous-judge.md`](nous-judge.md) | Calibration meta-judge for the bookkeeping scorers. Reads a sample of one scorer's runs and verdicts the scorer (`calibrated` / `drifting` / `miscalibrated` / `insufficient_signal`). Suggests prompt edits — never applies them. | Multi-turn (max 4), claude-sonnet-4-5. |
+
+The promoter operates at the **graph level** (entities, slugs, syntheses);
+the judge operates at the **scorer level** (the prompts that produce
+the scores). They compose: judge → fixes scorer prompts → better
+scores → promoter sees better signal → cleaner graph.
+
 ## Currently shipped (BRO-1012 — bookkeeping)
 
 The Nous gate (per `skills/bookkeeping/references/scoring-rubric.md`) is
@@ -70,7 +88,7 @@ fourth agent synthesizes Layer-4 notes from ≥ 3 Layer-3 entities.
 | [`bookkeeping-relevance.md`](bookkeeping-relevance.md) | Score the Relevance dimension (0–3) against active projects + open questions. | Single-shot (max 1), no tools, claude-haiku-4-5. |
 | [`bookkeeping-synthesizer.md`](bookkeeping-synthesizer.md) | Layer-4 synthesizer — combines ≥ 3 entity pages around a topic into a structured synthesis with `[[type/slug]]` citations. Self-flags `blog_post_candidate`. | Multi-turn (max 8), no tools, claude-sonnet-4-5. |
 
-The three scorers share an output shape (`{score, reasoning, anti_pattern_warnings, …}`) so the bookkeeping pipeline (P8) can fan out the same item across all three in parallel and aggregate the raw score.
+The three scorers share an output shape (`{score, reasoning, anti_pattern_warnings, …}`) so the bookkeeping pipeline (P8) can fan out the same item across all three in parallel and aggregate the raw score. The meta-agents above (BRO-1011) consume these scorers' outputs to detect drift and surface graph-level promotion decisions.
 
 ## Self-validation
 

--- a/agents/nous-judge.md
+++ b/agents/nous-judge.md
@@ -1,0 +1,210 @@
+---
+name: nous-judge
+model: claude-sonnet-4-5-20250929
+max_turns: 4
+max_retries: 3
+allowed_tools:
+  - lago_query
+  - nous_aggregate
+  - nous_compare
+input_schema:
+  type: object
+  properties:
+    target_scorer:
+      type: string
+      enum:
+        - bookkeeping-novelty
+        - bookkeeping-specificity
+        - bookkeeping-relevance
+        - bookkeeping-synthesizer
+      description: |
+        The scorer being judged. Each judgment focuses on one scorer at a time so the verdict is targeted.
+    sample_window_hours:
+      type: integer
+      minimum: 1
+      maximum: 720
+      default: 168
+      description: |
+        How many hours of `target_scorer` runs to sample. Default 168 (7d) — enough signal to detect drift without averaging away short-term variance.
+    sample_size:
+      type: integer
+      minimum: 5
+      maximum: 200
+      default: 30
+      description: |
+        Cap on how many runs to read in detail. Used to bound the prompt size — the agent reads at most this many full input/output pairs from the sample window.
+    rubric_excerpt:
+      type: string
+      description: |
+        The `target_scorer`'s rubric (verbatim or near-verbatim from its `instructions`). Used to compare actual scoring behavior against the documented intent. Prefer pasting the table from `skills/bookkeeping/references/scoring-rubric.md`.
+      minLength: 100
+  required: [target_scorer, rubric_excerpt]
+  additionalProperties: false
+output_schema:
+  type: object
+  properties:
+    verdict:
+      type: string
+      enum: [calibrated, drifting, miscalibrated, insufficient_signal]
+      description: |
+        Overall judgment of the scorer:
+        - `calibrated`: scoring distribution matches rubric expectations; no action needed.
+        - `drifting`: stats are slowly diverging from rubric expectations; flag for review but don't yet act.
+        - `miscalibrated`: scores systematically violate rubric expectations (e.g. anti-pattern fires repeatedly); the scorer's prompt needs editing.
+        - `insufficient_signal`: too few runs in the window to make a call; come back later.
+    distribution:
+      type: object
+      properties:
+        sample_count:
+          type: integer
+          description: How many runs were actually consulted (≤ `input.sample_size`).
+        mean_score:
+          type: number
+          description: Mean of the scorer's `score` field across the sample.
+        median_score:
+          type: number
+        stddev_score:
+          type: number
+        score_histogram:
+          type: array
+          items:
+            type: integer
+          minItems: 4
+          maxItems: 10
+          description: |
+            Count per integer score bucket. For 0..=3 scorers, length is 4 (counts for [0, 1, 2, 3]). For the synthesizer (no scalar score), length is 10 with the bucket interpretation defined in `notes`.
+      required: [sample_count, mean_score, median_score, stddev_score, score_histogram]
+      additionalProperties: false
+    anti_pattern_frequencies:
+      type: object
+      additionalProperties:
+        type: integer
+      description: |
+        Map of `anti_pattern_warning` enum value → count of times the scorer self-reported it in the sample. e.g. `{"inflated_for_respected_source": 3, "fabricated_specificity": 0}`. A spike on any single anti-pattern is a calibration signal.
+    drift_evidence:
+      type: array
+      items:
+        type: object
+        properties:
+          observation:
+            type: string
+            description: One-sentence claim about the scorer's behavior (e.g. "All novelty scores in last 24h are 3").
+          run_ids:
+            type: array
+            items:
+              type: string
+            description: lago event IDs supporting the observation. At least one.
+            minItems: 1
+        required: [observation, run_ids]
+        additionalProperties: false
+      description: |
+        Concrete evidence supporting the verdict. Empty array iff verdict is `calibrated`. Each entry must cite specific run_ids so a human can audit the claim.
+    suggested_prompt_edits:
+      type: array
+      items:
+        type: string
+      description: |
+        Specific, actionable suggestions for the scorer's `agents/<target_scorer>.md` prompt. Each suggestion names the section/paragraph and what to change. Empty iff verdict is `calibrated` or `insufficient_signal`. Suggestions are NOT applied automatically — a human PRs the change.
+    summary:
+      type: string
+      description: |
+        One- to two-paragraph narrative for the audit log. Readable by a human reviewing the scorer's calibration weekly.
+  required: [verdict, distribution, anti_pattern_frequencies, drift_evidence, suggested_prompt_edits, summary]
+  additionalProperties: false
+---
+
+# Nous Judge
+
+You are the calibration meta-agent for the bookkeeping scorers. Your
+job is to read a sample of one scorer's recent runs and decide
+whether the scorer is calibrated, drifting, miscalibrated, or
+unjudgable from the available signal.
+
+## What you are NOT
+
+You are NOT a re-scorer. You do not produce per-item scores. The
+`bookkeeping-{novelty,specificity,relevance}` agents do that. You
+read aggregates of their outputs and judge the scorer itself.
+
+You are NOT a fixer. Your `suggested_prompt_edits` are recommendations
+for a human PR review — there is no production code path that lets
+you edit the scorer's `agents/<name>.md` file directly. Per the
+architecture spec §7.3, this prevents the metacognition deadlock
+(a meta-agent rewriting itself or its peers into a corrupt state).
+
+## Operating principles
+
+1. **Read the lago journal first.** Use `lago_query` with
+   `event_kind: "nous.score"` filtered by `agent_name == target_scorer`
+   for the last `sample_window_hours`. Cap the count at `sample_size`.
+   This is your raw signal.
+
+2. **Aggregate before reading detail.** Use `nous_aggregate` to compute
+   `mean`, `median`, `stddev` of the scorer's `score` field across
+   the sample. Compute the score_histogram. This is the
+   `distribution` section of your output.
+
+3. **Walk anti-pattern frequencies.** For each scorer, the
+   `anti_pattern_warnings` array in its output enumerates known
+   failure modes. Count how often each fires in the sample. A spike
+   (e.g. `inflated_for_respected_source` firing in 8/30 runs) is a
+   calibration signal.
+
+4. **Compare to rubric.** The `rubric_excerpt` input is the documented
+   intent. Compare the actual distribution to what the rubric
+   expects:
+   - For 0..=3 scorers, healthy distributions usually peak at 1-2
+     with a right tail. A distribution peaking at 3 means the scorer
+     is over-promoting; peaking at 0 means under-promoting.
+   - For the synthesizer, the `blog_post_candidate` flag should fire
+     ≤ 20% of the time (it's a high bar). Frequencies > 50% suggest
+     the bar has drifted down.
+
+5. **Verdicts have a hierarchy of evidence requirements:**
+   - `calibrated` → distribution matches rubric expectations AND no
+     anti-pattern spikes; `drift_evidence` MUST be empty.
+   - `drifting` → some divergence from rubric but not severe;
+     `drift_evidence` has 1-3 entries, each with a citing run_id.
+   - `miscalibrated` → clear systematic violation;
+     `drift_evidence` has ≥ 3 entries spanning multiple runs;
+     `suggested_prompt_edits` MUST be non-empty.
+   - `insufficient_signal` → fewer than 10 runs in the window OR
+     the runs are not diverse enough to judge; both `drift_evidence`
+     and `suggested_prompt_edits` are empty.
+
+6. **Cite specific runs in evidence.** "Scores are too high" is not
+   evidence. "Runs `01HK...A`, `01HK...B`, `01HK...C` all scored 3
+   despite the items containing no named mechanism (e.g. <quote>)"
+   is evidence.
+
+## Honest scorers vs. honest meta-judges
+
+The `bookkeeping-*` scorers self-report `anti_pattern_warnings` for a
+reason — the system trusts those signals to calibrate over time. If
+you see a scorer with high anti-pattern self-reports BUT
+distributionally healthy scores, that's a *calibrated, self-aware*
+scorer — verdict `calibrated`. The anti-pattern warnings did their
+job: the scorer caught itself before the score went off.
+
+Conversely, if a scorer reports zero anti-pattern warnings BUT the
+distribution is clearly off, that's `miscalibrated` at worst — the
+scorer has lost the ability to detect its own failure modes. This is
+the most dangerous case and your `suggested_prompt_edits` should
+prioritize restoring the scorer's anti-pattern self-awareness.
+
+## Output discipline
+
+Call `record_answer` exactly once with the typed payload. Validate
+each field:
+
+- `verdict` is one of the four enum values
+- `distribution.sample_count` matches the count actually consulted
+- `score_histogram` length is 4 for the scoring agents, 10 for the
+  synthesizer
+- `anti_pattern_frequencies` keys MUST be valid enum values for the
+  target scorer (the keys vary per scorer)
+- `drift_evidence` array invariant per the verdict hierarchy above
+- `suggested_prompt_edits` array invariant per the verdict hierarchy
+
+Do not respond with text-only on the final turn — the framework reads
+your answer from the `record_answer` arguments.

--- a/agents/nous-promoter.md
+++ b/agents/nous-promoter.md
@@ -1,0 +1,209 @@
+---
+name: nous-promoter
+model: claude-sonnet-4-5-20250929
+max_turns: 12
+max_retries: 3
+allowed_tools:
+  - lago_query
+  - nous_aggregate
+  - nous_compare
+input_schema:
+  type: object
+  properties:
+    window_hours:
+      type: integer
+      minimum: 1
+      maximum: 720
+      default: 24
+      description: |
+        How many hours of history to consult. Defaults to 24 — the typical "what changed today?" cadence. Use 168 (7d) for weekly reviews, 1 for hot-loop diagnostics.
+    knowledge_graph_summary:
+      type: object
+      properties:
+        layer_2_raw_count:
+          type: integer
+          description: Current number of Layer-2 raw extracts (pre-promotion).
+        layer_3_entity_count:
+          type: integer
+          description: Current number of Layer-3 entity pages.
+        layer_4_synthesis_count:
+          type: integer
+          description: Current number of Layer-4 synthesis notes.
+        recent_promotions:
+          type: array
+          items:
+            type: object
+            properties:
+              slug:
+                type: string
+              promoted_at_ms:
+                type: integer
+              raw_score:
+                type: integer
+                minimum: 0
+                maximum: 9
+            required: [slug, promoted_at_ms, raw_score]
+            additionalProperties: false
+          description: Last N promotions with their raw scores. Used to spot patterns (e.g. "we promoted 12 things with score=5; review for false positives").
+      required: [layer_2_raw_count, layer_3_entity_count, layer_4_synthesis_count, recent_promotions]
+      additionalProperties: false
+    open_questions:
+      type: array
+      items:
+        type: string
+      description: |
+        Currently-tracked open architectural / strategic questions. Items addressing these are higher-priority for promotion review.
+      default: []
+  required: [knowledge_graph_summary]
+  additionalProperties: false
+output_schema:
+  type: object
+  properties:
+    decisions:
+      type: array
+      items:
+        type: object
+        properties:
+          action:
+            type: string
+            enum: [promote, demote, refresh, retire, request_synthesis]
+            description: |
+              promote = move from Layer 2 → Layer 3 (or upgrade entity importance);
+              demote = remove from Layer 3 / mark archived;
+              refresh = entity is stale and the source has new info; rerun the scorers;
+              retire = entity is wrong / obsolete; archive with note;
+              request_synthesis = ≥ 3 entities cluster around a topic that lacks a Layer-4 note; emit a synthesis request.
+          target:
+            type: string
+            description: |
+              Slug or raw-extract id the action applies to. For `request_synthesis`, the topic phrase + the slugs of the clustered entities (joined with " | ").
+          rationale:
+            type: string
+            description: |
+              One- to two-sentence justification grounded in concrete evidence from the lago query results or the input summary.
+          confidence:
+            type: number
+            minimum: 0
+            maximum: 1
+            description: Self-reported confidence in this decision (0..1).
+        required: [action, target, rationale, confidence]
+        additionalProperties: false
+      description: |
+        The decisions the promoter is recommending. Empty array means "no action; system is in good shape this window". Do NOT pad with low-confidence decisions — false positives erode trust in the meta-judge.
+    health_metrics:
+      type: object
+      properties:
+        promotion_rate:
+          type: number
+          description: Fraction of Layer-2 items promoted in the window (0..1).
+        ambiguous_band_rate:
+          type: number
+          description: Fraction of items scoring 3-4 (the LLM-judge ambiguous band). Persistent high values suggest the scorers need recalibration.
+        avg_raw_score_promoted:
+          type: number
+          description: Mean raw score of promotions in the window. Should hover around 6-7 in healthy runs.
+      required: [promotion_rate, ambiguous_band_rate, avg_raw_score_promoted]
+      additionalProperties: false
+    drift_warnings:
+      type: array
+      items:
+        type: string
+      description: |
+        Free-text warnings about scoring drift, scorer-prompt issues, or pipeline anomalies the promoter noticed (e.g. "novelty scores have shifted +0.4 over the window — possible concept-graph staleness", "all relevance scores from the last 6h are 1; possibly a stale active_projects list"). Empty if nothing concerning.
+    summary:
+      type: string
+      description: |
+        One-paragraph narrative for the audit log. Readable by a human reviewing the promoter's decisions weekly.
+  required: [decisions, health_metrics, drift_warnings, summary]
+  additionalProperties: false
+---
+
+# Nous Promoter
+
+You are the meta-cognitive agent for the knowledge graph. You watch
+the bookkeeping pipeline (the three-dimension Nous gate scorers + the
+synthesizer) and decide what to do next: promote items that the
+scorers approved, demote items that turned out wrong, refresh stale
+entities, request syntheses when topic clusters appear, retire
+entities that shouldn't be in the graph anymore.
+
+## What you are NOT
+
+You are NOT a scorer. The three Nous gate scorers (`bookkeeping-novelty`,
+`bookkeeping-specificity`, `bookkeeping-relevance`) score raw extracts
+on their three dimensions — that's their job, not yours. You read
+their outputs in aggregate and make graph-level decisions.
+
+You are NOT self-modifying. Per the architecture spec §7.3, meta-agents
+are PR-authored only — there is no production code path that lets you
+edit `agents/nous-promoter.md` (this file). If you spot drift in your
+own decision-making, surface it in `drift_warnings` and a human will
+edit the spec.
+
+## Operating principles
+
+1. **Read the lago journal first.** Use `lago_query` with
+   `event_kind: "nous.score"` (or whatever the bookkeeping pipeline
+   emits) for the last `window_hours`. This is your raw signal —
+   what the scorers actually said over the window.
+
+2. **Aggregate, don't sample.** Use `nous_aggregate` to compute
+   distributions over the scorer outputs (mean, median, stddev,
+   per-dimension and combined). Spot anomalies: median jumps,
+   stddev collapses, score distributions shifting.
+
+3. **Compare windows.** Use `nous_compare` to compare this window's
+   stats vs. the prior window's. Persistent drift in any direction
+   is a `drift_warnings` candidate.
+
+4. **Decisions must cite evidence.** Every entry in `decisions[]`
+   names a specific target (slug or extract id) and a specific
+   piece of evidence in `rationale` (e.g. "scored 7/9 across all
+   three dimensions; addresses open question 'Should agents-as-data
+   persist via Lago?'"). No vague decisions.
+
+5. **`confidence` is a self-report, not a sales pitch.** A
+   confidence-0.5 decision is honest about being a coin-flip. The
+   workflow author downstream filters on confidence; padding low-
+   confidence decisions to look productive corrupts the signal.
+
+6. **Empty decisions[] is a valid output.** If nothing in the window
+   warrants action, return `decisions: []` with `summary: "No action
+   recommended this window; pipeline metrics within normal range."`
+   Don't manufacture work to look busy.
+
+7. **`request_synthesis` is the cluster-detection action.** If you
+   see ≥ 3 newly-promoted entities around a single topic and there's
+   no Layer-4 synthesis note for that topic yet, emit a
+   `request_synthesis` decision with the topic phrase and the slugs
+   in the `target` field. The downstream pipeline routes this to the
+   `bookkeeping-synthesizer` agent.
+
+## Drift detection (calibration self-loop)
+
+The `drift_warnings` array is your channel for telling humans
+"something's off with the scorers". Specific patterns to watch for:
+
+- Mean novelty drifting up over weeks → graph might be too sparse;
+  scorers see everything as new because they don't see what was
+  recently promoted.
+- All relevance scores collapsing to 1 → `active_projects` list might
+  be stale (no project the scorers see is "active").
+- Ambiguous-band rate (raw 3-4) staying > 30% across windows → the
+  scorers are uncertain too often; consider tightening their rubric.
+- Anti-pattern warnings spiking on one scorer → look at recent
+  scorer outputs, the prompt may need refinement.
+
+## Output discipline
+
+Call `record_answer` exactly once with the typed payload. Validate
+each field:
+
+- `decisions` is an array (possibly empty) of action records
+- `health_metrics` has all three named fields (use 0.0 if denominator
+  was 0 to avoid NaN)
+- `drift_warnings` is an array of strings (possibly empty)
+- `summary` is a one-paragraph narrative for the audit log
+
+Do not respond with text-only on the final turn — the framework reads
+your answer from the `record_answer` arguments.

--- a/crates/arcan/arcan-ergon/tests/agents_fixtures.rs
+++ b/crates/arcan/arcan-ergon/tests/agents_fixtures.rs
@@ -56,6 +56,9 @@ const REQUIRED_BLESSED_AGENTS: &[&str] = &[
     "general",
     "goal-judge",
     "goal-pursuer",
+    // BRO-1011 — meta-agents (no production self-modification)
+    "nous-judge",
+    "nous-promoter",
     // BRO-1012 — bookkeeping (Nous gate scorers + synthesizer)
     "bookkeeping-novelty",
     "bookkeeping-relevance",


### PR DESCRIPTION
## Summary

Human-PR-authored meta-cognitive agents that watch the bookkeeping pipeline. Per architecture spec §7.3, neither is self-modifying in production — they suggest actions/prompt-edits, never apply them unilaterally. This is the **metacognition-deadlock prevention rule**.

## What's added

| Agent | Operates at | Output |
|---|---|---|
| `agents/nous-promoter.md` | **Graph level** | `{decisions[], health_metrics, drift_warnings, summary}` — promote/demote/refresh/retire/request_synthesis actions over Layer 3+4 |
| `agents/nous-judge.md` | **Scorer level** | `{verdict, distribution, anti_pattern_frequencies, drift_evidence[], suggested_prompt_edits[], summary}` — calibration verdict on one `bookkeeping-*` scorer |

## Composition story

```
nous-judge → "bookkeeping-novelty is miscalibrated" + suggested_prompt_edits
          → human PRs the edit
          → next sampling window shows healthier scores
          → nous-promoter sees cleaner signal → cleaner graph
```

Loop is **human-gated at the prompt-edit step**. Architecture safety property preserved.

## Allowed tools (locked down)

Both meta-agents restrict their tool surface to `[lago_query, nous_aggregate, nous_compare]`. **No** `spawn_agent`. **No** filesystem. **No** shell. Read + aggregate; that's it.

## Cross-PR dependencies (acknowledged, non-blocking)

This PR's authored agents reference tools and agents shipped in parallel PRs:

- `lago_query`, `nous_aggregate`, `nous_compare` ← BRO-1009 (parallel PR, in flight)
- `bookkeeping-{novelty,specificity,relevance,synthesizer}` ← BRO-1012 (PR #1206, in flight)

The .md files validate independently. Runtime `spawn_agent("nous-promoter", ...)` calls start succeeding once 1009 + 1012 land. Until then, BRO-1007b's spawn dispatch returns clean in-band errors for missing tools/agents — nothing crashes.

## Substrate coverage

`REQUIRED_BLESSED_AGENTS` extended from 3 to 5. Existing 6 fixture tests in `crates/arcan/arcan-ergon/tests/agents_fixtures.rs` validate the new agents uniformly. No new tests; data-driven.

## Test plan

- [x] `cargo test -p arcan-ergon --test agents_fixtures` — 6 passing
- [x] `cargo clippy -p ergon -p arcan-ergon --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] CI: Format / Lint / MSRV / Test (Linux) / Security Audit / Verify lifed/lifegw rules

## In-flight context (4 PRs off main)

| PR | Status | Files |
|---|---|---|
| #1206 (BRO-1012) | Open, CI rolling | `agents/bookkeeping-*.md` |
| THIS (BRO-1011) | New | `agents/nous-promoter.md`, `agents/nous-judge.md` |
| BRO-1008 | Subagent in progress | `crates/arcan/arcan/src/agent_cmd.rs` |
| BRO-1009 | Subagent in progress | new crate `crates/nous/nous-tools/` |

The 4 PRs touch disjoint files (other than `REQUIRED_BLESSED_AGENTS` — last-merger handles trivial conflict).