### PR TITLE
docs: topology-b substrate-stub gap audit correction (4th wiring gap)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,12 +107,21 @@ Arcan handles the agent loop, LLM provider calls, tool execution, and streaming.
 
 **Known gaps** (current targets, updated 2026-05-11):
 
-**Workflow tick path (3 wiring gaps; ~1 weekend of cleanup):**
+**Production wiring gaps (4 total — 3 small + 1 sizeable):**
+
+*Workflow tick path (3 small; ~1 weekend total):*
 - `ergon-life-sinks` crate has zero consumers — `crates/arcan/arcan-ergon/src/runner.rs:157` uses `BufferSink::new()`. Workflow stream events never reach lago; `lago replay --tree` cannot see them.
 - 3 of 4 ergon auto-hook adapters are Noop (`AutonomicBudgetHook`/`NousScoreHook`/`AnimaAttestHook` get Noop impls in `crates/arcan/arcan-ergon/src/hooks.rs:137-166`; only `PraxisCapabilityHook` is real). Workflow ticks bypass budget/score/attest.
 - `arcan agent test` is `--dry-run` only — no live-LLM invocation. BRO-1015 had to call Anthropic SDK directly from Python.
 
-**Direct tick path is unaffected by all three** — autonomic via `AutonomicPolicyAdapter`, nous via `NousToolObserver`, lago via `EventStorePort` all wired through the standard kernel ports.
+**Direct tick path (Topology A) is unaffected by all three** — autonomic via `AutonomicPolicyAdapter`, nous via `NousToolObserver`, lago via `EventStorePort` all wired through the standard kernel ports.
+
+*Topology B substrate-call gap (sizeable; ~1–2 weeks; discovered 2026-05-11):*
+- The 4 `*-proxy` crates (`arcan-proxy`, `lago-proxy`, `haima-proxy`, `anima-proxy`) ship **stubbed per-method bodies**. `arcan_proxy::create_agent` returns `format!("agent-{sid}")`; `dispatch_message` discards `sid`+`content` and emits 2 hardcoded `AgentEvent`s. The infrastructure on top of lifed (lifegw + saga + pool + breaker + admin plane) is real; the substrate-call wire below lifed is not.
+- Root cause: arcand exposes only an axum HTTP `:3000` server (Topology A surface). No `arcan.v1.AgentService` tonic server exists for arcan-proxy to call. lago-proxy is partially wired (`IngestService.Ingest`); the others are stubs.
+- **Practical implication**: Topology A is the only path that drives real agent work today. Topology B functions as authenticated/rate-limited/saga-orchestrated scaffolding around a fake substrate.
+- Fix: per-substrate tonic gRPC server (~200 LOC each, on arcand/haimad/anima side) + replace each `*-proxy` method body with a real client call (~50 LOC × 12 methods). gRPC contracts already exist in `life-runtime-proto::life::v1::*`.
+- Knowledge graph: `research/entities/concept/topology-b-substrate-stub-gap.md`.
 
 **Long-tail gaps (Phase 0 stabilization):**
 - Branching not exposed in arcan API (`arcand/canonical.rs:1265` hardcodes `BranchId::main()`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,23 +334,36 @@ live-anthropic smoke test (BRO-1013), `lago replay --tree`
 (BRO-1014), bookkeeping pipeline integration (BRO-1015). Architecture
 validated three ways: offline + live + production.
 
-⚠️ **Three wiring gaps — all localized to Workflow tick path:**
+⚠️ **Four wiring gaps — three localized to Workflow tick path; one is bigger:**
 
-1. **`ergon-life-sinks` has zero consumers** —
+1. **`ergon-life-sinks` has zero consumers** (Workflow tick path) —
    `crates/arcan/arcan-ergon/src/runner.rs:157` uses `BufferSink::new()`.
    Workflow stream events never reach lago; `lago replay --tree`
    cannot see them. ~30 LOC fix.
-2. **3 of 4 ergon auto-hook adapters are Noop** —
+2. **3 of 4 ergon auto-hook adapters are Noop** (Workflow tick path) —
    `crates/arcan/arcan-ergon/src/runner.rs:146-150` wires
    `NoopBudgetGate` / `NoopResponseScorer` / `NoopSoulAttester`
    (only `PraxisCapabilityHook` is real). Workflow ticks bypass
    budget/score/attest. ~50 LOC each + real impls.
-3. **`arcan agent test` is `--dry-run` only** — no live-LLM mode for
-   Python consumers. BRO-1008 follow-up.
+3. **`arcan agent test` is `--dry-run` only** (CLI) — no live-LLM mode
+   for Python consumers. BRO-1008 follow-up.
+4. **Topology B's substrate-call wire is stubbed** (production-shipping
+   blocker) — discovered 2026-05-11. The 4 `*-proxy` crates'
+   per-method bodies discard their args and return hardcoded shapes
+   (`arcan_proxy::create_agent` → `format!("agent-{sid}")`;
+   `dispatch_message` emits 2 hardcoded events). The scaffolding above
+   (lifegw + saga + pool + breaker) is real; the substrate call boundary
+   below lifed is not. arcand has no `arcan.v1.AgentService` tonic
+   server. Only Topology A drives real agent work today; Topology B is
+   authenticated/rate-limited scaffolding around a fake substrate.
+   ~1–2 weeks: per-substrate tonic server (~200 LOC) + per-proxy method
+   bodies (~50 LOC × 12 methods). See
+   `research/entities/concept/topology-b-substrate-stub-gap.md`.
 
-**Direct tick path is unaffected by gaps 1 & 2** — autonomic + nous +
-lago all wired through `PolicyGatePort` + `ToolHarnessPort` + turn
-middleware. The gaps are an ergon-Workflow-only blind spot.
+**Direct tick path (Topology A) is unaffected by gaps 1 & 2** —
+autonomic + nous + lago all wired through `PolicyGatePort` +
+`ToolHarnessPort` + turn middleware. Gap 4 affects Topology B only.
+Gap 3 is small / utility.
 
 ### Spec progress
 


### PR DESCRIPTION
## Summary

Companion to workspace commit `d56cbc5` documenting the 4th wiring gap discovered in the 2026-05-11 architecture audit follow-up. The original audit identified 3 wiring gaps all localized to the Workflow tick path; a trace through `arcan-proxy::client.rs` revealed a 4th and substantially bigger gap in Topology B's substrate-call wire.

## What changed

### `CLAUDE.md` — Architecture map section

Rewrote "Three wiring gaps" → "Four wiring gaps". The new gap:

> **Topology B's substrate-call wire is stubbed** (production-shipping blocker) — discovered 2026-05-11. The 4 `*-proxy` crates' per-method bodies discard their args and return hardcoded shapes (`arcan_proxy::create_agent` → `format!("agent-{sid}")`; `dispatch_message` emits 2 hardcoded events). The scaffolding above (lifegw + saga + pool + breaker) is real; the substrate call boundary below lifed is not. arcand has no `arcan.v1.AgentService` tonic server. Only Topology A drives real agent work today; Topology B is authenticated/rate-limited scaffolding around a fake substrate. ~1–2 weeks: per-substrate tonic server (~200 LOC) + per-proxy method bodies (~50 LOC × 12 methods).

### `AGENTS.md` — Known gaps section

Reorganised the gaps list into "Production wiring gaps (4 total — 3 small + 1 sizeable)" with the 3 workflow-tick-path gaps grouped first and the Topology B substrate gap broken out with its own detailed sub-section.

## Why it survived this long

Topology B was built top-down from the spec. lifegw + lifed shipped through 5 sub-phases each (M5/M7 = 100%). The proxies were specced to a clean trait surface, and their Sub-phase A/B stub bodies were explicitly tagged "real RPC bodies land in Sub-phase D" in `crates/life-runtime/CLAUDE.md`. Sub-phase D did ship — but it shipped the connection-pool wrapping AROUND the stubs, not the stub bodies themselves. The decoration looked like progress; the wire boundary stayed stubbed.

## Knowledge graph

- NEW: `research/entities/concept/topology-b-substrate-stub-gap.md` (workspace commit `d56cbc5`) — full evidence + per-substrate fix breakdown
- UPDATED: `research/entities/concept/life-two-topology-pattern.md` — adds ⚠️ Correction section + see-also link

## Test plan

- [x] CLAUDE.md + AGENTS.md render as valid markdown
- [x] Knowledge-graph entities lint clean (`python3 skills/bookkeeping/scripts/bookkeeping.py lint --all`)
- [x] Cross-reference between `topology-b-substrate-stub-gap` and `life-two-topology-pattern` resolves
- [ ] CI: doc-only changes, paths-ignore should skip most gates

## Next actionable

The Topology B substrate gap is the highest-leverage next ticket if you want to make production deployment viable. Per-substrate breakdown documented in the entity page. Each substrate is independently shippable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and expanded documentation detailing known workflow architecture gaps and system limitations, providing better organization of affected areas and current implementation status across different topologies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->