### PR TITLE
feat(nous-tools): NousLineage trait + nous_aggregate / nous_compare / lago_query praxis tools (BRO-1009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,53 @@
     aggregator design. Naming convention `bookkeeping-<dimension>`
     keeps related agents adjacent in directory listings.
 
+- **`nous-tools` crate** — lineage primitives + the three praxis tools
+  authored agents (BRO-1011 nous-promoter, BRO-1012 bookkeeping
+  scorers) need to consume nous output. (BRO-1009)
+  * **`NousLineage` trait + `LineageEvent` / `LineageFilter`** — the
+    provenance contract for nous decisions: which scorer ran, with what
+    input, what output, against which target, when, and (optionally)
+    against which lago `EventId`. `LineageFilter` matches by session,
+    agent, target, time window, and limit.
+  * **`InMemoryNousLineage`** — `Arc<RwLock<Vec<_>>>`-backed reference
+    implementation. Sequential `lineage-N` ids; preserves insertion
+    order on `query`. The lago-backed implementation is intentionally
+    deferred to a follow-up so the trait + in-memory ref ship as a
+    clean unit.
+  * **`nous_aggregate` praxis tool** — descriptive statistics
+    (`count`, `mean`, `median`, `min`, `max`, sample-stddev) over a
+    `Vec<f64>` of scores. Hand-rolled (no `statrs` / `medians`
+    workspace dep for ~20 LOC of arithmetic). Empty input returns
+    zeroes; `count == 1` returns `stddev == 0.0` (Bessel correction
+    undefined). Rejects NaN / inf / non-numeric entries with
+    `ToolError::InvalidInput`.
+  * **`nous_compare` praxis tool** — typed verdict over
+    `(a, b, threshold)`: `greater` / `lesser` / `equal` /
+    `within_threshold`. Default threshold `0.001`. Strict equality
+    returns `Equal` even inside the threshold band so the verdict
+    stays informative; `threshold = 0.0` collapses to strict
+    comparison.
+  * **`lago_query` praxis tool** — read-only event-journal queries
+    over `Arc<dyn lago_core::Journal>`. Filters by `event_kind`
+    discriminant (delegated to `EventQuery::with_kind`), `after_ts_ms`
+    / `before_ts_ms` window (lago stores microseconds; the tool
+    exposes ms for parity with `LineageEvent`), and `limit` (default
+    50, hard cap 500 to bound memory for untrusted agents). The sync
+    `Tool::execute` ↔ async `Journal::read` boundary is bridged via
+    a stashed `tokio::runtime::Handle` and `block_in_place` +
+    `block_on` (mirrors `praxis-mcp-bridge::McpTool`); falls back to
+    plain `block_on` outside an active runtime so the tool also works
+    from sync callers.
+  * **Tests** — 18 unit tests + 1 integration test
+    (`tests/tools.rs`) that exercises all three tools end-to-end
+    through the canonical `Tool::execute` path: record → query →
+    aggregate → compare. The integration test pins a real `Journal`
+    impl in-test (`VecJournal` over `Arc<RwLock<Vec<_>>>`) so the
+    `Arc<dyn Journal>` interface is exercised.
+  * **NOT in scope** — the lago-backed `NousLineage` impl and the
+    BRO-1011 `nous-promoter` authored agent that consumes these tools
+    land in follow-up tickets.
+
 - **First authored agents** at `agents/<name>.md` — the Layer-3 data
   files that prove the substrate end-to-end. (BRO-1010)
   * `agents/general.md` — multi-turn generalist (max 16 turns).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,6 +7043,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nous-tools"
+version = "0.3.0"
+dependencies = [
+ "aios-protocol",
+ "async-trait",
+ "futures",
+ "lago-core",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "nousd"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "crates/nous/nous-judge",
     "crates/nous/nous-lago",
     "crates/nous/nous-middleware",
+    "crates/nous/nous-tools",
     "crates/nous/nousd",
     # Anima — identity
     "crates/anima/anima-core",
@@ -221,6 +222,7 @@ nous-heuristics = { path = "crates/nous/nous-heuristics", version = "0.3.0" }
 nous-judge = { path = "crates/nous/nous-judge", version = "0.3.0" }
 nous-lago = { path = "crates/nous/nous-lago", version = "0.3.0" }
 nous-middleware = { path = "crates/nous/nous-middleware", version = "0.3.0" }
+nous-tools = { path = "crates/nous/nous-tools", version = "0.3.0" }
 # Opsis
 opsis-core = { path = "crates/opsis/opsis-core", version = "0.3.0" }
 opsis-engine = { path = "crates/opsis/opsis-engine", version = "0.3.0" }

--- a/crates/nous/nous-tools/Cargo.toml
+++ b/crates/nous/nous-tools/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nous-tools"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Nous lineage primitives + praxis tools (nous_aggregate, nous_compare, lago_query) for authored agents"
+
+[dependencies]
+aios-protocol.workspace = true
+lago-core.workspace = true
+async-trait.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+futures.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nous/nous-tools/src/aggregate.rs
+++ b/crates/nous/nous-tools/src/aggregate.rs
@@ -1,0 +1,275 @@
+//! `nous_aggregate` praxis tool — descriptive statistics over a vector
+//! of f64 scores.
+//!
+//! Designed for authored agents (BRO-1011 nous-promoter, bookkeeping
+//! scorers) that need a single quick summary line over historical
+//! lineage scores. Hand-rolled because it would not be worth taking
+//! a `statrs` / `medians` workspace dep for ~20 LOC; the tradeoff is
+//! flagged at the top of [`aggregate_scores`].
+
+use aios_protocol::tool::{
+    Tool, ToolAnnotations, ToolCall, ToolContext, ToolDefinition, ToolError, ToolResult,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Statistics returned by [`NousAggregateTool`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AggregateOutput {
+    pub count: usize,
+    pub mean: f64,
+    pub median: f64,
+    pub min: f64,
+    pub max: f64,
+    /// Sample standard deviation (Bessel-corrected, n-1 in the
+    /// denominator). Reported as `0.0` when `count <= 1`.
+    pub stddev: f64,
+}
+
+/// Praxis tool implementing `nous_aggregate`.
+///
+/// Input shape: `{ "scores": [f64, ...] }`. Output is an
+/// [`AggregateOutput`] serialized to JSON.
+#[derive(Debug, Clone, Default)]
+pub struct NousAggregateTool;
+
+impl NousAggregateTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for NousAggregateTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "nous_aggregate".into(),
+            description: "Compute count / mean / median / min / max / stddev over a vector of f64 \
+                 scores. Empty input returns count=0 and zero-valued stats."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "scores": {
+                        "type": "array",
+                        "items": { "type": "number" },
+                        "description": "List of numeric scores to aggregate."
+                    }
+                },
+                "required": ["scores"]
+            }),
+            title: Some("Nous Aggregate".into()),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "count": { "type": "integer", "minimum": 0 },
+                    "mean": { "type": "number" },
+                    "median": { "type": "number" },
+                    "min": { "type": "number" },
+                    "max": { "type": "number" },
+                    "stddev": { "type": "number", "minimum": 0 }
+                },
+                "required": ["count", "mean", "median", "min", "max", "stddev"]
+            })),
+            annotations: Some(ToolAnnotations {
+                read_only: true,
+                idempotent: true,
+                ..Default::default()
+            }),
+            category: Some("nous".into()),
+            tags: vec!["nous".into(), "stats".into(), "aggregate".into()],
+            timeout_secs: Some(5),
+        }
+    }
+
+    fn execute(&self, call: &ToolCall, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let scores_val = call
+            .input
+            .get("scores")
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "Missing required field 'scores'".into(),
+            })?;
+
+        let scores_arr = scores_val
+            .as_array()
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "'scores' must be a JSON array of numbers".into(),
+            })?;
+
+        let mut scores: Vec<f64> = Vec::with_capacity(scores_arr.len());
+        for (i, v) in scores_arr.iter().enumerate() {
+            let f = v.as_f64().ok_or_else(|| ToolError::InvalidInput {
+                message: format!("scores[{i}] is not a number"),
+            })?;
+            if !f.is_finite() {
+                return Err(ToolError::InvalidInput {
+                    message: format!("scores[{i}] is not finite (NaN/inf forbidden)"),
+                });
+            }
+            scores.push(f);
+        }
+
+        let stats = aggregate_scores(&scores);
+        let output = serde_json::to_value(&stats).map_err(|e| ToolError::ExecutionFailed {
+            tool_name: "nous_aggregate".into(),
+            message: format!("failed to serialize aggregate output: {e}"),
+        })?;
+
+        Ok(ToolResult {
+            call_id: call.call_id.clone(),
+            tool_name: call.tool_name.clone(),
+            output,
+            content: None,
+            is_error: false,
+            usage: None,
+        })
+    }
+}
+
+/// Pure-Rust statistics over an `&[f64]`. Hand-rolled to avoid taking
+/// a dependency for ~20 LOC of arithmetic.
+///
+/// Empty input returns the zero summary; single-element input returns
+/// `mean == median == min == max` and `stddev == 0.0`.
+pub fn aggregate_scores(scores: &[f64]) -> AggregateOutput {
+    if scores.is_empty() {
+        return AggregateOutput {
+            count: 0,
+            mean: 0.0,
+            median: 0.0,
+            min: 0.0,
+            max: 0.0,
+            stddev: 0.0,
+        };
+    }
+
+    let count = scores.len();
+    let sum: f64 = scores.iter().sum();
+    let mean = sum / count as f64;
+
+    let mut sorted: Vec<f64> = scores.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let min = sorted[0];
+    let max = sorted[count - 1];
+
+    let median = if count.is_multiple_of(2) {
+        (sorted[count / 2 - 1] + sorted[count / 2]) / 2.0
+    } else {
+        sorted[count / 2]
+    };
+
+    let stddev = if count <= 1 {
+        0.0
+    } else {
+        let var: f64 =
+            scores.iter().map(|s| (s - mean).powi(2)).sum::<f64>() / (count as f64 - 1.0);
+        var.sqrt()
+    };
+
+    AggregateOutput {
+        count,
+        mean,
+        median,
+        min,
+        max,
+        stddev,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            run_id: "test-run".into(),
+            session_id: "S".into(),
+            iteration: 0,
+            ..Default::default()
+        }
+    }
+
+    fn call(input: serde_json::Value) -> ToolCall {
+        ToolCall {
+            call_id: "call-1".into(),
+            tool_name: "nous_aggregate".into(),
+            input,
+            requested_capabilities: vec![],
+        }
+    }
+
+    #[test]
+    fn nous_aggregate_empty_input_returns_zero_count() {
+        let tool = NousAggregateTool::new();
+        let result = tool.execute(&call(json!({"scores": []})), &ctx()).unwrap();
+        assert!(!result.is_error);
+        let out: AggregateOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.count, 0);
+        assert_eq!(out.mean, 0.0);
+        assert_eq!(out.median, 0.0);
+        assert_eq!(out.min, 0.0);
+        assert_eq!(out.max, 0.0);
+        assert_eq!(out.stddev, 0.0);
+    }
+
+    #[test]
+    fn nous_aggregate_single_score_mean_eq_median_eq_score() {
+        let tool = NousAggregateTool::new();
+        let result = tool
+            .execute(&call(json!({"scores": [4.2]})), &ctx())
+            .unwrap();
+        let out: AggregateOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.count, 1);
+        assert_eq!(out.mean, 4.2);
+        assert_eq!(out.median, 4.2);
+        assert_eq!(out.min, 4.2);
+        assert_eq!(out.max, 4.2);
+        // n=1 → stddev defined as 0 (Bessel correction undefined).
+        assert_eq!(out.stddev, 0.0);
+    }
+
+    #[test]
+    fn nous_aggregate_known_set_produces_known_stats() {
+        // Set: [2, 4, 4, 4, 5, 5, 7, 9]
+        // mean = 5.0, median = (4+5)/2 = 4.5, min = 2, max = 9
+        // sample stddev (n-1) = sqrt(32/7) = 2.13808993...
+        let tool = NousAggregateTool::new();
+        let result = tool
+            .execute(
+                &call(json!({"scores": [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]})),
+                &ctx(),
+            )
+            .unwrap();
+        let out: AggregateOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.count, 8);
+        assert!((out.mean - 5.0).abs() < 1e-9);
+        assert!((out.median - 4.5).abs() < 1e-9);
+        assert_eq!(out.min, 2.0);
+        assert_eq!(out.max, 9.0);
+        let expected_stddev = (32.0_f64 / 7.0_f64).sqrt();
+        assert!(
+            (out.stddev - expected_stddev).abs() < 1e-9,
+            "stddev = {} expected = {}",
+            out.stddev,
+            expected_stddev
+        );
+    }
+
+    #[test]
+    fn nous_aggregate_rejects_non_array() {
+        let tool = NousAggregateTool::new();
+        let err = tool
+            .execute(&call(json!({"scores": "not-an-array"})), &ctx())
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn nous_aggregate_rejects_nan() {
+        let tool = NousAggregateTool::new();
+        let err = tool
+            .execute(&call(json!({"scores": [1.0, "not-a-number"]})), &ctx())
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+}

--- a/crates/nous/nous-tools/src/compare.rs
+++ b/crates/nous/nous-tools/src/compare.rs
@@ -1,0 +1,283 @@
+//! `nous_compare` praxis tool — compare two scalar scores with a
+//! configurable equality threshold.
+//!
+//! Used by promoter/judge agents that need a typed verdict
+//! (`greater` / `lesser` / `equal` / `within_threshold`) rather than a
+//! raw delta. Default threshold is `0.001`, chosen to absorb f64
+//! rounding noise on aggregated scores while still catching meaningful
+//! differences. Callers that want strict equality can pass `0.0`.
+
+use aios_protocol::tool::{
+    Tool, ToolAnnotations, ToolCall, ToolContext, ToolDefinition, ToolError, ToolResult,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Default equality tolerance (sub-thousandth of a score point).
+pub const DEFAULT_THRESHOLD: f64 = 0.001;
+
+/// Verdict returned by [`NousCompareTool`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompareVerdict {
+    Greater,
+    Lesser,
+    Equal,
+    WithinThreshold,
+}
+
+/// Output payload of [`NousCompareTool`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CompareOutput {
+    /// Signed delta `a - b`.
+    pub delta: f64,
+    /// `|delta|`.
+    pub abs_delta: f64,
+    pub verdict: CompareVerdict,
+}
+
+/// Praxis tool implementing `nous_compare`.
+///
+/// Input shape: `{ "a": f64, "b": f64, "threshold": Option<f64> }`.
+#[derive(Debug, Clone, Default)]
+pub struct NousCompareTool;
+
+impl NousCompareTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for NousCompareTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "nous_compare".into(),
+            description: "Compare two scalar scores. Returns delta, abs_delta, and a verdict \
+                 (greater / lesser / equal / within_threshold). The optional \
+                 'threshold' parameter (default 0.001) collapses near-equal values \
+                 into 'within_threshold'."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "a": { "type": "number" },
+                    "b": { "type": "number" },
+                    "threshold": { "type": "number", "minimum": 0 }
+                },
+                "required": ["a", "b"]
+            }),
+            title: Some("Nous Compare".into()),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "delta": { "type": "number" },
+                    "abs_delta": { "type": "number", "minimum": 0 },
+                    "verdict": {
+                        "type": "string",
+                        "enum": ["greater", "lesser", "equal", "within_threshold"]
+                    }
+                },
+                "required": ["delta", "abs_delta", "verdict"]
+            })),
+            annotations: Some(ToolAnnotations {
+                read_only: true,
+                idempotent: true,
+                ..Default::default()
+            }),
+            category: Some("nous".into()),
+            tags: vec!["nous".into(), "compare".into()],
+            timeout_secs: Some(5),
+        }
+    }
+
+    fn execute(&self, call: &ToolCall, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let a = extract_number(&call.input, "a")?;
+        let b = extract_number(&call.input, "b")?;
+
+        let threshold = match call.input.get("threshold") {
+            None => DEFAULT_THRESHOLD,
+            Some(v) => {
+                let t = v.as_f64().ok_or_else(|| ToolError::InvalidInput {
+                    message: "'threshold' must be a non-negative number".into(),
+                })?;
+                if !t.is_finite() || t < 0.0 {
+                    return Err(ToolError::InvalidInput {
+                        message: "'threshold' must be a finite non-negative number".into(),
+                    });
+                }
+                t
+            }
+        };
+
+        let result = compare_scores(a, b, threshold);
+        let output = serde_json::to_value(&result).map_err(|e| ToolError::ExecutionFailed {
+            tool_name: "nous_compare".into(),
+            message: format!("failed to serialize compare output: {e}"),
+        })?;
+
+        Ok(ToolResult {
+            call_id: call.call_id.clone(),
+            tool_name: call.tool_name.clone(),
+            output,
+            content: None,
+            is_error: false,
+            usage: None,
+        })
+    }
+}
+
+/// Pure comparison helper. Exposed for direct use by other crates.
+pub fn compare_scores(a: f64, b: f64, threshold: f64) -> CompareOutput {
+    let delta = a - b;
+    let abs_delta = delta.abs();
+    let verdict = if abs_delta <= threshold {
+        // Strict equality wins so the verdict is informative even
+        // when threshold is the default 0.001.
+        if a == b {
+            CompareVerdict::Equal
+        } else {
+            CompareVerdict::WithinThreshold
+        }
+    } else if delta > 0.0 {
+        CompareVerdict::Greater
+    } else {
+        CompareVerdict::Lesser
+    };
+    CompareOutput {
+        delta,
+        abs_delta,
+        verdict,
+    }
+}
+
+fn extract_number(input: &serde_json::Value, field: &str) -> Result<f64, ToolError> {
+    let v = input.get(field).ok_or_else(|| ToolError::InvalidInput {
+        message: format!("Missing required field '{field}'"),
+    })?;
+    let f = v.as_f64().ok_or_else(|| ToolError::InvalidInput {
+        message: format!("'{field}' must be a number"),
+    })?;
+    if !f.is_finite() {
+        return Err(ToolError::InvalidInput {
+            message: format!("'{field}' must be finite (NaN/inf forbidden)"),
+        });
+    }
+    Ok(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            run_id: "test-run".into(),
+            session_id: "S".into(),
+            iteration: 0,
+            ..Default::default()
+        }
+    }
+
+    fn call(input: serde_json::Value) -> ToolCall {
+        ToolCall {
+            call_id: "call-1".into(),
+            tool_name: "nous_compare".into(),
+            input,
+            requested_capabilities: vec![],
+        }
+    }
+
+    #[test]
+    fn nous_compare_within_threshold_marks_equal() {
+        let tool = NousCompareTool::new();
+        // 0.0001 difference < 0.001 default threshold → within_threshold.
+        let result = tool
+            .execute(&call(json!({"a": 1.0001, "b": 1.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert!((out.delta - 0.0001).abs() < 1e-12);
+        assert!((out.abs_delta - 0.0001).abs() < 1e-12);
+        assert_eq!(out.verdict, CompareVerdict::WithinThreshold);
+
+        // True equality returns the more informative `Equal` verdict.
+        let result = tool
+            .execute(&call(json!({"a": 1.0, "b": 1.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.delta, 0.0);
+        assert_eq!(out.verdict, CompareVerdict::Equal);
+    }
+
+    #[test]
+    fn nous_compare_greater_returns_positive_delta() {
+        let tool = NousCompareTool::new();
+        let result = tool
+            .execute(&call(json!({"a": 7.5, "b": 4.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert!((out.delta - 3.5).abs() < 1e-12);
+        assert!((out.abs_delta - 3.5).abs() < 1e-12);
+        assert_eq!(out.verdict, CompareVerdict::Greater);
+    }
+
+    #[test]
+    fn nous_compare_lesser_returns_negative_delta() {
+        let tool = NousCompareTool::new();
+        let result = tool
+            .execute(&call(json!({"a": 2.0, "b": 9.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert!((out.delta + 7.0).abs() < 1e-12);
+        assert!((out.abs_delta - 7.0).abs() < 1e-12);
+        assert_eq!(out.verdict, CompareVerdict::Lesser);
+    }
+
+    #[test]
+    fn nous_compare_custom_threshold_widens_equal_band() {
+        let tool = NousCompareTool::new();
+        // Difference = 0.5 < threshold 1.0 → within_threshold.
+        let result = tool
+            .execute(&call(json!({"a": 5.5, "b": 5.0, "threshold": 1.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.verdict, CompareVerdict::WithinThreshold);
+    }
+
+    #[test]
+    fn nous_compare_zero_threshold_demands_strict_equality() {
+        let tool = NousCompareTool::new();
+        let result = tool
+            .execute(&call(json!({"a": 1.0, "b": 1.0, "threshold": 0.0})), &ctx())
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.verdict, CompareVerdict::Equal);
+
+        let result = tool
+            .execute(
+                &call(json!({"a": 1.0001, "b": 1.0, "threshold": 0.0})),
+                &ctx(),
+            )
+            .unwrap();
+        let out: CompareOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.verdict, CompareVerdict::Greater);
+    }
+
+    #[test]
+    fn nous_compare_rejects_negative_threshold() {
+        let tool = NousCompareTool::new();
+        let err = tool
+            .execute(
+                &call(json!({"a": 1.0, "b": 2.0, "threshold": -0.1})),
+                &ctx(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn nous_compare_rejects_missing_fields() {
+        let tool = NousCompareTool::new();
+        let err = tool.execute(&call(json!({"a": 1.0})), &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+}

--- a/crates/nous/nous-tools/src/error.rs
+++ b/crates/nous/nous-tools/src/error.rs
@@ -1,0 +1,26 @@
+//! Errors emitted by the nous-tools lineage layer.
+//!
+//! Praxis tools surface their own errors through
+//! [`aios_protocol::tool::ToolError`]; this module is dedicated to the
+//! [`crate::NousLineage`] trait, which has its own append/query
+//! semantics distinct from tool dispatch.
+
+use thiserror::Error;
+
+/// Errors that can occur when recording or querying a [`crate::NousLineage`].
+#[derive(Debug, Error)]
+pub enum NousLineageError {
+    /// The backing store rejected the write (e.g. lock poisoning,
+    /// downstream lago error).
+    #[error("lineage store error: {0}")]
+    Store(String),
+
+    /// The provided filter was malformed (e.g. inverted time window).
+    #[error("invalid lineage filter: {0}")]
+    InvalidFilter(String),
+
+    /// Unexpected internal failure (kept open-ended so backends can
+    /// surface their own error messages without growing this enum).
+    #[error("internal lineage error: {0}")]
+    Internal(String),
+}

--- a/crates/nous/nous-tools/src/lago_query.rs
+++ b/crates/nous/nous-tools/src/lago_query.rs
@@ -1,0 +1,606 @@
+//! `lago_query` praxis tool — read-only event-journal queries.
+//!
+//! Authored agents (e.g. `nous-promoter`) need to walk lago events
+//! when reasoning over historical scoring decisions. This tool wraps
+//! [`lago_core::Journal`] in the canonical [`Tool`] trait so the same
+//! agent code path that calls `nous_aggregate` and `nous_compare` can
+//! also call `lago_query`.
+//!
+//! ## Filters
+//!
+//! - `event_kind` — exact match on the serialized event payload `type`
+//!   discriminant (e.g. `"Message"`, `"ToolCall"`, `"Custom"`). Lago
+//!   already supports this through `EventQuery::with_kind`.
+//! - `after_ts_ms` / `before_ts_ms` — inclusive timestamp window in
+//!   **milliseconds** since epoch. Lago events store microseconds; the
+//!   tool converts on the way in and out so callers think in the same
+//!   unit as `LineageEvent`.
+//! - `limit` — maximum events returned. Default `50`, hard-capped at
+//!   `500` to bound memory.
+//!
+//! ## Output
+//!
+//! ```jsonc
+//! {
+//!   "events": [
+//!     { "id": "<EventId>", "kind": "<discriminant>", "ts_ms": <u64>,
+//!       "payload": <serde_json::Value> },
+//!     ...
+//!   ]
+//! }
+//! ```
+//!
+//! ## Async over a sync trait
+//!
+//! `aios_protocol::tool::Tool::execute` is **synchronous** but the
+//! `Journal` API is async. The tool stashes a `tokio::runtime::Handle`
+//! at construction time and uses `block_on` to drive the async call,
+//! mirroring the established pattern in `praxis-mcp-bridge::McpTool`.
+
+use aios_protocol::tool::{
+    Tool, ToolAnnotations, ToolCall, ToolContext, ToolDefinition, ToolError, ToolResult,
+};
+use lago_core::{EventEnvelope, EventQuery, Journal};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+/// Default `limit` returned when the caller does not supply one.
+pub const DEFAULT_LIMIT: u32 = 50;
+/// Hard cap on `limit` regardless of caller input — bounds memory for
+/// untrusted agents.
+pub const MAX_LIMIT: u32 = 500;
+
+/// One event row in [`QueryOutput`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueriedEvent {
+    pub id: String,
+    pub kind: String,
+    /// Timestamp in milliseconds since epoch (lago stores microseconds;
+    /// this tool exposes ms for parity with [`crate::LineageEvent`]).
+    pub ts_ms: u64,
+    pub payload: serde_json::Value,
+}
+
+/// Output payload of [`LagoQueryTool`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryOutput {
+    pub events: Vec<QueriedEvent>,
+}
+
+/// Praxis tool implementing `lago_query`.
+pub struct LagoQueryTool {
+    journal: Arc<dyn Journal>,
+    runtime: Handle,
+}
+
+impl LagoQueryTool {
+    /// Construct the tool with the given journal and the **current**
+    /// tokio runtime handle. Panics outside a tokio runtime — callers
+    /// in test code should wrap construction in `#[tokio::test]` or
+    /// `Runtime::new()?.block_on(...)`.
+    pub fn new(journal: Arc<dyn Journal>) -> Self {
+        Self {
+            journal,
+            runtime: Handle::current(),
+        }
+    }
+
+    /// Construct with an explicit runtime handle (for cases where the
+    /// caller wants to dispatch from a non-async context).
+    pub fn with_runtime(journal: Arc<dyn Journal>, runtime: Handle) -> Self {
+        Self { journal, runtime }
+    }
+}
+
+impl Tool for LagoQueryTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "lago_query".into(),
+            description: "Read events from the lago journal. Supports filtering by event kind \
+                 discriminant, timestamp window (ms), and a bounded result limit \
+                 (default 50, max 500)."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "event_kind": {
+                        "type": "string",
+                        "description": "Exact match on event payload 'type' discriminant."
+                    },
+                    "after_ts_ms": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Inclusive lower bound on event timestamp (milliseconds)."
+                    },
+                    "before_ts_ms": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Inclusive upper bound on event timestamp (milliseconds)."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_LIMIT,
+                        "description": "Max events returned. Default 50; hard cap 500."
+                    }
+                }
+            }),
+            title: Some("Lago Query".into()),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "events": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string" },
+                                "kind": { "type": "string" },
+                                "ts_ms": { "type": "integer", "minimum": 0 },
+                                "payload": {}
+                            },
+                            "required": ["id", "kind", "ts_ms", "payload"]
+                        }
+                    }
+                },
+                "required": ["events"]
+            })),
+            annotations: Some(ToolAnnotations {
+                read_only: true,
+                idempotent: true,
+                ..Default::default()
+            }),
+            category: Some("nous".into()),
+            tags: vec!["nous".into(), "lago".into(), "query".into()],
+            timeout_secs: Some(15),
+        }
+    }
+
+    fn execute(&self, call: &ToolCall, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        // Decode + validate input.
+        let event_kind = match call.input.get("event_kind") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(v) => Some(
+                v.as_str()
+                    .ok_or_else(|| ToolError::InvalidInput {
+                        message: "'event_kind' must be a string".into(),
+                    })?
+                    .to_string(),
+            ),
+        };
+        let after_ts_ms = decode_optional_u64(&call.input, "after_ts_ms")?;
+        let before_ts_ms = decode_optional_u64(&call.input, "before_ts_ms")?;
+        if let (Some(a), Some(b)) = (after_ts_ms, before_ts_ms)
+            && a > b
+        {
+            return Err(ToolError::InvalidInput {
+                message: format!("after_ts_ms ({a}) must be <= before_ts_ms ({b})"),
+            });
+        }
+
+        let limit = decode_optional_u32(&call.input, "limit")?
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(1, MAX_LIMIT) as usize;
+
+        // Build a Lago query. Kind filtering is delegated to the journal
+        // for backends that can index it; the timestamp filter is
+        // applied client-side because EventQuery exposes seq filters,
+        // not timestamp filters.
+        let mut query = EventQuery::new().limit(limit);
+        if let Some(ref kind) = event_kind {
+            query = query.with_kind(kind.clone());
+        }
+
+        let journal = self.journal.clone();
+        let runtime = self.runtime.clone();
+        // `Tool::execute` is sync but `Journal::read` is async. We
+        // detect whether we are already inside a tokio runtime: if so,
+        // hop out of the async context with `block_in_place` so we can
+        // legally call `Handle::block_on` (this is the same trick
+        // `praxis-mcp-bridge::McpTool` uses, generalised for both
+        // contexts). If not, plain `block_on` is sufficient.
+        let envelopes: Vec<EventEnvelope> = if Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| {
+                runtime.block_on(async move { journal.read(query).await })
+            })
+        } else {
+            runtime.block_on(async move { journal.read(query).await })
+        }
+        .map_err(|e| ToolError::ExecutionFailed {
+            tool_name: "lago_query".into(),
+            message: format!("journal read failed: {e}"),
+        })?;
+
+        // Apply timestamp filter (us → ms) and shape the rows.
+        let mut events = Vec::with_capacity(envelopes.len());
+        for env in envelopes {
+            let ts_ms = env.timestamp / 1_000;
+            if let Some(after) = after_ts_ms
+                && ts_ms < after
+            {
+                continue;
+            }
+            if let Some(before) = before_ts_ms
+                && ts_ms > before
+            {
+                continue;
+            }
+
+            let payload_value =
+                serde_json::to_value(&env.payload).map_err(|e| ToolError::ExecutionFailed {
+                    tool_name: "lago_query".into(),
+                    message: format!("failed to serialize event payload: {e}"),
+                })?;
+            let kind = payload_value
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown")
+                .to_string();
+
+            events.push(QueriedEvent {
+                id: env.event_id.as_str().to_string(),
+                kind,
+                ts_ms,
+                payload: payload_value,
+            });
+
+            if events.len() >= limit {
+                break;
+            }
+        }
+
+        let output = serde_json::to_value(QueryOutput { events }).map_err(|e| {
+            ToolError::ExecutionFailed {
+                tool_name: "lago_query".into(),
+                message: format!("failed to serialize query output: {e}"),
+            }
+        })?;
+
+        Ok(ToolResult {
+            call_id: call.call_id.clone(),
+            tool_name: call.tool_name.clone(),
+            output,
+            content: None,
+            is_error: false,
+            usage: None,
+        })
+    }
+}
+
+fn decode_optional_u64(input: &serde_json::Value, field: &str) -> Result<Option<u64>, ToolError> {
+    match input.get(field) {
+        Some(serde_json::Value::Null) | None => Ok(None),
+        Some(v) => v.as_u64().map(Some).ok_or_else(|| ToolError::InvalidInput {
+            message: format!("'{field}' must be a non-negative integer"),
+        }),
+    }
+}
+
+fn decode_optional_u32(input: &serde_json::Value, field: &str) -> Result<Option<u32>, ToolError> {
+    match input.get(field) {
+        Some(serde_json::Value::Null) | None => Ok(None),
+        Some(v) => {
+            let n = v.as_u64().ok_or_else(|| ToolError::InvalidInput {
+                message: format!("'{field}' must be a non-negative integer"),
+            })?;
+            if n > u32::MAX as u64 {
+                return Err(ToolError::InvalidInput {
+                    message: format!("'{field}' exceeds u32::MAX"),
+                });
+            }
+            Ok(Some(n as u32))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lago_core::{
+        BranchId, EventEnvelope, EventId, EventPayload, EventStream, LagoResult, SeqNo, Session,
+        SessionId,
+    };
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::sync::RwLock;
+
+    /// Minimal test journal: stores a fixed `Vec<EventEnvelope>` and
+    /// honours kind / limit filters via [`EventQuery::matches_filters`].
+    /// Other journal methods are stubs (we only test `read` here).
+    pub struct VecJournal {
+        events: RwLock<Vec<EventEnvelope>>,
+    }
+
+    impl VecJournal {
+        pub fn new(events: Vec<EventEnvelope>) -> Self {
+            Self {
+                events: RwLock::new(events),
+            }
+        }
+    }
+
+    impl Journal for VecJournal {
+        fn append(
+            &self,
+            event: EventEnvelope,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            let seq = event.seq;
+            self.events.write().unwrap().push(event);
+            Box::pin(async move { Ok(seq) })
+        }
+
+        fn append_batch(
+            &self,
+            events: Vec<EventEnvelope>,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            let last = events.last().map(|e| e.seq).unwrap_or(0);
+            self.events.write().unwrap().extend(events);
+            Box::pin(async move { Ok(last) })
+        }
+
+        fn read(
+            &self,
+            query: EventQuery,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<EventEnvelope>>> + Send + '_>>
+        {
+            let snapshot = self.events.read().unwrap().clone();
+            Box::pin(async move {
+                let mut out: Vec<EventEnvelope> = snapshot
+                    .into_iter()
+                    .filter(|env| query.matches_filters(env))
+                    .collect();
+                if let Some(limit) = query.limit {
+                    out.truncate(limit);
+                }
+                Ok(out)
+            })
+        }
+
+        fn get_event(
+            &self,
+            event_id: &EventId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<EventEnvelope>>> + Send + '_>>
+        {
+            let target = event_id.clone();
+            let snapshot = self.events.read().unwrap().clone();
+            Box::pin(async move { Ok(snapshot.into_iter().find(|e| e.event_id == target)) })
+        }
+
+        fn head_seq(
+            &self,
+            _session_id: &SessionId,
+            _branch_id: &BranchId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+            let head = self
+                .events
+                .read()
+                .unwrap()
+                .iter()
+                .map(|e| e.seq)
+                .max()
+                .unwrap_or(0);
+            Box::pin(async move { Ok(head) })
+        }
+
+        fn stream(
+            &self,
+            _session_id: SessionId,
+            _branch_id: BranchId,
+            _after_seq: SeqNo,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<EventStream>> + Send + '_>>
+        {
+            // Not exercised in these tests.
+            Box::pin(async move {
+                let stream = futures::stream::empty::<LagoResult<EventEnvelope>>();
+                Ok(Box::pin(stream) as EventStream)
+            })
+        }
+
+        fn put_session(
+            &self,
+            _session: Session,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<()>> + Send + '_>> {
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn get_session(
+            &self,
+            _session_id: &SessionId,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<Session>>> + Send + '_>>
+        {
+            Box::pin(async move { Ok(None) })
+        }
+
+        fn list_sessions(
+            &self,
+        ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<Session>>> + Send + '_>>
+        {
+            Box::pin(async move { Ok(Vec::new()) })
+        }
+    }
+
+    fn make_event(id: &str, seq: u64, ts_us: u64, payload: EventPayload) -> EventEnvelope {
+        EventEnvelope {
+            event_id: EventId::from_string(id),
+            session_id: SessionId::from_string("S1"),
+            branch_id: BranchId::from_string("main"),
+            run_id: None,
+            seq,
+            timestamp: ts_us,
+            parent_id: None,
+            payload,
+            metadata: HashMap::new(),
+            schema_version: 1,
+        }
+    }
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            run_id: "test-run".into(),
+            session_id: "S1".into(),
+            iteration: 0,
+            ..Default::default()
+        }
+    }
+
+    fn call(input: serde_json::Value) -> ToolCall {
+        ToolCall {
+            call_id: "call-1".into(),
+            tool_name: "lago_query".into(),
+            input,
+            requested_capabilities: vec![],
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lago_query_filters_by_kind() {
+        let events = vec![
+            make_event(
+                "E1",
+                1,
+                1_000_000,
+                EventPayload::Message {
+                    role: "user".into(),
+                    content: "hi".into(),
+                    model: None,
+                    token_usage: None,
+                },
+            ),
+            make_event(
+                "E2",
+                2,
+                2_000_000,
+                EventPayload::ErrorRaised {
+                    message: "boom".into(),
+                },
+            ),
+            make_event(
+                "E3",
+                3,
+                3_000_000,
+                EventPayload::Message {
+                    role: "assistant".into(),
+                    content: "ok".into(),
+                    model: None,
+                    token_usage: None,
+                },
+            ),
+        ];
+        let journal: Arc<dyn Journal> = Arc::new(VecJournal::new(events));
+        let tool = LagoQueryTool::new(journal);
+
+        let result = tool
+            .execute(&call(json!({"event_kind": "Message"})), &ctx())
+            .unwrap();
+        let out: QueryOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.events.len(), 2);
+        assert_eq!(out.events[0].id, "E1");
+        assert_eq!(out.events[0].kind, "Message");
+        assert_eq!(out.events[0].ts_ms, 1_000); // 1_000_000 us → 1000 ms.
+        assert_eq!(out.events[1].id, "E3");
+
+        // Filter that matches nothing.
+        let result = tool
+            .execute(&call(json!({"event_kind": "DoesNotExist"})), &ctx())
+            .unwrap();
+        let out: QueryOutput = serde_json::from_value(result.output).unwrap();
+        assert!(out.events.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lago_query_respects_limit_and_hard_cap() {
+        // 600 events; the hard cap should clamp the output at 500.
+        let events: Vec<EventEnvelope> = (0..600)
+            .map(|i| {
+                make_event(
+                    &format!("E{i}"),
+                    i + 1,
+                    (i + 1) * 1_000,
+                    EventPayload::Message {
+                        role: "user".into(),
+                        content: format!("msg-{i}"),
+                        model: None,
+                        token_usage: None,
+                    },
+                )
+            })
+            .collect();
+        let journal: Arc<dyn Journal> = Arc::new(VecJournal::new(events));
+        let tool = LagoQueryTool::new(journal);
+
+        let result = tool.execute(&call(json!({"limit": 9999})), &ctx()).unwrap();
+        let out: QueryOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.events.len(), MAX_LIMIT as usize);
+
+        // Default limit = 50.
+        let result = tool.execute(&call(json!({})), &ctx()).unwrap();
+        let out: QueryOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.events.len(), DEFAULT_LIMIT as usize);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lago_query_filters_by_timestamp_window() {
+        let events = vec![
+            make_event(
+                "E1",
+                1,
+                1_000_000, // 1000 ms
+                EventPayload::Message {
+                    role: "user".into(),
+                    content: "early".into(),
+                    model: None,
+                    token_usage: None,
+                },
+            ),
+            make_event(
+                "E2",
+                2,
+                5_000_000, // 5000 ms
+                EventPayload::Message {
+                    role: "user".into(),
+                    content: "middle".into(),
+                    model: None,
+                    token_usage: None,
+                },
+            ),
+            make_event(
+                "E3",
+                3,
+                9_000_000, // 9000 ms
+                EventPayload::Message {
+                    role: "user".into(),
+                    content: "late".into(),
+                    model: None,
+                    token_usage: None,
+                },
+            ),
+        ];
+        let journal: Arc<dyn Journal> = Arc::new(VecJournal::new(events));
+        let tool = LagoQueryTool::new(journal);
+
+        let result = tool
+            .execute(
+                &call(json!({"after_ts_ms": 2000, "before_ts_ms": 7000})),
+                &ctx(),
+            )
+            .unwrap();
+        let out: QueryOutput = serde_json::from_value(result.output).unwrap();
+        assert_eq!(out.events.len(), 1);
+        assert_eq!(out.events[0].id, "E2");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lago_query_rejects_inverted_window() {
+        let journal: Arc<dyn Journal> = Arc::new(VecJournal::new(vec![]));
+        let tool = LagoQueryTool::new(journal);
+        let err = tool
+            .execute(
+                &call(json!({"after_ts_ms": 9000, "before_ts_ms": 1000})),
+                &ctx(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+}

--- a/crates/nous/nous-tools/src/lib.rs
+++ b/crates/nous/nous-tools/src/lib.rs
@@ -1,0 +1,37 @@
+//! # nous-tools — Lineage primitives + praxis tools for authored agents
+//!
+//! This crate ships the substrate layer (L2 in the authored-agents
+//! architecture) for nous-driven workflows:
+//!
+//! - [`NousLineage`] trait + [`InMemoryNousLineage`] reference impl —
+//!   a record/query interface for the provenance of every nous decision.
+//!   The lago-backed implementation is intentionally out of scope; this
+//!   crate ships the trait and an in-memory fixture so authored agents
+//!   (BRO-1011 nous-promoter, BRO-1012 bookkeeping scorers) can be wired
+//!   end-to-end without taking a dependency on the journal.
+//! - Three [`praxis`-style](aios_protocol::tool::Tool) tools that
+//!   authored agents need to consume nous output:
+//!   - [`NousAggregateTool`] — descriptive statistics over a `Vec<f64>`
+//!     of scores (count, mean, median, min, max, stddev).
+//!   - [`NousCompareTool`] — `a` vs `b` with a configurable equality
+//!     threshold; emits a typed verdict.
+//!   - [`LagoQueryTool`] — read-only event-journal queries over
+//!     [`lago_core::Journal`] with kind / time / limit filters.
+//!
+//! These primitives are referenced as the BRO-1009 row of the
+//! authored-agents architecture spec
+//! (`docs/superpowers/specs/2026-05-09-bro-1006-authored-agents-architecture.md`,
+//! §6.6 + §8). Lago-backed `NousLineage` and the BRO-1011 `nous-promoter`
+//! agent that consumes these tools live downstream.
+
+pub mod aggregate;
+pub mod compare;
+pub mod error;
+pub mod lago_query;
+pub mod lineage;
+
+pub use aggregate::{AggregateOutput, NousAggregateTool};
+pub use compare::{CompareOutput, CompareVerdict, NousCompareTool};
+pub use error::NousLineageError;
+pub use lago_query::{LagoQueryTool, QueriedEvent, QueryOutput};
+pub use lineage::{InMemoryNousLineage, LineageEvent, LineageFilter, LineageId, NousLineage};

--- a/crates/nous/nous-tools/src/lineage.rs
+++ b/crates/nous/nous-tools/src/lineage.rs
@@ -1,0 +1,348 @@
+//! `NousLineage` — provenance trail for nous decisions.
+//!
+//! Every time a nous evaluator (heuristic, judge, scorer) runs against
+//! some target, the substrate records a [`LineageEvent`]: which agent
+//! ran, what input it saw, what output it emitted, when, against which
+//! session, and which lago event (if any) the call traces back to.
+//!
+//! Authored agents in BRO-1011 (`nous-promoter`) and BRO-1012
+//! (bookkeeping scorers) consume this trail through
+//! [`NousLineage::query`] to reason over historical scores when
+//! deciding whether a candidate has earned promotion.
+//!
+//! This crate ships the trait + an in-memory reference implementation
+//! ([`InMemoryNousLineage`]). A lago-backed implementation that mirrors
+//! events into the journal is intentionally **out of scope** for
+//! BRO-1009 — it lands separately so the two crates can ship
+//! independently.
+
+use crate::error::NousLineageError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
+
+/// Opaque identifier returned by [`NousLineage::record`].
+///
+/// Backed by a string (rather than a typed ULID) so backends are free
+/// to use their own conventions — the in-memory backend uses sequential
+/// ULID-shaped strings, and a lago-backed backend would return the
+/// `EventId` of the persisted event.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LineageId(pub String);
+
+impl LineageId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A single nous evaluation event with its full provenance.
+///
+/// Fields are intentionally JSON-shaped (`serde_json::Value` for
+/// `input` and `output`) so different scorers can ship their own
+/// schemas without forcing a typed enum migration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LineageEvent {
+    /// The agent session under which this evaluation ran. Mirrors
+    /// `lago_core::SessionId` but kept as a `String` so this trait
+    /// does not pin the lineage substrate to lago.
+    pub session_id: String,
+    /// Stable name of the scorer/judge that produced this row,
+    /// e.g. `"bookkeeping.score-novelty"` or `"nous.promoter.judge"`.
+    pub agent_name: String,
+    /// Optional reference to the artifact that was scored. Free-form so
+    /// callers can use whatever URI / path / wikilink shape suits their
+    /// surface (e.g. `"research/notes/foo-raw.md#item-3"` or a lago
+    /// `EventId`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_ref: Option<String>,
+    /// The input payload the scorer received (shape is scorer-defined).
+    pub input: serde_json::Value,
+    /// The output payload the scorer emitted (shape is scorer-defined).
+    pub output: serde_json::Value,
+    /// Wall-clock timestamp of the event in milliseconds since epoch.
+    pub timestamp_ms: u64,
+    /// Optional pointer back to the lago event that triggered or
+    /// recorded this evaluation. Lets downstream agents walk from
+    /// lineage row → lago event → original artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lago_event_id: Option<String>,
+}
+
+/// Filter used by [`NousLineage::query`].
+///
+/// All fields are optional and combined with logical AND. An empty
+/// filter returns every recorded event.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LineageFilter {
+    /// Restrict to a single session.
+    pub session_id: Option<String>,
+    /// Restrict to a single agent (e.g. `"bookkeeping.score-novelty"`).
+    pub agent_name: Option<String>,
+    /// Restrict to evaluations whose `target_ref` matches exactly.
+    pub target_ref: Option<String>,
+    /// Inclusive lower bound on `timestamp_ms`.
+    pub after_ts_ms: Option<u64>,
+    /// Inclusive upper bound on `timestamp_ms`.
+    pub before_ts_ms: Option<u64>,
+    /// Maximum number of events returned (no cap means "all matching").
+    pub limit: Option<usize>,
+}
+
+impl LineageFilter {
+    /// Returns true if `event` satisfies every set field.
+    pub fn matches(&self, event: &LineageEvent) -> bool {
+        if let Some(ref s) = self.session_id
+            && &event.session_id != s
+        {
+            return false;
+        }
+        if let Some(ref a) = self.agent_name
+            && &event.agent_name != a
+        {
+            return false;
+        }
+        if let Some(ref t) = self.target_ref
+            && event.target_ref.as_ref() != Some(t)
+        {
+            return false;
+        }
+        if let Some(after) = self.after_ts_ms
+            && event.timestamp_ms < after
+        {
+            return false;
+        }
+        if let Some(before) = self.before_ts_ms
+            && event.timestamp_ms > before
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// The provenance trail for nous decisions.
+///
+/// Implementations must preserve insertion order on read — downstream
+/// promoters rely on chronological iteration to detect drift.
+#[async_trait]
+pub trait NousLineage: Send + Sync {
+    /// Record a single scoring/judging event with its full provenance.
+    async fn record(&self, event: LineageEvent) -> Result<LineageId, NousLineageError>;
+
+    /// Query the lineage by aggregator key (e.g. all scores for entity X).
+    async fn query(&self, filter: LineageFilter) -> Result<Vec<LineageEvent>, NousLineageError>;
+}
+
+/// In-memory reference implementation backed by an `Arc<RwLock<Vec<_>>>`.
+///
+/// Suitable for tests, fixtures, and short-lived single-process agents.
+/// Events are appended in record-order and returned in the same order
+/// from [`NousLineage::query`].
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryNousLineage {
+    inner: Arc<RwLock<Vec<(LineageId, LineageEvent)>>>,
+}
+
+impl InMemoryNousLineage {
+    /// Construct an empty lineage store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of events currently recorded.
+    ///
+    /// Useful for assertions in tests.
+    pub fn len(&self) -> usize {
+        self.inner.read().map(|guard| guard.len()).unwrap_or(0)
+    }
+
+    /// Returns true if no events have been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl NousLineage for InMemoryNousLineage {
+    async fn record(&self, event: LineageEvent) -> Result<LineageId, NousLineageError> {
+        let mut guard = self
+            .inner
+            .write()
+            .map_err(|e| NousLineageError::Store(format!("write lock poisoned: {e}")))?;
+        // Sequential id ("lineage-N") keeps the in-memory backend
+        // dependency-free (no ulid). A lago-backed backend would
+        // return the persisted EventId.
+        let id = LineageId::new(format!("lineage-{}", guard.len()));
+        guard.push((id.clone(), event));
+        Ok(id)
+    }
+
+    async fn query(&self, filter: LineageFilter) -> Result<Vec<LineageEvent>, NousLineageError> {
+        if let (Some(after), Some(before)) = (filter.after_ts_ms, filter.before_ts_ms)
+            && after > before
+        {
+            return Err(NousLineageError::InvalidFilter(format!(
+                "after_ts_ms ({after}) is greater than before_ts_ms ({before})"
+            )));
+        }
+
+        let guard = self
+            .inner
+            .read()
+            .map_err(|e| NousLineageError::Store(format!("read lock poisoned: {e}")))?;
+
+        let mut out = Vec::new();
+        for (_, ev) in guard.iter() {
+            if filter.matches(ev) {
+                out.push(ev.clone());
+                if let Some(limit) = filter.limit
+                    && out.len() >= limit
+                {
+                    break;
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(
+        session: &str,
+        agent: &str,
+        target: Option<&str>,
+        input: serde_json::Value,
+        output: serde_json::Value,
+        ts: u64,
+    ) -> LineageEvent {
+        LineageEvent {
+            session_id: session.to_string(),
+            agent_name: agent.to_string(),
+            target_ref: target.map(str::to_string),
+            input,
+            output,
+            timestamp_ms: ts,
+            lago_event_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn in_memory_nous_lineage_round_trip() {
+        let store = InMemoryNousLineage::new();
+        assert!(store.is_empty());
+
+        let a = ev(
+            "S1",
+            "bookkeeping.score-novelty",
+            Some("notes/a.md#1"),
+            json!({"text": "alpha"}),
+            json!({"score": 7}),
+            100,
+        );
+        let b = ev(
+            "S1",
+            "bookkeeping.score-novelty",
+            Some("notes/b.md#1"),
+            json!({"text": "beta"}),
+            json!({"score": 3}),
+            200,
+        );
+        let c = ev(
+            "S2",
+            "bookkeeping.score-relevance",
+            None,
+            json!({"text": "gamma"}),
+            json!({"score": 9}),
+            300,
+        );
+
+        let id_a = store.record(a.clone()).await.unwrap();
+        let id_b = store.record(b.clone()).await.unwrap();
+        let id_c = store.record(c.clone()).await.unwrap();
+
+        // Sequential ids preserve insertion order.
+        assert_eq!(id_a.as_str(), "lineage-0");
+        assert_eq!(id_b.as_str(), "lineage-1");
+        assert_eq!(id_c.as_str(), "lineage-2");
+        assert_eq!(store.len(), 3);
+
+        // Empty filter returns all events in insertion order.
+        let all = store.query(LineageFilter::default()).await.unwrap();
+        assert_eq!(all, vec![a.clone(), b.clone(), c.clone()]);
+
+        // Session filter.
+        let s1 = store
+            .query(LineageFilter {
+                session_id: Some("S1".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(s1, vec![a.clone(), b.clone()]);
+
+        // Agent filter.
+        let novelty = store
+            .query(LineageFilter {
+                agent_name: Some("bookkeeping.score-novelty".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(novelty, vec![a.clone(), b.clone()]);
+
+        // Target filter.
+        let only_a = store
+            .query(LineageFilter {
+                target_ref: Some("notes/a.md#1".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(only_a, vec![a.clone()]);
+
+        // Time window.
+        let window = store
+            .query(LineageFilter {
+                after_ts_ms: Some(150),
+                before_ts_ms: Some(250),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(window, vec![b.clone()]);
+
+        // Limit.
+        let one = store
+            .query(LineageFilter {
+                limit: Some(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(one, vec![a.clone()]);
+    }
+
+    #[tokio::test]
+    async fn invalid_window_is_rejected() {
+        let store = InMemoryNousLineage::new();
+        let err = store
+            .query(LineageFilter {
+                after_ts_ms: Some(500),
+                before_ts_ms: Some(100),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, NousLineageError::InvalidFilter(_)));
+    }
+}

--- a/crates/nous/nous-tools/tests/tools.rs
+++ b/crates/nous/nous-tools/tests/tools.rs
@@ -1,0 +1,299 @@
+//! End-to-end integration test exercising all three nous-tools through
+//! the `aios_protocol::tool::Tool` dispatch surface.
+//!
+//! Mirrors the path an authored agent takes:
+//!   1. spawn a session
+//!   2. record several lineage events
+//!   3. query lago for context
+//!   4. aggregate the scores
+//!   5. compare two aggregates and confirm the verdict.
+
+use aios_protocol::tool::{Tool, ToolCall, ToolContext};
+use lago_core::{
+    BranchId, EventEnvelope, EventId, EventPayload, EventQuery, EventStream, Journal, LagoResult,
+    SeqNo, Session, SessionId,
+};
+use nous_tools::{
+    AggregateOutput, CompareOutput, CompareVerdict, InMemoryNousLineage, LagoQueryTool,
+    LineageEvent, LineageFilter, NousAggregateTool, NousCompareTool, NousLineage, QueryOutput,
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+/// Stub journal — same shape as the unit-test fixture but lifted into
+/// the integration crate so the round-trip exercises the real dispatch
+/// surface.
+struct VecJournal {
+    events: RwLock<Vec<EventEnvelope>>,
+}
+
+impl VecJournal {
+    fn new(events: Vec<EventEnvelope>) -> Self {
+        Self {
+            events: RwLock::new(events),
+        }
+    }
+}
+
+impl Journal for VecJournal {
+    fn append(
+        &self,
+        event: EventEnvelope,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+        let seq = event.seq;
+        self.events.write().unwrap().push(event);
+        Box::pin(async move { Ok(seq) })
+    }
+
+    fn append_batch(
+        &self,
+        events: Vec<EventEnvelope>,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+        let last = events.last().map(|e| e.seq).unwrap_or(0);
+        self.events.write().unwrap().extend(events);
+        Box::pin(async move { Ok(last) })
+    }
+
+    fn read(
+        &self,
+        query: EventQuery,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<EventEnvelope>>> + Send + '_>>
+    {
+        let snapshot = self.events.read().unwrap().clone();
+        Box::pin(async move {
+            let mut out: Vec<EventEnvelope> = snapshot
+                .into_iter()
+                .filter(|env| query.matches_filters(env))
+                .collect();
+            if let Some(limit) = query.limit {
+                out.truncate(limit);
+            }
+            Ok(out)
+        })
+    }
+
+    fn get_event(
+        &self,
+        event_id: &EventId,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<EventEnvelope>>> + Send + '_>>
+    {
+        let target = event_id.clone();
+        let snapshot = self.events.read().unwrap().clone();
+        Box::pin(async move { Ok(snapshot.into_iter().find(|e| e.event_id == target)) })
+    }
+
+    fn head_seq(
+        &self,
+        _session_id: &SessionId,
+        _branch_id: &BranchId,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<SeqNo>> + Send + '_>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn stream(
+        &self,
+        _session_id: SessionId,
+        _branch_id: BranchId,
+        _after_seq: SeqNo,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<EventStream>> + Send + '_>> {
+        Box::pin(async move {
+            let stream = futures::stream::empty::<LagoResult<EventEnvelope>>();
+            Ok(Box::pin(stream) as EventStream)
+        })
+    }
+
+    fn put_session(
+        &self,
+        _session: Session,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<()>> + Send + '_>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn get_session(
+        &self,
+        _session_id: &SessionId,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Option<Session>>> + Send + '_>> {
+        Box::pin(async move { Ok(None) })
+    }
+
+    fn list_sessions(
+        &self,
+    ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<Vec<Session>>> + Send + '_>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+}
+
+fn ctx() -> ToolContext {
+    ToolContext {
+        run_id: "run-1".into(),
+        session_id: "S1".into(),
+        iteration: 0,
+        ..Default::default()
+    }
+}
+
+fn call(name: &str, input: serde_json::Value) -> ToolCall {
+    ToolCall {
+        call_id: format!("call-{name}"),
+        tool_name: name.into(),
+        input,
+        requested_capabilities: vec![],
+    }
+}
+
+fn make_event(id: &str, seq: u64, ts_us: u64, payload: EventPayload) -> EventEnvelope {
+    EventEnvelope {
+        event_id: EventId::from_string(id),
+        session_id: SessionId::from_string("S1"),
+        branch_id: BranchId::from_string("main"),
+        run_id: None,
+        seq,
+        timestamp: ts_us,
+        parent_id: None,
+        payload,
+        metadata: HashMap::new(),
+        schema_version: 1,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn end_to_end_promoter_flow() {
+    // 1. Lineage substrate populated with two scoring rounds.
+    let lineage = InMemoryNousLineage::new();
+    let scores_round_a: Vec<f64> = vec![6.0, 7.0, 8.0, 7.0, 6.0];
+    let scores_round_b: Vec<f64> = vec![7.5, 8.0, 9.0, 8.5, 7.0];
+
+    for (i, s) in scores_round_a.iter().enumerate() {
+        lineage
+            .record(LineageEvent {
+                session_id: "S1".into(),
+                agent_name: "bookkeeping.score-novelty".into(),
+                target_ref: Some(format!("notes/round-a-item-{i}")),
+                input: json!({"text": format!("a{i}")}),
+                output: json!({"score": s}),
+                timestamp_ms: 1_000 + i as u64,
+                lago_event_id: None,
+            })
+            .await
+            .unwrap();
+    }
+    for (i, s) in scores_round_b.iter().enumerate() {
+        lineage
+            .record(LineageEvent {
+                session_id: "S2".into(),
+                agent_name: "bookkeeping.score-novelty".into(),
+                target_ref: Some(format!("notes/round-b-item-{i}")),
+                input: json!({"text": format!("b{i}")}),
+                output: json!({"score": s}),
+                timestamp_ms: 2_000 + i as u64,
+                lago_event_id: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let recorded_a = lineage
+        .query(LineageFilter {
+            session_id: Some("S1".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let recorded_b = lineage
+        .query(LineageFilter {
+            session_id: Some("S2".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(recorded_a.len(), 5);
+    assert_eq!(recorded_b.len(), 5);
+
+    let extract_scores = |events: &[LineageEvent]| -> Vec<f64> {
+        events
+            .iter()
+            .filter_map(|e| e.output.get("score").and_then(|s| s.as_f64()))
+            .collect()
+    };
+
+    // 2. Aggregate via the `nous_aggregate` tool.
+    let aggregate = NousAggregateTool::new();
+    let agg_a_result = aggregate
+        .execute(
+            &call(
+                "nous_aggregate",
+                json!({"scores": extract_scores(&recorded_a)}),
+            ),
+            &ctx(),
+        )
+        .unwrap();
+    let agg_b_result = aggregate
+        .execute(
+            &call(
+                "nous_aggregate",
+                json!({"scores": extract_scores(&recorded_b)}),
+            ),
+            &ctx(),
+        )
+        .unwrap();
+    let agg_a: AggregateOutput = serde_json::from_value(agg_a_result.output).unwrap();
+    let agg_b: AggregateOutput = serde_json::from_value(agg_b_result.output).unwrap();
+    assert_eq!(agg_a.count, 5);
+    assert_eq!(agg_b.count, 5);
+    assert!((agg_a.mean - 6.8).abs() < 1e-9);
+    assert!((agg_b.mean - 8.0).abs() < 1e-9);
+
+    // 3. Compare via `nous_compare` — round B should beat round A.
+    let compare = NousCompareTool::new();
+    let cmp_result = compare
+        .execute(
+            &call(
+                "nous_compare",
+                json!({"a": agg_b.mean, "b": agg_a.mean, "threshold": 0.05}),
+            ),
+            &ctx(),
+        )
+        .unwrap();
+    let cmp: CompareOutput = serde_json::from_value(cmp_result.output).unwrap();
+    assert_eq!(cmp.verdict, CompareVerdict::Greater);
+    assert!((cmp.delta - 1.2).abs() < 1e-9);
+
+    // 4. Query lago for an event referenced by the lineage row.
+    let journal: Arc<dyn Journal> = Arc::new(VecJournal::new(vec![
+        make_event(
+            "E1",
+            1,
+            1_500_000,
+            EventPayload::Message {
+                role: "user".into(),
+                content: "round-a sample".into(),
+                model: None,
+                token_usage: None,
+            },
+        ),
+        make_event(
+            "E2",
+            2,
+            2_500_000,
+            EventPayload::Message {
+                role: "assistant".into(),
+                content: "round-b sample".into(),
+                model: None,
+                token_usage: None,
+            },
+        ),
+    ]));
+    let lago = LagoQueryTool::new(journal);
+    let lago_result = lago
+        .execute(
+            &call("lago_query", json!({"event_kind": "Message", "limit": 50})),
+            &ctx(),
+        )
+        .unwrap();
+    let lago_out: QueryOutput = serde_json::from_value(lago_result.output).unwrap();
+    assert_eq!(lago_out.events.len(), 2);
+    assert_eq!(lago_out.events[0].id, "E1");
+    assert_eq!(lago_out.events[1].id, "E2");
+}


### PR DESCRIPTION
## Summary

Ships the L2 substrate piece authored agents need to consume nous output.
Sibling of BRO-1007/1007b (registry + spawn) and BRO-1010 (first authored
agents). Closes the BRO-1009 row of the authored-agents architecture spec
(`docs/superpowers/specs/2026-05-09-bro-1006-authored-agents-architecture.md`,
§6.6 + §8). Unblocks BRO-1011 (`nous-promoter` agent).

## Scope

New crate `crates/nous/nous-tools/`:

- **`NousLineage` trait + `LineageEvent` / `LineageFilter`** — provenance
  contract for nous decisions (which scorer, what input, what output,
  against which target, when, optionally pinned to a lago `EventId`).
- **`InMemoryNousLineage`** — `Arc<RwLock<Vec<_>>>`-backed reference
  implementation. Sequential `lineage-N` ids; preserves insertion order
  on `query`.
- **`nous_aggregate` praxis tool** — descriptive statistics
  (`count` / `mean` / `median` / `min` / `max` / sample-stddev) over a
  `Vec<f64>` of scores. Hand-rolled (no `statrs` / `medians` workspace
  dep for ~20 LOC). Empty input returns zeroes; `count == 1` →
  `stddev == 0.0` (Bessel correction undefined).
- **`nous_compare` praxis tool** — typed verdict over `(a, b, threshold)`:
  `greater` / `lesser` / `equal` / `within_threshold`. Default threshold
  `0.001`. Strict equality returns `Equal` even inside the threshold band
  so the verdict stays informative; `threshold = 0.0` collapses to strict
  comparison.
- **`lago_query` praxis tool** — read-only event-journal queries over
  `Arc<dyn lago_core::Journal>`. Filters by `event_kind` discriminant
  (delegated to `EventQuery::with_kind`), `after_ts_ms` / `before_ts_ms`
  window (lago stores microseconds; this tool exposes milliseconds for
  parity with `LineageEvent`), and `limit` (default 50, hard cap 500 to
  bound memory).

## Tests

19 tests total — all green locally:

- 18 unit tests across the four modules (lineage, aggregate, compare,
  lago_query).
- 1 integration test at `tests/tools.rs` exercising
  `record → query → aggregate → compare → lago_query` end-to-end through
  the canonical `aios_protocol::tool::Tool::execute` path. Pins a real
  `Journal` impl in-test (`VecJournal` over `Arc<RwLock<Vec<_>>>`) so the
  `Arc<dyn Journal>` interface is exercised.

```
cargo test -p nous-tools --all-targets
test result: ok. 18 passed; 0 failed; 0 ignored
test result: ok. 1 passed; 0 failed; 0 ignored
```

Workspace clippy clean:
```
cargo clippy --workspace --lib --tests -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 43s
```

## Design notes

- **Sync `Tool` trait over async `Journal::read`** — `Tool::execute` is
  synchronous (the canonical contract). `Journal` is async + dyn. Bridge
  it by stashing a `tokio::runtime::Handle` at construction and using
  `block_in_place + block_on` when called from inside a runtime, plain
  `block_on` outside. Same trick `praxis-mcp-bridge::McpTool` uses,
  generalised so the tool also works from sync callers.
- **No new workspace deps** — only existing workspace deps
  (`async-trait`, `serde`, `serde_json`, `schemars`, `thiserror`,
  `tokio`, `tracing`, plus `aios-protocol` and `lago-core` from the
  workspace; `futures` is dev-only for the journal-stream stub).
- **Hand-rolled stats** — would not be worth a `statrs` / `medians` dep
  for ~20 LOC of arithmetic; the tradeoff is flagged at the top of
  `aggregate_scores`.
- **In-memory `LineageId` shape** — sequential `lineage-N` strings
  (no `ulid`) keeps the in-memory backend dependency-free; a lago-backed
  backend would return the persisted `EventId.as_str().to_string()` from
  the same `LineageId` type.

## NOT in scope

- **Lago-backed `NousLineage` impl** — deferred so the trait + in-memory
  ref can ship as one self-contained unit.
- **BRO-1011 `nous-promoter` authored agent** that consumes these tools.
- Any change to `nous-core`, `nous-judge`, `nous-heuristics`, or other
  sibling nous crates (those land their own changes in BRO-1011).

## Test plan

- [ ] `cargo check -p nous-tools` clean
- [ ] `cargo test -p nous-tools --all-targets` — 19 tests green
- [ ] `cargo clippy --workspace --lib --tests -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean
- [ ] CI Test (Linux) green
- [ ] CI Test (macOS) green
- [ ] CI Build Release green
- [ ] CI Lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)