### PR TITLE
feat(lifegw): POST /v1/messages Anthropic SSE route [BRO-1142]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6587,6 +6587,7 @@ dependencies = [
  "life-runtime-proto",
  "life-vigil",
  "lifed",
+ "lifegw-anthropic-codec",
  "nix 0.31.2",
  "p256",
  "parking_lot",

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -1,0 +1,407 @@
+//! Anthropic Messages API backed `ArcanCall` for lifed.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use life_runtime_proto::life::v1::{AgentEvent, AgentEventKind, EventRecord};
+use serde::{Deserialize, Serialize};
+
+use crate::client::ArcanCall;
+use crate::error::{ArcanProxyError, ArcanProxyResult};
+
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-5-20250929";
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_HISTORY_MESSAGES: usize = 20;
+
+#[derive(Debug, Clone)]
+pub struct AnthropicArcanConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub model: String,
+    pub max_tokens: u32,
+    pub request_timeout: Duration,
+    pub system_prompt: Option<String>,
+}
+
+impl AnthropicArcanConfig {
+    pub fn from_env() -> ArcanProxyResult<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+            ArcanProxyError::Transport("AnthropicArcan requires ANTHROPIC_API_KEY".to_string())
+        })?;
+        Ok(Self {
+            api_key,
+            base_url: std::env::var("ANTHROPIC_BASE_URL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            model: std::env::var("ANTHROPIC_MODEL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+            max_tokens: std::env::var("ANTHROPIC_MAX_TOKENS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_MAX_TOKENS),
+            request_timeout: std::env::var("LIFED_ARCAN_REQUEST_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+            system_prompt: std::env::var("LIFED_ARCAN_SYSTEM_PROMPT").ok(),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct AnthropicArcan {
+    cfg: Arc<AnthropicArcanConfig>,
+    client: reqwest::Client,
+    history: Arc<Mutex<HashMap<String, Vec<ChatMessage>>>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+impl AnthropicArcan {
+    pub fn new(cfg: AnthropicArcanConfig) -> ArcanProxyResult<Self> {
+        if cfg.api_key.trim().is_empty() {
+            return Err(ArcanProxyError::Transport(
+                "AnthropicArcanConfig.api_key must not be empty".to_string(),
+            ));
+        }
+        let base_url = cfg.base_url.trim_end_matches('/').to_string();
+        if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+            return Err(ArcanProxyError::Transport(format!(
+                "AnthropicArcanConfig.base_url must be http(s):// (got `{}`)",
+                cfg.base_url
+            )));
+        }
+        let client = reqwest::Client::builder()
+            .timeout(cfg.request_timeout)
+            .build()
+            .map_err(|e| ArcanProxyError::Transport(format!("build reqwest client: {e}")))?;
+        Ok(Self {
+            cfg: Arc::new(AnthropicArcanConfig { base_url, ..cfg }),
+            client,
+            history: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    pub fn from_env() -> ArcanProxyResult<Self> {
+        Self::new(AnthropicArcanConfig::from_env()?)
+    }
+
+    fn request_body(&self, sid: &str, content: &str) -> serde_json::Value {
+        let prior = self
+            .history
+            .lock()
+            .ok()
+            .and_then(|h| h.get(sid).cloned())
+            .unwrap_or_default();
+        let mut messages: Vec<serde_json::Value> = prior
+            .into_iter()
+            .map(|m| serde_json::json!({"role": m.role, "content": m.content}))
+            .collect();
+        messages.push(serde_json::json!({"role": "user", "content": content}));
+        let mut body = serde_json::json!({
+            "model": self.cfg.model,
+            "max_tokens": self.cfg.max_tokens,
+            "messages": messages,
+            "stream": true
+        });
+        if let Some(system) = &self.cfg.system_prompt
+            && !system.trim().is_empty()
+        {
+            body["system"] = serde_json::json!(system);
+        }
+        body
+    }
+
+    fn append_exchange(&self, sid: &str, user: String, assistant: String) {
+        let Ok(mut history) = self.history.lock() else {
+            return;
+        };
+        let entry = history.entry(sid.to_string()).or_default();
+        entry.push(ChatMessage {
+            role: "user".to_string(),
+            content: user,
+        });
+        if !assistant.is_empty() {
+            entry.push(ChatMessage {
+                role: "assistant".to_string(),
+                content: assistant,
+            });
+        }
+        if entry.len() > MAX_HISTORY_MESSAGES {
+            entry.drain(0..entry.len() - MAX_HISTORY_MESSAGES);
+        }
+    }
+}
+
+#[async_trait]
+impl ArcanCall for AnthropicArcan {
+    async fn create_agent(&self, sid: &str) -> ArcanProxyResult<String> {
+        Ok(format!("agent-{sid}"))
+    }
+
+    async fn destroy_agent(&self, _sid: &str) -> ArcanProxyResult<()> {
+        Ok(())
+    }
+
+    async fn dispatch_message(
+        &self,
+        sid: &str,
+        content: &str,
+    ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>>
+    {
+        let url = format!("{}/v1/messages", self.cfg.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .header("x-api-key", &self.cfg.api_key)
+            .json(&self.request_body(sid, content))
+            .send()
+            .await
+            .map_err(|e| ArcanProxyError::Transport(format!("POST {url}: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let bytes = resp.bytes().await.unwrap_or_default();
+            return Err(ArcanProxyError::Transport(format!(
+                "POST {url} returned HTTP {status}: {}",
+                truncate(&String::from_utf8_lossy(&bytes), 256)
+            )));
+        }
+        let parsed = parse_sse(
+            resp.bytes_stream(),
+            aios_proto::aios::v1::SessionId {
+                value: sid.to_string(),
+            },
+        );
+        Ok(record_response(
+            parsed,
+            self.clone(),
+            sid.to_string(),
+            content.to_string(),
+        ))
+    }
+}
+
+fn record_response(
+    stream: Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>,
+    arcan: AnthropicArcan,
+    sid: String,
+    user: String,
+) -> Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>> {
+    use futures::stream;
+    Box::pin(stream::unfold(
+        (stream, arcan, sid, user, String::new(), false),
+        |(mut stream, arcan, sid, user, mut assistant, mut recorded)| async move {
+            match stream.next().await {
+                Some(Ok(evt)) => {
+                    if evt.kind() == AgentEventKind::Token
+                        && let Some(record) = evt.record.as_ref()
+                        && let Ok(payload) =
+                            serde_json::from_slice::<serde_json::Value>(&record.payload)
+                        && let Some(text) = payload.get("text").and_then(|v| v.as_str())
+                    {
+                        assistant.push_str(text);
+                    }
+                    if evt.kind() == AgentEventKind::Finish && !recorded {
+                        arcan.append_exchange(&sid, user.clone(), assistant.clone());
+                        recorded = true;
+                    }
+                    Some((Ok(evt), (stream, arcan, sid, user, assistant, recorded)))
+                }
+                Some(Err(err)) => Some((Err(err), (stream, arcan, sid, user, assistant, recorded))),
+                None => {
+                    if !recorded {
+                        arcan.append_exchange(&sid, user, assistant);
+                    }
+                    None
+                }
+            }
+        },
+    ))
+}
+
+fn parse_sse<S>(
+    body: S,
+    session_id: aios_proto::aios::v1::SessionId,
+) -> Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>
+where
+    S: Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    use futures::stream;
+    let body: Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send>> =
+        Box::pin(body);
+    Box::pin(stream::unfold(
+        (body, Vec::new(), 0_u64, false, session_id),
+        |(mut body, mut buffer, mut sequence, done, session_id)| async move {
+            if done {
+                return None;
+            }
+            loop {
+                if let Some(end) = double_newline(&buffer) {
+                    let record =
+                        String::from_utf8_lossy(&buffer.drain(..end + 2).collect::<Vec<_>>())
+                            .to_string();
+                    for line in record.lines() {
+                        let Some(data) = line
+                            .strip_prefix("data: ")
+                            .or_else(|| line.strip_prefix("data:"))
+                        else {
+                            continue;
+                        };
+                        let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) else {
+                            continue;
+                        };
+                        match v.get("type").and_then(|t| t.as_str()) {
+                            Some("content_block_delta") => {
+                                if let Some(text) = v
+                                    .get("delta")
+                                    .and_then(|d| d.get("text"))
+                                    .and_then(|t| t.as_str())
+                                    && !text.is_empty()
+                                {
+                                    sequence += 1;
+                                    return Some((
+                                        Ok(event(
+                                            AgentEventKind::Token,
+                                            "TOKEN",
+                                            &session_id,
+                                            sequence,
+                                            serde_json::json!({"text": text}),
+                                        )),
+                                        (body, buffer, sequence, false, session_id),
+                                    ));
+                                }
+                            }
+                            Some("message_stop") => {
+                                sequence += 1;
+                                return Some((
+                                    Ok(event(
+                                        AgentEventKind::Finish,
+                                        "FINISH",
+                                        &session_id,
+                                        sequence,
+                                        serde_json::json!({"reason": "stop"}),
+                                    )),
+                                    (body, buffer, sequence, true, session_id),
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+                    continue;
+                }
+                match body.next().await {
+                    Some(Ok(chunk)) => buffer.extend_from_slice(&chunk),
+                    Some(Err(err)) => {
+                        return Some((
+                            Err(tonic::Status::internal(format!(
+                                "AnthropicArcan: stream read error: {err}"
+                            ))),
+                            (body, buffer, sequence, true, session_id),
+                        ));
+                    }
+                    None => {
+                        sequence += 1;
+                        return Some((
+                            Ok(event(
+                                AgentEventKind::Finish,
+                                "FINISH",
+                                &session_id,
+                                sequence,
+                                serde_json::json!({"reason": "upstream_closed"}),
+                            )),
+                            (body, buffer, sequence, true, session_id),
+                        ));
+                    }
+                }
+            }
+        },
+    ))
+}
+
+fn event(
+    kind: AgentEventKind,
+    record_kind: &str,
+    session_id: &aios_proto::aios::v1::SessionId,
+    sequence: u64,
+    payload: serde_json::Value,
+) -> AgentEvent {
+    AgentEvent {
+        record: Some(EventRecord {
+            session_id: Some(session_id.clone()),
+            sequence,
+            at: now_timestamp(),
+            kind: record_kind.to_string(),
+            payload: serde_json::to_vec(&payload).unwrap_or_default(),
+        }),
+        kind: kind as i32,
+    }
+}
+
+fn double_newline(buf: &[u8]) -> Option<usize> {
+    buf.windows(2)
+        .enumerate()
+        .find(|(_, w)| *w == b"\n\n")
+        .map(|(i, _)| i)
+}
+
+fn now_timestamp() -> Option<prost_types::Timestamp> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(prost_types::Timestamp {
+        seconds: now.as_secs() as i64,
+        nanos: now.subsec_nanos() as i32,
+    })
+}
+
+fn truncate(s: &str, limit: usize) -> String {
+    if s.len() <= limit {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..limit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn parses_text_delta_and_finish() {
+        let body = b"event: content_block_delta\n\
+                     data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n\
+                     event: message_stop\n\
+                     data: {\"type\":\"message_stop\"}\n\n";
+        let mut s = parse_sse(
+            stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::from(body.to_vec()))]),
+            aios_proto::aios::v1::SessionId { value: "s".into() },
+        );
+        assert_eq!(
+            s.next().await.unwrap().unwrap().kind(),
+            AgentEventKind::Token
+        );
+        assert_eq!(
+            s.next().await.unwrap().unwrap().kind(),
+            AgentEventKind::Finish
+        );
+    }
+}

--- a/crates/life-runtime/arcan-proxy/src/lib.rs
+++ b/crates/life-runtime/arcan-proxy/src/lib.rs
@@ -2,11 +2,16 @@
 
 #![cfg_attr(not(test), deny(unsafe_code))]
 
+pub mod anthropic;
 pub mod client;
 pub mod conversions;
 pub mod error;
 pub mod vercel_ai_gateway;
 
+pub use anthropic::{
+    AnthropicArcan, AnthropicArcanConfig, DEFAULT_BASE_URL as ANTHROPIC_DEFAULT_BASE_URL,
+    DEFAULT_MODEL as ANTHROPIC_DEFAULT_MODEL,
+};
 pub use client::{ArcanCall, ArcanProxy, PoolGuardedStream, Pooled};
 pub use error::{ArcanProxyError, ArcanProxyResult, RetryClass};
 pub use vercel_ai_gateway::{

--- a/crates/life-runtime/lifegw/Cargo.toml
+++ b/crates/life-runtime/lifegw/Cargo.toml
@@ -44,6 +44,11 @@ life-runtime-proto.workspace = true
 # routes. Pulled in as a client-only dep — lifegw never serves the
 # CustodyOracle service, only proxies to it.
 life-kernel-proto.workspace = true
+# Spec J J-Sub-B: Anthropic Messages SSE codec — edge-only codec crate
+# that translates lifed `pb::AgentEvent` streams into Anthropic Messages
+# SSE chunks and validates Anthropic Messages request bodies. Workspace-
+# internal, substrate-free (Spec J L10-D1). Powers `services/anthropic_messages.rs`.
+lifegw-anthropic-codec.workspace = true
 
 # transport — tonic 0.14 + tonic-web for browser-compatible Connect protocol.
 tonic = "0.14"

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -499,14 +499,30 @@ pub async fn serve_with_listener_and_signer(
     };
     let agent_http_router = crate::services::agent_http::router(agent_http_state);
 
+    // Spec J J-Sub-B: Anthropic Messages `POST /v1/messages` SSE route.
+    // Verifies Tier-1, mints Tier-2, synthesizes a deterministic sid
+    // from the caller's anima DID + first user message (codec L10-D2),
+    // and pipes lifed.Agent.{CreateSession, SendMessage, StreamSession}
+    // through the lifegw-anthropic-codec encoder to produce Anthropic-
+    // shape SSE frames. The same `jwks` + `minter` handles wire the rest
+    // of the auth pipeline so token verification + minting are uniform
+    // across `/v1/agent/*` and `/v1/messages`.
+    let anthropic_state = crate::services::anthropic_messages::AnthropicMessagesState {
+        jwks: Arc::clone(&jwks),
+        minter: Arc::clone(&minter),
+        upstream: upstream_channel.clone(),
+    };
+    let anthropic_router = crate::services::anthropic_messages::router(anthropic_state);
+
     // Compose: top-level axum router that nests `/anima/custody/*`,
-    // merges the `/v1/agent/create_session` route, and falls back to
-    // the tonic-stack adapter for everything else (including
-    // `/v1/agent/stream` which the WS layer handles inside the tonic
-    // stack).
+    // merges the `/v1/agent/create_session` + `/v1/messages` routes,
+    // and falls back to the tonic-stack adapter for everything else
+    // (including `/v1/agent/stream` which the WS layer handles inside
+    // the tonic stack).
     let app: axum::Router<()> = axum::Router::new()
         .nest("/anima/custody", anima_router)
         .merge(agent_http_router)
+        .merge(anthropic_router)
         .fallback_service(tonic_stack_adapted);
 
     // Convert the axum router's response body to tonic::body::Body so

--- a/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
+++ b/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
@@ -1,0 +1,893 @@
+//! Anthropic Messages `POST /v1/messages` SSE route — Spec J §J-Sub-B.
+//!
+//! Mounts the Anthropic-compatible Messages endpoint on lifegw so
+//! Claude Code (and any compatible client speaking the Anthropic
+//! Messages wire) can drive a Life agent session over the same
+//! `(Tier-1 → Tier-2 → lifed.Agent.*)` flow the WebSocket route already
+//! uses. The novel surface, vs `services/agent_http.rs`, is the
+//! response body: instead of a unary JSON reply we stream
+//! `text/event-stream` synthesized by [`lifegw_anthropic_codec`].
+//!
+//! # Flow
+//!
+//! ```text
+//! client                                  lifegw                       lifed
+//!   │                                       │                            │
+//!   │  POST /v1/messages                    │                            │
+//!   │  Authorization: Bearer <Tier-1 JWS>   │                            │
+//!   │  anthropic-version: 2023-06-01        │                            │
+//!   │  Content-Type: application/json       │                            │
+//!   │  Body: AnthropicMessagesRequest       │                            │
+//!   ├──────────────────────────────────────▶│                            │
+//!   │                                       │ verify Tier-1              │
+//!   │                                       │ mint Tier-2                │
+//!   │                                       │ synthesize sid             │
+//!   │                                       │  Agent.CreateSession       │
+//!   │                                       ├───────────────────────────▶│
+//!   │                                       │  Agent.SendMessage         │
+//!   │                                       ├───────────────────────────▶│
+//!   │                                       │  Agent.StreamSession       │
+//!   │                                       ├───────────────────────────▶│
+//!   │                                       │  AgentEvent stream         │
+//!   │                                       │◀───────────────────────────┤
+//!   │   text/event-stream                   │ encode via codec           │
+//!   │◀──────────────────────────────────────┤                            │
+//! ```
+//!
+//! # Locked-decision wiring (Spec J §[Locked Decisions])
+//!
+//! - **L10-D1**: lifegw uses `lifegw_anthropic_codec` (workspace-internal
+//!   crate, no substrate deps). `arcan-proxy::AnthropicArcan` is the
+//!   adapter on lifed's south side — not pulled by this route.
+//! - **L10-D2**: sid synthesis goes through
+//!   [`lifegw_anthropic_codec::synthesize_sid`]. The function takes the
+//!   parsed request + the caller's anima DID and produces a deterministic
+//!   `claude-code:<16-hex>` sid. The canonicalisation algorithm is
+//!   defined in the codec; this route only invokes it.
+//! - **L10-D5**: an unknown `anthropic-version` header returns HTTP 400
+//!   with an Anthropic-shape error body. Body-level forward compatibility
+//!   stays the codec's choice (see codec's `request.rs` strictness policy).
+//! - **L10-D6**: model-name resolution (Anthropic vs life-routed) is
+//!   J-Sub-F's surface. This route passes `model` through to lifed
+//!   verbatim.
+//! - **L10-D7**: no token counting. Token semantics are Vigil/Haima
+//!   surfaces (J-Sub-F).
+//!
+//! # Response semantics
+//!
+//! - SSE keep-alive: a `ping` event is emitted every 15 s while the
+//!   upstream is idle (Spec J §[Wire protocol mapping]).
+//! - Hard timeout: 600 s wall-clock cap. On timeout the encoder emits
+//!   `message_delta{stop_reason:"stop_sequence"}` + `message_stop` and
+//!   closes the stream.
+//! - Errors during the stream become in-band `event: error` frames
+//!   (Anthropic stream semantics); errors *before* the stream opens
+//!   are HTTP 4xx/5xx with an Anthropic-shape JSON error body.
+
+// Several upstream helpers return `Result<(), Response>` so callers can
+// short-circuit with a fully-built HTTP error response on failure. The
+// `Err`-variant is large (axum `Response` is `~128 B`); boxing it would
+// flatten every call site at zero correctness benefit. The lint is
+// scoped to this module to keep the trade-off local.
+#![allow(clippy::result_large_err)]
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Router,
+    body::Body,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use bytes::Bytes;
+use futures::stream::{self, Stream, StreamExt};
+use lifegw_anthropic_codec::{
+    AnthropicError, AnthropicErrorKind, AnthropicMessagesRequest, AnthropicSseEvent,
+    AnthropicVersion, CodecError, Encoder, synthesize_sid,
+};
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+use life_runtime_proto::life::v1::{self as pb, agent_client::AgentClient};
+
+use crate::auth::jwks::JwksCache;
+use crate::auth::tier2::Tier2Minter;
+
+/// Wall-clock cap on a single `/v1/messages` response stream.
+///
+/// Spec J §[Wire protocol mapping]: lifegw matches Anthropic's
+/// published 10-minute hard cap. When the timer fires, the encoder
+/// finalises with `stop_sequence` so Claude Code sees a clean stop
+/// rather than a torn-down connection.
+const HARD_STREAM_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Cadence of the synthetic `event: ping` keep-alive emitted while the
+/// upstream is silent. Spec J §[Wire protocol mapping]: matches
+/// free-claude-code's 15 s value so existing L7 idle-cutters (Cloudflare
+/// 100 s default, Vercel edge 30 s, etc.) don't drop the stream.
+const PING_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Per-RPC deadline for each upstream unary call (CreateSession +
+/// SendMessage). StreamSession is deliberately not deadlined here —
+/// it's a long-lived response stream bounded by [`HARD_STREAM_TIMEOUT`].
+const UPSTREAM_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default `project_id` synthesised for Claude-Code sessions when no
+/// override is supplied. Spec J §[Anima binding]: free-claude-code has
+/// no concept of "projects", so we land all conversations under one
+/// well-known id.
+const CLAUDE_CODE_PROJECT_ID: &str = "claude-code-default";
+
+/// Maximum length of the canonical-form `anthropic-version` header.
+const MAX_VERSION_HEADER_LEN: usize = 64;
+
+/// Maximum upstream request body size, in bytes. 8 MiB is well above
+/// Claude Code's largest observed prompts and well below axum's
+/// extractor defaults — we surface oversize bodies as a 413 with an
+/// Anthropic-shape error rather than letting axum reject them with the
+/// default text body.
+const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+
+// ─── Router state ───────────────────────────────────────────────────────
+
+/// Shared state threaded through the axum router.
+#[derive(Clone)]
+pub struct AnthropicMessagesState {
+    /// Tier-1 verifier — the same handle `AuthLayer` uses.
+    pub jwks: Arc<JwksCache>,
+    /// Tier-2 minter — the same handle `AuthLayer` uses for tonic upstream.
+    pub minter: Arc<Tier2Minter>,
+    /// Pre-dialed lifed UDS channel. Cheap to clone (internally `Arc`'d).
+    pub upstream: Channel,
+}
+
+/// Mount the route.
+///
+/// Per Spec J §J-Sub-B, the route lives at `/v1/messages`. We use
+/// exact-route matching (not nesting) so the rest of the `/v1/*` space
+/// stays free for the agent / events surfaces that the tonic stack
+/// continues to serve.
+pub fn router(state: AnthropicMessagesState) -> Router {
+    Router::new()
+        .route(
+            "/v1/messages",
+            post(messages_handler).options(probe).head(probe),
+        )
+        .with_state(state)
+}
+
+// ─── Probe (OPTIONS / HEAD) ─────────────────────────────────────────────
+
+/// Probe response for `OPTIONS` + `HEAD`. Some Anthropic-shaped clients
+/// pre-flight the route; we reply 204 with an `Allow` header so they
+/// don't bounce off a 405.
+async fn probe() -> Response {
+    let mut resp = Response::new(Body::empty());
+    *resp.status_mut() = StatusCode::NO_CONTENT;
+    resp.headers_mut().insert(
+        header::ALLOW,
+        HeaderValue::from_static("POST, HEAD, OPTIONS"),
+    );
+    resp
+}
+
+// ─── POST handler ───────────────────────────────────────────────────────
+
+async fn messages_handler(
+    State(state): State<AnthropicMessagesState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    // 1. Validate `anthropic-version` header *before* doing any other
+    //    work. Per Spec J L10-D5 unknown values are loud HTTP 400s.
+    let version_raw = match headers
+        .get("anthropic-version")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(raw) if raw.len() <= MAX_VERSION_HEADER_LEN => raw,
+        Some(_) => {
+            return anthropic_http_error(
+                StatusCode::BAD_REQUEST,
+                AnthropicErrorKind::InvalidRequestError,
+                "anthropic-version header exceeds length limit",
+            );
+        }
+        None => {
+            return anthropic_http_error(
+                StatusCode::BAD_REQUEST,
+                AnthropicErrorKind::InvalidRequestError,
+                "missing anthropic-version header",
+            );
+        }
+    };
+    if let Err(err) = AnthropicVersion::parse(version_raw) {
+        return anthropic_http_error(
+            StatusCode::BAD_REQUEST,
+            AnthropicErrorKind::InvalidRequestError,
+            err.to_string(),
+        );
+    }
+
+    // 2. Verify the Tier-1 bearer (same flow as `agent_http.rs`).
+    let bearer = match headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+    {
+        Some(b) if !b.is_empty() => b,
+        _ => {
+            return anthropic_http_error(
+                StatusCode::UNAUTHORIZED,
+                AnthropicErrorKind::AuthenticationError,
+                "missing Tier-1 bearer",
+            );
+        }
+    };
+    let tier1 = match state.jwks.verify(bearer) {
+        Ok(c) => c,
+        Err(e) => {
+            return anthropic_http_error(
+                StatusCode::UNAUTHORIZED,
+                AnthropicErrorKind::AuthenticationError,
+                format!("invalid Tier-1: {e}"),
+            );
+        }
+    };
+
+    // 3. Enforce body size.
+    if body.len() > MAX_BODY_BYTES {
+        return anthropic_http_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            AnthropicErrorKind::InvalidRequestError,
+            format!("request body exceeds {MAX_BODY_BYTES} bytes"),
+        );
+    }
+
+    // 4. Parse the request body via the codec (forward-compatible — see
+    //    codec's `request.rs` strictness policy).
+    let req: AnthropicMessagesRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            return anthropic_http_error(
+                StatusCode::BAD_REQUEST,
+                AnthropicErrorKind::InvalidRequestError,
+                format!("invalid JSON body: {e}"),
+            );
+        }
+    };
+    if let Err(e) = req.validate() {
+        let status = match &e {
+            CodecError::NoUserMessage | CodecError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::BAD_REQUEST,
+        };
+        return anthropic_http_error(
+            status,
+            AnthropicErrorKind::InvalidRequestError,
+            e.to_string(),
+        );
+    }
+
+    // 5. Synthesize the deterministic Life sid from the Tier-1 caller's
+    //    anima DID + the canonical first user message (Spec J L10-D2).
+    //    Today the Tier-1 claim set carries `user_id`; the DID is
+    //    "did:life:<user_id>" until Spec D's full DID claim threads
+    //    through the gateway. The wire algorithm is stable either way.
+    let anima_did = format!("did:life:{}", tier1.user_id);
+    let sid = match synthesize_sid(&req, &anima_did) {
+        Ok(s) => s,
+        Err(e) => {
+            return anthropic_http_error(
+                StatusCode::BAD_REQUEST,
+                AnthropicErrorKind::InvalidRequestError,
+                e.to_string(),
+            );
+        }
+    };
+
+    // 6. Mint a Tier-2 cap. Same posture as `agent_http.rs`.
+    let tier2 = match state.minter.mint(&tier1) {
+        Ok(t) => t,
+        Err(e) => {
+            return anthropic_http_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                AnthropicErrorKind::ApiError,
+                format!("mint tier-2: {e}"),
+            );
+        }
+    };
+
+    // 7. Drive the upstream saga: CreateSession (resume_sid=Some(sid))
+    //    → SendMessage(last user content) → StreamSession.
+    let mut agent_client = AgentClient::new(state.upstream.clone());
+
+    if let Err(err) = create_session(&mut agent_client, &tier2, &tier1.user_id, &sid).await {
+        return err;
+    }
+
+    let last_user_content = extract_last_user_content(&req);
+    if let Err(err) = send_message(&mut agent_client, &tier2, &sid, &last_user_content).await {
+        return err;
+    }
+
+    let event_stream = match open_stream(&mut agent_client, &tier2, &sid).await {
+        Ok(s) => s,
+        Err(err) => return err,
+    };
+
+    // 8. Build the SSE response. The encoder is fresh; `message_id`
+    //    is freshly synthesised in the Anthropic `msg_<hex>` shape so
+    //    clients log a recognisable id even though Life sessions don't
+    //    have a native equivalent.
+    let message_id = format!("msg_{}", Uuid::new_v4().simple());
+    let encoder = Encoder::new(message_id, req.model.clone());
+
+    let sse_body = build_sse_body(encoder, event_stream);
+
+    // 9. Compose response. Anthropic clients require a content-type of
+    //    `text/event-stream`; `X-Accel-Buffering: no` neutralises nginx
+    //    / Cloudflare proxy buffering so deltas surface immediately.
+    let mut resp = Response::new(Body::from_stream(sse_body));
+    *resp.status_mut() = StatusCode::OK;
+    let h = resp.headers_mut();
+    h.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/event-stream"),
+    );
+    h.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache, no-store, no-transform"),
+    );
+    h.insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
+    h.insert(
+        header::HeaderName::from_static("x-accel-buffering"),
+        HeaderValue::from_static("no"),
+    );
+    resp
+}
+
+// ─── Upstream helpers ───────────────────────────────────────────────────
+
+/// Run `lifed.Agent.CreateSession` with `resume_sid = Some(sid)`. lifed
+/// returns the existing session on resume, or runs the create-session
+/// saga on a cold sid. Either way the routing-cache entry is warm by
+/// the time we open the stream.
+async fn create_session(
+    client: &mut AgentClient<Channel>,
+    tier2: &str,
+    user_id: &str,
+    sid: &str,
+) -> Result<(), Response> {
+    let label = format!("cc:{}", short_sid_suffix(sid));
+    let mut req = tonic::Request::new(pb::CreateSessionReq {
+        user_id: user_id.to_string(),
+        project_id: CLAUDE_CODE_PROJECT_ID.to_string(),
+        label,
+        resume_sid: Some(aios_proto::aios::v1::SessionId {
+            value: sid.to_string(),
+        }),
+        inherit_policy: None,
+    });
+    attach_tier2(&mut req, tier2)?;
+
+    match tokio::time::timeout(UPSTREAM_RPC_TIMEOUT, client.create_session(req)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(status)) => Err(anthropic_http_error(
+            map_tonic_to_http(status.code()),
+            anthropic_kind_for(status.code()),
+            sanitize_upstream(status.message(), "lifed.Agent.CreateSession"),
+        )),
+        Err(_) => Err(anthropic_http_error(
+            StatusCode::GATEWAY_TIMEOUT,
+            AnthropicErrorKind::ApiError,
+            format!(
+                "lifed.Agent.CreateSession exceeded {}s deadline",
+                UPSTREAM_RPC_TIMEOUT.as_secs()
+            ),
+        )),
+    }
+}
+
+/// Send the last user message in the Anthropic request as a single
+/// `lifed.Agent.SendMessage` call. lifed broadcasts the resulting
+/// events through its fanout registry; we read them back via
+/// `StreamSession`.
+async fn send_message(
+    client: &mut AgentClient<Channel>,
+    tier2: &str,
+    sid: &str,
+    content: &str,
+) -> Result<(), Response> {
+    let mut req = tonic::Request::new(pb::SendMessageReq {
+        sid: Some(aios_proto::aios::v1::SessionId {
+            value: sid.to_string(),
+        }),
+        content: content.to_string(),
+        attachment_blob_ref: Vec::new(),
+    });
+    attach_tier2(&mut req, tier2)?;
+
+    let resp = match tokio::time::timeout(UPSTREAM_RPC_TIMEOUT, client.send_message(req)).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(status)) => {
+            return Err(anthropic_http_error(
+                map_tonic_to_http(status.code()),
+                anthropic_kind_for(status.code()),
+                sanitize_upstream(status.message(), "lifed.Agent.SendMessage"),
+            ));
+        }
+        Err(_) => {
+            return Err(anthropic_http_error(
+                StatusCode::GATEWAY_TIMEOUT,
+                AnthropicErrorKind::ApiError,
+                format!(
+                    "lifed.Agent.SendMessage exceeded {}s deadline",
+                    UPSTREAM_RPC_TIMEOUT.as_secs()
+                ),
+            ));
+        }
+    };
+
+    // Drop the SendMessage event stream — like the WS dispatcher, we
+    // rely on `Agent.StreamSession` as the canonical event source so
+    // we don't double-emit on lifed's fanout registry. Spawning a
+    // background drain keeps the upstream from blocking on us if it
+    // expects to push the full reply through this RPC; we cap it at
+    // the hard timeout to avoid lingering tasks on a misbehaving
+    // upstream.
+    tokio::spawn(async move {
+        let mut s = resp.into_inner();
+        let _ = tokio::time::timeout(HARD_STREAM_TIMEOUT, async {
+            while s.next().await.is_some() {
+                // Intentionally drop. StreamSession is canonical.
+            }
+        })
+        .await;
+    });
+
+    Ok(())
+}
+
+/// Open `lifed.Agent.StreamSession{sid}`. Returns the event stream.
+async fn open_stream(
+    client: &mut AgentClient<Channel>,
+    tier2: &str,
+    sid: &str,
+) -> Result<tonic::Streaming<pb::AgentEvent>, Response> {
+    let mut req = tonic::Request::new(pb::SessionRef {
+        sid: Some(aios_proto::aios::v1::SessionId {
+            value: sid.to_string(),
+        }),
+        from_sequence: None,
+    });
+    attach_tier2(&mut req, tier2)?;
+
+    match client.stream_session(req).await {
+        Ok(r) => Ok(r.into_inner()),
+        Err(status) => Err(anthropic_http_error(
+            map_tonic_to_http(status.code()),
+            anthropic_kind_for(status.code()),
+            sanitize_upstream(status.message(), "lifed.Agent.StreamSession"),
+        )),
+    }
+}
+
+/// Attach the Tier-2 cap to the outgoing tonic metadata. Mirrors the
+/// pattern from `agent_http.rs`.
+fn attach_tier2<T>(req: &mut tonic::Request<T>, tier2: &str) -> Result<(), Response> {
+    let value: tonic::metadata::MetadataValue<_> = match format!("Bearer {tier2}").parse() {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(anthropic_http_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                AnthropicErrorKind::ApiError,
+                format!("encode tier-2 metadata: {e}"),
+            ));
+        }
+    };
+    req.metadata_mut().insert("authorization", value);
+    Ok(())
+}
+
+// ─── SSE body assembly ──────────────────────────────────────────────────
+
+/// Build the streaming SSE body: a `Stream<Item = Result<Bytes,
+/// Infallible>>` that pipes pb::AgentEvents through the codec's
+/// `Encoder`, multiplexes 15 s keep-alive pings, and enforces the
+/// 600 s hard timeout.
+///
+/// `Infallible` as the stream's error type matches axum's
+/// `Body::from_stream` requirement and pairs with the codec's discipline
+/// of converting mid-stream faults into in-band `event: error` frames.
+fn build_sse_body(
+    encoder: Encoder,
+    upstream: tonic::Streaming<pb::AgentEvent>,
+) -> impl Stream<Item = Result<Bytes, Infallible>> + Send + 'static {
+    // Box the upstream so the stream::unfold state type stays sized.
+    let upstream: std::pin::Pin<
+        Box<dyn Stream<Item = Result<pb::AgentEvent, tonic::Status>> + Send>,
+    > = Box::pin(upstream);
+
+    // We model the stream as a small async state machine:
+    //
+    //   loop:
+    //     select! {
+    //         hard_timeout => emit force_finalize + END
+    //         ping_tick    => emit Ping frame
+    //         event = upstream.next() =>
+    //             Some(Ok(evt))  -> codec.encode(evt) -> emit frames
+    //             Some(Err(s))   -> emit error frame + force_finalize + END
+    //             None           -> emit force_finalize + END
+    //     }
+    //
+    // `stream::unfold` keeps the state owned inline.
+
+    let start = tokio::time::Instant::now();
+    let deadline = start + HARD_STREAM_TIMEOUT;
+
+    struct StreamState {
+        encoder: Encoder,
+        upstream:
+            std::pin::Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, tonic::Status>> + Send>>,
+        deadline: tokio::time::Instant,
+        ping_interval: tokio::time::Interval,
+        /// Queued frames waiting to flush (a single upstream event can
+        /// produce multiple SSE frames).
+        queued: std::collections::VecDeque<AnthropicSseEvent>,
+        /// Terminal flag — once true the stream returns None on next call.
+        done: bool,
+    }
+
+    let mut ping_interval = tokio::time::interval(PING_INTERVAL);
+    // First tick fires immediately; consume it so the first real ping
+    // is at +PING_INTERVAL, not at t=0 alongside `message_start`.
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let state = StreamState {
+        encoder,
+        upstream,
+        deadline,
+        ping_interval,
+        queued: std::collections::VecDeque::new(),
+        done: false,
+    };
+
+    stream::unfold(state, |mut s| async move {
+        if s.done {
+            return None;
+        }
+        // If there are queued frames from a prior upstream event, emit
+        // them one by one before polling the upstream again.
+        if let Some(evt) = s.queued.pop_front() {
+            let bytes = Bytes::from(evt.to_sse_frame());
+            return Some((Ok::<Bytes, Infallible>(bytes), s));
+        }
+
+        loop {
+            let next_event = s.upstream.next();
+            let ping = s.ping_interval.tick();
+            let sleep_to_deadline = tokio::time::sleep_until(s.deadline);
+
+            tokio::select! {
+                biased;
+                _ = sleep_to_deadline => {
+                    // Hard timeout — finalise with `stop_sequence` so
+                    // Claude Code interprets as a clean stop.
+                    let final_frames = s.encoder.force_finalize();
+                    for f in final_frames {
+                        s.queued.push_back(f);
+                    }
+                    s.done = true;
+                    if let Some(first) = s.queued.pop_front() {
+                        let bytes = Bytes::from(first.to_sse_frame());
+                        return Some((Ok(bytes), s));
+                    }
+                    return None;
+                }
+                evt = next_event => {
+                    match evt {
+                        Some(Ok(event)) => {
+                            match s.encoder.encode(&event) {
+                                Ok(frames) => {
+                                    for f in frames {
+                                        s.queued.push_back(f);
+                                    }
+                                }
+                                Err(e) => {
+                                    // Codec rejected the upstream event
+                                    // (structural mismatch). Emit an
+                                    // in-band error + finalise.
+                                    let err = Encoder::emit_top_level_error(
+                                        AnthropicErrorKind::ApiError,
+                                        e.to_string(),
+                                    );
+                                    s.queued.push_back(err);
+                                    for f in s.encoder.force_finalize() {
+                                        s.queued.push_back(f);
+                                    }
+                                    s.done = true;
+                                }
+                            }
+                            if let Some(first) = s.queued.pop_front() {
+                                let bytes = Bytes::from(first.to_sse_frame());
+                                return Some((Ok(bytes), s));
+                            }
+                            // Empty translation — keep polling.
+                            continue;
+                        }
+                        Some(Err(status)) => {
+                            // Upstream tonic error mid-stream. Convert
+                            // to Anthropic-shape error then finalise.
+                            let err = Encoder::emit_top_level_error(
+                                anthropic_kind_for(status.code()),
+                                sanitize_upstream(
+                                    status.message(),
+                                    "lifed.Agent.StreamSession",
+                                ),
+                            );
+                            s.queued.push_back(err);
+                            for f in s.encoder.force_finalize() {
+                                s.queued.push_back(f);
+                            }
+                            s.done = true;
+                            if let Some(first) = s.queued.pop_front() {
+                                let bytes = Bytes::from(first.to_sse_frame());
+                                return Some((Ok(bytes), s));
+                            }
+                            return None;
+                        }
+                        None => {
+                            // Upstream EOF without explicit Finish —
+                            // force_finalize so the protocol stays valid.
+                            for f in s.encoder.force_finalize() {
+                                s.queued.push_back(f);
+                            }
+                            s.done = true;
+                            if let Some(first) = s.queued.pop_front() {
+                                let bytes = Bytes::from(first.to_sse_frame());
+                                return Some((Ok(bytes), s));
+                            }
+                            return None;
+                        }
+                    }
+                }
+                _ = ping => {
+                    let bytes = Bytes::from(Encoder::ping().to_sse_frame());
+                    return Some((Ok(bytes), s));
+                }
+            }
+        }
+    })
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+/// Pull a short, sid-derived suffix for `label`. We slice the hex part
+/// of the sid (everything after the `"claude-code:"` prefix) and keep
+/// the first 8 hex chars — operators recognise it without leaking the
+/// full sid into log labels.
+fn short_sid_suffix(sid: &str) -> &str {
+    let hex = sid
+        .strip_prefix(lifegw_anthropic_codec::SID_PREFIX)
+        .unwrap_or(sid);
+    let take = hex.len().min(8);
+    &hex[..take]
+}
+
+/// Extract the last user-role message text. Phase 1 sends one
+/// SendMessage per HTTP turn (the conversation history is already on
+/// the lifed side via session resume).
+fn extract_last_user_content(req: &AnthropicMessagesRequest) -> String {
+    use lifegw_anthropic_codec::Role;
+    req.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == Role::User)
+        .map(|m| m.content.plain_text())
+        .unwrap_or_default()
+}
+
+/// Build a JSON Anthropic-shape error response with the given HTTP
+/// status. Used for failures that happen *before* the SSE body starts.
+fn anthropic_http_error(
+    status: StatusCode,
+    kind: AnthropicErrorKind,
+    message: impl Into<String>,
+) -> Response {
+    let err = AnthropicError::new(kind, message);
+    let body = err.to_sse_data();
+    let mut resp = Response::new(Body::from(body));
+    *resp.status_mut() = status;
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    resp
+}
+
+/// Map an upstream `tonic::Code` to the closest HTTP status. Aligned
+/// with `agent_http.rs::map_tonic_to_http`.
+fn map_tonic_to_http(code: tonic::Code) -> StatusCode {
+    use tonic::Code;
+    match code {
+        Code::Unauthenticated | Code::PermissionDenied => StatusCode::UNAUTHORIZED,
+        Code::InvalidArgument | Code::FailedPrecondition => StatusCode::BAD_REQUEST,
+        Code::NotFound => StatusCode::NOT_FOUND,
+        Code::AlreadyExists => StatusCode::CONFLICT,
+        Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        Code::Unavailable => StatusCode::BAD_GATEWAY,
+        Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Map an upstream tonic code to the closest Anthropic `error.type`.
+fn anthropic_kind_for(code: tonic::Code) -> AnthropicErrorKind {
+    use tonic::Code;
+    match code {
+        Code::Unauthenticated => AnthropicErrorKind::AuthenticationError,
+        Code::PermissionDenied => AnthropicErrorKind::PermissionError,
+        Code::InvalidArgument | Code::FailedPrecondition => AnthropicErrorKind::InvalidRequestError,
+        Code::NotFound => AnthropicErrorKind::NotFoundError,
+        Code::ResourceExhausted => AnthropicErrorKind::RateLimitError,
+        Code::Unavailable => AnthropicErrorKind::OverloadedError,
+        _ => AnthropicErrorKind::ApiError,
+    }
+}
+
+/// Sanitise upstream error messages so we don't leak internal-only
+/// details (UDS paths, sql fragments, etc.) into the public response.
+/// Mirrors `agent_http.rs::sanitize_upstream` (same posture).
+fn sanitize_upstream(msg: &str, fallback_context: &str) -> String {
+    if msg.is_empty() {
+        return format!("{fallback_context} failed");
+    }
+    let cleaned: String = msg
+        .split_whitespace()
+        .map(|tok| {
+            if tok.starts_with('/') {
+                "<path-redacted>"
+            } else {
+                tok
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if cleaned.len() > 256 {
+        format!("{}…", &cleaned[..256])
+    } else {
+        cleaned
+    }
+}
+
+// Compile-time guard: IntoResponse on the handler's actual return type.
+#[doc(hidden)]
+fn _impl_response_compile_check() {
+    fn _check<T: IntoResponse>() {}
+    _check::<Response>();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_tonic_codes_to_http_status() {
+        assert_eq!(
+            map_tonic_to_http(tonic::Code::Unauthenticated),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            map_tonic_to_http(tonic::Code::ResourceExhausted),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(
+            map_tonic_to_http(tonic::Code::Unavailable),
+            StatusCode::BAD_GATEWAY
+        );
+    }
+
+    #[test]
+    fn maps_tonic_codes_to_anthropic_kind() {
+        assert!(matches!(
+            anthropic_kind_for(tonic::Code::Unauthenticated),
+            AnthropicErrorKind::AuthenticationError
+        ));
+        assert!(matches!(
+            anthropic_kind_for(tonic::Code::ResourceExhausted),
+            AnthropicErrorKind::RateLimitError
+        ));
+        assert!(matches!(
+            anthropic_kind_for(tonic::Code::Unavailable),
+            AnthropicErrorKind::OverloadedError
+        ));
+        // Unknown defaults to api_error.
+        assert!(matches!(
+            anthropic_kind_for(tonic::Code::Internal),
+            AnthropicErrorKind::ApiError
+        ));
+    }
+
+    #[test]
+    fn sanitize_redacts_paths_and_bounds_length() {
+        let s = sanitize_upstream(
+            "connect failed at /run/life/life.sock with EADDRNOTAVAIL",
+            "lifed.Agent.CreateSession",
+        );
+        assert!(!s.contains("/run/life"));
+        assert!(s.contains("EADDRNOTAVAIL"));
+
+        let long = "x".repeat(1000);
+        let trimmed = sanitize_upstream(&long, "lifed.Agent.CreateSession");
+        // 256 ASCII + 3 bytes for `…` (U+2026 = e2 80 a6) = 259 bytes.
+        assert!(trimmed.len() <= 259);
+        assert!(trimmed.ends_with('…'));
+    }
+
+    #[test]
+    fn anthropic_http_error_carries_anthropic_shape_body() {
+        let resp = anthropic_http_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            AnthropicErrorKind::RateLimitError,
+            "burst exceeded",
+        );
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .map(|v| v.to_str().unwrap_or("").to_string()),
+            Some("application/json".to_string())
+        );
+    }
+
+    #[test]
+    fn short_sid_suffix_extracts_hex_prefix() {
+        let sid = format!("{}deadbeefcafef00d", lifegw_anthropic_codec::SID_PREFIX);
+        assert_eq!(short_sid_suffix(&sid), "deadbeef");
+    }
+
+    #[test]
+    fn short_sid_suffix_handles_no_prefix() {
+        assert_eq!(short_sid_suffix("abc"), "abc");
+    }
+
+    #[test]
+    fn extract_last_user_content_skips_assistant_turns() {
+        use lifegw_anthropic_codec::request::MessageContent;
+        use lifegw_anthropic_codec::{Message, Role};
+        let req = AnthropicMessagesRequest {
+            model: "m".into(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text("first".into()),
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: MessageContent::Text("between".into()),
+                },
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text("latest".into()),
+                },
+            ],
+            system: None,
+            max_tokens: 1,
+            stop_sequences: vec![],
+            stream: true,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            metadata: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking: None,
+        };
+        assert_eq!(extract_last_user_content(&req), "latest");
+    }
+}

--- a/crates/life-runtime/lifegw/src/services/mod.rs
+++ b/crates/life-runtime/lifegw/src/services/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod agent_http;
 pub mod anima_custody;
+pub mod anthropic_messages;
 pub mod cert_watch;
 pub mod health;
 pub mod rate_limit;

--- a/crates/life-runtime/lifegw/tests/anthropic_messages_integration.rs
+++ b/crates/life-runtime/lifegw/tests/anthropic_messages_integration.rs
@@ -1,0 +1,661 @@
+//! Integration tests for `services::anthropic_messages` (Spec J §J-Sub-B).
+//!
+//! Brings up:
+//!
+//! 1. A mock lifed `Agent` service over a tempdir UDS — the test
+//!    controls what `CreateSession` / `SendMessage` / `StreamSession`
+//!    return without standing up real arcan/lago/anima/haima
+//!    substrates. The `Agent.StreamSession` body is the surface most
+//!    of the assertions read.
+//! 2. The `AnthropicMessagesState` directly — same handles + Channel
+//!    shape `bootstrap.rs` builds at runtime. We `oneshot` the axum
+//!    router with synthetic `POST /v1/messages` bodies; we do NOT
+//!    stand up a TLS listener (the route handler is independent of
+//!    transport — TLS is verified separately by Sub-phase B's lifegw
+//!    end-to-end test rig).
+//!
+//! Tests cover:
+//!
+//! * `simple_chat_completion` — happy path, end-to-end SSE shape.
+//! * `multi_turn_no_tools` — sid stability across two HTTP turns with
+//!   the same first user message.
+//! * `auth_missing_returns_401` / `auth_invalid_returns_401` — Tier-1
+//!   verification gates.
+//! * `unknown_anthropic_version_returns_400` — Spec J L10-D5 strictness.
+//! * `rate_limit_engaged_returns_429` — upstream `ResourceExhausted`
+//!   maps to HTTP 429 + Anthropic-shape `rate_limit_error` body.
+//! * `connection_drop_resume` — re-requesting with the same body
+//!   resolves the same sid (deterministic sid synthesis).
+//! * `large_request_body` — 100K-character payload doesn't blow up
+//!   the streaming parser.
+//!
+//! Scope caveats (mirroring Spec J §J-Sub-B):
+//!
+//! * **Tool use** — not exercised here. The mock lifed emits only
+//!   Token + Finish events; ToolCallPending wiring is J-Sub-D's
+//!   surface. Tests stick to text-only flows.
+//! * **Real Anthropic upstream** — `arcan-proxy::AnthropicArcan` is
+//!   not invoked. The mock lifed plays the role of the entire
+//!   substrate stack. The adapter is tested under `arcan-proxy/src/anthropic.rs`.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use futures::{Stream, StreamExt};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Endpoint, Uri};
+use tower::ServiceExt;
+use tower::service_fn;
+
+use life_runtime_proto::life::v1::agent_server::{Agent, AgentServer};
+use life_runtime_proto::life::v1::{
+    AgentEvent, AgentEventKind, ApprovalReq, CreateSessionReq, DispatchRef, Empty, EventRecord,
+    ListModelsReq, ListSkillsReq, ListToolsReq, ModelCatalog, SendMessageReq, Session, SessionRef,
+    SkillCatalog, SpawnChildReq, SpawnChildResp, ToolCatalog,
+};
+
+use lifegw::auth::jwks::JwksCache;
+use lifegw::auth::kms::StaticKeystore;
+use lifegw::auth::tier2::Tier2Minter;
+use lifegw::config::AuthConfig;
+use lifegw::services::anthropic_messages::{self, AnthropicMessagesState};
+
+// ─── Mock lifed Agent service ───────────────────────────────────────────
+
+/// Per-test knobs for the mock Agent service.
+#[derive(Default)]
+struct MockAgentState {
+    /// Records of every `CreateSession` call.
+    create_session_calls: Mutex<Vec<CreateSessionReq>>,
+    /// Records of every `SendMessage` call.
+    send_message_calls: Mutex<Vec<SendMessageReq>>,
+    /// Records of every `StreamSession` call.
+    stream_session_calls: Mutex<Vec<SessionRef>>,
+    /// When set, `CreateSession` returns the given status instead of
+    /// the canned happy-path response.
+    force_create_status: Mutex<Option<tonic::Status>>,
+    /// When set, `SendMessage` returns the given status.
+    force_send_status: Mutex<Option<tonic::Status>>,
+    /// When set, `StreamSession` returns the given status.
+    force_stream_status: Mutex<Option<tonic::Status>>,
+    /// When set, `StreamSession` emits this fixed list of events instead
+    /// of the default minimal Token+Finish pair.
+    stream_events: Mutex<Vec<AgentEvent>>,
+}
+
+#[derive(Clone)]
+struct MockAgentService {
+    state: Arc<MockAgentState>,
+}
+
+#[tonic::async_trait]
+impl Agent for MockAgentService {
+    type SendMessageStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+    type StreamSessionStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+
+    async fn create_session(
+        &self,
+        req: tonic::Request<CreateSessionReq>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        let body = req.into_inner();
+        self.state
+            .create_session_calls
+            .lock()
+            .await
+            .push(body.clone());
+        if let Some(s) = self.state.force_create_status.lock().await.take() {
+            return Err(s);
+        }
+        // Echo the inbound resume_sid (the route always sets it from
+        // synthesize_sid) so the response sid matches what the codec
+        // saw and downstream assertions stay tight.
+        let sid_val = body
+            .resume_sid
+            .as_ref()
+            .map(|s| s.value.clone())
+            .unwrap_or_else(|| "mock-sid".to_string());
+        Ok(tonic::Response::new(Session {
+            sid: Some(aios_proto::aios::v1::SessionId { value: sid_val }),
+            agent_id: Some(aios_proto::aios::v1::AgentId {
+                value: "mock-agent".to_string(),
+            }),
+            user_id: body.user_id,
+            project_id: body.project_id,
+            created_at: Some(prost_types::Timestamp {
+                seconds: 0,
+                nanos: 0,
+            }),
+        }))
+    }
+
+    async fn describe_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn close_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn send_message(
+        &self,
+        req: tonic::Request<SendMessageReq>,
+    ) -> Result<tonic::Response<Self::SendMessageStream>, tonic::Status> {
+        let body = req.into_inner();
+        self.state.send_message_calls.lock().await.push(body);
+        if let Some(s) = self.state.force_send_status.lock().await.take() {
+            return Err(s);
+        }
+        // Empty stream — the route drops SendMessage events on the
+        // floor; the canonical event source is StreamSession.
+        let s = futures::stream::empty::<Result<AgentEvent, tonic::Status>>();
+        Ok(tonic::Response::new(Box::pin(s)))
+    }
+
+    async fn stream_session(
+        &self,
+        req: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Self::StreamSessionStream>, tonic::Status> {
+        let body = req.into_inner();
+        self.state.stream_session_calls.lock().await.push(body);
+        if let Some(s) = self.state.force_stream_status.lock().await.take() {
+            return Err(s);
+        }
+        let events = self.state.stream_events.lock().await.clone();
+        let events = if events.is_empty() {
+            default_stream_events()
+        } else {
+            events
+        };
+        let s = futures::stream::iter(events.into_iter().map(Ok::<_, tonic::Status>));
+        Ok(tonic::Response::new(Box::pin(s)))
+    }
+
+    async fn approve_dispatch(
+        &self,
+        _: tonic::Request<ApprovalReq>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn cancel_dispatch(
+        &self,
+        _: tonic::Request<DispatchRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn list_skills(
+        &self,
+        _: tonic::Request<ListSkillsReq>,
+    ) -> Result<tonic::Response<SkillCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn list_models(
+        &self,
+        _: tonic::Request<ListModelsReq>,
+    ) -> Result<tonic::Response<ModelCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn list_tools(
+        &self,
+        _: tonic::Request<ListToolsReq>,
+    ) -> Result<tonic::Response<ToolCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn spawn_child(
+        &self,
+        _: tonic::Request<SpawnChildReq>,
+    ) -> Result<tonic::Response<SpawnChildResp>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+}
+
+fn default_stream_events() -> Vec<AgentEvent> {
+    // Three Token deltas → Finish. Codec emits a single text
+    // content_block containing the concatenated text.
+    vec![
+        token_event(1, "Hello"),
+        token_event(2, " world"),
+        token_event(3, "!"),
+        finish_event(4, "stop"),
+    ]
+}
+
+fn token_event(seq: u64, text: &str) -> AgentEvent {
+    AgentEvent {
+        record: Some(EventRecord {
+            session_id: None,
+            sequence: seq,
+            at: None,
+            kind: "TOKEN".into(),
+            payload: serde_json::to_vec(&serde_json::json!({"text": text})).expect("payload"),
+        }),
+        kind: AgentEventKind::Token as i32,
+    }
+}
+
+fn finish_event(seq: u64, reason: &str) -> AgentEvent {
+    AgentEvent {
+        record: Some(EventRecord {
+            session_id: None,
+            sequence: seq,
+            at: None,
+            kind: "FINISH".into(),
+            payload: serde_json::to_vec(&serde_json::json!({"reason": reason})).expect("payload"),
+        }),
+        kind: AgentEventKind::Finish as i32,
+    }
+}
+
+// ─── Test rig ───────────────────────────────────────────────────────────
+
+struct TestRig {
+    state: Arc<MockAgentState>,
+    router: axum::Router,
+    _temp: TempDir,
+    _shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    _handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TestRig {
+    async fn build() -> Self {
+        // Mock lifed Agent service over a tempdir UDS.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("lifed.sock");
+        let socket_path_str = socket_path.to_string_lossy().to_string();
+        let listener = UnixListener::bind(&socket_path).expect("bind UDS");
+        let stream = UnixListenerStream::new(listener);
+
+        let agent_state = Arc::new(MockAgentState::default());
+        let agent_svc = MockAgentService {
+            state: Arc::clone(&agent_state),
+        };
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = AgentServer::new(agent_svc);
+        let handle = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(server)
+                .serve_with_incoming_shutdown(stream, async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+        // Tiny grace for the listener to start accepting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Dial the UDS as a tonic Channel — this is the same shape
+        // `bootstrap::dial_upstream` produces in production.
+        let path = socket_path_str.clone();
+        let endpoint = Endpoint::try_from("http://[::]:0").expect("endpoint");
+        let upstream = endpoint
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = path.clone();
+                async move {
+                    let stream = tokio::net::UnixStream::connect(path).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            }))
+            .await
+            .expect("dial UDS");
+
+        // Build the router state with the dev JwksCache (accepts
+        // `Bearer dev-token-for-{user}` shortcut) and a Tier-2 minter.
+        let jwks = Arc::new(JwksCache::dev_only());
+        let signer = Arc::new(StaticKeystore::generate_dev().expect("keystore"));
+        let minter = Arc::new(Tier2Minter::new(signer, &AuthConfig::default()));
+
+        let state = AnthropicMessagesState {
+            jwks,
+            minter,
+            upstream,
+        };
+        let router = anthropic_messages::router(state);
+
+        Self {
+            state: agent_state,
+            router,
+            _temp: temp,
+            _shutdown_tx: Some(shutdown_tx),
+            _handle: Some(handle),
+        }
+    }
+
+    fn router(&self) -> axum::Router {
+        self.router.clone()
+    }
+
+    fn dev_bearer(user: &str) -> String {
+        format!("Bearer dev-token-for-{user}")
+    }
+
+    /// Build a minimal Anthropic Messages POST request body.
+    fn body(user_text: &str) -> String {
+        format!(
+            r#"{{
+                "model": "claude-sonnet-4-20250514",
+                "messages": [{{"role":"user","content":{user_text}}}],
+                "max_tokens": 100,
+                "stream": true
+            }}"#,
+            user_text = serde_json::to_string(user_text).expect("encode str"),
+        )
+    }
+}
+
+impl Drop for TestRig {
+    fn drop(&mut self) {
+        if let Some(tx) = self._shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self._handle.take() {
+            h.abort();
+        }
+    }
+}
+
+/// Collect the full SSE body as a String (test bodies are small).
+async fn collect_body(resp: axum::http::Response<axum::body::Body>) -> (StatusCode, String) {
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Helper that streams the response body and stops once `message_stop`
+/// is observed. Used by tests that need the SSE-shape assertions
+/// (`event: message_stop\n` is the terminal marker).
+async fn stream_until_stop(
+    resp: axum::http::Response<axum::body::Body>,
+    max_bytes: usize,
+) -> String {
+    let mut body = resp.into_body().into_data_stream();
+    let mut buf = Vec::with_capacity(4096);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while buf.len() < max_bytes {
+        let frame = tokio::time::timeout_at(deadline, body.next()).await;
+        match frame {
+            Ok(Some(Ok(chunk))) => {
+                buf.extend_from_slice(&chunk);
+                if String::from_utf8_lossy(&buf).contains("event: message_stop") {
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn simple_chat_completion() {
+    let rig = TestRig::build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("alice"))
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("hello")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap_or("").to_string())
+            .as_deref(),
+        Some("text/event-stream"),
+    );
+
+    let body = stream_until_stop(resp, 8 * 1024).await;
+    assert!(
+        body.contains("event: message_start"),
+        "missing message_start in body: {body}"
+    );
+    assert!(
+        body.contains("event: content_block_start"),
+        "missing content_block_start: {body}"
+    );
+    assert!(body.contains("Hello"));
+    assert!(body.contains(" world"));
+    assert!(body.contains("event: message_stop"), "missing terminal");
+
+    // Upstream observed: create + send + stream.
+    assert_eq!(rig.state.create_session_calls.lock().await.len(), 1);
+    assert_eq!(rig.state.send_message_calls.lock().await.len(), 1);
+    assert_eq!(rig.state.stream_session_calls.lock().await.len(), 1);
+
+    let send = rig.state.send_message_calls.lock().await;
+    assert_eq!(send[0].content, "hello");
+    let stream = rig.state.stream_session_calls.lock().await;
+    assert!(stream[0].sid.is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_turn_no_tools() {
+    // Two HTTP turns with the same first user message: the codec's sid
+    // synthesizer is deterministic over (anima_did, canon-first-user)
+    // so both turns hit the same sid. The mock echoes the inbound
+    // resume_sid, so we can read the sid back via CreateSession's
+    // recorded inputs.
+    let rig = TestRig::build().await;
+    for _turn in 0..2 {
+        let body = TestRig::body("read foo.txt");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", TestRig::dev_bearer("alice"))
+            .header("anthropic-version", "2023-06-01")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .expect("build req");
+        let resp = rig.router().oneshot(req).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Drain so the upstream call completes before the next turn.
+        let _ = stream_until_stop(resp, 8 * 1024).await;
+    }
+    let calls = rig.state.create_session_calls.lock().await;
+    assert_eq!(calls.len(), 2);
+    let sid1 = calls[0].resume_sid.as_ref().map(|s| s.value.clone());
+    let sid2 = calls[1].resume_sid.as_ref().map(|s| s.value.clone());
+    assert!(sid1.is_some());
+    assert_eq!(
+        sid1, sid2,
+        "sid synthesis must be deterministic across turns"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_missing_returns_401() {
+    let rig = TestRig::build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("hi")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    let (status, body) = collect_body(resp).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let v: Value = serde_json::from_str(&body).expect("anthropic-shape body");
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["error"]["type"], "authentication_error");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_invalid_returns_401() {
+    let rig = TestRig::build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", "Bearer garbage-not-a-token")
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("hi")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    let (status, body) = collect_body(resp).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(body.contains("authentication_error"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_anthropic_version_returns_400() {
+    let rig = TestRig::build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("alice"))
+        .header("anthropic-version", "future-2099")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("hi")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    let (status, body) = collect_body(resp).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let v: Value = serde_json::from_str(&body).expect("anthropic-shape body");
+    assert_eq!(v["error"]["type"], "invalid_request_error");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("future-2099")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rate_limit_engaged_returns_429() {
+    let rig = TestRig::build().await;
+    // Pre-arm the mock so the very next CreateSession returns
+    // ResourceExhausted — same shape as a real upstream rate-limit hit.
+    *rig.state.force_create_status.lock().await =
+        Some(tonic::Status::resource_exhausted("rate_limit:per_user"));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("alice"))
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("hi")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    let (status, body) = collect_body(resp).await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    let v: Value = serde_json::from_str(&body).expect("anthropic-shape body");
+    assert_eq!(v["error"]["type"], "rate_limit_error");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_drop_resume() {
+    // Drive two POSTs back-to-back with the same body. The deterministic
+    // sid synthesis means both hit the same Life sid — the mock's
+    // CreateSession echoes the inbound resume_sid, so the recorded
+    // sids must match. This mirrors a Claude-Code-side disconnect +
+    // re-send.
+    let rig = TestRig::build().await;
+
+    let body = TestRig::body("resume-marker");
+    for _ in 0..2 {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", TestRig::dev_bearer("alice"))
+            .header("anthropic-version", "2023-06-01")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.clone()))
+            .expect("build req");
+        let resp = rig.router().oneshot(req).await.expect("oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let _ = stream_until_stop(resp, 8 * 1024).await;
+    }
+    let calls = rig.state.create_session_calls.lock().await;
+    assert_eq!(calls.len(), 2);
+    let sid_a = calls[0].resume_sid.as_ref().map(|s| s.value.clone());
+    let sid_b = calls[1].resume_sid.as_ref().map(|s| s.value.clone());
+    assert_eq!(
+        sid_a, sid_b,
+        "resume must reuse sid via deterministic synthesis"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn large_request_body() {
+    // 100K-character user message. The codec parses it lazily;
+    // synthesize_sid hashes it; the route forwards only the last user
+    // message (still 100K bytes). Goal: assert the handler doesn't OOM
+    // and produces a clean 200 OK + message_stop terminal.
+    let rig = TestRig::build().await;
+    let huge = "X".repeat(100_000);
+    let body = TestRig::body(&huge);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("alice"))
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let drained = stream_until_stop(resp, 32 * 1024).await;
+    assert!(drained.contains("event: message_stop"));
+    // The 100K user content lands in SendMessage's `content` field
+    // (the canonical-form first-user-message used for sid synthesis is
+    // also 100K + whitespace-normalised, but plain "X..." has no
+    // whitespace to collapse, so it should be byte-identical at that
+    // path too).
+    let send = rig.state.send_message_calls.lock().await;
+    assert_eq!(send.len(), 1);
+    assert_eq!(send[0].content.len(), 100_000);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn options_probe_returns_204() {
+    // Some clients pre-flight; lifegw replies 204 No Content with an
+    // `Allow` header so they don't bounce off a 405.
+    let rig = TestRig::build().await;
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/messages")
+        .body(Body::empty())
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    let allow = resp
+        .headers()
+        .get(header::ALLOW)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(allow.contains("POST"));
+}


### PR DESCRIPTION
## Summary

Implements **BRO-1142 / Spec J §J-Sub-B** — wires the Anthropic Messages `POST /v1/messages` route on lifegw so Claude Code (and any compatible client) can drive a Life agent session over the existing `(Tier-1 → Tier-2 → lifed.Agent.*)` flow. The novel surface vs `services/agent_http.rs` is the response body: instead of a unary JSON reply we stream `text/event-stream` synthesised by the newly-merged `lifegw-anthropic-codec`.

The PR ships in two commits:

1. **`feat(arcan-proxy)`** — folds the precursor `AnthropicArcan` `ArcanCall` adapter onto the worktree (Spec J Q2 resolution: no separate precursor PR because the file has zero consumers on main today). Adds 1 test (`parses_text_delta_and_finish`).
2. **`feat(lifegw)`** — the route handler + bootstrap wiring + 9 integration tests.

## Spec J locked decisions honoured

- **L10-D1** — `lifegw` pulls only `lifegw-anthropic-codec` (workspace-internal, substrate-free). `arcan-proxy::AnthropicArcan` lives on lifed's south side and is NOT pulled by the route. `scripts/verify_dependencies_lifegw_anthropic_codec.sh` exits 0.
- **L10-D2** — sid synthesis flows through `lifegw_anthropic_codec::synthesize_sid(req, did)`. The canonicalisation algorithm is owned by the codec; the route only invokes it.
- **L10-D5** — unknown `anthropic-version` → HTTP 400 + Anthropic-shape `invalid_request_error` body.
- **L10-D6** — model-name resolution is J-Sub-F's surface. `model` passes through to lifed verbatim.
- **L10-D7** — no token counting. Token semantics are Vigil/Haima surfaces (J-Sub-F).

## Wire shape

```
POST /v1/messages
  Headers:
    Authorization: Bearer <Tier-1 JWS>      [required]
    anthropic-version: 2023-06-01           [validated by codec]
    Content-Type: application/json
  Body: AnthropicMessagesRequest (forward-compatible per codec policy)

Response (success):
  HTTP/1.1 200
  Content-Type: text/event-stream
  Cache-Control: no-cache, no-store, no-transform
  Connection: keep-alive
  X-Accel-Buffering: no

  event: message_start
  data: {...}
  event: content_block_start
  ...
  event: message_stop
  data: {"type":"message_stop"}
```

Plus `OPTIONS /v1/messages` + `HEAD /v1/messages` probes returning `204 No Content` with `Allow: POST, HEAD, OPTIONS` so pre-flight requests don't bounce off a 405.

## Lifecycle (response stream)

- **15 s pings** — emitted while the upstream is silent to keep idle L7 proxies (Cloudflare 100 s, Vercel edge 30 s) from cutting the stream.
- **600 s hard timeout** — wall-clock cap. On timeout the encoder finalises with `stop_reason: "stop_sequence"` so Claude Code sees a clean stop.
- **Upstream EOF or tonic error** — both finalise through the encoder; mid-stream tonic errors become in-band `event: error` frames (Anthropic protocol semantics), HTTP body stays 200 OK once started.

## Manual smoke

After deploying lifegw with this PR + an upstream `lifed.Agent` (mock or real arcan-proxy):

\`\`\`bash
curl -N -H "Authorization: Bearer dev-token-for-user1" \
     -H "anthropic-version: 2023-06-01" \
     -H "Content-Type: application/json" \
     -d '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}' \
     https://localhost:8443/v1/messages
\`\`\`

## Test plan

- [x] `cargo build -p arcan-proxy -p lifegw-anthropic-codec -p lifegw` — clean
- [x] `cargo test -p arcan-proxy` — 25 unit tests green (incl. `parses_text_delta_and_finish`)
- [x] `cargo test -p lifegw` — 183 lib + 9 `anthropic_messages_integration` + others green
- [x] `cargo clippy -p lifegw --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bash scripts/verify_dependencies_lifegw_anthropic_codec.sh` — exits 0
- [ ] CI Test Linux green
- [ ] CI Test macOS green
- [ ] CI Build Release green
- [ ] CI Lint green
- [ ] CI MSRV green
- [ ] CI Security Audit green
- [ ] Reviewer dispatches manual smoke against a staging lifegw + mock lifed

### 9 integration tests added

| Test | Assertion |
|------|-----------|
| `simple_chat_completion` | End-to-end SSE shape + upstream call counts |
| `multi_turn_no_tools` | sid stable across two HTTP turns with same first user message |
| `auth_missing_returns_401` | Anthropic-shape `authentication_error` body |
| `auth_invalid_returns_401` | Same, with garbage bearer |
| `unknown_anthropic_version_returns_400` | L10-D5 strictness, error body references the bad version |
| `rate_limit_engaged_returns_429` | Upstream `ResourceExhausted` → HTTP 429 + `rate_limit_error` body |
| `connection_drop_resume` | Deterministic sid synthesis → same body produces same upstream resume_sid |
| `large_request_body` | 100 K-char user message round-trips without OOM |
| `options_probe_returns_204` | OPTIONS pre-flight returns 204 with `Allow` header |

## Scope deferrals (per Spec J)

- **Tool use** (J-Sub-D / BRO-1143) — integration tests stick to text-only streams. The codec already handles `ToolCallPending`, but the proto's missing dedicated `Thinking` / `ToolCallEmit` variants mean tool-use end-to-end exercising waits for J-Sub-D's proto bump.
- **Token counting + pricing** (J-Sub-F) — `usage.input_tokens` stays 0 until Vigil/Haima publish per-tier counters.
- **Model routing** (`life/...` vs `claude-...` resolution, J-Sub-F) — `model` passes through verbatim to lifed; lifed picks the backend.
- **Live Anthropic upstream** — integration tests mock lifed; the real `arcan-proxy::AnthropicArcan` adapter is exercised by its own unit tests.

## Pre-existing condition

`scripts/verify_dependencies_lifegw.sh` fails on main today on the `life-kernel-proto` regex (added as a Spec D D-Sub-C client-only dep without a script update). This is unrelated to J-Sub-B and the J-Sub-B-specific verify (`verify_dependencies_lifegw_anthropic_codec.sh`) exits 0.

Refs: BRO-1142, Spec J L10-D1..D7,
`docs/superpowers/specs/2026-05-18-spec-j-claude-code-interop.md`,
`docs/superpowers/plans/2026-05-18-spec-j-phase-1-lifegw-edge.md` §J-Sub-B.