### PR TITLE
feat(chronos): M0 scaffold — temporal substrate primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "chronos-core"
+version = "0.3.0"
+dependencies = [
+ "aios-protocol",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
+name = "chronos-lago"
+version = "0.3.0"
+dependencies = [
+ "aios-protocol",
+ "chronos-core",
+ "lago-core",
+ "lago-journal",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "chronos-triggers"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "chronos-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "chronosd"
+version = "0.3.0"
+dependencies = [
+ "aios-protocol",
+ "anyhow",
+ "chronos-core",
+ "chronos-lago",
+ "chronos-triggers",
+ "clap",
+ "lago-core",
+ "lago-journal",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,11 @@ members = [
     "crates/autonomic/autonomic-core",
     "crates/autonomic/autonomic-lago",
     "crates/autonomic/autonomicd",
+    # Chronos — temporality (M0 scaffold; see docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md)
+    "crates/chronos/chronos-core",
+    "crates/chronos/chronos-triggers",
+    "crates/chronos/chronos-lago",
+    "crates/chronos/chronosd",
     # Praxis — tool execution
     "crates/praxis/praxis-core",
     "crates/praxis/praxis-mcp-bridge",
@@ -196,6 +201,10 @@ autonomic-api = { path = "crates/autonomic/autonomic-api", version = "0.3.0" }
 autonomic-controller = { path = "crates/autonomic/autonomic-controller", version = "0.3.0" }
 autonomic-core = { path = "crates/autonomic/autonomic-core", version = "0.3.0" }
 autonomic-lago = { path = "crates/autonomic/autonomic-lago", version = "0.3.0" }
+# Chronos — temporality
+chronos-core = { path = "crates/chronos/chronos-core", version = "0.3.0" }
+chronos-triggers = { path = "crates/chronos/chronos-triggers", version = "0.3.0" }
+chronos-lago = { path = "crates/chronos/chronos-lago", version = "0.3.0" }
 haima-api = { path = "crates/haima/haima-api", version = "0.3.0" }
 haima-core = { path = "crates/haima/haima-core", version = "0.3.0" }
 haima-insurance = { path = "crates/haima/haima-insurance", version = "0.3.0" }

--- a/crates/chronos/CLAUDE.md
+++ b/crates/chronos/CLAUDE.md
@@ -1,0 +1,142 @@
+# Chronos — Temporality Primitive for the Life Agent OS
+
+> *Chronos* (χρόνος, Greek: time) — the substrate that answers **when an agent should wake**
+> and **what it should do when it wakes**. Biological analogue: circadian rhythm.
+
+**Status**: M0 (scaffold + heartbeat trigger). M1–M3 planned per
+`docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md`.
+
+## Architecture
+
+```
+chronos/
+├── chronos-core/         # Pure types + traits + WakeRouter (depends ONLY on aios-protocol)
+├── chronos-triggers/     # HeartbeatTrigger (real) + stubs for http/cron/fs/sub-agent/threshold/webhook
+├── chronos-lago/         # Lago bridge — record_wake → Custom("chronos.wake")
+└── chronosd/             # Daemon binary — lib + bin split, like haimad / autonomicd
+```
+
+`chronos-api`, `chronos-substrate-proto`, and `life-chronos` (Topology B + kernel adapter)
+are M3+ work and not scaffolded yet.
+
+## Core Types (chronos-core)
+
+| Type | Purpose |
+|------|---------|
+| `WakeEvent` | `{ event_id, fired_at_unix_ms, source, payload, target_session? }` — the universal wake shape |
+| `WakeEventId` | ULID newtype, sortable by creation time |
+| `WakeSource` | `Heartbeat | Http | Cron | FsWatch | SubAgentReturn | Threshold | Webhook` |
+| `WakeTrigger` | `async fn next_wake(&mut self) -> Option<WakeEvent>; fn name(&self) -> &'static str` |
+| `WakeRouter` | Multiplexes triggers concurrently via tokio mpsc into a single stream |
+| `ChronosError` / `ChronosResult` | Crate-local error type |
+
+## Event Namespace
+
+All chronos events use `EventKind::Custom { event_type: "chronos.*", data }`, mirroring the
+autonomic (`autonomic.*`) and haima (`finance.*`) convention.
+
+| event_type | When emitted |
+|------------|--------------|
+| `chronos.wake` | A trigger fired and produced a `WakeEvent`. (M0 — the only one for now.) |
+| `chronos.agenda.added` | An agenda item was created. (M1+) |
+| `chronos.agenda.completed` | An agenda item completed after the kernel ran it. (M2+) |
+
+The kernel does NOT yet ship a typed `EventKind::ChronosWake` variant — see the
+[plan](../../docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md) §"Constraints"
+for the reasoning. Promote to a typed variant after M2-M3 stabilizes the payload shape.
+
+## Dependency Rules
+
+```
+chronos-core → aios-protocol (ONLY internal dep) + tokio, serde, ulid, thiserror
+chronos-triggers → chronos-core (no other internal deps)
+chronos-lago → chronos-core + aios-protocol + lago-core (read), lago-journal (dev only)
+chronosd → all the above + lago-journal + anyhow + clap + tracing-subscriber
+```
+
+Enforced by `scripts/architecture/verify_dependencies_chronos.sh`. The CI lane runs
+`cargo metadata` and walks edges; violations fail the build.
+
+## Daemon CLI
+
+```
+chronosd --heartbeat-seconds 5 --data-dir /tmp/chronos-smoke
+```
+
+Flags:
+
+| Flag | Default | Env | Purpose |
+|------|---------|-----|---------|
+| `--heartbeat-seconds` | 10 | `CHRONOSD_HEARTBEAT_SECONDS` | Tick interval. ≥1. |
+| `--data-dir` | `/tmp/chronosd` | `CHRONOSD_DATA_DIR` | Holds the lago redb journal (created on startup). |
+| `--journal-filename` | `journal.redb` | `CHRONOSD_JOURNAL_FILENAME` | File name inside `--data-dir`. |
+| `--router-buffer` | 64 | `CHRONOSD_ROUTER_BUFFER` | Mpsc capacity for the router. ≥1. |
+
+SIGTERM and SIGINT trigger a clean shutdown that drains the router within ~2 seconds.
+
+## Default Routing
+
+Wakes without a `target_session` land in the **`chronos.system`** session on the **`main`**
+branch. This keeps heartbeat noise out of real user sessions while remaining replayable.
+
+Constants exposed by `chronos-lago`:
+
+```rust
+pub const CHRONOS_WAKE_EVENT_TYPE: &str = "chronos.wake";
+pub const CHRONOS_SYSTEM_SESSION: &str = "chronos.system";
+pub const CHRONOS_DEFAULT_BRANCH: &str = "main";
+```
+
+## Commands
+
+```bash
+# Build & test the four chronos crates
+cargo build  -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd
+cargo test   -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd
+cargo clippy -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd -- -D warnings
+
+# Run the daemon (writes one chronos.wake every 5 seconds to /tmp/chronos-smoke/journal.redb)
+cargo run -p chronosd -- --heartbeat-seconds 5 --data-dir /tmp/chronos-smoke
+
+# Replay the journal as a tree
+cargo run -p lago-cli -- replay --tree --data /tmp/chronos-smoke/journal.redb
+```
+
+## Milestone Roadmap
+
+| Milestone | Goal | Status |
+|-----------|------|--------|
+| M0 | Scaffold + heartbeat trigger writes `chronos.wake` events to lago | **shipped (this scaffold)** |
+| M1 | Agenda store + HTTP `POST /v1/wake` ingest | planned |
+| M2 | Kernel wake handoff — `WakeEvent → kernel.dispatch(session_id, intent)` | planned |
+| M3 | File-watch + sub-agent return triggers | planned |
+| Beyond M3 | `chronos-substrate-proto`, cron, webhook, threshold triggers, multi-priority queue | planned |
+
+## Conventions
+
+- **Edition**: 2024 (Rust 1.85)
+- **No unsafe**: `#![forbid(unsafe_code)]` in every crate
+- **Errors**: `thiserror` for libraries, `anyhow` for binaries
+- **Custom prefix**: every chronos event MUST use `"chronos."` namespace
+- **Module style**: `name.rs` file-based modules (not `mod.rs`)
+- **Heartbeat interval**: 10s in dev, 60s+ in production — NOT 1s (floods the journal)
+- **`tokio-cron-scheduler`** (when added in M3+): pin to a workspace-consistent version
+
+## Integration Points (future)
+
+| Crate | How Chronos integrates |
+|-------|------------------------|
+| **arcand** | (M2) calls `tick_on_branch(session_id, branch, TickInput { objective })` on wake fire |
+| **Lago** | every wake journals as `Custom("chronos.wake")`; agenda transitions as `Custom("chronos.agenda.*")` |
+| **Nous** | (M3+) threshold trigger fires when `nous_score < 0.3` |
+| **Vigil** | (M2+) wake event spans carry `chronos.source` + `chronos.target_session` |
+| **Spec D Anima** | (M2) wake invokes use the session's anima identity — no special handling needed |
+
+## Constraints (carried over from the plan)
+
+1. **Don't touch the canonical loop in `aios-runtime`.** Chronos calls `tick_on_branch`
+   from outside the loop body.
+2. **Use `Custom { event_type, data }` for all chronos events** until the contract stabilizes.
+3. **L3 governance budget**: edits to `CLAUDE.md` / `AGENTS.md` / `METALAYER.md` /
+   `.life/control/policy.yaml` count against the λ₃ budget — batch them at the end of M2.
+4. **Default heartbeat**: 10s dev, 60s+ production. Never 1s.

--- a/crates/chronos/chronos-core/Cargo.toml
+++ b/crates/chronos/chronos-core/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "chronos-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Core types and traits for Chronos — the temporal substrate of the Life Agent OS"
+
+[dependencies]
+aios-protocol.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
+tracing.workspace = true
+ulid.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/chronos/chronos-core/src/error.rs
+++ b/crates/chronos/chronos-core/src/error.rs
@@ -1,0 +1,22 @@
+//! Crate-local error type.
+
+use thiserror::Error;
+
+/// Errors produced by chronos primitives.
+///
+/// `Trigger` wraps source-specific failures (e.g. a cron parse error in M3+). `Router` is
+/// reserved for routing-level invariant violations the router itself surfaces.
+#[derive(Debug, Error)]
+pub enum ChronosError {
+    /// A trigger failed to produce events (descriptive string for now; a real error type can
+    /// be added once concrete trigger sources are implemented in M1+).
+    #[error("chronos trigger error: {0}")]
+    Trigger(String),
+
+    /// The router observed an invariant violation.
+    #[error("chronos router error: {0}")]
+    Router(String),
+}
+
+/// Result alias used throughout chronos-core.
+pub type ChronosResult<T> = std::result::Result<T, ChronosError>;

--- a/crates/chronos/chronos-core/src/lib.rs
+++ b/crates/chronos/chronos-core/src/lib.rs
@@ -1,0 +1,59 @@
+//! Chronos core — types, traits, and the wake router for the temporal substrate of the Life Agent OS.
+//!
+//! Chronos answers two questions for the kernel:
+//!
+//! 1. **"When should an agent wake?"** — a unified surface that coalesces all wake sources
+//!    (HTTP `/runs`, cron, file changes, sub-agent completions, threshold crossings, webhooks,
+//!    heartbeats) into a single ordered event stream the kernel can subscribe to.
+//! 2. **"What should the agent do when it wakes?"** — a durable per-session agenda that survives
+//!    daemon restarts (introduced in M1; not in this crate's M0 surface).
+//!
+//! ## Dependency rule
+//!
+//! `chronos-core` depends ONLY on `aios-protocol` from the Life internal-crate graph. No lago,
+//! no arcan, no autonomic. Enforced by `scripts/architecture/verify_dependencies_chronos.sh`.
+//!
+//! ## Module shape (M0)
+//!
+//! - [`WakeEvent`] — universal wake shape (id, timestamp, source, payload, optional target session)
+//! - [`WakeSource`] — taxonomy of where a wake can come from
+//! - [`WakeTrigger`] — async trait every trigger implements (heartbeat, http, cron, fs, …)
+//! - [`WakeRouter`] — multiplexes triggers concurrently into a single stream
+//! - [`ChronosError`] / [`ChronosResult`] — crate-local error type
+//!
+//! ## Why `tokio` in core?
+//!
+//! [`WakeRouter`] needs an `mpsc` channel to multiplex concurrent triggers. The autonomic-core
+//! crate also pulls tokio for the same reasons — workspace convention is "internal Life crates
+//! beyond aios-protocol" rule, not "external Rust crates" rule.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+mod error;
+mod router;
+mod trigger;
+mod wake;
+
+pub use error::{ChronosError, ChronosResult};
+pub use router::WakeRouter;
+pub use trigger::WakeTrigger;
+pub use wake::{WakeEvent, WakeEventId, WakeSource};
+
+/// Re-export of `aios_protocol::SessionId` so consumers can build [`WakeEvent::target_session`]
+/// without taking a direct dependency on aios-protocol themselves.
+pub use aios_protocol::SessionId;
+
+/// Return milliseconds since the Unix epoch.
+///
+/// Used by triggers when constructing [`WakeEvent`] timestamps. Returns 0 if the clock is
+/// before the Unix epoch (which would indicate a misconfigured system clock — the wake event
+/// is still produced so observability can surface the anomaly).
+pub fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/crates/chronos/chronos-core/src/router.rs
+++ b/crates/chronos/chronos-core/src/router.rs
@@ -47,10 +47,7 @@ impl WakeRouter {
             info!(trigger = name, "trigger started");
             while let Some(event) = trigger.next_wake().await {
                 if tx.send(event).await.is_err() {
-                    warn!(
-                        trigger = name,
-                        "router closed; trigger forwarder exiting"
-                    );
+                    warn!(trigger = name, "router closed; trigger forwarder exiting");
                     break;
                 }
             }

--- a/crates/chronos/chronos-core/src/router.rs
+++ b/crates/chronos/chronos-core/src/router.rs
@@ -1,0 +1,201 @@
+//! [`WakeRouter`] — multiplexes concurrent triggers into a single wake stream.
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::{WakeEvent, WakeTrigger};
+
+/// Multiplexes multiple [`WakeTrigger`] sources into a single async stream of [`WakeEvent`]s.
+///
+/// Each trigger runs in its own tokio task and pushes events into a shared mpsc channel.
+/// The daemon's main loop consumes via [`WakeRouter::next_wake`] and dispatches downstream.
+///
+/// ## Buffer capacity
+///
+/// The internal mpsc channel is bounded. If a trigger produces faster than the daemon
+/// drains, the trigger's `tx.send` will await — backpressure flows naturally into the
+/// trigger's own loop. Pick a capacity large enough that bursts (e.g. fs watch storms) are
+/// absorbed, small enough that runaway triggers can't OOM the daemon.
+pub struct WakeRouter {
+    rx: mpsc::Receiver<WakeEvent>,
+    tx: mpsc::Sender<WakeEvent>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl WakeRouter {
+    /// Construct a new router with the supplied buffer capacity. 64 is a reasonable default
+    /// for dev; production deployments with many concurrent triggers may want more.
+    pub fn new(buffer: usize) -> Self {
+        let buffer = buffer.max(1);
+        let (tx, rx) = mpsc::channel(buffer);
+        Self {
+            rx,
+            tx,
+            handles: Vec::new(),
+        }
+    }
+
+    /// Spawn a trigger as a tokio task that forwards its events into the router.
+    ///
+    /// The task lives until the trigger returns `None` from [`WakeTrigger::next_wake`] or
+    /// the router is dropped (which closes the receiver and breaks the send loop).
+    pub fn add_trigger(&mut self, mut trigger: Box<dyn WakeTrigger>) {
+        let tx = self.tx.clone();
+        let name = trigger.name();
+        let handle = tokio::spawn(async move {
+            info!(trigger = name, "trigger started");
+            while let Some(event) = trigger.next_wake().await {
+                if tx.send(event).await.is_err() {
+                    warn!(
+                        trigger = name,
+                        "router closed; trigger forwarder exiting"
+                    );
+                    break;
+                }
+            }
+            info!(trigger = name, "trigger exhausted");
+        });
+        self.handles.push(handle);
+    }
+
+    /// Block until the next wake event arrives, or all triggers have exhausted.
+    ///
+    /// Returns `None` once every spawned trigger has returned `None` AND the router's
+    /// internal sender has been dropped (which happens in [`WakeRouter::shutdown`]).
+    pub async fn next_wake(&mut self) -> Option<WakeEvent> {
+        self.rx.recv().await
+    }
+
+    /// Number of trigger forwarder tasks currently spawned.
+    pub fn trigger_count(&self) -> usize {
+        self.handles.len()
+    }
+
+    /// Drop the router's own sender and abort all forwarder tasks. After this returns,
+    /// [`WakeRouter::next_wake`] drains the buffer then returns `None` permanently.
+    pub async fn shutdown(self) {
+        // Drop self.tx first so the receiver can EOF cleanly after the buffer drains.
+        let WakeRouter {
+            mut rx,
+            tx,
+            handles,
+        } = self;
+        drop(tx);
+        for handle in &handles {
+            handle.abort();
+        }
+        for handle in handles {
+            // Ignore join errors from aborted tasks.
+            let _ = handle.await;
+        }
+        rx.close();
+        while rx.recv().await.is_some() {}
+    }
+}
+
+impl Default for WakeRouter {
+    fn default() -> Self {
+        Self::new(64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::{WakeEvent, WakeSource, WakeTrigger};
+
+    /// Test trigger that emits N events then returns None.
+    struct CountingTrigger {
+        remaining: usize,
+        name: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl WakeTrigger for CountingTrigger {
+        async fn next_wake(&mut self) -> Option<WakeEvent> {
+            if self.remaining == 0 {
+                return None;
+            }
+            self.remaining -= 1;
+            // tiny yield so events from concurrent triggers interleave deterministically.
+            tokio::task::yield_now().await;
+            Some(WakeEvent::new(WakeSource::Heartbeat))
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    #[tokio::test]
+    async fn router_drains_a_single_trigger() {
+        let mut router = WakeRouter::new(8);
+        router.add_trigger(Box::new(CountingTrigger {
+            remaining: 3,
+            name: "test",
+        }));
+
+        let mut count = 0;
+        // Wait at most 1 second total for events to flow through.
+        let deadline = tokio::time::sleep(Duration::from_secs(1));
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                evt = router.next_wake() => match evt {
+                    Some(_) => count += 1,
+                    None => break,
+                },
+                _ = &mut deadline => panic!("router stalled before draining 3 events"),
+            }
+            if count == 3 {
+                break;
+            }
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn router_multiplexes_two_triggers() {
+        let mut router = WakeRouter::new(16);
+        router.add_trigger(Box::new(CountingTrigger {
+            remaining: 5,
+            name: "a",
+        }));
+        router.add_trigger(Box::new(CountingTrigger {
+            remaining: 5,
+            name: "b",
+        }));
+        assert_eq!(router.trigger_count(), 2);
+
+        let mut count = 0;
+        let deadline = tokio::time::sleep(Duration::from_secs(1));
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                evt = router.next_wake() => match evt {
+                    Some(_) => count += 1,
+                    None => break,
+                },
+                _ = &mut deadline => panic!("router stalled before draining 10 events"),
+            }
+            if count == 10 {
+                break;
+            }
+        }
+        assert_eq!(count, 10);
+    }
+
+    #[tokio::test]
+    async fn router_shutdown_drains_and_returns_none() {
+        let mut router = WakeRouter::new(4);
+        router.add_trigger(Box::new(CountingTrigger {
+            remaining: 2,
+            name: "shutdown-test",
+        }));
+        let _ = router.next_wake().await.expect("first event");
+        router.shutdown().await;
+    }
+}

--- a/crates/chronos/chronos-core/src/trigger.rs
+++ b/crates/chronos/chronos-core/src/trigger.rs
@@ -1,0 +1,28 @@
+//! The [`WakeTrigger`] async trait.
+
+use crate::WakeEvent;
+
+/// A source of wake events. Implementations push events into the router by returning them
+/// from [`WakeTrigger::next_wake`] in a loop. The router spawns each trigger as its own
+/// tokio task and forwards their events into a single stream.
+///
+/// ## Returning `None`
+///
+/// A trigger returns `None` to signal it has no more events — either because it's a
+/// one-shot, or because it received an internal shutdown signal. The router then drops
+/// the trigger; remaining triggers keep producing.
+///
+/// ## Trait object safety
+///
+/// `#[async_trait::async_trait]` boxes the future, which makes `Box<dyn WakeTrigger>` work.
+/// The boxing overhead is negligible for the wake rate Chronos expects (≤ 100/sec system-wide).
+#[async_trait::async_trait]
+pub trait WakeTrigger: Send {
+    /// Pull the next wake event from this trigger.
+    ///
+    /// Returning `None` signals the trigger is exhausted; the router will stop polling it.
+    async fn next_wake(&mut self) -> Option<WakeEvent>;
+
+    /// Short identifier for logs and observability (e.g. `"heartbeat"`, `"http"`).
+    fn name(&self) -> &'static str;
+}

--- a/crates/chronos/chronos-core/src/wake.rs
+++ b/crates/chronos/chronos-core/src/wake.rs
@@ -1,0 +1,180 @@
+//! [`WakeEvent`] and its supporting types.
+
+use aios_protocol::SessionId;
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a wake event.
+///
+/// ULIDs are sortable by creation time, which is convenient for ordering wake events when
+/// inspecting the journal. Stored as a string in [`WakeEvent`] serialization to keep the
+/// representation stable across language boundaries.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WakeEventId(pub String);
+
+impl WakeEventId {
+    /// Mint a new ULID-based wake event id.
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    /// View the underlying string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for WakeEventId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for WakeEventId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Taxonomy of wake sources Chronos coalesces into a single stream.
+///
+/// Heartbeat is the only source implemented in M0. The others are present so that the
+/// universal `WakeEvent` shape doesn't need to change as triggers come online in M1+.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WakeSource {
+    /// Periodic timer-driven wake — chronosd's own pulse.
+    Heartbeat,
+    /// External HTTP `POST /v1/wake` (M1).
+    Http,
+    /// Cron expression matched the current minute (M3+).
+    Cron,
+    /// Filesystem event (create / modify / delete) (M3).
+    FsWatch,
+    /// A spawned sub-agent returned to its parent's agenda (M3).
+    SubAgentReturn,
+    /// A metric threshold crossing fired (e.g. Nous score < 0.3) (M3+).
+    Threshold,
+    /// Inbound webhook from a trusted external system (M3+).
+    Webhook,
+}
+
+impl WakeSource {
+    /// Lowercase string identifier suitable for log fields and event-type suffixes.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WakeSource::Heartbeat => "heartbeat",
+            WakeSource::Http => "http",
+            WakeSource::Cron => "cron",
+            WakeSource::FsWatch => "fs_watch",
+            WakeSource::SubAgentReturn => "sub_agent_return",
+            WakeSource::Threshold => "threshold",
+            WakeSource::Webhook => "webhook",
+        }
+    }
+}
+
+/// A single wake fired by any of the registered triggers.
+///
+/// The shape is intentionally open: source-specific data lives in [`WakeEvent::payload`]
+/// (a `serde_json::Value`). This avoids growing the type once per trigger source and lets
+/// the lago projection layer carry the payload through unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WakeEvent {
+    /// ULID minted at the moment the trigger fired.
+    pub event_id: WakeEventId,
+    /// Milliseconds since the Unix epoch when the trigger fired.
+    pub fired_at_unix_ms: i64,
+    /// Which trigger source emitted the wake.
+    pub source: WakeSource,
+    /// Source-specific data (e.g. heartbeat interval, HTTP body, fs path).
+    pub payload: serde_json::Value,
+    /// Optional target session — if `None`, the wake is routed to the `chronos.system` session.
+    pub target_session: Option<SessionId>,
+}
+
+impl WakeEvent {
+    /// Construct a wake event with the supplied source and an empty JSON object payload.
+    ///
+    /// Convenience constructor for the heartbeat / stub cases. Callers needing richer
+    /// payloads can construct [`WakeEvent`] directly.
+    pub fn new(source: WakeSource) -> Self {
+        Self {
+            event_id: WakeEventId::new(),
+            fired_at_unix_ms: super::now_unix_ms(),
+            source,
+            payload: serde_json::Value::Object(serde_json::Map::new()),
+            target_session: None,
+        }
+    }
+
+    /// Attach a payload value to a wake event using the builder pattern.
+    #[must_use]
+    pub fn with_payload(mut self, payload: serde_json::Value) -> Self {
+        self.payload = payload;
+        self
+    }
+
+    /// Attach a target session id using the builder pattern.
+    #[must_use]
+    pub fn with_target_session(mut self, session: SessionId) -> Self {
+        self.target_session = Some(session);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wake_event_id_unique() {
+        let a = WakeEventId::new();
+        let b = WakeEventId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn wake_source_string_taxonomy_stable() {
+        // These string values land in lago payloads. Changing them is a contract break;
+        // this test prevents accidental rename.
+        assert_eq!(WakeSource::Heartbeat.as_str(), "heartbeat");
+        assert_eq!(WakeSource::Http.as_str(), "http");
+        assert_eq!(WakeSource::Cron.as_str(), "cron");
+        assert_eq!(WakeSource::FsWatch.as_str(), "fs_watch");
+        assert_eq!(WakeSource::SubAgentReturn.as_str(), "sub_agent_return");
+        assert_eq!(WakeSource::Threshold.as_str(), "threshold");
+        assert_eq!(WakeSource::Webhook.as_str(), "webhook");
+    }
+
+    #[test]
+    fn wake_event_constructor_sets_source_and_empty_payload() {
+        let e = WakeEvent::new(WakeSource::Heartbeat);
+        assert_eq!(e.source, WakeSource::Heartbeat);
+        assert!(e.payload.is_object());
+        assert_eq!(e.payload.as_object().map(|o| o.len()), Some(0));
+        assert!(e.target_session.is_none());
+        assert!(e.fired_at_unix_ms >= 0);
+    }
+
+    #[test]
+    fn wake_event_builder_attaches_payload_and_target() {
+        let e = WakeEvent::new(WakeSource::Http)
+            .with_payload(serde_json::json!({"intent": "rebuild_index"}))
+            .with_target_session(SessionId::from_string("sess-42"));
+        assert_eq!(e.source, WakeSource::Http);
+        assert_eq!(e.payload["intent"], "rebuild_index");
+        assert_eq!(e.target_session.as_ref().map(|s| s.as_str()), Some("sess-42"));
+    }
+
+    #[test]
+    fn wake_event_roundtrips_through_json() {
+        let e = WakeEvent::new(WakeSource::Heartbeat)
+            .with_payload(serde_json::json!({"interval_ms": 5_000_u64}));
+        let json = serde_json::to_string(&e).expect("serialize");
+        let back: WakeEvent = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.source, WakeSource::Heartbeat);
+        assert_eq!(back.event_id, e.event_id);
+        assert_eq!(back.payload["interval_ms"], 5_000);
+    }
+}

--- a/crates/chronos/chronos-core/src/wake.rs
+++ b/crates/chronos/chronos-core/src/wake.rs
@@ -164,7 +164,10 @@ mod tests {
             .with_target_session(SessionId::from_string("sess-42"));
         assert_eq!(e.source, WakeSource::Http);
         assert_eq!(e.payload["intent"], "rebuild_index");
-        assert_eq!(e.target_session.as_ref().map(|s| s.as_str()), Some("sess-42"));
+        assert_eq!(
+            e.target_session.as_ref().map(|s| s.as_str()),
+            Some("sess-42")
+        );
     }
 
     #[test]

--- a/crates/chronos/chronos-lago/Cargo.toml
+++ b/crates/chronos/chronos-lago/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "chronos-lago"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Lago bridge for Chronos — records wake events to the Life journal"
+
+[dependencies]
+chronos-core.workspace = true
+aios-protocol.workspace = true
+lago-core.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+lago-journal.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/chronos/chronos-lago/src/lib.rs
+++ b/crates/chronos/chronos-lago/src/lib.rs
@@ -106,8 +106,7 @@ mod tests {
     use super::*;
 
     fn open_journal(dir: &Path) -> Arc<dyn Journal> {
-        Arc::new(RedbJournal::open(dir.join("test.redb")).expect("open redb"))
-            as Arc<dyn Journal>
+        Arc::new(RedbJournal::open(dir.join("test.redb")).expect("open redb")) as Arc<dyn Journal>
     }
 
     #[tokio::test]
@@ -125,7 +124,9 @@ mod tests {
             .expect("append");
         assert!(seq > 0, "journal should assign a positive sequence");
 
-        let query = EventQuery::new().session(session.clone()).branch(branch.clone());
+        let query = EventQuery::new()
+            .session(session.clone())
+            .branch(branch.clone());
         let stored = journal.read(query).await.expect("read");
         assert_eq!(stored.len(), 1, "exactly one wake should be persisted");
 

--- a/crates/chronos/chronos-lago/src/lib.rs
+++ b/crates/chronos/chronos-lago/src/lib.rs
@@ -1,0 +1,197 @@
+//! Lago bridge for Chronos.
+//!
+//! Records wake events as `EventKind::Custom { event_type: "chronos.wake", data: … }` entries
+//! in the lago journal. The `chronos.*` namespace mirrors the pattern used by autonomic
+//! (`autonomic.*`) and haima (`finance.*`) — a typed `EventKind::ChronosWake` variant is
+//! deliberately deferred until the contract stabilizes after M2-M3.
+//!
+//! ## Why Custom for now?
+//!
+//! The kernel-level `EventKind` enum in `aios-protocol` is a stability surface that crosses
+//! every substrate. Adding a variant means coordinating a release across all consumers.
+//! `Custom { event_type, data }` is the contract-stable escape: chronos can iterate on its
+//! payload shape without coordinating an EventKind rev. When the wake event shape stops
+//! changing (post-M3), graduate to `EventKind::ChronosWake` via a separate aios-protocol PR.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aios_protocol::EventKind;
+use chronos_core::WakeEvent;
+use lago_core::error::LagoError;
+use lago_core::event::EventEnvelope;
+use lago_core::id::{BranchId, EventId, SeqNo, SessionId};
+use lago_core::journal::Journal;
+use tracing::{debug, instrument};
+
+/// Lago `event_type` written for chronos wake events. The kernel does not yet have a typed
+/// variant; this string is the stable identifier downstream consumers (replay, projections,
+/// dashboards) key on.
+pub const CHRONOS_WAKE_EVENT_TYPE: &str = "chronos.wake";
+
+/// Default session id used when a wake event has no `target_session` set. Routed to a
+/// dedicated "system" session so heartbeat noise doesn't pollute real user sessions.
+pub const CHRONOS_SYSTEM_SESSION: &str = "chronos.system";
+
+/// Default branch used when chronosd writes its system-session wakes.
+pub const CHRONOS_DEFAULT_BRANCH: &str = "main";
+
+/// Append a [`WakeEvent`] to the lago journal.
+///
+/// Resolves the target session by precedence:
+///
+/// 1. `event.target_session` if `Some` (converted from `aios_protocol::SessionId` to
+///    `lago_core::id::SessionId` via `from_string`).
+/// 2. `default_session` otherwise.
+///
+/// The branch is always `default_branch` — Chronos M0 doesn't model per-event branching.
+#[instrument(skip(journal, event), fields(
+    chronos.wake.source = event.source.as_str(),
+    chronos.wake.event_id = %event.event_id,
+))]
+pub async fn record_wake(
+    journal: Arc<dyn Journal>,
+    event: &WakeEvent,
+    default_session: &SessionId,
+    default_branch: &BranchId,
+) -> Result<SeqNo, LagoError> {
+    let session_id = match event.target_session.as_ref() {
+        Some(s) => SessionId::from_string(s.as_str()),
+        None => default_session.clone(),
+    };
+
+    let data = serde_json::json!({
+        "event_id": event.event_id.as_str(),
+        "fired_at_unix_ms": event.fired_at_unix_ms,
+        "source": event.source.as_str(),
+        "payload": event.payload,
+        "target_session": event.target_session.as_ref().map(|s| s.as_str()),
+    });
+
+    let envelope = EventEnvelope {
+        event_id: EventId::new(),
+        session_id,
+        branch_id: default_branch.clone(),
+        run_id: None,
+        seq: 0, // assigned by the journal
+        timestamp: EventEnvelope::now_micros(),
+        parent_id: None,
+        payload: EventKind::Custom {
+            event_type: CHRONOS_WAKE_EVENT_TYPE.to_string(),
+            data,
+        },
+        metadata: HashMap::new(),
+        schema_version: 1,
+    };
+
+    let seq = journal.append(envelope).await?;
+    debug!(seq, "chronos.wake appended");
+    Ok(seq)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use aios_protocol::EventKind;
+    use chronos_core::{WakeEvent, WakeSource};
+    use lago_core::id::{BranchId, SessionId};
+    use lago_core::journal::{EventQuery, Journal};
+    use lago_journal::RedbJournal;
+
+    use super::*;
+
+    fn open_journal(dir: &Path) -> Arc<dyn Journal> {
+        Arc::new(RedbJournal::open(dir.join("test.redb")).expect("open redb"))
+            as Arc<dyn Journal>
+    }
+
+    #[tokio::test]
+    async fn record_wake_roundtrips_through_lago() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = open_journal(dir.path());
+        let session = SessionId::from_string(CHRONOS_SYSTEM_SESSION);
+        let branch = BranchId::from_string(CHRONOS_DEFAULT_BRANCH);
+
+        let event = WakeEvent::new(WakeSource::Heartbeat)
+            .with_payload(serde_json::json!({ "interval_ms": 5000_u64 }));
+
+        let seq = record_wake(journal.clone(), &event, &session, &branch)
+            .await
+            .expect("append");
+        assert!(seq > 0, "journal should assign a positive sequence");
+
+        let query = EventQuery::new().session(session.clone()).branch(branch.clone());
+        let stored = journal.read(query).await.expect("read");
+        assert_eq!(stored.len(), 1, "exactly one wake should be persisted");
+
+        match &stored[0].payload {
+            EventKind::Custom { event_type, data } => {
+                assert_eq!(event_type, CHRONOS_WAKE_EVENT_TYPE);
+                assert_eq!(data["source"], "heartbeat");
+                assert_eq!(data["payload"]["interval_ms"], 5000);
+                assert_eq!(data["event_id"], event.event_id.as_str());
+            }
+            other => panic!("expected EventKind::Custom, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn record_wake_routes_to_target_session_when_set() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = open_journal(dir.path());
+        let fallback = SessionId::from_string(CHRONOS_SYSTEM_SESSION);
+        let branch = BranchId::from_string(CHRONOS_DEFAULT_BRANCH);
+
+        let target = aios_protocol::SessionId::from_string("user-session-xyz");
+        let event = WakeEvent::new(WakeSource::Http).with_target_session(target);
+
+        let _seq = record_wake(journal.clone(), &event, &fallback, &branch)
+            .await
+            .expect("append");
+
+        // The wake should live in the user session, not the fallback.
+        let user_q = EventQuery::new()
+            .session(SessionId::from_string("user-session-xyz"))
+            .branch(branch.clone());
+        let user_events = journal.read(user_q).await.expect("read user session");
+        assert_eq!(user_events.len(), 1, "wake routed to user session");
+
+        let fallback_q = EventQuery::new()
+            .session(fallback.clone())
+            .branch(branch.clone());
+        let fallback_events = journal.read(fallback_q).await.expect("read fallback");
+        assert!(
+            fallback_events.is_empty(),
+            "fallback session should be empty when target_session is set"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_wake_appends_monotonically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = open_journal(dir.path());
+        let session = SessionId::from_string(CHRONOS_SYSTEM_SESSION);
+        let branch = BranchId::from_string(CHRONOS_DEFAULT_BRANCH);
+
+        let mut seqs = Vec::new();
+        for _ in 0..4 {
+            let event = WakeEvent::new(WakeSource::Heartbeat);
+            let seq = record_wake(journal.clone(), &event, &session, &branch)
+                .await
+                .expect("append");
+            seqs.push(seq);
+        }
+
+        for window in seqs.windows(2) {
+            assert!(
+                window[1] > window[0],
+                "sequences must be monotonically increasing: {seqs:?}"
+            );
+        }
+    }
+}

--- a/crates/chronos/chronos-triggers/Cargo.toml
+++ b/crates/chronos/chronos-triggers/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "chronos-triggers"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Wake-trigger implementations for Chronos (heartbeat M0; http/cron/fs/sub-agent in M1+)"
+
+[dependencies]
+chronos-core.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/chronos/chronos-triggers/src/heartbeat.rs
+++ b/crates/chronos/chronos-triggers/src/heartbeat.rs
@@ -1,0 +1,91 @@
+//! [`HeartbeatTrigger`] — the one real trigger in M0.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chronos_core::{WakeEvent, WakeSource, WakeTrigger};
+
+/// Periodic timer-driven trigger.
+///
+/// Sleeps for [`HeartbeatTrigger::interval`] then emits a `WakeSource::Heartbeat` event,
+/// repeating until dropped (or the router closes its receiver). Used as the simplest possible
+/// wake source to exercise the full Chronos pipeline (trigger → router → lago journal) before
+/// real triggers come online.
+///
+/// ## Choosing an interval
+///
+/// - **Dev**: 5–10 seconds is convenient for human-pace debugging.
+/// - **Production**: 60 seconds (or more) avoids journal-noise for the system session.
+/// - **Avoid**: ≤ 1 second — floods the journal and consumes redb compaction budget.
+pub struct HeartbeatTrigger {
+    /// How long between heartbeat fires.
+    pub interval: Duration,
+}
+
+impl HeartbeatTrigger {
+    /// Construct a heartbeat trigger with the supplied interval.
+    pub fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+}
+
+#[async_trait]
+impl WakeTrigger for HeartbeatTrigger {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        tokio::time::sleep(self.interval).await;
+        let payload = serde_json::json!({
+            "interval_ms": self.interval.as_millis() as u64,
+        });
+        Some(WakeEvent::new(WakeSource::Heartbeat).with_payload(payload))
+    }
+
+    fn name(&self) -> &'static str {
+        "heartbeat"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use chronos_core::{WakeSource, WakeTrigger};
+
+    use super::HeartbeatTrigger;
+
+    #[tokio::test]
+    async fn heartbeat_emits_at_configured_interval() {
+        let mut h = HeartbeatTrigger::new(Duration::from_millis(20));
+        let start = std::time::Instant::now();
+        let mut events = Vec::with_capacity(3);
+        for _ in 0..3 {
+            let e = h.next_wake().await.expect("heartbeat emits");
+            events.push(e);
+        }
+        let elapsed = start.elapsed();
+
+        // Each tick takes >= 20ms; 3 ticks take >= 60ms. Allow up to 1s of slack for slow CI.
+        assert!(
+            elapsed >= Duration::from_millis(60),
+            "heartbeat fired too quickly: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "heartbeat fired too slowly: {elapsed:?}"
+        );
+
+        for e in &events {
+            assert_eq!(e.source, WakeSource::Heartbeat);
+            assert_eq!(e.payload["interval_ms"], 20);
+            assert!(e.fired_at_unix_ms > 0);
+        }
+        // Each event id should be unique.
+        assert_ne!(events[0].event_id, events[1].event_id);
+        assert_ne!(events[1].event_id, events[2].event_id);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_trigger_name_is_stable() {
+        let h = HeartbeatTrigger::new(Duration::from_millis(10));
+        assert_eq!(h.name(), "heartbeat");
+    }
+}

--- a/crates/chronos/chronos-triggers/src/lib.rs
+++ b/crates/chronos/chronos-triggers/src/lib.rs
@@ -1,0 +1,25 @@
+//! Wake-trigger implementations for Chronos.
+//!
+//! M0 ships [`HeartbeatTrigger`] (a periodic timer) and stub placeholders for the other
+//! source types. Stubs implement [`chronos_core::WakeTrigger`] but return `None` from
+//! `next_wake` — they're present so the [`chronos_core::WakeRouter`] can be wired with
+//! every taxonomy variant from day one, without breaking the trait once real impls land.
+//!
+//! ## Per-milestone roadmap
+//!
+//! - **M0** (this crate, today): [`HeartbeatTrigger`], stubs for the rest.
+//! - **M1**: real [`HttpTrigger`] backed by an axum server in `chronos-api`.
+//! - **M3**: real [`FsWatchTrigger`] (via the `notify` crate) and `SubAgentReturnTrigger`.
+//! - **Beyond**: cron, webhook, threshold.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod heartbeat;
+mod stubs;
+
+pub use heartbeat::HeartbeatTrigger;
+pub use stubs::{
+    CronTriggerStub, FsWatchTriggerStub, HttpTriggerStub, SubAgentReturnTriggerStub,
+    ThresholdTriggerStub, WebhookTriggerStub,
+};

--- a/crates/chronos/chronos-triggers/src/stubs.rs
+++ b/crates/chronos/chronos-triggers/src/stubs.rs
@@ -1,0 +1,116 @@
+//! Stub trigger implementations for taxonomy variants not yet implemented in M0.
+//!
+//! Each stub implements [`chronos_core::WakeTrigger`] but returns `None` from `next_wake`,
+//! which causes the router to drop it cleanly. They exist so chronosd can be wired with the
+//! full taxonomy from day one — when a real implementation arrives, swap the stub for the
+//! real type at the call site without touching the router.
+
+use async_trait::async_trait;
+use chronos_core::{WakeEvent, WakeTrigger};
+
+/// HTTP wake-trigger placeholder. Real impl in M1 backed by `chronos-api`.
+pub struct HttpTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for HttpTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "http (stub)"
+    }
+}
+
+/// Cron expression-driven wake-trigger placeholder. Real impl beyond M3 via `tokio-cron-scheduler`.
+pub struct CronTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for CronTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "cron (stub)"
+    }
+}
+
+/// Filesystem-watch wake-trigger placeholder. Real impl in M3 via the `notify` crate.
+pub struct FsWatchTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for FsWatchTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "fs_watch (stub)"
+    }
+}
+
+/// Sub-agent return wake-trigger placeholder. Real impl in M3 — listens for `agent.completed`
+/// lago events and fires wakes on the parent session's agenda.
+pub struct SubAgentReturnTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for SubAgentReturnTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "sub_agent_return (stub)"
+    }
+}
+
+/// Metric-threshold wake-trigger placeholder. Real impl beyond M3 — fires when a configured
+/// metric crosses a threshold (e.g. Nous score < 0.3 → wake "review" agent).
+pub struct ThresholdTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for ThresholdTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "threshold (stub)"
+    }
+}
+
+/// External webhook wake-trigger placeholder. Real impl beyond M3 — signature-validated
+/// HTTPS endpoint exposed via `chronos-api`.
+pub struct WebhookTriggerStub;
+
+#[async_trait]
+impl WakeTrigger for WebhookTriggerStub {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "webhook (stub)"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn every_stub_returns_none() {
+        let stubs: Vec<Box<dyn WakeTrigger>> = vec![
+            Box::new(HttpTriggerStub),
+            Box::new(CronTriggerStub),
+            Box::new(FsWatchTriggerStub),
+            Box::new(SubAgentReturnTriggerStub),
+            Box::new(ThresholdTriggerStub),
+            Box::new(WebhookTriggerStub),
+        ];
+        for mut s in stubs {
+            assert!(s.next_wake().await.is_none(), "stub {} returned Some", s.name());
+        }
+    }
+}

--- a/crates/chronos/chronos-triggers/src/stubs.rs
+++ b/crates/chronos/chronos-triggers/src/stubs.rs
@@ -110,7 +110,11 @@ mod tests {
             Box::new(WebhookTriggerStub),
         ];
         for mut s in stubs {
-            assert!(s.next_wake().await.is_none(), "stub {} returned Some", s.name());
+            assert!(
+                s.next_wake().await.is_none(),
+                "stub {} returned Some",
+                s.name()
+            );
         }
     }
 }

--- a/crates/chronos/chronosd/Cargo.toml
+++ b/crates/chronos/chronosd/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "chronosd"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Chronos daemon — the temporal substrate of the Life Agent OS"
+
+[lib]
+name = "chronosd"
+path = "src/lib.rs"
+
+[[bin]]
+name = "chronosd"
+path = "src/main.rs"
+
+[dependencies]
+aios-protocol.workspace = true
+chronos-core.workspace = true
+chronos-triggers.workspace = true
+chronos-lago.workspace = true
+lago-core.workspace = true
+lago-journal.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/chronos/chronosd/src/lib.rs
+++ b/crates/chronos/chronosd/src/lib.rs
@@ -1,0 +1,232 @@
+//! chronosd — daemon library.
+//!
+//! The thin `main.rs` parses CLI args and calls into [`run`]. Splitting the runtime into a
+//! library function mirrors the haimad / autonomicd convention and lets the test suite exercise
+//! the daemon's setup/shutdown path without spawning a subprocess.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chronos_core::{WakeRouter, WakeTrigger};
+use chronos_lago::{CHRONOS_DEFAULT_BRANCH, CHRONOS_SYSTEM_SESSION, record_wake};
+use chronos_triggers::HeartbeatTrigger;
+use lago_core::id::{BranchId, SessionId};
+use lago_core::journal::Journal;
+use lago_journal::RedbJournal;
+use tokio::sync::oneshot;
+use tracing::{info, warn};
+
+/// All configuration the daemon needs to start. Built from CLI / config-file in `main.rs`.
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    /// Heartbeat tick interval. Default 10s (dev); 60s recommended for production.
+    pub heartbeat_interval: Duration,
+    /// Directory containing the lago redb journal. Will be created if it doesn't exist.
+    pub data_dir: PathBuf,
+    /// Optional explicit lago file name within `data_dir`. Defaults to `journal.redb`.
+    pub journal_filename: String,
+    /// Internal mpsc capacity for the [`WakeRouter`].
+    pub router_buffer: usize,
+}
+
+impl DaemonConfig {
+    /// Resolve the journal redb file path inside the data directory.
+    pub fn journal_path(&self) -> PathBuf {
+        self.data_dir.join(&self.journal_filename)
+    }
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: Duration::from_secs(10),
+            data_dir: PathBuf::from("/tmp/chronosd"),
+            journal_filename: "journal.redb".to_string(),
+            router_buffer: 64,
+        }
+    }
+}
+
+/// Run the daemon. Returns when the shutdown signal fires AND the router drains.
+///
+/// `shutdown` is an optional oneshot receiver. When `Some`, the caller can trigger a clean
+/// shutdown programmatically (used by tests). When `None`, the daemon installs SIGTERM/SIGINT
+/// handlers and shuts down on those instead.
+pub async fn run(config: DaemonConfig, shutdown: Option<oneshot::Receiver<()>>) -> Result<()> {
+    info!(
+        heartbeat_seconds = config.heartbeat_interval.as_secs(),
+        data_dir = %config.data_dir.display(),
+        journal = %config.journal_filename,
+        "chronosd starting"
+    );
+
+    // 1. Materialize data directory + lago journal.
+    std::fs::create_dir_all(&config.data_dir)
+        .with_context(|| format!("creating data dir {}", config.data_dir.display()))?;
+    let journal_path = config.journal_path();
+    let journal: Arc<dyn Journal> = Arc::new(
+        RedbJournal::open(&journal_path)
+            .with_context(|| format!("opening redb journal at {}", journal_path.display()))?,
+    );
+
+    // 2. Default session/branch the daemon writes its system wakes into.
+    let fallback_session = SessionId::from_string(CHRONOS_SYSTEM_SESSION);
+    let branch = BranchId::from_string(CHRONOS_DEFAULT_BRANCH);
+
+    // 3. Build the router. M0 only wires the heartbeat trigger; the stubs are deliberately
+    //    NOT added — they'd just return None immediately and confuse the trace.
+    let mut router = WakeRouter::new(config.router_buffer);
+    let heartbeat: Box<dyn WakeTrigger> =
+        Box::new(HeartbeatTrigger::new(config.heartbeat_interval));
+    router.add_trigger(heartbeat);
+
+    // 4. Shutdown plumbing.
+    let mut shutdown_rx = shutdown;
+
+    // 5. Main loop.
+    let mut wake_count = 0_u64;
+    loop {
+        tokio::select! {
+            event = router.next_wake() => {
+                let Some(event) = event else {
+                    warn!("router exhausted; exiting main loop");
+                    break;
+                };
+                match record_wake(journal.clone(), &event, &fallback_session, &branch).await {
+                    Ok(seq) => {
+                        wake_count += 1;
+                        info!(
+                            seq,
+                            wake_total = wake_count,
+                            source = event.source.as_str(),
+                            "wake recorded"
+                        );
+                    }
+                    Err(err) => {
+                        warn!(error = %err, "failed to record wake; continuing");
+                    }
+                }
+            }
+            _ = wait_for_shutdown(&mut shutdown_rx) => {
+                info!(wake_total = wake_count, "shutdown signal received");
+                break;
+            }
+        }
+    }
+
+    // 6. Drain the router. Bounded — shutdown should complete in well under 2 seconds.
+    router.shutdown().await;
+    info!(wake_total = wake_count, "chronosd shut down cleanly");
+    Ok(())
+}
+
+/// Wait for either the supplied programmatic shutdown receiver to fire OR an OS signal
+/// (SIGTERM / SIGINT on Unix; Ctrl-C on Windows). Returns when any of them resolves.
+async fn wait_for_shutdown(programmatic: &mut Option<oneshot::Receiver<()>>) {
+    // If a programmatic shutdown channel is configured, use it; otherwise fall through to
+    // the OS signal handlers.
+    if let Some(rx) = programmatic.as_mut() {
+        let _ = rx.await;
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "failed to install SIGTERM handler; falling back to ctrl-c");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "failed to install SIGINT handler; falling back to ctrl-c");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => info!("SIGTERM received"),
+            _ = sigint.recv() => info!("SIGINT received"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        info!("ctrl-c received");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use lago_core::id::{BranchId, SessionId};
+    use lago_core::journal::{EventQuery, Journal};
+    use tokio::sync::oneshot;
+    use tokio::time::sleep;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn daemon_starts_writes_a_heartbeat_and_shuts_down_on_signal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = DaemonConfig {
+            heartbeat_interval: Duration::from_millis(40),
+            data_dir: tmp.path().to_path_buf(),
+            journal_filename: "journal.redb".into(),
+            router_buffer: 16,
+        };
+
+        let (tx, rx) = oneshot::channel();
+        let cfg_for_task = cfg.clone();
+        let daemon = tokio::spawn(async move { run(cfg_for_task, Some(rx)).await });
+
+        // Let the daemon emit a handful of heartbeats.
+        sleep(Duration::from_millis(200)).await;
+        tx.send(()).expect("signal shutdown");
+
+        let started_at = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(2), daemon)
+            .await
+            .expect("daemon shutdown within 2s")
+            .expect("daemon task ok")
+            .expect("daemon run ok");
+        let elapsed = started_at.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "shutdown took too long: {elapsed:?}"
+        );
+
+        // Read the journal back and confirm at least one chronos.wake landed.
+        let journal: Arc<dyn Journal> =
+            Arc::new(RedbJournal::open(cfg.journal_path()).expect("reopen redb"))
+                as Arc<dyn Journal>;
+        let query = EventQuery::new()
+            .session(SessionId::from_string(CHRONOS_SYSTEM_SESSION))
+            .branch(BranchId::from_string(CHRONOS_DEFAULT_BRANCH));
+        let events = journal.read(query).await.expect("read");
+        assert!(
+            !events.is_empty(),
+            "at least one heartbeat wake should be persisted"
+        );
+        for envelope in &events {
+            match &envelope.payload {
+                aios_protocol::EventKind::Custom { event_type, data } => {
+                    assert_eq!(event_type, chronos_lago::CHRONOS_WAKE_EVENT_TYPE);
+                    assert_eq!(data["source"], "heartbeat");
+                }
+                other => panic!("expected EventKind::Custom, got {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/chronos/chronosd/src/main.rs
+++ b/crates/chronos/chronosd/src/main.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
-use clap::Parser;
 use chronosd::{DaemonConfig, run};
+use clap::Parser;
 
 /// CLI surface for `chronosd`. See `chronosd --help` for the rendered version.
 #[derive(Debug, Parser)]
@@ -28,7 +28,11 @@ struct Cli {
     data_dir: PathBuf,
 
     /// File name (within `--data-dir`) for the redb journal.
-    #[arg(long, default_value = "journal.redb", env = "CHRONOSD_JOURNAL_FILENAME")]
+    #[arg(
+        long,
+        default_value = "journal.redb",
+        env = "CHRONOSD_JOURNAL_FILENAME"
+    )]
     journal_filename: String,
 
     /// Mpsc buffer capacity for the [`chronos_core::WakeRouter`]. Larger values absorb

--- a/crates/chronos/chronosd/src/main.rs
+++ b/crates/chronos/chronosd/src/main.rs
@@ -1,0 +1,64 @@
+//! chronosd — Chronos daemon binary.
+//!
+//! Thin CLI front-end. All runtime logic lives in [`chronosd`] the library; see
+//! `src/lib.rs`.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use chronosd::{DaemonConfig, run};
+
+/// CLI surface for `chronosd`. See `chronosd --help` for the rendered version.
+#[derive(Debug, Parser)]
+#[command(
+    name = "chronosd",
+    about = "Chronos daemon — the temporal substrate of the Life Agent OS",
+    version
+)]
+struct Cli {
+    /// Heartbeat tick interval in seconds. Default 10. Use 60+ in production to keep
+    /// the system-session journal quiet.
+    #[arg(long, default_value_t = 10, env = "CHRONOSD_HEARTBEAT_SECONDS")]
+    heartbeat_seconds: u64,
+
+    /// Directory holding the lago redb journal. Created on startup if missing.
+    #[arg(long, default_value = "/tmp/chronosd", env = "CHRONOSD_DATA_DIR")]
+    data_dir: PathBuf,
+
+    /// File name (within `--data-dir`) for the redb journal.
+    #[arg(long, default_value = "journal.redb", env = "CHRONOSD_JOURNAL_FILENAME")]
+    journal_filename: String,
+
+    /// Mpsc buffer capacity for the [`chronos_core::WakeRouter`]. Larger values absorb
+    /// trigger bursts; smaller values surface backpressure faster.
+    #[arg(long, default_value_t = 64, env = "CHRONOSD_ROUTER_BUFFER")]
+    router_buffer: usize,
+}
+
+impl From<Cli> for DaemonConfig {
+    fn from(cli: Cli) -> Self {
+        DaemonConfig {
+            heartbeat_interval: Duration::from_secs(cli.heartbeat_seconds.max(1)),
+            data_dir: cli.data_dir,
+            journal_filename: cli.journal_filename,
+            router_buffer: cli.router_buffer.max(1),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Standard tracing setup: env-filter for selective verbosity, compact event formatting.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .init();
+
+    let cli = Cli::parse();
+    let config: DaemonConfig = cli.into();
+    run(config, None).await
+}

--- a/docs/testing/harness/runs/2026-05-13-chronos-m0.md
+++ b/docs/testing/harness/runs/2026-05-13-chronos-m0.md
@@ -1,0 +1,301 @@
+---
+tags:
+  - broomva
+  - life
+  - testing
+  - harness
+  - run-report
+  - chronos
+  - temporality
+  - m0
+type: run-report
+status: complete
+created: 2026-05-13
+plan: docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md
+worktree: ../life-chronos-m0
+branch: feat/chronos-m0
+base: a048510f (main)
+---
+
+# Run Report — Chronos M0 — 2026-05-13 — feat/chronos-m0
+
+> Scaffold of the **Chronos** temporal primitive — the fifth Life substrate (alongside
+> anima, lago, autonomic, vigil) and the answer to "when should an agent wake?". M0
+> ships the four foundational crates + the daemon binary writing `chronos.wake` events
+> to lago, end-to-end verified by a live 16-second daemon run. M1–M3 are queued per
+> the plan.
+
+## What shipped
+
+| Crate | LOC | Tests | Role |
+|-------|----:|------:|------|
+| `chronos-core` | ~315 | 8 | `WakeEvent` / `WakeSource` / `WakeTrigger` trait / `WakeRouter` mpsc multiplexer / `now_unix_ms` |
+| `chronos-triggers` | ~210 | 3 | `HeartbeatTrigger` (real) + 6 stub triggers (`Http`/`Cron`/`FsWatch`/`SubAgentReturn`/`Threshold`/`Webhook`) |
+| `chronos-lago` | ~195 | 3 | `record_wake` → `EventEnvelope { payload: Custom { event_type: "chronos.wake", … } }` + namespace constants |
+| `chronosd` | ~225 | 1 | Daemon binary (lib + bin split like haimad). Clap CLI, tokio runtime, SIGTERM/SIGINT handlers, oneshot test shutdown |
+| `chronos/CLAUDE.md` | ~160 | — | Per-crate instructions in the established Anima/Haima style |
+| `scripts/architecture/verify_dependencies_chronos.sh` | ~95 | — | Cargo-metadata-based dep audit (4 source crates × allowed set) |
+
+Plus 7 lines added to workspace `Cargo.toml` (4 `members` + 3 `[workspace.dependencies]`).
+**No existing-crate source files modified** — change is strictly additive.
+
+Total new LOC: **~1,200**. Total new tests: **15 chronos + 0 regressions**.
+
+### Files touched
+
+```
+crates/chronos/                                         ← all new
+├── CLAUDE.md
+├── chronos-core/
+│   ├── Cargo.toml
+│   └── src/{lib,wake,trigger,router,error}.rs
+├── chronos-triggers/
+│   ├── Cargo.toml
+│   └── src/{lib,heartbeat,stubs}.rs
+├── chronos-lago/
+│   ├── Cargo.toml
+│   └── src/lib.rs
+└── chronosd/
+    ├── Cargo.toml
+    └── src/{lib,main}.rs
+scripts/architecture/verify_dependencies_chronos.sh    ← new
+Cargo.toml                                              ← edited (members + workspace.deps)
+Cargo.lock                                              ← regenerated (chronos crates resolved)
+```
+
+## Acceptance criteria — all green
+
+| Plan check | Status | Evidence |
+|---|---|---|
+| `cargo build -p chronosd` (debug) succeeds | ✅ | First-time worktree build, 2m17s. Compiles aios-protocol → chronos-core → lago-core → chronos-triggers → lago-journal → chronos-lago → chronosd. |
+| `cargo build -p chronosd --release` succeeds | ✅ | 34.83s release-profile build. Binary at `.target/release/chronosd` (3.6MB). |
+| `cargo test -p chronos-*` passes | ✅ | 15/15 tests green: chronos-core 8, chronos-triggers 3, chronos-lago 3, chronosd 1. All four crates plus doc-tests. |
+| `cargo clippy -p chronos-* --lib --bins --tests -- -D warnings` clean | ✅ | One let-binding lint fixed in chronosd's lib test (clippy::let_unit_value); workspace lint config inherited via `[lints] workspace = true`. |
+| Heartbeat unit test asserts interval semantics | ✅ | `chronos_triggers::heartbeat::tests::heartbeat_emits_at_configured_interval` — 3 events at 20ms interval, asserts elapsed ≥ 60ms, payload contains `interval_ms`, ids unique. |
+| Lago roundtrip test | ✅ | `chronos_lago::tests::record_wake_roundtrips_through_lago` — opens `RedbJournal`, appends a wake, reads back, asserts `EventKind::Custom { event_type: "chronos.wake", data }` shape. |
+| Daemon integration (clean startup + shutdown) | ✅ | `chronosd::tests::daemon_starts_writes_a_heartbeat_and_shuts_down_on_signal` — spawns the daemon, drives 200ms, signals shutdown via oneshot, asserts shutdown < 2s, reopens redb, confirms `chronos.wake` events present. |
+| `verify_dependencies_chronos.sh` passes | ✅ | Cargo-metadata-based audit: chronos-core → aios-protocol only; chronos-triggers → chronos-core only; chronos-lago → chronos-core + aios-protocol + lago-core; chronosd → chronos-* + aios-protocol + lago-core + lago-journal. |
+| Running `chronosd --heartbeat-seconds 5 --data-dir /tmp/...` produces a `chronos.wake` lago event every 5s | ✅ | **Live 16s run** at `/tmp/chronos-smoke-20260513-094018/`: 3 events recorded at `t=5s, 10s, 15s` after start (timestamps 14:40:24, :29, :34). See journal dump below. |
+| `lago log` / `lago replay` shows events with monotonic seq | ✅ | `lago log` shows 3 events with `seq 1, 2, 3`, all `type: Custom(chronos.wake)`, `branch: main`, expected payload shape. `lago replay` shows `<root> seq 1..3` (0 spawns — correct, since chronos M0 doesn't emit `spawn_agent`). |
+| SIGTERM clean shutdown ≤ 2s | ✅ | **Live measurement: 0.046s** (sub-50ms). Logs: `SIGTERM received` → `shutdown signal received wake_total=3` → `chronosd shut down cleanly wake_total=3`. |
+| `cargo build --workspace` (regression) | ✅ | 1m19s with warm cache. All 125 workspace members compile. |
+| Existing tests across `arcan`, `arcand`, `aios-runtime`, `praxis-skills`, `praxis-tools`, `arcan-praxis` still pass | ✅ | **315/315 tests green, 0 regressions.** Counts: arcand 122 + arcan 57 + arcan-praxis 25 + praxis-skills 17 + praxis-tools 33 + plus assorted sub-modules across `arcan`'s integration tree (15, 16, 10, 4, 3, 3, 10, 0). Plan referenced "264 tests on yesterday's dirty WIP"; on `main` (where this worktree lives) the count is 315 — either way no chronos-induced regressions. |
+
+### Live smoke evidence (verbatim daemon stdout)
+
+```
+2026-05-13T14:40:19.030Z INFO chronosd: chronosd starting heartbeat_seconds=5 data_dir=/tmp/chronos-smoke-20260513-094018 journal=journal.redb
+2026-05-13T14:40:19.046Z INFO chronos_core::router: trigger started trigger="heartbeat"
+2026-05-13T14:40:24.100Z INFO chronosd: wake recorded seq=1 wake_total=1 source="heartbeat"
+2026-05-13T14:40:29.055Z INFO chronosd: wake recorded seq=2 wake_total=2 source="heartbeat"
+2026-05-13T14:40:34.061Z INFO chronosd: wake recorded seq=3 wake_total=3 source="heartbeat"
+2026-05-13T14:40:34.779Z INFO chronosd: SIGTERM received
+2026-05-13T14:40:34.780Z INFO chronosd: shutdown signal received wake_total=3
+2026-05-13T14:40:34.780Z INFO chronosd: chronosd shut down cleanly wake_total=3
+```
+
+### Journal dump via `lago log`
+
+```
+seq 1  01KRGWG7ZGYS8KZ732C1C5GRKE  [1778683224.048]
+  branch: main
+  type:   Custom(chronos.wake)
+  data:   {
+    "event_id": "01KRGWG7ZGKCZGMPYGQV231VQC",
+    "fired_at_unix_ms": 1778683224048,
+    "payload": { "interval_ms": 5000 },
+    "source": "heartbeat",
+    "target_session": null
+  }
+
+seq 2  01KRGWGCVV9DFKHQE6TJSNRQKR  [1778683229.051]
+  branch: main
+  type:   Custom(chronos.wake)
+  data:   { event_id: 01KRGWGCVVBKR4CBV94YR8703S, fired_at_unix_ms: 1778683229051, source: "heartbeat", … }
+
+seq 3  01KRGWGHR53WS7CFQ0RE3WMVH6  [1778683234.053]
+  branch: main
+  type:   Custom(chronos.wake)
+  data:   { event_id: 01KRGWGHR5BVY1K4XYTZ8HYFKN, fired_at_unix_ms: 1778683234053, source: "heartbeat", … }
+
+--- 3 event(s) ---
+```
+
+The plan literally specified `lago replay --tree`; that subcommand IS specific to
+spawn_agent recursion trees (see its `--help`: "Reads the session's `ergon.stream`
+events"). For chronos.wake events the right tool is `lago log` (also re-confirmed
+by the replay output `<root> seq 1..3` showing the same monotonic sequence). M2 will
+emit `spawn_agent` events from wake handoff into the kernel and at that point
+`lago replay --tree` will start showing chronos→kernel→agent trees naturally.
+
+## Mid-session events worth recording
+
+### Two small fixes during build
+
+Two minor issues surfaced during the first compile and were resolved without
+re-architecting:
+
+1. **`EventKind` namespace** — I'd initially imported it from `lago_core::event` (where
+   the autonomic publisher seemed to suggest it lived); compiler corrected: it lives in
+   `aios_protocol::EventKind`. Lago's `EventEnvelope` struct uses
+   `aios_protocol::EventKind` for its `payload` field. Fixed via two `use` edits in
+   `chronos-lago/src/lib.rs` and `chronosd/src/lib.rs` + adding
+   `aios-protocol.workspace = true` to chronosd's Cargo.toml.
+2. **`EventId::new_uuid()` doesn't exist on lago-core's typed_id** — autonomic uses
+   `EventId::new()` (which generates a ULID via the lago-core macro). Changed.
+
+Both were trivial; total mid-session churn was ~5 minutes including re-build.
+
+### Disk pressure → external clean → resume
+
+Halfway through verification the root volume hit 100% (119Mi free of 460Gi), caused by
+~44G of accumulated `.target/` artifacts across three concurrent Life worktrees:
+
+- 14G `/Users/broomva/broomva/core/life/.target` (parent tree)
+- 18G `/Users/broomva/broomva/core/life/.worktrees/lumen-phase-alpha-m7-w/.target` (another active branch — left untouched)
+- 12G `/Users/broomva/broomva/core/life-chronos-m0/.target` (this worktree's build, preserved)
+
+`cargo check`, `df`, even file writes started failing with `ENOSPC`. Per the
+executing-plans skill's "stop when blocked" rule, I surfaced the constraint and the
+user ran `rm -rf /Users/broomva/broomva/core/life/.target` (the safest target — the
+parent tree's WIP lives in source files, not build artifacts). After cleanup the
+disk dropped to 27% used and verification resumed: workspace rebuild (1m19s),
+regression tests (315/315), live smoke (0.046s shutdown), `lago log` confirmation.
+
+**Lesson for future worktree-driven sessions**: long-lived worktrees with their own
+`.target/` directories accumulate quickly; `p9 janitor` doesn't sweep target dirs.
+Worth considering a small `bstack target-clean` recipe that, after a merge, cleans
+the merged worktree's `.target/` automatically.
+
+## Architectural decisions baked into M0
+
+These are the decisions M1+ inherits; documented here so the next session doesn't
+relitigate them.
+
+1. **`WakeTrigger` uses `async_trait` for object-safety.** Native `async fn` in trait
+   is stable in Rust 2024 but not always object-safe — `Box<dyn WakeTrigger>` in
+   `WakeRouter` requires the boxed-future form. Mirrors the autonomic subscriber
+   pattern. Boxing cost is negligible at chronos's wake rate (≤ 100/sec).
+2. **`WakeRouter` is mpsc-channel-based.** Triggers run as separate tokio tasks that
+   forward into a shared receiver. Lets HeartbeatTrigger (sleep-then-emit),
+   HttpTrigger (await-on-server), and FsWatchTrigger (await-on-notify) all run
+   concurrently without serializing through the trait's `&mut self` receiver. Tests
+   in `chronos_core::router::tests` (`router_drains_a_single_trigger`,
+   `router_multiplexes_two_triggers`, `router_shutdown_drains_and_returns_none`)
+   validate concurrent + shutdown semantics.
+3. **`WakeEvent.target_session` is `Option<aios_protocol::SessionId>`.** Conversion to
+   `lago_core::id::SessionId` happens in `chronos-lago::record_wake` via
+   `SessionId::from_string(s.as_str())`. Both are `String`-newtype `typed_id!`
+   outputs but distinct nominal types per their respective crates.
+4. **Wakes without a target session land in `chronos.system` / `main`.** Keeps
+   heartbeat noise out of real user sessions; remains queryable via
+   `lago log --session chronos.system`. Constants exposed by `chronos-lago` so M1+
+   doesn't drift.
+5. **`EventKind::Custom { event_type: "chronos.wake", data }` — NOT a typed variant.**
+   Mirrors autonomic (`autonomic.*`) and haima (`finance.*`). Promote to
+   `EventKind::ChronosWake` via a separate aios-protocol PR after M2-M3 stabilizes
+   the payload shape (plan §"Constraints" #2). The kernel-level enum is an L0
+   contract surface; we don't churn it every time a substrate iterates.
+6. **`chronosd` is lib + bin split.** Matches haimad/autonomicd convention; lets the
+   test suite exercise the full daemon lifecycle without spawning a subprocess.
+   Programmatic shutdown via `Option<oneshot::Receiver<()>>` — production passes
+   `None`, tests pass `Some(rx)`. Same code path; identical `wait_for_shutdown`.
+7. **CLI: `--heartbeat-seconds` not `--heartbeat 5s`.** Avoided adding a new
+   workspace dep (`humantime`) for a single string-parse use case. Documented in the
+   plan-vs-shipped delta below; trivially upgradable when M3+ needs duration parsing
+   for cron expressions.
+8. **`tokio` feature surface** carefully scoped per crate:
+   - `chronos-core`: `sync` (mpsc), `rt` + `macros` + `time` (tests need them)
+   - `chronos-triggers`: same plus heartbeat's `time::sleep`
+   - `chronos-lago`: no tokio direct (just async via `Journal::append`)
+   - `chronosd`: full daemon set (`signal`, `time`, `sync`, `rt-multi-thread`, `macros`)
+
+## Plan-vs-shipped delta
+
+The plan was followed end-to-end with three minor adjustments:
+
+| Plan | Shipped | Why |
+|------|---------|-----|
+| `chronosd --heartbeat 5s` (humantime parsing) | `chronosd --heartbeat-seconds 5` (u64) | Avoided new workspace dep for a single flag. Trivial to add `humantime` later. |
+| Plan reference: "MSRV 1.85" | Workspace MSRV is `1.93` | Plan's reference was stale; chronos uses workspace MSRV via `rust-version.workspace = true`. |
+| Plan literal: `lago replay --tree` | `lago log` + `lago replay` (no --tree flag option) | `replay --tree` is specifically for `spawn_agent` recursion trees (lago replay --help). `lago log` is the right command for general events and is shown in the journal dump above. `lago replay` (without --tree) confirms the same seq range. |
+
+No other deviations. The architectural intent (continuity is in state, chronos
+coordinates wakes does not run agents, every wake journals) is preserved.
+
+## What M1 inherits
+
+The trait surface and event shape are sufficient to wire M1 without further core
+churn:
+
+- **M1 (agenda store + HTTP wake):** add `AgendaStore` trait + `LagoAgendaStore` impl
+  in chronos-lago; new `crates/chronos/chronos-api` axum crate; promote
+  `HttpTriggerStub` to a real impl that forwards from a `POST /v1/wake` handler.
+- **M2 (kernel handoff):** wire `WakeRouter::next_wake()` → `kernel.dispatch(...)` in
+  arcand's startup; add `KernelDispatcher` trait in chronos-core; arcand implements
+  it as a thin wrapper around `canonical::run_session`.
+- **M3 (fs + sub-agent triggers):** swap `FsWatchTriggerStub` for the `notify`-based
+  real impl; subscribe to `agent.completed` lago events for `SubAgentReturnTrigger`.
+
+No M1+ work requires breaking the M0 surface. The `WakeRouter::add_trigger` call site
+is the only place each new trigger registers; everything else composes.
+
+## Sign-off
+
+```
+Patch:                        PASS  (4 new crates, ~1,200 LOC, 15 new tests, additive only)
+Discovery (dep audit):        PASS  (verify_dependencies_chronos.sh green)
+Build (debug + release):      PASS  (chronosd release binary at .target/release/chronosd, 3.6MB)
+Tests (chronos crates):       PASS  (15/15)
+Clippy (-D warnings):         PASS  (one let_unit_value fix mid-session)
+Workspace build:              PASS  (1m19s warm-cache build of all 125 members)
+Regression tests:             PASS  (315/315 across arcan/arcand/aios-runtime/praxis-skills/praxis-tools/arcan-praxis)
+Live smoke (chronosd 16s):    PASS  (3 wakes @ 5s intervals, SIGTERM clean shutdown in 0.046s)
+Journal verification:         PASS  (`lago log` shows monotonic seq 1..3 of Custom(chronos.wake) on chronos.system/main with expected payload)
+
+Signed: Claude
+Date:   2026-05-13
+```
+
+## Next actions
+
+- [ ] Open PR for `feat/chronos-m0` citing this run report.
+- [ ] File Linear tickets for M1 / M2 / M3 (BRO-tbd) per plan §"Bstack primitives" P3.
+- [ ] File the knowledge graph entity page at
+      `~/broomva/research/entities/concept/chronos-temporal-primitive.md` (plan §
+      "Knowledge graph bookkeeping"). Score should be ≥ 7/9 on the Nous gate.
+- [ ] After M1 lands, update workspace CLAUDE.md's "Future Projects" table to move
+      Chronos from "planned" → "scaffolded (M0)" → "active (M1)".
+- [ ] (workspace ops) Consider a `bstack target-clean` recipe that, after a merge,
+      sweeps the merged worktree's `.target/` — would have prevented this session's
+      mid-run disk pressure.
+
+## Replay evidence
+
+- Worktree: `/Users/broomva/broomva/core/life-chronos-m0/` (branch `feat/chronos-m0`, base `a048510f`).
+- Release binary: `.target/release/chronosd`.
+- Smoke journal: `/tmp/chronos-smoke-20260513-094018/journal.redb` (3.6MB redb; minimum page allocation for 3 events).
+- New crates: 4 (chronos-core, chronos-triggers, chronos-lago, chronosd).
+- Tests: 15 new + 315 regression = 330 verified, all passing.
+- Dep-rule script: `scripts/architecture/verify_dependencies_chronos.sh` —
+  `bash scripts/architecture/verify_dependencies_chronos.sh` from the worktree root.
+
+## Bstack primitives invoked this session
+
+- **P10 (Worktree Hygiene):** `git worktree add -b feat/chronos-m0 ../life-chronos-m0 main`. Parent tree's WIP preserved. Clean tree throughout.
+- **P14 (Dependency-Chain Reasoning):** explicit upstream enumeration before each
+  substantive write (aios-protocol → lago-core/journal → workspace deps); downstream
+  empty for M0 (chronos is standalone until M2 kernel handoff).
+- **P15 (State-Snapshot Before Action):** git status / branch / ahead-behind / open
+  PRs surfaced at session start (1 unrelated feature PR + 9 dependabot, no
+  conflicts).
+- **P11 (Empirical Feedback Loop):** live 16s `chronosd` run + `lago log` /
+  `lago replay` against the actual journal, capturing multi-modal evidence
+  (daemon stdout logs + journal contents + shutdown timing) rather than relying on
+  unit tests alone.
+- **P2 (Control Gate):** A `rm -rf /tmp/chronos-smoke` attempt was correctly rejected
+  by the safety protocol mid-session; switched to a timestamped fresh dir
+  (`/tmp/chronos-smoke-20260513-094018`) instead.
+- **P8 (Skill Freshness):** flagged to user at session start (7d overdue); not
+  blocking. User can run `npx skills update -g` + touch the last-update file at
+  leisure.

--- a/scripts/architecture/verify_dependencies_chronos.sh
+++ b/scripts/architecture/verify_dependencies_chronos.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# verify_dependencies_chronos.sh
+#
+# Enforces the chronos crate dependency rules locked by the M0 plan
+# (`docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md` §"Dependency rules").
+#
+#   chronos-core      → aios-protocol ONLY  (no other internal Life crates; tokio/serde/etc OK)
+#   chronos-triggers  → chronos-core ONLY  (depends on chronos-core; no other internal Life crates)
+#   chronos-lago      → chronos-core + aios-protocol + lago-core  (lago-journal allowed for dev only)
+#   chronosd          → chronos-* + aios-protocol + lago-*        (no arcan/autonomic/haima/etc)
+#
+# Dev-dependencies are intentionally exempt — the rules constrain the PRODUCTION dep graph.
+# Mirror this style when adding new substrate primitives (e.g. aegis, nous expansion).
+#
+# Exit code 0 on pass, 1 on rule violation.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_JSON="$(mktemp -t chronos-deps.XXXXXX)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+cargo metadata --format-version 1 > "$TMP_JSON"
+
+python3 - "$TMP_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+# Build {package_name -> [non-dev deps]} from cargo metadata.
+edges = {}
+for pkg in data.get("packages", []):
+    name = pkg["name"]
+    non_dev_deps = sorted({
+        d["name"]
+        for d in pkg.get("dependencies", [])
+        if d.get("kind") not in ("dev",)
+    })
+    edges[name] = non_dev_deps
+
+# Internal-crate detection: prefix-based, matching how the existing
+# verify_dependencies.sh classifies crates.
+INTERNAL_PREFIXES = (
+    "aios-", "lago-", "arcan-", "autonomic-", "praxis-", "haima-",
+    "nous-", "anima-", "ergon", "opsis-", "soma", "vigil", "spaces",
+    "life-", "chronos-", "lifed", "lifegw",
+)
+
+def is_internal(dep):
+    return any(dep == p.rstrip("-") or dep.startswith(p) for p in INTERNAL_PREFIXES)
+
+# Allowed internal dependencies per source crate.
+ALLOWED = {
+    "chronos-core":     {"aios-protocol"},
+    "chronos-triggers": {"chronos-core"},
+    "chronos-lago":     {"chronos-core", "aios-protocol", "lago-core"},
+    "chronosd":         {
+        "chronos-core", "chronos-triggers", "chronos-lago",
+        "aios-protocol", "lago-core", "lago-journal",
+    },
+}
+
+failures = []
+missing = []
+for src, allowed_set in ALLOWED.items():
+    if src not in edges:
+        missing.append(src)
+        continue
+    for dep in edges[src]:
+        if not is_internal(dep):
+            continue
+        if dep in allowed_set:
+            continue
+        failures.append(
+            f"{src} -> {dep} is forbidden "
+            f"(allowed internal deps for {src}: {sorted(allowed_set)})"
+        )
+
+if missing:
+    print(f"chronos dependency audit warning: crates not in cargo metadata: {missing}")
+    # Treat as failure — running the script means the workspace should know about them.
+    print("chronos dependency audit FAILED (missing crates)")
+    sys.exit(1)
+
+if failures:
+    print("chronos dependency audit FAILED:")
+    for f in sorted(set(failures)):
+        print(f"  - {f}")
+    sys.exit(1)
+
+print("chronos dependency audit passed")
+PY


### PR DESCRIPTION
## Summary

Scaffolds **Chronos** — the temporal/scheduling substrate of the Life Agent OS, the fifth substrate primitive alongside anima (identity), lago (memory), autonomic (homeostasis), and vigil (observability). Chronos answers *"when should an agent wake?"* by coalescing wake sources (heartbeat, http, cron, fs, sub-agent return, threshold, webhook) into a unified `WakeEvent` stream the kernel can subscribe to.

M0 ships the four foundational crates + the daemon binary writing `chronos.wake` events to lago, end-to-end verified by a live 16-second daemon run. M1–M3 are queued per `docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md`.

## What ships

- `crates/chronos/chronos-core` — `WakeEvent` / `WakeSource` / `WakeTrigger` trait / `WakeRouter` mpsc multiplexer (8 unit tests)
- `crates/chronos/chronos-triggers` — `HeartbeatTrigger` (real) + 6 stubs for `Http`/`Cron`/`FsWatch`/`SubAgentReturn`/`Threshold`/`Webhook` (3 unit tests)
- `crates/chronos/chronos-lago` — `record_wake` → `EventEnvelope { payload: Custom { event_type: "chronos.wake", … } }` (3 unit tests)
- `crates/chronos/chronosd` — daemon binary, lib+bin split à la `haimad`; clap CLI, tokio runtime, SIGTERM/SIGINT handlers, programmatic oneshot for tests (1 integration test)
- `crates/chronos/CLAUDE.md` — per-crate instructions in the Anima/Haima style
- `scripts/architecture/verify_dependencies_chronos.sh` — dep-rule CI lane:
  - `chronos-core` → `aios-protocol` only
  - `chronos-triggers` → `chronos-core` only
  - `chronos-lago` → + `lago-core` (and `lago-journal` dev-only)
  - `chronosd` → + `lago-journal`
- Workspace `Cargo.toml`: +4 `members`, +3 `[workspace.dependencies]` (additive only; **zero existing-crate `*.rs` sources modified**)

Total: **+1,933 LOC, 0 deletions, 15 new tests, 4 new crates.**

## Architectural decisions baked into M0 (M1+ inherits)

1. `WakeTrigger` uses `async_trait` for object-safety — required for `Box<dyn WakeTrigger>` in the router. Boxing overhead negligible at chronos wake rates (≤100/sec).
2. `WakeRouter` is mpsc-channel-based — each trigger runs as its own tokio task that forwards into a shared receiver, letting heartbeat / http / fs-watch run concurrently without serializing through `&mut self`.
3. `WakeEvent.target_session: Option<aios_protocol::SessionId>` — conversion to `lago_core::id::SessionId` happens in `chronos-lago::record_wake`.
4. Wakes without a target land in `chronos.system / main` — keeps heartbeat noise out of user sessions; remains queryable via `lago log --session chronos.system`.
5. `EventKind::Custom { event_type: "chronos.wake", data }` — mirrors `autonomic.*` and `finance.*`; promote to typed `EventKind::ChronosWake` after M2-M3 stabilizes the payload (separate aios-protocol PR).
6. `chronosd` lib+bin split — matches `haimad`/`autonomicd`; lets the test suite exercise the full daemon lifecycle via `Option<oneshot::Receiver<()>>` instead of spawning subprocesses.

## Plan-vs-shipped delta

- `--heartbeat-seconds 5` instead of `--heartbeat 5s` — avoided new `humantime` workspace dep for one flag; trivially upgradable for M3+ cron expressions.
- `lago log` instead of `lago replay --tree` for the smoke verification — `replay --tree` is specifically for `spawn_agent` recursion trees; chronos M0 emits leaf wakes only. (M2 kernel handoff will start producing trees.)

## Test plan

- [x] `cargo build -p chronosd` debug + release (binary at `.target/release/chronosd`, 3.6 MB)
- [x] `cargo test -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd` — **15/15 green**
- [x] `cargo clippy -p chronos-* --lib --bins --tests -- -D warnings` — clean
- [x] `bash scripts/architecture/verify_dependencies_chronos.sh` — passes
- [x] `cargo build --workspace` — 1m19s, all 125 members compile
- [x] `cargo test -p arcan -p arcand -p aios-runtime -p praxis-skills -p praxis-tools -p arcan-praxis` — **315/315 green, 0 regressions**
- [x] Live 16s smoke: `chronosd --heartbeat-seconds 5 --data-dir /tmp/chronos-smoke-20260513-094018` — 3 wakes recorded at 5s intervals (seq 1/2/3), **SIGTERM clean shutdown in 0.046s** (acceptance ≤ 2s)
- [x] `lago log --session chronos.system --branch main` shows monotonic `Custom(chronos.wake)` events with expected payload shape (`event_id` ULID, `fired_at_unix_ms`, `source: "heartbeat"`, `payload: { interval_ms: 5000 }`, `target_session: null`)

## Reviewer guidance

- Architectural shape (`WakeEvent`, `WakeSource`, `WakeTrigger`, `WakeRouter`) is intended to be M2-stable — please flag anything that would force a breaking change once the kernel handoff lands.
- Stub triggers (`HttpTriggerStub` et al.) are deliberate placeholders — they return `None` so the router shape is exercised but they don't fire. Real impls follow milestone-by-milestone (M1 HTTP, M3 FsWatch + SubAgentReturn, beyond M3 cron/webhook/threshold).
- The Custom-prefix-vs-typed-variant trade-off (point 5 above) is the most opinionated decision; happy to typed-promote earlier if a reviewer prefers.

## Run report

Full run report with empirical evidence, architectural decisions, and mid-session events (including a disk-pressure pause for an external `.target/` clean) at `docs/testing/harness/runs/2026-05-13-chronos-m0.md`.

## What M1 inherits

Trait surface and event shape are sufficient to wire M1 without further core churn:

- **M1**: `AgendaStore` trait + `LagoAgendaStore` impl in chronos-lago; new `crates/chronos/chronos-api` axum crate; promote `HttpTriggerStub` to a real `POST /v1/wake` handler.
- **M2**: wire `WakeRouter::next_wake()` → `kernel.dispatch(...)` in arcand's startup; add `KernelDispatcher` trait in chronos-core.
- **M3**: swap `FsWatchTriggerStub` for `notify`-based real impl; subscribe to `agent.completed` lago events for `SubAgentReturnTrigger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Chronos temporal system with wake event routing and daemon service.
  * Added heartbeat trigger for periodic wake events.
  * Integrated wake events with journal persistence.
  * Added daemon CLI with configurable intervals and data storage.

* **Documentation**
  * Architecture guide for Chronos subsystem.
  * Test run report documenting Chronos M0 release.

* **Chores**
  * Added dependency constraint verification script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1241)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->