### PR TITLE
docs: 2026-05-11 architecture map + Tier A scorecard refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,21 +91,38 @@ Arcan handles the agent loop, LLM provider calls, tool execution, and streaming.
 - ✅ Default policy rules (5 rules, 3 roles, 2 hooks)
 - ✅ CLI commands (session, log, cat, branch, init)
 - ✅ AI SDK v6 streaming (UiPart enum, boundary signals, Vercel format)
+- ✅ Spec C — life-runtime cluster (lifed M5 100%, lifegw M7 100%)
+- ✅ Spec D — Anima Custody (6/6 sub-phases shipped 2026-05-02)
+- ✅ Authored agents architecture (BRO-1005..1012 + Tier A validation, 9 blessed agents at `agents/`)
+- ✅ `lago replay --tree` recursion-tree visualization (BRO-1014)
+- ✅ Bookkeeping P8 calls authored scorer agents in production (BRO-1015)
 
-**Architecture scorecard**:
+**Architecture scorecard** (updated 2026-05-11):
 
 - Agent loop: 9/10 | Persistence: 10/10 | Tool harness: 9/10
-- Memory: 8/10 | Context quality: 9/10 | Self-learning: 2/10 — EGRI substrate wired (autoany-aios + autoany-lago adapters), cross-run inheritance available. No live self-improvement loop yet.
-- Observability: 2/10 | Security: 4/10 | Operational tooling: 8/10
+- Memory: 8/10 | Context quality: 9/10 | Self-learning: 4/10 — authored-agents architecture validated end-to-end via Tier A; nous-promoter + nous-judge meta-agents shipped as data; no live self-improvement loop yet (still human-PR-gated per spec §7.3).
+- Observability: 6/10 — Direct tick path fully wired (event store, nous observer, knowledge middleware); Workflow tick path blind (sinks not wired, see gap below).
+- Security: 7/10 — anima custody + Tier-2 capability tokens + autonomic gating (Direct path) + Vercel JWT verification + Tier-aware tool filtering.
+- Operational tooling: 9/10 — `lago log` / `lago replay --tree` / `arcan agent {list,show,new,test}` / P9 watcher / bookkeeping pipeline.
 
-**Known gaps** (blocks Phase 0 stabilization):
+**Known gaps** (current targets, updated 2026-05-11):
 
-- Branching not exposed (Lago supports it, Arcan defaults to "main")
+**Workflow tick path (3 wiring gaps; ~1 weekend of cleanup):**
+- `ergon-life-sinks` crate has zero consumers — `crates/arcan/arcan-ergon/src/runner.rs:157` uses `BufferSink::new()`. Workflow stream events never reach lago; `lago replay --tree` cannot see them.
+- 3 of 4 ergon auto-hook adapters are Noop (`AutonomicBudgetHook`/`NousScoreHook`/`AnimaAttestHook` get Noop impls in `crates/arcan/arcan-ergon/src/hooks.rs:137-166`; only `PraxisCapabilityHook` is real). Workflow ticks bypass budget/score/attest.
+- `arcan agent test` is `--dry-run` only — no live-LLM invocation. BRO-1015 had to call Anthropic SDK directly from Python.
+
+**Direct tick path is unaffected by all three** — autonomic via `AutonomicPolicyAdapter`, nous via `NousToolObserver`, lago via `EventStorePort` all wired through the standard kernel ports.
+
+**Long-tail gaps (Phase 0 stabilization):**
+- Branching not exposed in arcan API (`arcand/canonical.rs:1265` hardcodes `BranchId::main()`)
 - No OS-level sandbox isolation (soft sandbox only)
 - Network isolation declared but not enforced
-- Mount trait defined but unimplemented
-- No conformance test suite across aiOS/Arcan/Lago
-- aiOS still standalone (unification planned for Phase 7)
+- `Mount` trait defined but unimplemented
+- No conformance test suite across aios/arcan/lago
+- aios still standalone (unification planned for Phase 7)
+- Spec E E-Sub-B through F queued (mlx + vllm + vigil + autonomic + conformance)
+- Lumen Phase α not yet implemented (spec on `lumen-spec-side-branch`)
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,108 @@ human-authored via PR** and CANNOT self-modify in production. This
 prevents the metacognition deadlock (a meta-agent improving itself
 into a corrupt state).
 
+## Architecture map (2026-05-11 audit)
+
+The workspace has grown to **125 members** across 16 clusters. Two
+deployment topologies and an 8-layer model govern how a user request
+flows through the system. Full inventory lives at
+`docs/architecture/architecture-map-2026-05-11.md` (see also the
+auto-memory entry `project_life_architecture_map_2026_05_11.md`). The
+short version follows.
+
+### Two topologies
+
+| Topology | When | Path |
+|---|---|---|
+| **A — single-binary `arcan serve`** | dev / local / smoke | HTTP `:3000` → `arcand::canonical::run_session` → `KernelRuntime::tick_on_branch` → tick body (Direct OR Workflow) |
+| **B — production multi-tenant** | cloud | HTTPS → `lifegw` (TLS+JWKS+rate-limit+WS) → tonic UDS → `lifed` (saga+pool+breaker) → `*-proxy` → substrate daemons (`arcand`, `lagod`, `haimad`, `soma`) |
+
+### 8-layer model
+
+```
+L0 — Kernel contract       aios-protocol, aios-proto, aios-events, aios-policy
+L1 — Substrate primitives  lago, praxis, anima, autonomic, vigil, nous, haima,
+                           opsis, inference (each its own daemon if applicable)
+L2 — Substrate adapters    arcan-lago, arcan-praxis, arcan-anima, arcan-aios-adapters,
+                           autonomic-lago, haima-lago, nous-lago, anima-lago, opsis-lago
+L3 — Port traits           aios-runtime: ModelProviderPort, ToolHarnessPort,
+                           PolicyGatePort, EventStorePort, ApprovalPort,
+                           WorkflowTickDispatcher
+L3.5 — Tick body           Direct OR ergon::Workflow
+L4 — Tick engine           aios-runtime::KernelRuntime — 8-phase tick
+                           (Perceive → Deliberate → StateEstimated → body
+                            → Commit → Reflect → Sleep|Recover)
+L5 — Session orchestration arcand::ConsciousnessActor
+L6 — Transport / API       lifegw, lifed, arcand HTTP, life-relay,
+                           arcan-console, arcan-prosopon, life-cli
+L7 — User                  browser, CLI, external agents (MCP)
+```
+
+### Wired vs stubbed (current state)
+
+✅ **Direct tick path** — fully wired: autonomic gating via
+`AutonomicPolicyAdapter`, nous scoring via `NousToolObserver`,
+KnowledgeEventMiddleware, lago events via `EventStorePort`. Every
+phase emits durable events. Replayable via `lago log` / `lago replay --tree`.
+
+✅ **Lifegw** (M7 100%) — TLS 1.3, JWKS single-flight, Tier-2 mint,
+rate limiter, WS upgrade + heartbeat, admin plane, cert reloader,
+anima custody routes.
+
+✅ **Lifed** (M5 100%) — Agent/Events/Wallet/Identity services, real
+saga (forward+compensate), routing cache, idempotency, pool +
+circuit breaker (half-open CAS), OTLP exporter, 15 metric series.
+
+✅ **Spec D Anima Custody** (100%) — 6 backends shipped (InProcess /
+Vault / TPM / hardware-wallet / Soma / WebCrypto+Remote), P-256 auth
++ secp256k1 wallet, DID multicodec `0x1200`, rotation/revocation flow.
+
+✅ **Authored agents** — 9 blessed agents at `agents/`, FsAgentRegistry
+loads at boot, spawn_agent dispatch with RecursionContext (BRO-1007b),
+live-anthropic smoke test (BRO-1013), `lago replay --tree`
+(BRO-1014), bookkeeping pipeline integration (BRO-1015). Architecture
+validated three ways: offline + live + production.
+
+⚠️ **Three wiring gaps — all localized to Workflow tick path:**
+
+1. **`ergon-life-sinks` has zero consumers** —
+   `crates/arcan/arcan-ergon/src/runner.rs:157` uses `BufferSink::new()`.
+   Workflow stream events never reach lago; `lago replay --tree`
+   cannot see them. ~30 LOC fix.
+2. **3 of 4 ergon auto-hook adapters are Noop** —
+   `crates/arcan/arcan-ergon/src/runner.rs:146-150` wires
+   `NoopBudgetGate` / `NoopResponseScorer` / `NoopSoulAttester`
+   (only `PraxisCapabilityHook` is real). Workflow ticks bypass
+   budget/score/attest. ~50 LOC each + real impls.
+3. **`arcan agent test` is `--dry-run` only** — no live-LLM mode for
+   Python consumers. BRO-1008 follow-up.
+
+**Direct tick path is unaffected by gaps 1 & 2** — autonomic + nous +
+lago all wired through `PolicyGatePort` + `ToolHarnessPort` + turn
+middleware. The gaps are an ergon-Workflow-only blind spot.
+
+### Spec progress
+
+| Spec | Status | Notes |
+|---|---|---|
+| Spec A — soma kernel daemon | M0/M1 shipped 2026-04-25 | base kernel daemon |
+| Spec B — life-kernel core | shipped | trait surface |
+| Spec C — life-runtime cluster | M0..M7 shipped | lifed + lifegw + 4 proxies + life-runtime-pool |
+| Spec C₁ — soma scope | M0 shipped | renamed from lifed |
+| Spec C₂ — lifed facade | M5 100% | 5 sub-phases A–E |
+| Spec C₃ — lifegw edge | M7 100% | 5 sub-phases A–E |
+| Spec D — anima production custody | 100% (6/6 sub-phases) | shipped 2026-05-02 |
+| Spec E — Agent-Loop Compute Contract | 17% (E-Sub-A only) | B/C/D/E/F queued |
+| Authored-agents architecture (BRO-1006) | 100% | spec validated end-to-end via Tier A 2026-05-11 |
+
+### Branching policy (production)
+
+Lago supports branching (per `lago branch`); arcand currently
+hardcodes `BranchId::main()` at `crates/arcan/arcand/src/canonical.rs:1265`.
+Exposing branch as a route param is a small follow-up that unlocks
+parallel exploration workflows. Listed as "Phase 0 stabilization gap"
+above and in `MEMORY.md`.
+
 ## Shared Conventions
 
 All projects follow these rules (Spaces WASM module uses Rust 2021 edition due to SpacetimeDB requirements):


### PR DESCRIPTION
## Summary

Updates CLAUDE.md and AGENTS.md to reflect the current state of the Life Agent OS after Tier A validation (BRO-1013/1014/1015 merged 2026-05-11). Adds the architecture map captured in this session's audit so new agents joining the workspace have an authoritative landing page instead of needing to traverse 125 crates.

## What changed

### `CLAUDE.md` — new section after "Where does new behavior live?"

**Architecture map (2026-05-11 audit)** documents:

- **Two deployment topologies** — single-binary `arcan serve` (dev/local) vs production multi-tenant via lifegw → lifed → substrates.
- **8-layer model** (L0 kernel contract → L7 user), invariant across both topologies.
- **Wired vs stubbed inventory** — concrete file references for each.
- **Spec progress table** — A (soma) / B (kernel core) / C (lifegw + lifed 100%) / D (anima custody 100%) / E (Spec E inference 17%) / BRO-1006 authored-agents (100%).
- **Branching gap** — `arcand/canonical.rs:1265` hardcodes `BranchId::main()` despite lago supporting branching; small follow-up.

### `AGENTS.md` — scorecard + known gaps refresh

- Added recent completions to the "Key completions" list (Spec C M5+M7, Spec D, authored agents, `lago replay --tree`, bookkeeping P8 integration).
- Updated the architecture scorecard: Observability 6/10 (was 2/10) after the Direct tick path's full wiring; Self-learning 4/10 (was 2/10) after the authored-agents architecture validation; Security 7/10 after Spec D Anima Custody.
- Reorganised "Known gaps" into two tiers: 3 specific Workflow-tick-path wiring gaps (with file references; ~1 weekend total) and long-tail Phase 0 stabilization gaps.

## Three Workflow-tick-path wiring gaps surfaced

All localized to `crates/arcan/arcan-ergon/src/runner.rs:146-157`. Direct tick path is unaffected.

1. **`ergon-life-sinks` has zero consumers** — `BufferSink::new()` instead of `FanoutSink(LagoSink, VigilSink, LifegwSink)`. Workflow stream events never reach lago; `lago replay --tree` cannot see them. ~30 LOC fix.
2. **3 of 4 ergon auto-hook adapters are Noop** — `AutonomicBudgetHook` / `NousScoreHook` / `AnimaAttestHook` wrap Noop stubs in `crates/arcan/arcan-ergon/src/hooks.rs:137-166`. Only `PraxisCapabilityHook` is real. Workflow ticks bypass budget/score/attest.
3. **`arcan agent test` is `--dry-run` only** — BRO-1015 had to call Anthropic SDK directly. Live-LLM mode is a BRO-1008 follow-up.

Recommended fix order: gap 1 → gap 2 → gap 3 → branching exposure → Spec E E-Sub-B+C parallel.

## Companion artifacts

Knowledge-graph entities (`broomva/workspace` repo `dad5fd3`):

- `research/entities/concept/workflow-tick-stream-blind-spot.md`
- `research/entities/concept/hook-adapter-noop-gap.md`
- `research/entities/concept/life-two-topology-pattern.md`
- `research/entities/pattern/authored-agents-as-data.md`

All four lint clean.

Auto-memory snapshot at `~/.claude/projects/-Users-broomva-broomva/memory/project_life_architecture_map_2026_05_11.md`.

## Test plan

- [x] CLAUDE.md + AGENTS.md render as valid markdown
- [x] Cross-references between entity pages resolve
- [x] Bookkeeping linter clean on all 4 new entities
- [ ] CI: doc-only changes, paths-ignore should skip most gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with current architecture status and deployment configuration details.
  * Added comprehensive architecture mapping documentation including deployment topology paths and architectural model information.
  * Expanded technical tracking with detailed progress status and current system limitations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->