### PR TITLE
feat(topology-b): haima substrate gRPC wire — Phase 3 of substrate-stub gap (BRO-1018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,86 @@
   be updated post-merge with "arcan: closed; lago/haima/anima:
   remaining".
 
+- **`haima.v1.WalletSubstrate` gRPC server** — closes Phase 3 of the
+  Topology B substrate-stub gap (BRO-1018), following the BRO-1016
+  arcan pattern. Until this PR, `haima-proxy`'s six per-method bodies
+  (`bind_wallet`, `unbind_wallet`, `get_balance`, `statement`,
+  `debit`, `transfer`) discarded their arguments and returned
+  hardcoded shapes (`format!("wallet-{sid}-{project_id}")`,
+  999_000 / 100_000 micros, etc.); lifed's saga `BindWallet` step ran
+  correctly but the haima substrate-call boundary below it was fake.
+  Phase 3 wires the haima side end-to-end so per-task billing
+  (`TaskBilled` → `RevenueReceived`) becomes real.
+  * **New proto**: `core/life/proto/haima/v1/substrate.proto` declares
+    `haima.v1.WalletSubstrate` service with 6 RPCs (`BindWallet`,
+    `UnbindWallet`, `GetBalance`, `Statement` server-streaming,
+    `Debit`, `Transfer`). Imports `aios.v1.SessionId`. Substrate-plane
+    shape (no auth tokens — those are lifed's concerns one tier up,
+    attached as the bearer and verified separately).
+  * **New crate**: `crates/haima/haima-substrate-proto/` mirrors the
+    `arcan-substrate-proto` codegen pattern verbatim. Workspace
+    member. `tonic-prost-build` over the proto + `aios.v1.*` imports
+    via `extern_path` so we don't regenerate canonical aios types.
+  * **haimad substrate state + server**: new modules
+    `crates/haima/haimad/src/state.rs` (in-memory wallet + ledger
+    registry, secp256k1-backed via `haima-wallet::evm`, ULID-ordered
+    entries) and `crates/haima/haimad/src/substrate.rs` (gRPC
+    `SubstrateService` adapter). Each RPC is a thin adapter onto a
+    `HaimaState` method. `BindWallet` is idempotent on
+    `(sid, project_id)`; `UnbindWallet` is idempotent (unknown
+    wallets return Ok). `Transfer` is atomic two-leg under a single
+    write lock. The F2 `haima-lago::FinancePublisher` integration is
+    NOT wired in this PR — that's a follow-up; today HaimaState is
+    the source of truth and the F2 publisher remains the durable
+    fan-out path.
+  * **haimad split into lib + bin**: `crates/haima/haimad/src/lib.rs`
+    re-exports `state` + `substrate` so integration tests can pull
+    them; the existing `main.rs` becomes the binary entry. No
+    external consumer of `haimad` as a library exists today, so the
+    shift is purely additive.
+  * **UDS bind**: new `--uds-socket <PATH>` flag (env
+    `HAIMA_UDS_SOCKET`) on `haimad`. When set, the daemon spawns a
+    UDS-bound tonic gRPC server alongside the existing HTTP `:3003`
+    server, sharing a single `Arc<HaimaState>`. Mirrors arcand's
+    BRO-1016 `serve_substrate_uds` helper shape (parent-dir create,
+    stale socket cleanup, best-effort socket removal on shutdown).
+    Topology A users unaffected — the flag is opt-in.
+  * **haima-proxy real bodies**: replaced the 6 stub methods in
+    `crates/life-runtime/haima-proxy/src/client.rs` with real tonic
+    calls against the generated `WalletSubstrateClient`. The
+    `let _ = (...)` argument discards are gone. `statement` streams
+    return `LedgerGuardedStream<S>` wrapping the upstream tonic
+    stream so the pool guard tracks terminal close (success/failure
+    per Spec C₂ §7.2). `record_outcome` replaces the previous
+    bare-success helper so permanent (non-retryable) errors don't
+    trip the breaker on policy/auth misconfiguration.
+  * **Integration test**:
+    `crates/haima/haimad/tests/topology_b_e2e_haima.rs` (3 tests, all
+    green). Spins up haimad's substrate on a temp UDS, constructs a
+    real `HaimaProxy` against it, exercises bind/unbind/transfer/
+    debit/statement/balance end-to-end. `bind_wallet_creates_real_wallet`
+    confirms the saga step would actually create a wallet
+    substrate-side (not just return a `format!()` literal).
+    `transfer_mutates_real_substrate_state` confirms both ledger
+    legs land in the substrate's HaimaState. `proxy_to_server_round_trip`
+    composes the full bind → debit → balance → statement chain.
+  * **Tests**: 16 added (6 state unit + 3 CLI + 4 proxy + 3 e2e). All
+    pass under `cargo test -p haimad -p haima-proxy --all-targets`.
+  * **Dep-rule CI**: `scripts/verify_dependencies_lifed.sh` passes —
+    `haima-substrate-proto` is a wire-only crate (proto + generated
+    code; no haima runtime deps), so adding it to `haima-proxy`'s
+    deps doesn't violate proxy-isolation rules.
+
+  **Topology B status after this PR**: 2 of 4 substrate gRPC wires
+  now functional (arcan via BRO-1016, haima via BRO-1018). Siblings
+  BRO-1017 (lago) and BRO-1019 (anima) remain stubbed. Each is
+  independently shippable using this PR's pattern.
+
+  **Knowledge graph**:
+  `research/entities/concept/topology-b-substrate-stub-gap.md`
+  should be updated post-merge with "arcan + haima: closed;
+  lago/anima: remaining".
+
 - **`lago replay --tree`** — reconstruct the agent-spawn recursion tree
   for a session, closing acceptance criterion §9.4 of the authored-
   agents architecture spec. (BRO-1014)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,6 +4215,7 @@ dependencies = [
  "aios-protocol",
  "async-trait",
  "futures",
+ "haima-substrate-proto",
  "hyper-util",
  "life-runtime-pool",
  "prost 0.14.3",
@@ -4225,6 +4226,18 @@ dependencies = [
  "tonic-prost",
  "tower 0.5.3",
  "tracing",
+]
+
+[[package]]
+name = "haima-substrate-proto"
+version = "0.3.0"
+dependencies = [
+ "aios-proto",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -4275,25 +4288,38 @@ dependencies = [
 name = "haimad"
 version = "0.3.0"
 dependencies = [
+ "aios-proto",
  "aios-protocol",
  "anyhow",
+ "async-trait",
  "axum 0.8.8",
+ "chrono",
  "clap",
+ "futures",
  "haima-api",
  "haima-core",
  "haima-lago",
  "haima-outcome",
+ "haima-proxy",
+ "haima-substrate-proto",
  "haima-wallet",
  "haima-x402",
  "life-paths",
  "life-vigil",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
+ "tonic 0.14.5",
  "tracing",
  "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "crates/haima/haima-insurance",
     "crates/haima/haima-lago",
     "crates/haima/haima-outcome",
+    "crates/haima/haima-substrate-proto",
     "crates/haima/haima-wallet",
     "crates/haima/haima-x402",
     "crates/haima/haimad",
@@ -257,6 +258,8 @@ life-kernel-facade    = { path = "crates/life-kernel/life-kernel-facade", versio
 
 # Arcan substrate wire crate — BRO-1016 (Topology B substrate-stub gap close).
 arcan-substrate-proto = { path = "crates/arcan/arcan-substrate-proto", version = "0.3.0" }
+# Haima substrate wire crate — BRO-1018 (Phase 3 of the Topology B substrate-stub gap close).
+haima-substrate-proto = { path = "crates/haima/haima-substrate-proto", version = "0.3.0" }
 
 # M5 — lifed facade-aggregator daemon (Spec C₂)
 arcan-proxy        = { path = "crates/life-runtime/arcan-proxy",        version = "0.3.0" }

--- a/crates/haima/haima-substrate-proto/Cargo.toml
+++ b/crates/haima/haima-substrate-proto/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "haima-substrate-proto"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Substrate-plane proto types — generated from core/life/proto/haima/v1/substrate.proto. The wire contract between lifed (via haima-proxy) and haimad."
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+aios-proto = { workspace = true }
+prost = "0.14"
+prost-types = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
+
+[build-dependencies]
+tonic-prost-build = "0.14"
+
+[lints]
+workspace = true

--- a/crates/haima/haima-substrate-proto/build.rs
+++ b/crates/haima/haima-substrate-proto/build.rs
@@ -1,0 +1,47 @@
+//! Build script for `haima-substrate-proto`.
+//!
+//! Generates Rust types from `core/life/proto/haima/v1/substrate.proto`
+//! using `tonic-prost-build`. The proto root is three levels up from
+//! the crate manifest dir (`crates/haima/haima-substrate-proto/` →
+//! `core/life/`).
+//!
+//! Uses `extern_path` to reuse the canonical `aios.v1.*` types from
+//! the `aios-proto` crate instead of regenerating them inside this
+//! crate (Spec C₂ §10.3 — single Rust representation per wire type).
+//!
+//! Mirrors `crates/arcan/arcan-substrate-proto/build.rs` verbatim
+//! aside from the proto sub-path so the two codegen crates stay
+//! identifiable as siblings (BRO-1016 / BRO-1018).
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let proto_root = manifest_dir
+        .parent() // crates/haima/
+        .and_then(|p| p.parent()) // crates/
+        .and_then(|p| p.parent()) // core/life/
+        .ok_or("walking up to core/life/")?
+        .join("proto");
+
+    let proto_file = proto_root.join("haima").join("v1").join("substrate.proto");
+    println!("cargo:rerun-if-changed={}", proto_file.display());
+    // Track the imported aios.v1.* sources too so a vocabulary edit
+    // forces a regen.
+    let aios_dir = proto_root.join("aios").join("v1");
+    if let Ok(entries) = std::fs::read_dir(&aios_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("proto") {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        // Reuse the canonical aios.v1 types from aios-proto.
+        .extern_path(".aios.v1", "::aios_proto::aios::v1")
+        .compile_protos(&[proto_file], &[proto_root])?;
+
+    Ok(())
+}

--- a/crates/haima/haima-substrate-proto/src/lib.rs
+++ b/crates/haima/haima-substrate-proto/src/lib.rs
@@ -1,0 +1,25 @@
+//! Generated `haima.v1` proto types — the substrate-plane wire
+//! contract between lifed (via `haima-proxy`) and haimad.
+//!
+//! All types live under `haima::v1` (the proto package path). The
+//! generated client + server stubs are used by `haima-proxy` and the
+//! `haimad::substrate` UDS server respectively. `aios.v1.*` types are
+//! re-exported from `aios-proto` via `extern_path` (Spec C₂ §10.3).
+//!
+//! Reference: `docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md`
+//! and BRO-1018 (closes Phase 3 of the Topology-B substrate-stub gap
+//! audit captured in `research/entities/concept/topology-b-substrate-stub-gap.md`).
+//! Sibling of `arcan-substrate-proto` (BRO-1016).
+
+#![deny(unsafe_code)]
+#![allow(missing_docs)] // generated code
+
+#[allow(unused_qualifications, clippy::all)]
+pub mod haima {
+    pub mod v1 {
+        tonic::include_proto!("haima.v1");
+    }
+}
+
+// Re-export aios-proto for callers that want a single import path.
+pub use aios_proto::aios as aios_v1;

--- a/crates/haima/haimad/Cargo.toml
+++ b/crates/haima/haimad/Cargo.toml
@@ -8,6 +8,14 @@ authors.workspace = true
 repository.workspace = true
 description = "Haima daemon — agentic finance engine for the Agent OS"
 
+[lib]
+name = "haimad"
+path = "src/lib.rs"
+
+[[bin]]
+name = "haimad"
+path = "src/main.rs"
+
 [dependencies]
 haima-core.workspace = true
 haima-wallet.workspace = true
@@ -15,19 +23,37 @@ haima-x402.workspace = true
 haima-lago.workspace = true
 haima-api.workspace = true
 haima-outcome.workspace = true
+haima-substrate-proto.workspace = true
 aios-protocol.workspace = true
+aios-proto.workspace = true
+async-trait.workspace = true
 axum.workspace = true
+chrono.workspace = true
+futures.workspace = true
+prost = "0.14"
+prost-types = "0.14"
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
+tonic = "0.14"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 life-vigil.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 tokio-util.workspace = true
 clap.workspace = true
 toml.workspace = true
 anyhow.workspace = true
+ulid.workspace = true
 life-paths.workspace = true
+
+[dev-dependencies]
+haima-proxy = { workspace = true }
+futures.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream.workspace = true
 
 [lints]
 workspace = true

--- a/crates/haima/haimad/src/lib.rs
+++ b/crates/haima/haimad/src/lib.rs
@@ -1,0 +1,18 @@
+//! Haima daemon library — exposed surfaces consumed by the haimad
+//! binary (`src/main.rs`) and by integration tests.
+//!
+//! ## Layout
+//!
+//! - `state` — in-memory wallet + ledger registry (`HaimaState`).
+//! - `substrate` — `haima.v1.WalletSubstrate` gRPC server impl
+//!   (BRO-1018, Phase 3 of the Topology B substrate-stub gap close).
+//!
+//! The HTTP `:3003` x402 / facilitator surface stays in
+//! `haima-api` and is wired from `main.rs`. The substrate-plane gRPC
+//! server is opt-in via the `--uds-socket` flag (env
+//! `HAIMA_UDS_SOCKET`).
+//!
+//! Reference: `research/entities/concept/topology-b-substrate-stub-gap.md`.
+
+pub mod state;
+pub mod substrate;

--- a/crates/haima/haimad/src/main.rs
+++ b/crates/haima/haimad/src/main.rs
@@ -5,11 +5,23 @@
 //!
 //! Auth is controlled via `HAIMA_JWT_SECRET` or `AUTH_SECRET` env var.
 //! If neither is set, the server starts without auth (local dev mode).
+//!
+//! Topology B (BRO-1018): When `--uds-socket <PATH>` (or
+//! `HAIMA_UDS_SOCKET`) is set, the daemon ADDITIONALLY binds
+//! `haima.v1.WalletSubstrate` on the configured Unix-domain socket
+//! alongside the HTTP plane. Both run concurrently behind a shared
+//! `Arc<haimad::state::HaimaState>`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Parser;
 use haima_api::AppState;
 use haima_api::auth::AuthConfig;
 use haima_outcome::{OutcomeEngine, SlaMonitorConfig, spawn_sla_monitor};
+use haima_substrate_proto::haima::v1::wallet_substrate_server::WalletSubstrateServer;
+use haimad::state::HaimaState;
+use haimad::substrate::SubstrateService;
 use tokio_util::task::TaskTracker;
 use tracing::{info, warn};
 
@@ -35,6 +47,15 @@ struct Args {
     /// SLA monitor check interval in seconds (default: 30).
     #[arg(long, default_value = "30")]
     sla_check_interval_secs: u64,
+
+    /// Bind haimad's substrate-plane gRPC server
+    /// (`haima.v1.WalletSubstrate`) on this Unix-domain socket
+    /// alongside the HTTP server. When unset, the gRPC server is NOT
+    /// started — Topology-A users keep the existing HTTP-only
+    /// experience. Topology-B operators set this so lifed's
+    /// haima-proxy can dial in. BRO-1018.
+    #[arg(long, env = "HAIMA_UDS_SOCKET", value_name = "PATH")]
+    uds_socket: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -74,6 +95,12 @@ async fn main() -> anyhow::Result<()> {
     engine.register_default_contracts().await;
     info!("outcome engine bootstrapped with default contracts");
 
+    // Substrate-plane state (shared with the gRPC server below when
+    // UDS bind is enabled). The HTTP plane does not use it today —
+    // the F2 lago wire will eventually project HaimaState changes
+    // back into haima-api's FinancialState so both planes converge.
+    let haima_state = Arc::new(HaimaState::new());
+
     // Track background tasks for graceful shutdown.
     let tracker = TaskTracker::new();
 
@@ -88,6 +115,28 @@ async fn main() -> anyhow::Result<()> {
         // Keep the task alive until the tracker is closed
         std::future::pending::<()>().await;
     });
+
+    // ── Optional substrate-plane gRPC server (Topology B) ──────────
+    //
+    // When `--uds-socket <PATH>` (or `HAIMA_UDS_SOCKET`) is set, bind
+    // `haima.v1.WalletSubstrate` on the configured Unix-domain
+    // socket. This is ADDITIVE to the HTTP server below — both run
+    // concurrently on a single shared `Arc<HaimaState>`. BRO-1018
+    // closes Phase 3 of the Topology B substrate-stub gap captured in
+    // `research/entities/concept/topology-b-substrate-stub-gap.md`.
+    if let Some(socket_path) = args.uds_socket.clone() {
+        let substrate_state = Arc::clone(&haima_state);
+        tracker.spawn(async move {
+            if let Err(err) = serve_substrate_uds(socket_path, substrate_state).await {
+                tracing::error!(error = %err, "substrate-plane gRPC server exited with error");
+            }
+        });
+    } else {
+        tracing::debug!(
+            "substrate-plane gRPC server NOT bound — pass --uds-socket <PATH> or set \
+             HAIMA_UDS_SOCKET to enable Topology-B routing"
+        );
+    }
 
     let app = haima_api::router(state);
 
@@ -110,6 +159,44 @@ async fn main() -> anyhow::Result<()> {
     }
 
     info!("haimad stopped");
+    Ok(())
+}
+
+/// Bind `haima.v1.WalletSubstrate` on a Unix-domain socket. Mirrors
+/// arcand's `serve_substrate_uds` shape from BRO-1016 — prepare path,
+/// bind, hand off to tonic with graceful shutdown via the shared
+/// `shutdown_signal()`. Socket is removed on exit (best-effort).
+async fn serve_substrate_uds(socket_path: PathBuf, state: Arc<HaimaState>) -> anyhow::Result<()> {
+    if let Some(parent) = socket_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("create parent dir {}: {e}", parent.display()))?;
+    }
+    if socket_path.exists() {
+        std::fs::remove_file(&socket_path)
+            .map_err(|e| anyhow::anyhow!("unlink stale socket {}: {e}", socket_path.display()))?;
+    }
+
+    let listener = tokio::net::UnixListener::bind(&socket_path)
+        .map_err(|e| anyhow::anyhow!("bind {}: {e}", socket_path.display()))?;
+
+    info!(
+        socket = %socket_path.display(),
+        "haima substrate-plane gRPC listening (haima.v1.WalletSubstrate)"
+    );
+
+    let service = SubstrateService::new(state);
+    let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
+
+    tonic::transport::Server::builder()
+        .add_service(WalletSubstrateServer::new(service))
+        .serve_with_incoming_shutdown(incoming, shutdown_signal())
+        .await
+        .map_err(|e| anyhow::anyhow!("substrate serve: {e}"))?;
+
+    // Clean up the socket file on graceful shutdown. Best-effort.
+    let _ = std::fs::remove_file(&socket_path);
     Ok(())
 }
 
@@ -153,11 +240,21 @@ mod tests {
         assert_eq!(args.bind, "127.0.0.1:3003");
         assert!(args.lago_data_dir.is_none());
         assert!(args.config.is_none());
+        assert!(args.uds_socket.is_none());
     }
 
     #[test]
     fn cli_parses_custom_bind() {
         let args = Args::parse_from(["haimad", "--bind", "0.0.0.0:9090"]);
         assert_eq!(args.bind, "0.0.0.0:9090");
+    }
+
+    #[test]
+    fn cli_parses_uds_socket() {
+        let args = Args::parse_from(["haimad", "--uds-socket", "/tmp/haima.sock"]);
+        assert_eq!(
+            args.uds_socket.as_deref(),
+            Some(std::path::Path::new("/tmp/haima.sock"))
+        );
     }
 }

--- a/crates/haima/haimad/src/state.rs
+++ b/crates/haima/haimad/src/state.rs
@@ -1,0 +1,495 @@
+//! Haima substrate state — in-memory wallet binding + ledger registry
+//! consumed by `haimad::substrate::SubstrateService` under Topology B.
+//!
+//! Phase 3 (BRO-1018) scope:
+//! - One wallet per `(user_id, project_id)` pair. Wallets are
+//!   secp256k1-backed and live in process memory for the lifetime of
+//!   the daemon.
+//! - Per-wallet ledger entries (debits + transfers). Entries are
+//!   ULID-ordered so the substrate `Statement` RPC can serve a stable
+//!   stream.
+//! - Per-session binding lookup so the saga compensation path
+//!   (`UnbindWallet`) can find the wallet by id.
+//!
+//! What this is NOT (yet):
+//! - On-chain. The local secp256k1 backend produces real EVM
+//!   addresses, but balances are off-chain and start with a default
+//!   credit so demos / tests have something to debit. Replacing the
+//!   default with a `BalanceSynced` flow against a real provider is
+//!   tracked under haima Phase F4.
+//! - Persistent. `haima-lago::FinancePublisher` is the durable path
+//!   (Phase F2) — currently a no-op stub. Once F2 ships, every
+//!   ledger entry written here also fans out to lago via
+//!   `EventKind::Custom("finance.*", ...)`.
+//!
+//! Concurrency: `HaimaState` is internally locked (`std::sync::RwLock`
+//! over a tokio-friendly granularity — we never hold the lock across
+//! `await`). All public methods are synchronous and intentionally
+//! cheap (no I/O). The substrate handlers wrap them inside async fns
+//! so the trait shape stays uniform with the proxy.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use chrono::{DateTime, Utc};
+use haima_core::wallet::ChainId;
+use haima_wallet::evm::generate_keypair;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use ulid::Ulid;
+
+/// Default starting balance for a freshly-bound wallet, in
+/// micro-credits. 1 USDC; matches the proxy stub's pre-BRO-1018
+/// return shape so the wire change is invisible to lifed's tests.
+pub const DEFAULT_BIND_BALANCE_MICROS: u64 = 1_000_000;
+
+/// The currency ticker emitted for every Balance the substrate
+/// returns under Phase 3. Wallets are USDC-only today.
+pub const DEFAULT_CURRENCY: &str = "USDC";
+
+#[derive(Debug, Error)]
+pub enum HaimaStateError {
+    #[error("wallet not found: {0}")]
+    WalletNotFound(String),
+    #[error("insufficient balance: have {have} micros, want {want}")]
+    InsufficientBalance { have: u64, want: u64 },
+    #[error("crypto: {0}")]
+    Crypto(String),
+}
+
+pub type HaimaStateResult<T> = Result<T, HaimaStateError>;
+
+/// A wallet bound to a `(user_id, project_id)` pair.
+///
+/// The on-chain `address` is derived from a freshly generated
+/// secp256k1 keypair on bind. The private key is held by the daemon
+/// only — proxy callers never see it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalletRecord {
+    pub wallet_id: String,
+    pub user_id: String,
+    pub project_id: String,
+    pub address: String,
+    pub chain: String,
+    pub balance_micros: u64,
+    pub bound_at: DateTime<Utc>,
+}
+
+/// A single ledger entry — credit or debit. Positive `delta_micros`
+/// is a credit (transfer-in); negative is a debit (transfer-out).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LedgerEntry {
+    pub entry_id: String,
+    pub wallet_id: String,
+    pub at: DateTime<Utc>,
+    pub delta_micros: i64,
+    pub reason: String,
+    pub sid: String,
+}
+
+#[derive(Debug, Default)]
+struct StateInner {
+    /// Wallets indexed by deterministic wallet_id (`wallet-{sid}-{project}`).
+    /// Mirrors the proxy's pre-BRO-1018 shape so external introspection
+    /// tooling that scrapes ids stays compatible.
+    wallets: HashMap<String, WalletRecord>,
+    /// Per-wallet ledger entries, in append order. Entries are scoped
+    /// by `wallet_id`; the `Statement` RPC walks the vec and filters
+    /// on the requested time window.
+    ledger: HashMap<String, Vec<LedgerEntry>>,
+}
+
+/// Process-wide haima substrate state. Cheap to clone (internally
+/// `Arc<RwLock<…>>`). Constructed once in haimad bootstrap and shared
+/// by every `SubstrateService` instance.
+#[derive(Debug, Default)]
+pub struct HaimaState {
+    inner: RwLock<StateInner>,
+}
+
+impl HaimaState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Deterministic wallet id derived from `(sid, project_id)`. The
+    /// shape mirrors the proxy's pre-BRO-1018 return value so callers
+    /// that key on it (e.g. `BindWallet` saga compensation passes
+    /// `wallet-{sid}` style ids back to `UnbindWallet`) don't break.
+    pub fn wallet_id_for(sid: &str, project_id: &str) -> String {
+        format!("wallet-{sid}-{project_id}")
+    }
+
+    /// Idempotent bind: returns the existing wallet if `(sid, project)`
+    /// is already bound, otherwise mints a new secp256k1 keypair,
+    /// derives the EVM address, and stores the record with a default
+    /// 1 USDC balance.
+    pub fn bind_wallet(&self, sid: &str, project_id: &str) -> HaimaStateResult<WalletRecord> {
+        let wallet_id = Self::wallet_id_for(sid, project_id);
+
+        // Fast path: already bound.
+        {
+            let guard = self.inner.read().expect("poisoned");
+            if let Some(existing) = guard.wallets.get(&wallet_id) {
+                return Ok(existing.clone());
+            }
+        }
+
+        // Generate the keypair OUTSIDE the lock to keep the critical
+        // section short. `_priv` is dropped here — Phase 3 does not
+        // need to retain it because no sign operations route through
+        // the substrate yet (signing stays in haima-wallet's
+        // LocalSigner which haima-x402 owns).
+        let (_priv, addr) =
+            generate_keypair().map_err(|e| HaimaStateError::Crypto(e.to_string()))?;
+        let now = Utc::now();
+        let record = WalletRecord {
+            wallet_id: wallet_id.clone(),
+            user_id: String::new(), // populated on first user-scoped op
+            project_id: project_id.to_string(),
+            address: addr.address,
+            chain: ChainId::base().to_string(),
+            balance_micros: DEFAULT_BIND_BALANCE_MICROS,
+            bound_at: now,
+        };
+
+        let mut guard = self.inner.write().expect("poisoned");
+        // Re-check under the write lock — another caller may have
+        // bound concurrently between the read drop and the write
+        // acquire. Idempotency is the contract.
+        Ok(guard.wallets.entry(wallet_id).or_insert(record).clone())
+    }
+
+    /// Idempotent unbind. Removes the wallet record and drops its
+    /// ledger. Missing wallets return Ok (saga compensation paths
+    /// stay clean — Spec C₂ §4.2).
+    pub fn unbind_wallet(&self, wallet_id: &str) {
+        let mut guard = self.inner.write().expect("poisoned");
+        guard.wallets.remove(wallet_id);
+        guard.ledger.remove(wallet_id);
+    }
+
+    /// Look up a wallet by `(user_id, project_id)`. Materializes a
+    /// default-bound wallet on first access so substrate callers
+    /// always see a balance (matches the proxy's pre-BRO-1018
+    /// fallback shape). Tracks the user_id on the record so callers
+    /// can introspect later.
+    pub fn get_or_create_user_wallet(
+        &self,
+        user_id: &str,
+        project_id: &str,
+    ) -> HaimaStateResult<WalletRecord> {
+        // Use `user_id` as the sid for the deterministic id since
+        // GetBalance / Debit / Transfer all flow through (user_id,
+        // project_id) — the sid is a per-session context, not the
+        // wallet key. This mirrors the proxy's pre-BRO-1018 stub
+        // signature exactly.
+        let wallet_id = Self::wallet_id_for(user_id, project_id);
+        // Fast read path.
+        {
+            let guard = self.inner.read().expect("poisoned");
+            if let Some(existing) = guard.wallets.get(&wallet_id) {
+                return Ok(existing.clone());
+            }
+        }
+
+        // Generate outside the lock.
+        let (_priv, addr) =
+            generate_keypair().map_err(|e| HaimaStateError::Crypto(e.to_string()))?;
+        let now = Utc::now();
+        let record = WalletRecord {
+            wallet_id: wallet_id.clone(),
+            user_id: user_id.to_string(),
+            project_id: project_id.to_string(),
+            address: addr.address,
+            chain: ChainId::base().to_string(),
+            balance_micros: DEFAULT_BIND_BALANCE_MICROS,
+            bound_at: now,
+        };
+
+        let mut guard = self.inner.write().expect("poisoned");
+        // Re-check under the write lock; another caller may have
+        // raced ahead. Re-set user_id if the existing record was
+        // bound via `bind_wallet` without a user (initial value was
+        // empty string).
+        let entry = guard.wallets.entry(wallet_id).or_insert(record);
+        if entry.user_id.is_empty() {
+            entry.user_id = user_id.to_string();
+        }
+        Ok(entry.clone())
+    }
+
+    /// Apply a debit. Errors if the wallet doesn't exist OR if the
+    /// balance would go negative. Records a ledger entry on success.
+    pub fn debit(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        amount_micros: u64,
+        sid: &str,
+        reason: &str,
+    ) -> HaimaStateResult<(LedgerEntry, WalletRecord)> {
+        let wallet_id = Self::wallet_id_for(user_id, project_id);
+        // Materialize the wallet outside the write lock so we don't
+        // hold the lock across keypair gen on the cold path.
+        let _ = self.get_or_create_user_wallet(user_id, project_id)?;
+
+        let mut guard = self.inner.write().expect("poisoned");
+        let wallet = guard
+            .wallets
+            .get_mut(&wallet_id)
+            .ok_or_else(|| HaimaStateError::WalletNotFound(wallet_id.clone()))?;
+        if wallet.balance_micros < amount_micros {
+            return Err(HaimaStateError::InsufficientBalance {
+                have: wallet.balance_micros,
+                want: amount_micros,
+            });
+        }
+        wallet.balance_micros -= amount_micros;
+        let updated = wallet.clone();
+        let entry = LedgerEntry {
+            entry_id: Ulid::new().to_string(),
+            wallet_id: wallet_id.clone(),
+            at: Utc::now(),
+            delta_micros: -(amount_micros as i64),
+            reason: reason.to_string(),
+            sid: sid.to_string(),
+        };
+        guard
+            .ledger
+            .entry(wallet_id)
+            .or_default()
+            .push(entry.clone());
+        Ok((entry, updated))
+    }
+
+    /// Apply a transfer between two `(user, project)` wallets. Both
+    /// wallets are materialized on demand; both legs land in the
+    /// ledger atomically under a single write lock.
+    pub fn transfer(
+        &self,
+        from_user: &str,
+        from_project: &str,
+        to_user: &str,
+        to_project: &str,
+        amount_micros: u64,
+        memo: &str,
+    ) -> HaimaStateResult<(LedgerEntry, WalletRecord, WalletRecord)> {
+        // Materialize both wallets first (outside the write lock).
+        let _ = self.get_or_create_user_wallet(from_user, from_project)?;
+        let _ = self.get_or_create_user_wallet(to_user, to_project)?;
+
+        let from_id = Self::wallet_id_for(from_user, from_project);
+        let to_id = Self::wallet_id_for(to_user, to_project);
+        let entry_id = Ulid::new().to_string();
+        let now = Utc::now();
+
+        let mut guard = self.inner.write().expect("poisoned");
+
+        // Pull balances + perform the credit/debit. We avoid two
+        // simultaneous &mut into `wallets` by reading the from-balance
+        // first and writing both legs sequentially.
+        let from_have = guard
+            .wallets
+            .get(&from_id)
+            .map(|w| w.balance_micros)
+            .ok_or_else(|| HaimaStateError::WalletNotFound(from_id.clone()))?;
+        if from_have < amount_micros {
+            return Err(HaimaStateError::InsufficientBalance {
+                have: from_have,
+                want: amount_micros,
+            });
+        }
+
+        let from_updated = {
+            let from = guard
+                .wallets
+                .get_mut(&from_id)
+                .ok_or_else(|| HaimaStateError::WalletNotFound(from_id.clone()))?;
+            from.balance_micros -= amount_micros;
+            from.clone()
+        };
+        let to_updated = {
+            let to = guard
+                .wallets
+                .get_mut(&to_id)
+                .ok_or_else(|| HaimaStateError::WalletNotFound(to_id.clone()))?;
+            to.balance_micros += amount_micros;
+            to.clone()
+        };
+
+        // Record BOTH legs in the ledger so Statement returns a
+        // symmetric trail.
+        let debit_entry = LedgerEntry {
+            entry_id: entry_id.clone(),
+            wallet_id: from_id.clone(),
+            at: now,
+            delta_micros: -(amount_micros as i64),
+            reason: format!("transfer:{memo}"),
+            sid: String::new(),
+        };
+        let credit_entry = LedgerEntry {
+            entry_id: entry_id.clone(),
+            wallet_id: to_id.clone(),
+            at: now,
+            delta_micros: amount_micros as i64,
+            reason: format!("transfer:{memo}"),
+            sid: String::new(),
+        };
+        guard
+            .ledger
+            .entry(from_id)
+            .or_default()
+            .push(debit_entry.clone());
+        guard.ledger.entry(to_id).or_default().push(credit_entry);
+
+        Ok((debit_entry, from_updated, to_updated))
+    }
+
+    /// Snapshot the ledger for a `(user, project)` wallet within the
+    /// time window. Bounds are inclusive on `since_ms` and exclusive
+    /// on `until_ms` (matches the proxy semantics).
+    pub fn statement(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        since_ms: i64,
+        until_ms: i64,
+        limit: u32,
+    ) -> Vec<LedgerEntry> {
+        let wallet_id = Self::wallet_id_for(user_id, project_id);
+        let guard = self.inner.read().expect("poisoned");
+        let Some(entries) = guard.ledger.get(&wallet_id) else {
+            return Vec::new();
+        };
+        let cap = if limit == 0 {
+            usize::MAX
+        } else {
+            limit as usize
+        };
+        entries
+            .iter()
+            .filter(|e| {
+                let ms = e.at.timestamp_millis();
+                ms >= since_ms && ms < until_ms
+            })
+            .take(cap)
+            .cloned()
+            .collect()
+    }
+
+    /// Direct balance probe. Returns 0 + default currency if the
+    /// wallet has never been bound. Used by `GetBalance` so a cold
+    /// call doesn't materialize the wallet — `get_or_create_user_wallet`
+    /// is reserved for callers that need a `WalletRecord` back.
+    pub fn balance(&self, user_id: &str, project_id: &str) -> (u64, String) {
+        let wallet_id = Self::wallet_id_for(user_id, project_id);
+        let guard = self.inner.read().expect("poisoned");
+        match guard.wallets.get(&wallet_id) {
+            Some(w) => (w.balance_micros, DEFAULT_CURRENCY.to_string()),
+            None => (0, DEFAULT_CURRENCY.to_string()),
+        }
+    }
+
+    /// Test-only probe.
+    #[doc(hidden)]
+    pub fn wallet_count(&self) -> usize {
+        self.inner.read().expect("poisoned").wallets.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_is_idempotent() {
+        let st = HaimaState::new();
+        let a = st.bind_wallet("sid-1", "proj-1").expect("bind");
+        let b = st.bind_wallet("sid-1", "proj-1").expect("rebind");
+        assert_eq!(a.wallet_id, b.wallet_id);
+        assert_eq!(a.address, b.address);
+        assert_eq!(st.wallet_count(), 1);
+    }
+
+    #[test]
+    fn unbind_drops_wallet_and_ledger() {
+        let st = HaimaState::new();
+        let w = st.bind_wallet("sid-2", "proj-2").expect("bind");
+        // Touch a ledger entry to make sure unbind clears it too.
+        let _ = st
+            .debit("sid-2", "proj-2", 1, "sid-2", "test")
+            .expect("debit");
+        st.unbind_wallet(&w.wallet_id);
+        assert_eq!(st.wallet_count(), 0);
+        assert!(st.statement("sid-2", "proj-2", 0, i64::MAX, 0).is_empty());
+        // Idempotent: second unbind doesn't blow up.
+        st.unbind_wallet(&w.wallet_id);
+    }
+
+    #[test]
+    fn debit_respects_balance() {
+        let st = HaimaState::new();
+        let _ = st.bind_wallet("u", "p").expect("bind");
+        // 1 USDC = 1_000_000 micros. Debit 600k → 400k remains.
+        let (e, w) = st.debit("u", "p", 600_000, "sid-x", "fee").expect("debit");
+        assert_eq!(w.balance_micros, 400_000);
+        assert_eq!(e.delta_micros, -600_000);
+        // Over-debit should fail.
+        let err = st
+            .debit("u", "p", 500_000, "sid-x", "fee2")
+            .expect_err("over-debit");
+        assert!(matches!(err, HaimaStateError::InsufficientBalance { .. }));
+    }
+
+    #[test]
+    fn transfer_moves_balance_and_records_both_legs() {
+        let st = HaimaState::new();
+        let _from = st
+            .get_or_create_user_wallet("alice", "proj-A")
+            .expect("from");
+        let _to = st.get_or_create_user_wallet("bob", "proj-B").expect("to");
+
+        let (entry, from_after, to_after) = st
+            .transfer("alice", "proj-A", "bob", "proj-B", 100_000, "drinks")
+            .expect("transfer");
+        assert_eq!(from_after.balance_micros, 900_000);
+        assert_eq!(to_after.balance_micros, 1_100_000);
+        assert_eq!(entry.delta_micros, -100_000);
+
+        // Both legs landed in the ledger.
+        let from_stmt = st.statement("alice", "proj-A", 0, i64::MAX, 0);
+        let to_stmt = st.statement("bob", "proj-B", 0, i64::MAX, 0);
+        assert_eq!(from_stmt.len(), 1);
+        assert_eq!(to_stmt.len(), 1);
+        assert_eq!(from_stmt[0].delta_micros, -100_000);
+        assert_eq!(to_stmt[0].delta_micros, 100_000);
+    }
+
+    #[test]
+    fn balance_returns_zero_for_unknown_wallet() {
+        let st = HaimaState::new();
+        let (m, c) = st.balance("ghost", "void");
+        assert_eq!(m, 0);
+        assert_eq!(c, DEFAULT_CURRENCY);
+    }
+
+    #[test]
+    fn statement_filters_window() {
+        let st = HaimaState::new();
+        let _ = st.bind_wallet("u", "p").expect("bind");
+        // Three quick debits.
+        for i in 0..3 {
+            let _ = st
+                .debit("u", "p", 100, "sid", &format!("n{i}"))
+                .expect("debit");
+        }
+        let all = st.statement("u", "p", 0, i64::MAX, 0);
+        assert_eq!(all.len(), 3);
+        let limited = st.statement("u", "p", 0, i64::MAX, 2);
+        assert_eq!(limited.len(), 2);
+        // A pre-history window returns empty.
+        let none = st.statement("u", "p", 0, 1, 0);
+        assert!(none.is_empty());
+    }
+}

--- a/crates/haima/haimad/src/substrate.rs
+++ b/crates/haima/haimad/src/substrate.rs
@@ -1,0 +1,259 @@
+//! Substrate-plane gRPC service for haimad.
+//!
+//! Implements `haima.v1.WalletSubstrate` (defined in
+//! `proto/haima/v1/substrate.proto`, generated in
+//! `haima-substrate-proto`). This is the UDS-bound entry point that
+//! lifed reaches via `haima-proxy` under Topology B. It is ADDITIVE
+//! to haimad's existing HTTP `:3003` server (Topology A x402 routes)
+//! — both can run concurrently behind a shared `Arc<HaimaState>`.
+//!
+//! Phase 3 scope (BRO-1018):
+//! - `BindWallet`: idempotent session binding via `HaimaState`.
+//! - `UnbindWallet`: idempotent compensation hook.
+//! - `GetBalance`: cold balance probe (no materialization).
+//! - `Statement`: server-streaming ledger window.
+//! - `Debit`: ledger sink (lifed enforces idempotency at the public plane).
+//! - `Transfer`: ledger sink, atomic two-leg.
+//!
+//! Phase 4 (separate ticket) will wire `haima-lago::FinancePublisher`
+//! into every mutating RPC so each ledger entry also produces a
+//! `EventKind::Custom("finance.*", ...)` lago event. Today the
+//! publisher stays in haima's F2 backlog; HaimaState is the only
+//! source of truth for the wire.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use futures::Stream;
+use haima_substrate_proto::haima::v1::{
+    self as haima_pb, wallet_substrate_server::WalletSubstrate,
+};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use crate::state::{HaimaState, HaimaStateError};
+
+/// Bounded channel capacity for the `Statement` server-streaming
+/// response. Mirrors arcand's BRO-1016 capacity choice — 64 is more
+/// than enough headroom for slow consumers given Statement's bounded
+/// nature (no live tail; entries are produced from an in-memory vec).
+const STATEMENT_CHANNEL_CAPACITY: usize = 64;
+
+/// haimad's `haima.v1.WalletSubstrate` impl. Holds an `Arc<HaimaState>`
+/// so every RPC reuses the same in-memory wallet + ledger registry
+/// that the HTTP plane will (eventually) project from when the F2
+/// lago integration lands.
+pub struct SubstrateService {
+    state: Arc<HaimaState>,
+}
+
+impl SubstrateService {
+    pub fn new(state: Arc<HaimaState>) -> Self {
+        Self { state }
+    }
+
+    /// Expose the underlying state — integration tests + the daemon
+    /// bootstrap need to share the `Arc<HaimaState>` so they can
+    /// observe the side effects of substrate-plane writes.
+    pub fn state(&self) -> &Arc<HaimaState> {
+        &self.state
+    }
+}
+
+#[tonic::async_trait]
+impl WalletSubstrate for SubstrateService {
+    type StatementStream =
+        Pin<Box<dyn Stream<Item = Result<haima_pb::LedgerEntry, Status>> + Send + 'static>>;
+
+    async fn bind_wallet(
+        &self,
+        req: Request<haima_pb::BindWalletReq>,
+    ) -> Result<Response<haima_pb::BindWalletResp>, Status> {
+        let body = req.into_inner();
+        let sid_proto = body
+            .sid
+            .ok_or_else(|| Status::invalid_argument("missing sid"))?;
+        if sid_proto.value.is_empty() {
+            return Err(Status::invalid_argument("empty sid"));
+        }
+        if body.project_id.is_empty() {
+            return Err(Status::invalid_argument("empty project_id"));
+        }
+        let record = self
+            .state
+            .bind_wallet(&sid_proto.value, &body.project_id)
+            .map_err(map_state_error)?;
+        Ok(Response::new(haima_pb::BindWalletResp {
+            wallet_id: record.wallet_id,
+            address: record.address,
+            bound_at: Some(prost_types::Timestamp::from(SystemTime::now())),
+        }))
+    }
+
+    async fn unbind_wallet(
+        &self,
+        req: Request<haima_pb::UnbindWalletReq>,
+    ) -> Result<Response<haima_pb::UnbindWalletResp>, Status> {
+        let body = req.into_inner();
+        // Idempotent: unknown wallets unbind to Ok(empty). Saga
+        // compensation paths stay clean (Spec C₂ §4.2).
+        self.state.unbind_wallet(&body.wallet_id);
+        Ok(Response::new(haima_pb::UnbindWalletResp {}))
+    }
+
+    async fn get_balance(
+        &self,
+        req: Request<haima_pb::GetBalanceReq>,
+    ) -> Result<Response<haima_pb::Balance>, Status> {
+        let body = req.into_inner();
+        if body.user_id.is_empty() {
+            return Err(Status::invalid_argument("empty user_id"));
+        }
+        if body.project_id.is_empty() {
+            return Err(Status::invalid_argument("empty project_id"));
+        }
+        let (micros, currency) = self.state.balance(&body.user_id, &body.project_id);
+        Ok(Response::new(haima_pb::Balance {
+            micros,
+            currency,
+            as_of: Some(prost_types::Timestamp::from(SystemTime::now())),
+        }))
+    }
+
+    async fn statement(
+        &self,
+        req: Request<haima_pb::StatementReq>,
+    ) -> Result<Response<Self::StatementStream>, Status> {
+        let body = req.into_inner();
+        if body.user_id.is_empty() {
+            return Err(Status::invalid_argument("empty user_id"));
+        }
+        if body.project_id.is_empty() {
+            return Err(Status::invalid_argument("empty project_id"));
+        }
+        // Snapshot first so the lock isn't held across the spawn.
+        let entries = self.state.statement(
+            &body.user_id,
+            &body.project_id,
+            body.since_ms,
+            // Treat 0 as "no upper bound" — matches the proxy's
+            // default when the public-plane caller omits `until`.
+            if body.until_ms == 0 {
+                i64::MAX
+            } else {
+                body.until_ms
+            },
+            body.limit,
+        );
+
+        let (tx, rx) =
+            mpsc::channel::<Result<haima_pb::LedgerEntry, Status>>(STATEMENT_CHANNEL_CAPACITY);
+
+        tokio::spawn(async move {
+            for entry in entries {
+                let proto_entry = haima_pb::LedgerEntry {
+                    entry_id: entry.entry_id,
+                    at_unix_ms: entry.at.timestamp_millis(),
+                    delta_micros: entry.delta_micros,
+                    reason: entry.reason,
+                    sid: entry.sid,
+                };
+                if tx.send(Ok(proto_entry)).await.is_err() {
+                    // Receiver dropped — stop early.
+                    break;
+                }
+            }
+            // Drop tx so the stream terminates cleanly.
+            drop(tx);
+        });
+
+        let stream = ReceiverStream::new(rx);
+        Ok(Response::new(Box::pin(stream) as Self::StatementStream))
+    }
+
+    async fn debit(
+        &self,
+        req: Request<haima_pb::DebitReq>,
+    ) -> Result<Response<haima_pb::DebitReceipt>, Status> {
+        let body = req.into_inner();
+        if body.user_id.is_empty() {
+            return Err(Status::invalid_argument("empty user_id"));
+        }
+        if body.project_id.is_empty() {
+            return Err(Status::invalid_argument("empty project_id"));
+        }
+        let (entry, wallet) = self
+            .state
+            .debit(
+                &body.user_id,
+                &body.project_id,
+                body.amount_micros,
+                &body.sid,
+                &body.reason,
+            )
+            .map_err(map_state_error)?;
+        Ok(Response::new(haima_pb::DebitReceipt {
+            entry_id: entry.entry_id,
+            new_balance: Some(haima_pb::Balance {
+                micros: wallet.balance_micros,
+                currency: crate::state::DEFAULT_CURRENCY.to_string(),
+                as_of: Some(prost_types::Timestamp::from(SystemTime::now())),
+            }),
+        }))
+    }
+
+    async fn transfer(
+        &self,
+        req: Request<haima_pb::TransferReq>,
+    ) -> Result<Response<haima_pb::TransferReceipt>, Status> {
+        let body = req.into_inner();
+        if body.from_user.is_empty()
+            || body.from_project.is_empty()
+            || body.to_user.is_empty()
+            || body.to_project.is_empty()
+        {
+            return Err(Status::invalid_argument(
+                "from/to user_id and project_id are required",
+            ));
+        }
+        let (entry, from, to) = self
+            .state
+            .transfer(
+                &body.from_user,
+                &body.from_project,
+                &body.to_user,
+                &body.to_project,
+                body.amount_micros,
+                &body.memo,
+            )
+            .map_err(map_state_error)?;
+        Ok(Response::new(haima_pb::TransferReceipt {
+            entry_id: entry.entry_id,
+            from_balance: Some(haima_pb::Balance {
+                micros: from.balance_micros,
+                currency: crate::state::DEFAULT_CURRENCY.to_string(),
+                as_of: Some(prost_types::Timestamp::from(SystemTime::now())),
+            }),
+            to_balance: Some(haima_pb::Balance {
+                micros: to.balance_micros,
+                currency: crate::state::DEFAULT_CURRENCY.to_string(),
+                as_of: Some(prost_types::Timestamp::from(SystemTime::now())),
+            }),
+        }))
+    }
+}
+
+/// Map `HaimaStateError` to a `tonic::Status`. Permanent failures
+/// (insufficient balance, malformed input) become `failed_precondition`
+/// or `invalid_argument`; infrastructure failures become `internal`.
+fn map_state_error(err: HaimaStateError) -> Status {
+    match err {
+        HaimaStateError::WalletNotFound(id) => Status::not_found(format!("wallet not found: {id}")),
+        HaimaStateError::InsufficientBalance { have, want } => Status::failed_precondition(
+            format!("insufficient balance: have {have} micros, want {want}"),
+        ),
+        HaimaStateError::Crypto(e) => Status::internal(format!("crypto: {e}")),
+    }
+}

--- a/crates/haima/haimad/tests/topology_b_e2e_haima.rs
+++ b/crates/haima/haimad/tests/topology_b_e2e_haima.rs
@@ -1,0 +1,258 @@
+//! Topology-B end-to-end wire test for BRO-1018.
+//!
+//! Boots a minimal `HaimaState`, exposes `haima.v1.WalletSubstrate`
+//! on a tempdir UDS, dials it via `haima-proxy`'s `HaimaProxy`
+//! builder, and asserts that:
+//!
+//! 1. `HaimaProxy::bind_wallet(sid, project_id)` actually causes the
+//!    underlying `HaimaState` to gain that wallet — proving the wire
+//!    moves args through the substrate (not a hardcoded shape).
+//! 2. `HaimaProxy::transfer(...)` actually mutates the real substrate
+//!    ledger (both legs land), proving the wire transports the
+//!    operation end-to-end. The F2 lago publisher integration is out
+//!    of scope for Phase 3 — substrate state IS the source of truth
+//!    until F2 wires `haima-lago::FinancePublisher`.
+//! 3. Proxy → server round-trip: bind → debit → statement → transfer
+//!    composes against the same in-memory state, with each call
+//!    visible to the next.
+//!
+//! This is the contract the four-PR Topology-B audit (entity page
+//! `research/entities/concept/topology-b-substrate-stub-gap.md`)
+//! demanded a real wire for. Lifed isn't wired in here — adding it
+//! would pull haima-core / haima-wallet into the `lifed`/`haima-proxy`
+//! dep tree and break `scripts/verify_dependencies_lifed.sh`. The
+//! lifed → haima-proxy boundary is already covered by lifed's own
+//! integration suite (it exercises the `HaimaCall` trait), so
+//! end-to-end coverage in production is the COMPOSITION of those two
+//! suites — same pattern as BRO-1016's
+//! `topology_b_e2e_arcan.rs`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use haima_proxy::HaimaProxy;
+use haima_substrate_proto::haima::v1::wallet_substrate_server::WalletSubstrateServer;
+use haimad::state::HaimaState;
+use haimad::substrate::SubstrateService;
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+
+/// Spin up the substrate gRPC server on a tempdir UDS socket and
+/// return the socket path + shutdown handle. The server consumes a
+/// shared `Arc<HaimaState>` so the test can read its state after
+/// driving calls through the proxy.
+struct SubstrateUnderTest {
+    socket: PathBuf,
+    _tempdir: TempDir,
+    state: Arc<HaimaState>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SubstrateUnderTest {
+    async fn start() -> Self {
+        let tempdir = TempDir::new().expect("tempdir");
+        let socket = tempdir.path().join("haimad.sock");
+        let state = Arc::new(HaimaState::new());
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let service = SubstrateService::new(Arc::clone(&state));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind UDS");
+        let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
+
+        let server_handle = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(WalletSubstrateServer::new(service))
+                .serve_with_incoming_shutdown(incoming, async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        // Wait for the socket to appear.
+        for _ in 0..200 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(socket.exists(), "substrate socket bound");
+
+        Self {
+            socket,
+            _tempdir: tempdir,
+            state,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+        }
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.server_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn bind_wallet_creates_real_wallet() {
+    let env = SubstrateUnderTest::start().await;
+    let proxy = HaimaProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    let wallet_id = proxy
+        .bind_wallet("bro-1018-bind-sid", "proj-bind")
+        .await
+        .expect("bind_wallet");
+
+    // Substrate-side proof: BEFORE BRO-1018 this would have stayed at
+    // 0 wallets because the proxy returned `format!("wallet-{sid}-{project_id}")`
+    // without touching the substrate. AFTER BRO-1018 the substrate
+    // HaimaState now has the wallet — and its id matches the proxy
+    // return value.
+    assert_eq!(
+        env.state.wallet_count(),
+        1,
+        "wallet materialised substrate-side"
+    );
+    assert_eq!(
+        wallet_id,
+        HaimaState::wallet_id_for("bro-1018-bind-sid", "proj-bind"),
+        "wallet_id mirrors the deterministic substrate shape"
+    );
+
+    // Idempotency: re-binding the same (sid, project_id) returns the
+    // same wallet_id and does NOT create a duplicate substrate-side.
+    let wallet_id_again = proxy
+        .bind_wallet("bro-1018-bind-sid", "proj-bind")
+        .await
+        .expect("re-bind idempotent");
+    assert_eq!(wallet_id, wallet_id_again);
+    assert_eq!(
+        env.state.wallet_count(),
+        1,
+        "still one wallet after idempotent re-bind"
+    );
+
+    // Unbind drops the wallet on the substrate side — saga
+    // compensation path proven.
+    proxy
+        .unbind_wallet(&wallet_id)
+        .await
+        .expect("unbind_wallet");
+    assert_eq!(env.state.wallet_count(), 0, "wallet dropped substrate-side");
+    // Idempotent: a second unbind on an unknown wallet still returns Ok.
+    proxy
+        .unbind_wallet("wallet-never-existed")
+        .await
+        .expect("unbind unknown wallet ok");
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn transfer_mutates_real_substrate_state() {
+    let env = SubstrateUnderTest::start().await;
+    let proxy = HaimaProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    // Both wallets are materialised on demand by `transfer` (the
+    // substrate's `get_or_create_user_wallet` covers cold reads).
+    let (entry_id, from_after, to_after) = proxy
+        .transfer(
+            "alice",
+            "proj-A",
+            "bob",
+            "proj-B",
+            100_000, // 0.1 USDC
+            "memo-test",
+        )
+        .await
+        .expect("transfer");
+    assert!(!entry_id.is_empty(), "entry_id non-empty");
+
+    // Default starting balance is 1_000_000 micros; alice should be
+    // down 100k and bob should be up 100k.
+    assert_eq!(from_after.micros, 900_000);
+    assert_eq!(to_after.micros, 1_100_000);
+
+    // Substrate-side proof: F2 lago publisher is stubbed, so the
+    // wire contract for BRO-1018 is "the substrate's in-memory
+    // ledger actually changed." Before BRO-1018, the proxy returned
+    // hardcoded balances (999_000 / 100_000) regardless of args.
+    // After BRO-1018, balances and entries are derived from the
+    // server-side HaimaState.
+    let bal_alice = env.state.balance("alice", "proj-A");
+    let bal_bob = env.state.balance("bob", "proj-B");
+    assert_eq!(bal_alice.0, 900_000);
+    assert_eq!(bal_bob.0, 1_100_000);
+
+    // Both legs landed in the server-side ledger.
+    let alice_ledger = env.state.statement("alice", "proj-A", 0, i64::MAX, 0);
+    let bob_ledger = env.state.statement("bob", "proj-B", 0, i64::MAX, 0);
+    assert_eq!(alice_ledger.len(), 1);
+    assert_eq!(bob_ledger.len(), 1);
+    assert_eq!(alice_ledger[0].delta_micros, -100_000);
+    assert_eq!(bob_ledger[0].delta_micros, 100_000);
+    // Memo flows through.
+    assert!(alice_ledger[0].reason.contains("memo-test"));
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn proxy_to_server_round_trip() {
+    let env = SubstrateUnderTest::start().await;
+    let proxy = HaimaProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    // Compose the typical lifed saga path: bind → debit → statement.
+    let _wallet_id = proxy.bind_wallet("sid-rt", "proj-rt").await.expect("bind");
+
+    // BindWallet uses (sid, project_id); Debit / GetBalance /
+    // Transfer use (user_id, project_id). Use the same string for
+    // both axes so the ids align with the deterministic shape
+    // `wallet-{sid}-{project_id}`.
+    let (entry_id, balance_after) = proxy
+        .debit("sid-rt", "proj-rt", 250_000, "sid-rt", "round-trip")
+        .await
+        .expect("debit");
+    assert!(!entry_id.is_empty());
+    // 1_000_000 - 250_000 = 750_000.
+    assert_eq!(balance_after.micros, 750_000);
+    assert_eq!(balance_after.currency, "USDC");
+
+    // GetBalance probes substrate-side state directly. Mirrors the
+    // post-debit value because the wire just exposes HaimaState.
+    let probed = proxy
+        .get_balance("sid-rt", "proj-rt")
+        .await
+        .expect("get_balance");
+    assert_eq!(probed.micros, 750_000);
+
+    // Statement streams the one entry we just produced.
+    let mut stmt = proxy
+        .statement("sid-rt", "proj-rt", 0, i64::MAX, 0)
+        .await
+        .expect("statement");
+    let first = stmt
+        .next()
+        .await
+        .expect("≥1 entry")
+        .expect("stream item ok");
+    assert_eq!(first.delta_micros, -250_000);
+    assert_eq!(first.reason, "round-trip");
+    // No second entry — the cap is one debit.
+    assert!(stmt.next().await.is_none());
+    drop(stmt);
+
+    env.shutdown().await;
+}

--- a/crates/life-runtime/haima-proxy/Cargo.toml
+++ b/crates/life-runtime/haima-proxy/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 aios-protocol.workspace = true
 aios-proto.workspace = true
+haima-substrate-proto.workspace = true
 life-runtime-pool.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/life-runtime/haima-proxy/src/client.rs
+++ b/crates/life-runtime/haima-proxy/src/client.rs
@@ -8,14 +8,25 @@
 //! Sub-phase E: each `*Proxy` owns the `Arc<Pool>` per Spec C₂ §7. The
 //! [`Pooled<C>`] adapter wraps any inner [`HaimaCall`] (real proxy or
 //! mock) and applies pool semaphore + circuit-breaker bracketing.
+//!
+//! BRO-1018 (Phase 3 of the Topology B substrate-stub gap close):
+//! every `HaimaProxy::<rpc>` method below now issues a real
+//! `haima.v1.WalletSubstrate` tonic call instead of returning a
+//! hardcoded shape. The `Pooled<C>` adapter and the `LedgerGuardedStream`
+//! wrapper are unchanged — they bracket whichever inner `HaimaCall`
+//! the caller hands them, so mocks compose identically.
 
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use aios_proto::aios::v1 as aios_v1;
 use async_trait::async_trait;
 use futures::Stream;
+use haima_substrate_proto::haima::v1::{
+    self as haima_pb, wallet_substrate_client::WalletSubstrateClient,
+};
 use life_runtime_pool::pool::{Pool, PoolGuard};
 use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint, Uri};
@@ -102,21 +113,57 @@ impl HaimaProxy {
         }
     }
 
+    /// Bind a wallet to a session. BRO-1018 wires this to the real
+    /// `haima.v1.WalletSubstrate.BindWallet` RPC. The substrate is
+    /// idempotent on `(sid, project_id)`, so re-issuing the call
+    /// after a saga retry is safe.
     pub async fn bind_wallet(&self, sid: &str, project_id: &str) -> HaimaProxyResult<String> {
         let guard = self.acquire_guard().await?;
-        let mut req = tonic::Request::new((sid.to_string(), project_id.to_string()));
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::BindWalletReq {
+            sid: Some(aios_v1::SessionId {
+                value: sid.to_owned(),
+            }),
+            project_id: project_id.to_owned(),
+        });
         self.attach_token(&mut req);
-        let _ = req;
-        let out = format!("wallet-{sid}-{project_id}");
-        record_success(guard);
-        Ok(out)
+        match client.bind_wallet(req).await.map_err(HaimaProxyError::from) {
+            Ok(resp) => {
+                let wallet_id = resp.into_inner().wallet_id;
+                record_outcome(guard, true);
+                Ok(wallet_id)
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
     }
 
+    /// Unbind a wallet. BRO-1018 wires this to
+    /// `haima.v1.WalletSubstrate.UnbindWallet`. Idempotent —
+    /// wallets that don't exist substrate-side return Ok(empty).
     pub async fn unbind_wallet(&self, wallet_id: &str) -> HaimaProxyResult<()> {
         let guard = self.acquire_guard().await?;
-        let _ = wallet_id;
-        record_success(guard);
-        Ok(())
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::UnbindWalletReq {
+            wallet_id: wallet_id.to_owned(),
+        });
+        self.attach_token(&mut req);
+        match client
+            .unbind_wallet(req)
+            .await
+            .map_err(HaimaProxyError::from)
+        {
+            Ok(_) => {
+                record_outcome(guard, true);
+                Ok(())
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
     }
 
     pub async fn get_balance(
@@ -125,13 +172,26 @@ impl HaimaProxy {
         project_id: &str,
     ) -> HaimaProxyResult<WalletBalance> {
         let guard = self.acquire_guard().await?;
-        let _ = (user_id, project_id);
-        let out = WalletBalance {
-            micros: 1_000_000,
-            currency: "USDC".to_string(),
-        };
-        record_success(guard);
-        Ok(out)
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::GetBalanceReq {
+            user_id: user_id.to_owned(),
+            project_id: project_id.to_owned(),
+        });
+        self.attach_token(&mut req);
+        match client.get_balance(req).await.map_err(HaimaProxyError::from) {
+            Ok(resp) => {
+                let body = resp.into_inner();
+                record_outcome(guard, true);
+                Ok(WalletBalance {
+                    micros: body.micros,
+                    currency: body.currency,
+                })
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
     }
 
     pub async fn statement(
@@ -143,11 +203,41 @@ impl HaimaProxy {
         limit: u32,
     ) -> HaimaProxyResult<Pin<Box<dyn Stream<Item = Result<LedgerEntry, tonic::Status>> + Send>>>
     {
-        let _ = (user_id, project_id, since_ms, until_ms, limit);
         let guard = self.acquire_guard().await?;
-        let (tx, rx) = tokio::sync::mpsc::channel(1);
-        drop(tx);
-        let inner = tokio_stream::wrappers::ReceiverStream::new(rx);
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::StatementReq {
+            user_id: user_id.to_owned(),
+            project_id: project_id.to_owned(),
+            since_ms,
+            until_ms,
+            limit,
+        });
+        self.attach_token(&mut req);
+        let upstream = match client.statement(req).await {
+            Ok(resp) => resp.into_inner(),
+            Err(s) => {
+                let err = HaimaProxyError::from(s);
+                record_outcome(guard, !err.is_retryable());
+                return Err(err);
+            }
+        };
+        // Map haima.v1.LedgerEntry → public-plane LedgerEntry at the
+        // wire boundary. The struct shapes are identical except for
+        // the wallet_id field (Phase-3 server-side returns wallet_id
+        // but the public-plane LedgerEntry has no slot for it — lifed's
+        // public-plane Wallet.Statement already drops it via the
+        // service mapping in `services/wallet.rs`).
+        use futures::StreamExt;
+        let mapped = upstream.map(|res| {
+            res.map(|e| LedgerEntry {
+                entry_id: e.entry_id,
+                at_unix_ms: e.at_unix_ms,
+                delta_micros: e.delta_micros,
+                reason: e.reason,
+                sid: e.sid,
+            })
+        });
+        let inner = Box::pin(mapped);
         Ok(Box::pin(LedgerGuardedStream::new(inner, guard)))
     }
 
@@ -160,16 +250,35 @@ impl HaimaProxy {
         reason: &str,
     ) -> HaimaProxyResult<(String, WalletBalance)> {
         let guard = self.acquire_guard().await?;
-        let _ = (user_id, project_id, amount_micros, sid, reason);
-        let out = (
-            "entry-1".to_string(),
-            WalletBalance {
-                micros: 999_000,
-                currency: "USDC".to_string(),
-            },
-        );
-        record_success(guard);
-        Ok(out)
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::DebitReq {
+            user_id: user_id.to_owned(),
+            project_id: project_id.to_owned(),
+            amount_micros,
+            sid: sid.to_owned(),
+            reason: reason.to_owned(),
+        });
+        self.attach_token(&mut req);
+        match client.debit(req).await.map_err(HaimaProxyError::from) {
+            Ok(resp) => {
+                let body = resp.into_inner();
+                let bal = body.new_balance.ok_or_else(|| {
+                    HaimaProxyError::InvalidResponse("debit: missing new_balance".to_string())
+                })?;
+                record_outcome(guard, true);
+                Ok((
+                    body.entry_id,
+                    WalletBalance {
+                        micros: bal.micros,
+                        currency: bal.currency,
+                    },
+                ))
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
     }
 
     pub async fn transfer(
@@ -182,33 +291,58 @@ impl HaimaProxy {
         memo: &str,
     ) -> HaimaProxyResult<(String, WalletBalance, WalletBalance)> {
         let guard = self.acquire_guard().await?;
-        let _ = (
-            from_user,
-            from_project,
-            to_user,
-            to_project,
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::TransferReq {
+            from_user: from_user.to_owned(),
+            from_project: from_project.to_owned(),
+            to_user: to_user.to_owned(),
+            to_project: to_project.to_owned(),
             amount_micros,
-            memo,
-        );
-        let out = (
-            "entry-1".to_string(),
-            WalletBalance {
-                micros: 999_000,
-                currency: "USDC".to_string(),
-            },
-            WalletBalance {
-                micros: 100_000,
-                currency: "USDC".to_string(),
-            },
-        );
-        record_success(guard);
-        Ok(out)
+            memo: memo.to_owned(),
+        });
+        self.attach_token(&mut req);
+        match client.transfer(req).await.map_err(HaimaProxyError::from) {
+            Ok(resp) => {
+                let body = resp.into_inner();
+                let from_bal = body.from_balance.ok_or_else(|| {
+                    HaimaProxyError::InvalidResponse("transfer: missing from_balance".to_string())
+                })?;
+                let to_bal = body.to_balance.ok_or_else(|| {
+                    HaimaProxyError::InvalidResponse("transfer: missing to_balance".to_string())
+                })?;
+                record_outcome(guard, true);
+                Ok((
+                    body.entry_id,
+                    WalletBalance {
+                        micros: from_bal.micros,
+                        currency: from_bal.currency,
+                    },
+                    WalletBalance {
+                        micros: to_bal.micros,
+                        currency: to_bal.currency,
+                    },
+                ))
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
     }
 }
 
-fn record_success(guard: Option<PoolGuard>) {
+/// Record a `PoolGuard` outcome based on whether the call succeeded
+/// or whether the error is a non-retryable / permanent failure (the
+/// breaker treats permanent faults as success — they aren't infra
+/// problems — per Spec C₂ §7.2). Mirrors the policy applied by
+/// `Pooled<C>::bracket`.
+fn record_outcome(guard: Option<PoolGuard>, success_or_permanent: bool) {
     if let Some(g) = guard {
-        g.record_success();
+        if success_or_permanent {
+            g.record_success();
+        } else {
+            g.record_failure();
+        }
     }
 }
 
@@ -491,5 +625,12 @@ mod tests {
         proxy.attach_token(&mut req);
         let auth = req.metadata().get("authorization").expect("authz set");
         assert_eq!(auth.to_str().unwrap(), "Bearer haima.jws.token");
+    }
+
+    #[tokio::test]
+    async fn record_outcome_no_op_when_guard_absent() {
+        // Compile-only smoke: the helper accepts None and does not panic.
+        record_outcome(None, true);
+        record_outcome(None, false);
     }
 }

--- a/proto/haima/v1/substrate.proto
+++ b/proto/haima/v1/substrate.proto
@@ -1,0 +1,142 @@
+syntax = "proto3";
+
+package haima.v1;
+
+import "google/protobuf/timestamp.proto";
+import "aios/v1/identifiers.proto";
+
+// Substrate-plane Wallet service. Called by lifed (via haima-proxy)
+// over UDS. NOT the public-plane shape — that's life.v1.Wallet in
+// proto/life/v1/wallet.proto, served by lifed's WalletService.
+//
+// This service exists so lifed's saga driver + Wallet handlers can
+// route wallet operations to haimad without going through haimad's
+// HTTP `:3003` server (which carries x402/facilitator routes for the
+// public-plane). Spec reference:
+// docs/superpowers/specs/2026-04-25-life-runtime-architecture-spec.md
+// §L1 + the BRO-1016 / topology-b-substrate-stub-gap entity page.
+//
+// All RPCs are operations against the haima wallet substrate scoped
+// by (user_id, project_id, sid) — the substrate plane stays oblivious
+// to tier-2/3 token claims (those are lifed's concern, attached as
+// the bearer one tier up and verified separately).
+service WalletSubstrate {
+  // Idempotent on (sid, project_id). Binds a wallet to the session;
+  // creates the wallet entry on first call. Returns the wallet_id —
+  // currently a deterministic `wallet-{sid}-{project_id}` shape
+  // mirroring the Phase-1 sid→agent 1:1 invariant in arcan.
+  rpc BindWallet(BindWalletReq) returns (BindWalletResp);
+
+  // Idempotent. Unbind a wallet from its session (saga compensation
+  // path). Wallets that don't exist return Ok(empty).
+  rpc UnbindWallet(UnbindWalletReq) returns (UnbindWalletResp);
+
+  // Get the current balance for a (user_id, project_id) wallet.
+  // Returns a default 1 USDC balance for newly-bound wallets so the
+  // Phase-3 wire stays useful before haima's on-chain balance sync
+  // ships.
+  rpc GetBalance(GetBalanceReq) returns (Balance);
+
+  // Server-streaming. Returns ledger entries for a (user_id,
+  // project_id) wallet within the requested time window. Streaming
+  // matches the public-plane Wallet.Statement shape (Spec C₂ §6.2).
+  rpc Statement(StatementReq) returns (stream LedgerEntry);
+
+  // Idempotent debit (drives an off-chain ledger entry). lifed
+  // already idempotents the Debit RPC at the public-plane boundary
+  // via the `idempotency-key` envelope; the substrate is a simple
+  // ledger sink (no double-debit protection — that's lifed's job).
+  rpc Debit(DebitReq) returns (DebitReceipt);
+
+  // Transfer micros from one (user_id, project_id) wallet to
+  // another. Returns the entry_id plus updated balances on both
+  // ends. Idempotency lives at the public plane (lifed Wallet.Transfer
+  // was made idempotent in M5 Sub-phase D follow-up #3); the
+  // substrate accepts every Transfer as a fresh ledger event.
+  rpc Transfer(TransferReq) returns (TransferReceipt);
+}
+
+message BindWalletReq {
+  aios.v1.SessionId sid = 1;
+  string project_id = 2;
+}
+
+message BindWalletResp {
+  string wallet_id = 1;
+  // Address of the EVM wallet bound to the session (the deterministic
+  // local secp256k1 backend produces a fresh keypair on first bind).
+  string address = 2;
+  google.protobuf.Timestamp bound_at = 3;
+}
+
+message UnbindWalletReq {
+  string wallet_id = 1;
+}
+
+message UnbindWalletResp {}
+
+message GetBalanceReq {
+  string user_id = 1;
+  string project_id = 2;
+}
+
+message Balance {
+  // Balance in micro-credits (1 USDC = 1_000_000 μc).
+  uint64 micros = 1;
+  // Currency ticker — "USDC" today; future versions may expose
+  // multi-currency balances.
+  string currency = 2;
+  google.protobuf.Timestamp as_of = 3;
+}
+
+message StatementReq {
+  string user_id = 1;
+  string project_id = 2;
+  // Inclusive lower bound for entry timestamps in Unix ms.
+  int64 since_ms = 3;
+  // Exclusive upper bound for entry timestamps in Unix ms.
+  int64 until_ms = 4;
+  // Max entries to emit. 0 means "no cap" (server may still apply
+  // an internal hard limit to bound memory).
+  uint32 limit = 5;
+}
+
+message LedgerEntry {
+  string entry_id = 1;
+  // Entry timestamp in Unix ms.
+  int64 at_unix_ms = 2;
+  // Signed delta in micro-credits (positive = credit, negative =
+  // debit). Matches the proxy-side LedgerEntry shape verbatim so
+  // wire mapping is a trivial copy.
+  int64 delta_micros = 3;
+  string reason = 4;
+  string sid = 5;
+}
+
+message DebitReq {
+  string user_id = 1;
+  string project_id = 2;
+  uint64 amount_micros = 3;
+  string sid = 4;
+  string reason = 5;
+}
+
+message DebitReceipt {
+  string entry_id = 1;
+  Balance new_balance = 2;
+}
+
+message TransferReq {
+  string from_user = 1;
+  string from_project = 2;
+  string to_user = 3;
+  string to_project = 4;
+  uint64 amount_micros = 5;
+  string memo = 6;
+}
+
+message TransferReceipt {
+  string entry_id = 1;
+  Balance from_balance = 2;
+  Balance to_balance = 3;
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Topology B substrate-stub gap close-out. Sibling of [#1214](https://github.com/broomva/life/pull/1214) (BRO-1016 / arcan), following the same pattern exactly:

1. Define a substrate-plane proto (`haima.v1.WalletSubstrate`, 6 RPCs).
2. Land a UDS-bound tonic server in haimad (additive to the existing HTTP `:3003` x402 plane).
3. Replace haima-proxy's six stub method bodies (which discarded args + returned hardcoded shapes) with real tonic client calls.
4. Cover end-to-end with an integration test.

Until this PR, haima-proxy's per-method bodies returned `format!(\"wallet-{sid}-{project_id}\")`, hardcoded balances (999_000 / 100_000 micros), and dropped streams immediately. lifed's saga \`BindWallet\` step ran correctly but the haima substrate-call boundary below it was fake. After this PR, every method actually hits haimad's HaimaState (in-memory wallet + ledger registry, secp256k1-backed via haima-wallet::evm).

**Big unlock**: per-task billing (\`TaskBilled\` → \`RevenueReceived\`) becomes real on the substrate side — once F2 wires haima-lago::FinancePublisher into HaimaState, the finance events also fan out to lago.

## What ships

- **New proto**: \`proto/haima/v1/substrate.proto\` — \`haima.v1.WalletSubstrate\` service (6 RPCs: BindWallet, UnbindWallet, GetBalance, Statement server-streaming, Debit, Transfer).
- **New crate**: \`crates/haima/haima-substrate-proto/\` — tonic-prost codegen, sibling of arcan-substrate-proto. Wire-only.
- **haimad lib + bin split**: new \`src/lib.rs\` re-exports \`state\` + \`substrate\`. No external lib consumer existed → purely additive.
- **\`crates/haima/haimad/src/state.rs\`** — \`HaimaState\` in-memory wallet + ledger registry. Per-\`(user_id, project_id)\` wallets, ULID-ordered ledger entries, atomic two-leg transfer under \`RwLock\`. Never holds the lock across \`await\` (sync methods + async wrappers).
- **\`crates/haima/haimad/src/substrate.rs\`** — gRPC \`SubstrateService\` adapter. Each RPC is a thin handler onto a HaimaState method. Lifts \`HaimaStateError\` to \`tonic::Status\` (\`failed_precondition\` for insufficient balance, \`not_found\` for missing wallets, etc.).
- **\`crates/haima/haimad/src/main.rs\`** — adds \`--uds-socket <PATH>\` flag (env \`HAIMA_UDS_SOCKET\`) with the same \`serve_substrate_uds\` helper shape arcand uses (parent dir create, stale socket cleanup, best-effort removal on shutdown).
- **\`crates/life-runtime/haima-proxy/src/client.rs\`** — six methods rewritten to issue real tonic calls. \`record_outcome\` replaces the bare \`record_success\` helper so permanent errors don't trip the breaker (per Spec C₂ §7.2). \`statement\` streams wrap upstream into \`LedgerGuardedStream\`.
- **\`crates/haima/haimad/tests/topology_b_e2e_haima.rs\`** — 3 integration tests, all green:
  1. \`bind_wallet_creates_real_wallet\` — proves wallet materialises substrate-side + idempotency + unbind drop.
  2. \`transfer_mutates_real_substrate_state\` — proves both legs land in real ledger, balances move.
  3. \`proxy_to_server_round_trip\` — full bind → debit → balance → statement composes.

## Validation

- \`cargo check -p haimad -p haima-proxy\` — clean
- \`cargo test -p haimad -p haima-proxy --all-targets\` — **16/16 pass** (6 state unit + 3 CLI + 4 proxy + 3 e2e)
- \`cargo clippy --workspace --lib --tests -- -D warnings\` — clean across the workspace
- \`cargo fmt --all -- --check\` — clean
- \`bash scripts/verify_dependencies_lifed.sh\` — passes (\`haima-substrate-proto\` is wire-only)

## What's NOT in scope

- F2 \`haima-lago::FinancePublisher\` wire — HaimaState is the substrate's source of truth today. Once F2 ships, each ledger entry also fans out to lago via \`EventKind::Custom(\"finance.*\")\`.
- On-chain settlement — wallets are secp256k1-backed (real addresses) but balances start with a default 1 USDC and stay off-chain.
- x402 payment paths (those are higher-level HTTP routes on \`haimad:3003\`).
- New haima-core operations (no surface had to be extended).
- lago substrate (BRO-1017, sibling in parallel).
- anima substrate (BRO-1019, deferred until soma overlap is surveyed).

## Topology B status after this PR

2 of 4 substrate gRPC wires now functional (arcan via BRO-1016, haima via this PR). Siblings BRO-1017 (lago) and BRO-1019 (anima) remain stubbed.

## Test plan

- [x] \`cargo test -p haimad -p haima-proxy --all-targets\`
- [x] \`cargo clippy --workspace --lib --tests -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`bash scripts/verify_dependencies_lifed.sh\`
- [ ] CI green (Test Linux ~11 min; \`Verify lifed dependency rules\` is the architectural gate)

## References

- Pattern PR: #1214 (BRO-1016 / arcan)
- Knowledge graph entity: \`research/entities/concept/topology-b-substrate-stub-gap.md\` (to be updated post-merge: \"arcan + haima: closed; lago/anima: remaining\")

Generated with [Claude Code](https://claude.com/claude-code)