### PR TITLE
fix(lifegw): P20 fix-round 1 for #1331 — rate-limit + secret redaction + 6 concerns [BRO-1142]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,6 +6607,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
+ "tokio-util",
  "toml",
  "tonic 0.14.5",
  "tonic-prost",

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -19,7 +19,15 @@ pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_HISTORY_MESSAGES: usize = 20;
 
-#[derive(Debug, Clone)]
+/// `AnthropicArcanConfig` carries the credential + connection settings
+/// for the Anthropic Messages-backed `ArcanCall` adapter.
+///
+/// **Security:** [`Debug`] is implemented manually to redact `api_key`.
+/// Any future `tracing::debug!("{cfg:?}")` / `dbg!` / Vigil span attribute
+/// MUST stay safe by construction — the rest of the workspace uses the
+/// same redact-on-Debug pattern for secrets (`Zeroizing<String>` is the
+/// other axis, used in Spec D KMS keystore).
+#[derive(Clone)]
 pub struct AnthropicArcanConfig {
     pub api_key: String,
     pub base_url: String,
@@ -27,6 +35,19 @@ pub struct AnthropicArcanConfig {
     pub max_tokens: u32,
     pub request_timeout: Duration,
     pub system_prompt: Option<String>,
+}
+
+impl std::fmt::Debug for AnthropicArcanConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicArcanConfig")
+            .field("api_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("request_timeout", &self.request_timeout)
+            .field("system_prompt", &self.system_prompt)
+            .finish()
+    }
 }
 
 impl AnthropicArcanConfig {
@@ -62,6 +83,12 @@ impl AnthropicArcanConfig {
 pub struct AnthropicArcan {
     cfg: Arc<AnthropicArcanConfig>,
     client: reqwest::Client,
+    // TODO(BRO-1143): cross-sid eviction + LRU cap. The per-sid bound
+    // (`MAX_HISTORY_MESSAGES`) is sufficient for J-Sub-B's text-only flows,
+    // but production tool flows (J-Sub-D, when `AnthropicArcan` wires into
+    // lifed as a real `ArcanCall` impl) will accumulate sids indefinitely.
+    // Wrap in an LRU keyed by last-touch instant, or piggy-back on the
+    // routing-cache idle-TTL pattern, when J-Sub-D lands.
     history: Arc<Mutex<HashMap<String, Vec<ChatMessage>>>>,
 }
 
@@ -384,6 +411,34 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::stream;
+
+    /// Fix-round 1 — C-2 regression guard. Asserts that the `Debug`
+    /// impl on `AnthropicArcanConfig` redacts the api_key field so a
+    /// future `tracing::debug!("{cfg:?}")` or Vigil span attribute can
+    /// not leak the credential into telemetry.
+    #[test]
+    fn debug_impl_redacts_api_key() {
+        let cfg = AnthropicArcanConfig {
+            api_key: "secret-key-value".to_string(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: DEFAULT_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            system_prompt: Some("you are a helpful assistant".to_string()),
+        };
+        let rendered = format!("{cfg:?}");
+        assert!(
+            rendered.contains("<redacted>"),
+            "Debug must print `<redacted>` placeholder: {rendered}"
+        );
+        assert!(
+            !rendered.contains("secret-key-value"),
+            "Debug must NOT contain the api_key value: {rendered}"
+        );
+        // Non-secret fields still appear.
+        assert!(rendered.contains(DEFAULT_MODEL));
+        assert!(rendered.contains("helpful assistant"));
+    }
 
     #[tokio::test]
     async fn parses_text_delta_and_finish() {

--- a/crates/life-runtime/lifegw/Cargo.toml
+++ b/crates/life-runtime/lifegw/Cargo.toml
@@ -106,6 +106,11 @@ reqwest = { workspace = true }
 # concurrency / state
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "fs", "sync", "time", "io-util"] }
 tokio-stream = { workspace = true }
+# Spec J J-Sub-B fix-round 1 (I-5): `CancellationToken` ties the
+# upstream `SendMessage` drain task to the SSE response body lifecycle
+# — when the client disconnects, the drain stops cleanly instead of
+# burning a connection-pool slot for up to `HARD_STREAM_TIMEOUT`.
+tokio-util = { workspace = true }
 arc-swap = "1"
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -507,10 +507,18 @@ pub async fn serve_with_listener_and_signer(
     // shape SSE frames. The same `jwks` + `minter` handles wire the rest
     // of the auth pipeline so token verification + minting are uniform
     // across `/v1/agent/*` and `/v1/messages`.
+    //
+    // C-1 fix-round 1: share the same `TokenBucketLimiter` instance the
+    // AuthLayer uses for the tonic stack — `/v1/messages` is a 600 s
+    // streaming endpoint, so being outside the AuthLayer's rate-limit
+    // path was strictly worse than the `agent_http` precedent. Passing
+    // the limiter to the route makes the budget uniform across
+    // `/v1/agent/*` and `/v1/messages`.
     let anthropic_state = crate::services::anthropic_messages::AnthropicMessagesState {
         jwks: Arc::clone(&jwks),
         minter: Arc::clone(&minter),
         upstream: upstream_channel.clone(),
+        rate_limiter: Some(rate_limiter.clone()),
     };
     let anthropic_router = crate::services::anthropic_messages::router(anthropic_state);
 

--- a/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
+++ b/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
@@ -48,8 +48,17 @@
 //!   with an Anthropic-shape error body. Body-level forward compatibility
 //!   stays the codec's choice (see codec's `request.rs` strictness policy).
 //! - **L10-D6**: model-name resolution (Anthropic vs life-routed) is
-//!   J-Sub-F's surface. This route passes `model` through to lifed
-//!   verbatim.
+//!   J-Sub-F's surface. The `model` field on the inbound Anthropic body
+//!   is **NOT** forwarded to lifed — `CreateSessionReq` and
+//!   `SendMessageReq` have no `model` field. The route captures
+//!   `req.model` only for the codec encoder, where it becomes
+//!   `gen_ai.response.model` plus the `model` field on the `message_start`
+//!   envelope. Backend selection (Anthropic upstream vs life-routed
+//!   substrate) is derived from agent identity inside lifed; the wire
+//!   model name only roundtrips through SSE framing today. J-Sub-F is
+//!   where actual model-based routing lands; until then the comment in
+//!   the PR body table that said "passes through to lifed" was wrong
+//!   and is corrected here.
 //! - **L10-D7**: no token counting. Token semantics are Vigil/Haima
 //!   surfaces (J-Sub-F).
 //!
@@ -78,7 +87,7 @@ use std::time::Duration;
 use axum::{
     Router,
     body::Body,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
     routing::post,
@@ -89,6 +98,7 @@ use lifegw_anthropic_codec::{
     AnthropicError, AnthropicErrorKind, AnthropicMessagesRequest, AnthropicSseEvent,
     AnthropicVersion, CodecError, Encoder, synthesize_sid,
 };
+use tokio_util::sync::CancellationToken;
 use tonic::transport::Channel;
 use uuid::Uuid;
 
@@ -96,6 +106,7 @@ use life_runtime_proto::life::v1::{self as pb, agent_client::AgentClient};
 
 use crate::auth::jwks::JwksCache;
 use crate::auth::tier2::Tier2Minter;
+use crate::services::rate_limit::TokenBucketLimiter;
 
 /// Wall-clock cap on a single `/v1/messages` response stream.
 ///
@@ -130,6 +141,12 @@ const MAX_VERSION_HEADER_LEN: usize = 64;
 /// extractor defaults — we surface oversize bodies as a 413 with an
 /// Anthropic-shape error rather than letting axum reject them with the
 /// default text body.
+///
+/// Fix-round 1 — I-4: this constant is enforced at the *router* level
+/// via [`DefaultBodyLimit::max`] so axum rejects oversize bodies during
+/// the body read (streaming-time) rather than after the full payload
+/// has been buffered into a `Bytes` extractor. The post-extract size
+/// check has been removed as redundant.
 const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 
 // ─── Router state ───────────────────────────────────────────────────────
@@ -143,6 +160,15 @@ pub struct AnthropicMessagesState {
     pub minter: Arc<Tier2Minter>,
     /// Pre-dialed lifed UDS channel. Cheap to clone (internally `Arc`'d).
     pub upstream: Channel,
+    /// Fix-round 1 — C-1: per-user + per-IP token-bucket limiter
+    /// shared with `AuthLayer`. The handler consults the same limiter
+    /// the tonic stack uses post–Tier-1-verify and pre–Tier-2-mint, so
+    /// `/v1/messages` traffic is gated by the same budget. Until the
+    /// limiter exists every Anthropic-shaped POST holds a streaming
+    /// slot for up to `HARD_STREAM_TIMEOUT` (600 s) without back-pressure
+    /// — strictly worse than the `agent_http` precedent (10 s unary).
+    /// Tests opt out by leaving this `None`.
+    pub rate_limiter: Option<TokenBucketLimiter>,
 }
 
 /// Mount the route.
@@ -157,6 +183,11 @@ pub fn router(state: AnthropicMessagesState) -> Router {
             "/v1/messages",
             post(messages_handler).options(probe).head(probe),
         )
+        // I-4 (fix-round 1): cap body size at the router boundary so
+        // axum rejects oversized payloads during the read rather than
+        // after the entire body has been buffered into `Bytes`. axum's
+        // default ceiling is 2 MiB; we override to MAX_BODY_BYTES.
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .with_state(state)
 }
 
@@ -238,14 +269,43 @@ async fn messages_handler(
         }
     };
 
-    // 3. Enforce body size.
-    if body.len() > MAX_BODY_BYTES {
-        return anthropic_http_error(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            AnthropicErrorKind::InvalidRequestError,
-            format!("request body exceeds {MAX_BODY_BYTES} bytes"),
-        );
+    // C-1 (fix-round 1): rate-limit check AFTER Tier-1 verify (so we
+    // have a real `user_id` to key the bucket on) and BEFORE Tier-2
+    // mint + the upstream saga (so over-budget traffic doesn't pay
+    // the JWS-mint CPU cost or hold a streaming slot). The limiter is
+    // the same handle `AuthLayer` uses for the tonic stack, so a user
+    // who exhausts their bucket across `/v1/agent/*` will also hit the
+    // limit on `/v1/messages` (single shared budget per user).
+    //
+    // Per the prompt's hard rule, rate-limit failures map to HTTP 429
+    // + Anthropic-shape `rate_limit_error` body (the body shape lifed
+    // would otherwise produce via `ResourceExhausted` → 429 mapping
+    // for an upstream-side rejection).
+    if let Some(limiter) = state.rate_limiter.as_ref() {
+        let peer_ip = peer_ip_from_request(&headers)
+            .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+        let decision = limiter.check(&tier1.user_id, peer_ip);
+        if decision.is_reject() {
+            tracing::debug!(
+                user = %tier1.user_id,
+                ip = %peer_ip,
+                reason = decision.reason(),
+                "rate limit rejected /v1/messages request"
+            );
+            return anthropic_http_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                AnthropicErrorKind::RateLimitError,
+                decision.reason().to_string(),
+            );
+        }
+        // Suppress unused-decision warning when reason is informational only.
+        let _ = decision;
     }
+
+    // 3. Body size is enforced at the router level via
+    //    `DefaultBodyLimit::max(MAX_BODY_BYTES)` — axum rejects
+    //    oversized requests with a 413 during the body read before
+    //    this handler is even called. See `router(...)` below.
 
     // 4. Parse the request body via the codec (forward-compatible — see
     //    codec's `request.rs` strictness policy).
@@ -308,8 +368,24 @@ async fn messages_handler(
         return err;
     }
 
+    // I-5 (fix-round 1): a `CancellationToken` ties the SendMessage
+    // upstream drain task to the SSE response body lifecycle. The
+    // body-stream holds the matching `DropGuard`; when axum drops the
+    // body (client disconnect, hyper teardown, error), the guard fires
+    // `cancel()` and the drain stops cleanly instead of burning a
+    // connection-pool slot for up to HARD_STREAM_TIMEOUT.
+    let cancel = CancellationToken::new();
+
     let last_user_content = extract_last_user_content(&req);
-    if let Err(err) = send_message(&mut agent_client, &tier2, &sid, &last_user_content).await {
+    if let Err(err) = send_message(
+        &mut agent_client,
+        &tier2,
+        &sid,
+        &last_user_content,
+        cancel.clone(),
+    )
+    .await
+    {
         return err;
     }
 
@@ -325,7 +401,7 @@ async fn messages_handler(
     let message_id = format!("msg_{}", Uuid::new_v4().simple());
     let encoder = Encoder::new(message_id, req.model.clone());
 
-    let sse_body = build_sse_body(encoder, event_stream);
+    let sse_body = build_sse_body(encoder, event_stream, cancel);
 
     // 9. Compose response. Anthropic clients require a content-type of
     //    `text/event-stream`; `X-Accel-Buffering: no` neutralises nginx
@@ -395,11 +471,19 @@ async fn create_session(
 /// `lifed.Agent.SendMessage` call. lifed broadcasts the resulting
 /// events through its fanout registry; we read them back via
 /// `StreamSession`.
+///
+/// The upstream `SendMessage` returns its own event stream which we
+/// intentionally drop (`StreamSession` is canonical — see the WS
+/// dispatcher's same invariant). I-5 fix-round 1: the drain task obeys
+/// the caller-provided `cancel` token, so a client disconnect cancels
+/// the drain immediately instead of holding the upstream slot for up
+/// to `HARD_STREAM_TIMEOUT`.
 async fn send_message(
     client: &mut AgentClient<Channel>,
     tier2: &str,
     sid: &str,
     content: &str,
+    cancel: CancellationToken,
 ) -> Result<(), Response> {
     let mut req = tonic::Request::new(pb::SendMessageReq {
         sid: Some(aios_proto::aios::v1::SessionId {
@@ -431,21 +515,37 @@ async fn send_message(
         }
     };
 
-    // Drop the SendMessage event stream — like the WS dispatcher, we
-    // rely on `Agent.StreamSession` as the canonical event source so
-    // we don't double-emit on lifed's fanout registry. Spawning a
-    // background drain keeps the upstream from blocking on us if it
-    // expects to push the full reply through this RPC; we cap it at
-    // the hard timeout to avoid lingering tasks on a misbehaving
-    // upstream.
+    // Spawn a background drain that pulls (and drops) the SendMessage
+    // reply stream. We rely on `Agent.StreamSession` as the canonical
+    // event source so we don't double-emit on lifed's fanout registry.
+    //
+    // The drain stops on any of three signals (whichever wins):
+    //   - `cancel.cancelled()` — client disconnected / response body
+    //     dropped (the new behaviour).
+    //   - upstream EOF / error — natural stream end.
+    //   - HARD_STREAM_TIMEOUT — backstop against pathologically slow
+    //     upstreams that never close.
+    //
+    // Without the cancel arm, a client-side disconnect at second 5
+    // would still pump for up to 595 more seconds, holding the tonic
+    // client + upstream pool slot.
     tokio::spawn(async move {
         let mut s = resp.into_inner();
-        let _ = tokio::time::timeout(HARD_STREAM_TIMEOUT, async {
-            while s.next().await.is_some() {
-                // Intentionally drop. StreamSession is canonical.
+        let drain = async {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    next = s.next() => {
+                        if next.is_none() {
+                            break;
+                        }
+                        // Intentionally drop the frame. StreamSession is canonical.
+                    }
+                }
             }
-        })
-        .await;
+        };
+        let _ = tokio::time::timeout(HARD_STREAM_TIMEOUT, drain).await;
     });
 
     Ok(())
@@ -502,9 +602,16 @@ fn attach_tier2<T>(req: &mut tonic::Request<T>, tier2: &str) -> Result<(), Respo
 /// `Infallible` as the stream's error type matches axum's
 /// `Body::from_stream` requirement and pairs with the codec's discipline
 /// of converting mid-stream faults into in-band `event: error` frames.
+///
+/// I-5 (fix-round 1): the stream owns the `DropGuard` derived from
+/// `cancel`. When axum drops the response body (client disconnect,
+/// hyper teardown, error path), the guard fires `cancel()` and the
+/// upstream `SendMessage` drain task spawned by [`send_message`] stops
+/// immediately.
 fn build_sse_body(
     encoder: Encoder,
     upstream: tonic::Streaming<pb::AgentEvent>,
+    cancel: CancellationToken,
 ) -> impl Stream<Item = Result<Bytes, Infallible>> + Send + 'static {
     // Box the upstream so the stream::unfold state type stays sized.
     let upstream: std::pin::Pin<
@@ -539,6 +646,15 @@ fn build_sse_body(
         queued: std::collections::VecDeque<AnthropicSseEvent>,
         /// Terminal flag — once true the stream returns None on next call.
         done: bool,
+        /// I-5 (fix-round 1): RAII guard that cancels the upstream
+        /// `SendMessage` drain task when this state machine is
+        /// dropped. The guard's `Drop` impl calls `cancel.cancel()`,
+        /// which wakes the drain's `cancel.cancelled()` arm.
+        ///
+        /// The field is kept alive for the full life of the SSE body —
+        /// when axum drops the body (any termination path: hyper
+        /// finished, client disconnect, error), the guard fires.
+        _drop_guard: tokio_util::sync::DropGuard,
     }
 
     let mut ping_interval = tokio::time::interval(PING_INTERVAL);
@@ -553,6 +669,7 @@ fn build_sse_body(
         ping_interval,
         queued: std::collections::VecDeque::new(),
         done: false,
+        _drop_guard: cancel.drop_guard(),
     };
 
     stream::unfold(state, |mut s| async move {
@@ -688,6 +805,49 @@ fn extract_last_user_content(req: &AnthropicMessagesRequest) -> String {
         .find(|m| m.role == Role::User)
         .map(|m| m.content.plain_text())
         .unwrap_or_default()
+}
+
+/// Resolve the request's peer IP for the rate-limiter's per-IP bucket.
+///
+/// Mirrors the precedence rules from `auth::middleware::peer_ip_from_request`
+/// but reads only the `HeaderMap` axum hands us (axum's `ConnectInfo`
+/// would have to be wired through a separate extractor, which would mean
+/// rebuilding the route mount point; XFF + Forwarded headers cover the
+/// only deployment topology that matters — lifegw behind Vercel edge —
+/// and the L7 in front sets one of those two headers for every request).
+///
+/// Order of precedence:
+/// 1. `X-Forwarded-For` (leftmost non-empty value).
+/// 2. `Forwarded` (RFC 7239 `for=<ip>` token).
+/// 3. `None` — caller falls back to `0.0.0.0` so the limiter still
+///    enforces a defence-in-depth single-shared-bucket budget.
+fn peer_ip_from_request(headers: &HeaderMap) -> Option<std::net::IpAddr> {
+    if let Some(hv) = headers.get("x-forwarded-for")
+        && let Ok(s) = hv.to_str()
+        && let Some(first) = s.split(',').map(str::trim).find(|x| !x.is_empty())
+        && let Some(ip) = crate::auth::middleware::parse_ip_or_socket(first)
+    {
+        return Some(ip);
+    }
+    if let Some(hv) = headers.get("forwarded")
+        && let Ok(s) = hv.to_str()
+    {
+        for part in s.split(';') {
+            for kv in part.split(',') {
+                let trimmed = kv.trim();
+                let rest = trimmed
+                    .strip_prefix("for=")
+                    .or_else(|| trimmed.strip_prefix("For="));
+                if let Some(rest) = rest {
+                    let raw = rest.trim_matches('"');
+                    if let Some(ip) = crate::auth::middleware::parse_ip_or_socket(raw) {
+                        return Some(ip);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Build a JSON Anthropic-shape error response with the given HTTP

--- a/crates/life-runtime/lifegw/tests/anthropic_messages_integration.rs
+++ b/crates/life-runtime/lifegw/tests/anthropic_messages_integration.rs
@@ -24,10 +24,28 @@
 //! * `unknown_anthropic_version_returns_400` — Spec J L10-D5 strictness.
 //! * `rate_limit_engaged_returns_429` — upstream `ResourceExhausted`
 //!   maps to HTTP 429 + Anthropic-shape `rate_limit_error` body.
-//! * `connection_drop_resume` — re-requesting with the same body
-//!   resolves the same sid (deterministic sid synthesis).
+//! * `deterministic_sid_across_turns` (formerly `connection_drop_resume`)
+//!   — re-requesting with the same body resolves the same sid via the
+//!   codec's deterministic synthesis (`synthesize_sid(req, anima_did)`).
+//!   This is the sid-stability assertion, NOT a real mid-stream drop +
+//!   `from_sequence` replay test — the handler currently passes
+//!   `from_sequence: None` (see `open_stream`). The actual drop+resume
+//!   E2E lives in J-Sub-G; the unit-level companion is
+//!   `connection_drop_resume_replays_from_sequence` below (marked
+//!   `#[ignore]` until the mock lifed grows from_sequence playback).
+//! * `connection_drop_resume_replays_from_sequence` — placeholder for
+//!   the real drop+resume case once J-Sub-G lands.
 //! * `large_request_body` — 100K-character payload doesn't blow up
 //!   the streaming parser.
+//! * `oversize_body_returns_413` — bodies above `MAX_BODY_BYTES` get
+//!   rejected at the router boundary by axum's `DefaultBodyLimit`.
+//! * `rate_limit_engaged_returns_429_on_messages_route` (C-1 fix-round 1)
+//!   — when a `TokenBucketLimiter` is wired into `AnthropicMessagesState`,
+//!   over-budget traffic returns HTTP 429 with an Anthropic-shape
+//!   `rate_limit_error` body BEFORE the upstream saga fires.
+//! * SSE order helpers — `simple_chat_completion` now asserts the
+//!   `message_start → content_block_* → message_delta → message_stop`
+//!   order, not just that each frame appears somewhere in the body.
 //!
 //! Scope caveats (mirroring Spec J §J-Sub-B):
 //!
@@ -281,6 +299,17 @@ struct TestRig {
 
 impl TestRig {
     async fn build() -> Self {
+        Self::build_with_rate_limiter(None).await
+    }
+
+    /// Fix-round 1 (C-1): build a rig where the route shares the given
+    /// `TokenBucketLimiter` with the (in this isolated test) absent
+    /// AuthLayer. Production bootstrap wires the same handle across
+    /// AuthLayer + AnthropicMessagesState; this helper lets a unit
+    /// test exercise the limiter against `/v1/messages` directly.
+    async fn build_with_rate_limiter(
+        rate_limiter: Option<lifegw::services::rate_limit::TokenBucketLimiter>,
+    ) -> Self {
         // Mock lifed Agent service over a tempdir UDS.
         let temp = tempfile::tempdir().expect("tempdir");
         let socket_path = temp.path().join("lifed.sock");
@@ -331,6 +360,7 @@ impl TestRig {
             jwks,
             minter,
             upstream,
+            rate_limiter,
         };
         let router = anthropic_messages::router(state);
 
@@ -388,6 +418,79 @@ async fn collect_body(resp: axum::http::Response<axum::body::Body>) -> (StatusCo
     (status, String::from_utf8_lossy(&bytes).into_owned())
 }
 
+/// Parse an SSE body into an ordered list of `event:` names. We don't
+/// care about `data:` payloads for ordering assertions — just the
+/// sequence of event types as they appear on the wire.
+///
+/// I-3 (fix-round 1): the previous `simple_chat_completion` body used
+/// `body.contains(...)` for each frame name, which is order-independent.
+/// A broken encoder that emitted `content_block_delta` before
+/// `content_block_start` would have passed. This helper makes the test
+/// pin the wire shape: it returns the events in document order, and
+/// the assertion asserts the canonical ordering.
+fn sse_event_names(body: &str) -> Vec<&str> {
+    body.lines()
+        .filter_map(|l| l.strip_prefix("event: "))
+        .map(str::trim)
+        .collect()
+}
+
+/// Assert the canonical Anthropic SSE ordering invariant. The encoder
+/// MUST emit:
+///
+///   message_start → content_block_start → content_block_delta+
+///       → content_block_stop → message_delta → message_stop
+///
+/// Pings can intersperse anywhere (15 s keep-alive cadence, not
+/// expected in the unit tests but tolerated). The assertion walks the
+/// event list with a state machine.
+fn assert_canonical_sse_order(events: &[&str]) {
+    #[derive(Debug, PartialEq, Eq)]
+    enum Phase {
+        AwaitMessageStart,
+        AwaitBlockStart,
+        InBlock,
+        AfterBlockStop,
+        AfterMessageDelta,
+        Done,
+    }
+    let mut phase = Phase::AwaitMessageStart;
+    let mut block_open = false;
+    for e in events {
+        if *e == "ping" {
+            continue;
+        }
+        match (&phase, *e) {
+            (Phase::AwaitMessageStart, "message_start") => phase = Phase::AwaitBlockStart,
+            (Phase::AwaitBlockStart, "content_block_start") => {
+                phase = Phase::InBlock;
+                block_open = true;
+            }
+            (Phase::InBlock, "content_block_delta") => {
+                // 1+ deltas allowed.
+            }
+            (Phase::InBlock, "content_block_stop") => {
+                phase = Phase::AfterBlockStop;
+                block_open = false;
+            }
+            (Phase::AfterBlockStop, "content_block_start") => {
+                phase = Phase::InBlock;
+                block_open = true;
+            }
+            (Phase::AfterBlockStop, "message_delta") => phase = Phase::AfterMessageDelta,
+            (Phase::AfterMessageDelta, "message_stop") => phase = Phase::Done,
+            (p, e) => panic!(
+                "canonical SSE order violation: phase={p:?} unexpected event `{e}`; full events={events:?}"
+            ),
+        }
+    }
+    assert_eq!(
+        phase,
+        Phase::Done,
+        "stream did not reach `message_stop` (last phase {phase:?}, block_open={block_open})"
+    );
+}
+
 /// Helper that streams the response body and stops once `message_stop`
 /// is observed. Used by tests that need the SSE-shape assertions
 /// (`event: message_stop\n` is the terminal marker).
@@ -437,17 +540,16 @@ async fn simple_chat_completion() {
     );
 
     let body = stream_until_stop(resp, 8 * 1024).await;
-    assert!(
-        body.contains("event: message_start"),
-        "missing message_start in body: {body}"
-    );
-    assert!(
-        body.contains("event: content_block_start"),
-        "missing content_block_start: {body}"
-    );
+    // I-3 (fix-round 1): the previous version used per-frame
+    // `body.contains(...)` which is order-independent. Walk the SSE
+    // event names in document order and assert the canonical
+    // Anthropic ordering invariant via the state machine helper.
+    let events = sse_event_names(&body);
+    assert_canonical_sse_order(&events);
+    // Spot-check the encoded content — the text deltas carry the
+    // concatenated upstream tokens.
     assert!(body.contains("Hello"));
     assert!(body.contains(" world"));
-    assert!(body.contains("event: message_stop"), "missing terminal");
 
     // Upstream observed: create + send + stream.
     assert_eq!(rig.state.create_session_calls.lock().await.len(), 1);
@@ -577,12 +679,15 @@ async fn rate_limit_engaged_returns_429() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn connection_drop_resume() {
-    // Drive two POSTs back-to-back with the same body. The deterministic
-    // sid synthesis means both hit the same Life sid — the mock's
-    // CreateSession echoes the inbound resume_sid, so the recorded
-    // sids must match. This mirrors a Claude-Code-side disconnect +
-    // re-send.
+async fn deterministic_sid_across_turns() {
+    // I-2 fix-round 1 (rename from `connection_drop_resume`): the
+    // canonical assertion this test makes is that two completed POSTs
+    // with the same body produce the same sid via the codec's
+    // deterministic synthesis. The handler always passes
+    // `from_sequence: None` (see `open_stream`) so there is NO
+    // resume-from-cursor exercised here. The name was misleading; the
+    // body is right. See `connection_drop_resume_replays_from_sequence`
+    // below for the real-drop case (currently `#[ignore]`'d).
     let rig = TestRig::build().await;
 
     let body = TestRig::body("resume-marker");
@@ -607,6 +712,35 @@ async fn connection_drop_resume() {
         sid_a, sid_b,
         "resume must reuse sid via deterministic synthesis"
     );
+}
+
+/// I-2 fix-round 1: documented placeholder for the real drop+resume
+/// semantics. The handler currently passes `from_sequence: None` to
+/// `lifed.Agent.StreamSession` (see `open_stream`), so a mid-stream
+/// drop cannot today be replayed from a sequence cursor; lifed-side
+/// replay against the lago substrate is the J-Sub-G E2E surface (real
+/// lifed + real lago, not the in-memory mock used by this rig).
+///
+/// Kept `#[ignore]`'d so the test name documents the coverage gap
+/// without falsely passing CI. When the mock lifed grows
+/// from_sequence playback (or when J-Sub-G's E2E smoke takes over the
+/// assertion), unblock this and assert the recorded `SessionRef`'s
+/// `from_sequence` is `Some(n)` after a disconnect.
+#[ignore = "real drop+resume requires lifed-side from_sequence replay; \
+            the mock lifed in this rig cannot exercise it; the integration \
+            test is owned by J-Sub-G E2E smoke (BRO-1144)."]
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_drop_resume_replays_from_sequence() {
+    // When un-ignored, this test should:
+    //   1. Open POST 1, read N tokens from the SSE body, then drop
+    //      the response (simulating client disconnect).
+    //   2. Wait for the upstream `StreamSession` to terminate.
+    //   3. Open POST 2 with the SAME body, expect the handler to
+    //      issue `StreamSession{from_sequence: Some(N)}`.
+    //   4. Assert via the mock's `stream_session_calls` log that the
+    //      second call carries `from_sequence=Some(N)`.
+    // For now the handler always passes `from_sequence: None`; this
+    // body is intentionally left blank pending that wire-up.
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -658,4 +792,108 @@ async fn options_probe_returns_204() {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     assert!(allow.contains("POST"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn oversize_body_returns_413() {
+    // I-4 fix-round 1: bodies above MAX_BODY_BYTES (8 MiB) MUST be
+    // rejected at the router boundary by axum's
+    // `DefaultBodyLimit::max(...)`. The expected status is 413; the
+    // body is whatever axum produces for the limit rejection (we don't
+    // pin its shape since axum owns the body — the security invariant
+    // is that the request never reaches the handler with a 1 GiB
+    // payload buffered into RAM).
+    let rig = TestRig::build().await;
+    // 9 MiB > 8 MiB MAX_BODY_BYTES. Synthesize a JSON body whose
+    // serialised form crosses the threshold — pad the user text with
+    // a long ASCII run.
+    let pad = "A".repeat(9 * 1024 * 1024);
+    let body = TestRig::body(&pad);
+    let body_len = body.len();
+    assert!(
+        body_len > 8 * 1024 * 1024,
+        "test body must exceed 8 MiB to exercise the limit: {body_len}"
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("alice"))
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .expect("build req");
+    let resp = rig.router().oneshot(req).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "oversize body must be rejected before reaching the handler"
+    );
+    // The handler MUST NOT have observed the upstream saga.
+    assert!(rig.state.create_session_calls.lock().await.is_empty());
+    assert!(rig.state.send_message_calls.lock().await.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rate_limit_engaged_returns_429_on_messages_route() {
+    // C-1 fix-round 1: the route now consults the shared
+    // `TokenBucketLimiter` post-Tier-1-verify and pre-Tier-2-mint. Wire
+    // a tiny budget (capacity 2, no refill) and assert the 3rd request
+    // returns 429 + an Anthropic-shape `rate_limit_error` body BEFORE
+    // the upstream `CreateSession` saga fires.
+    let limiter = lifegw::services::rate_limit::TokenBucketLimiter::new(
+        /* user_capacity */ 2, /* user_refill_per_sec */ 0,
+        /* ip_capacity */ 10_000, /* ip_refill_per_min */ 60, /* max_buckets */ 64,
+    );
+
+    let rig = TestRig::build_with_rate_limiter(Some(limiter)).await;
+
+    // First 2 requests succeed.
+    for i in 0..2 {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", TestRig::dev_bearer("rl-burst"))
+            .header("anthropic-version", "2023-06-01")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(TestRig::body(&format!("hi-{i}"))))
+            .expect("build req");
+        let resp = rig.router().oneshot(req).await.expect("oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "request {i} within budget must succeed"
+        );
+        let _ = stream_until_stop(resp, 8 * 1024).await;
+    }
+
+    // 3rd request — over budget, no refill → 429.
+    let req3 = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("authorization", TestRig::dev_bearer("rl-burst"))
+        .header("anthropic-version", "2023-06-01")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(TestRig::body("third")))
+        .expect("build req");
+    let resp = rig.router().oneshot(req3).await.expect("oneshot");
+    let (status, body) = collect_body(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "3rd request must hit the limiter — got body {body}"
+    );
+    let v: Value = serde_json::from_str(&body).expect("anthropic-shape body");
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["error"]["type"], "rate_limit_error");
+    let msg = v["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("rate_limit"),
+        "rate-limit reason must surface in body: {msg}"
+    );
+
+    // The upstream saga MUST NOT have fired for the rejected request.
+    // Only 2 CreateSession calls (one per accepted POST).
+    assert_eq!(rig.state.create_session_calls.lock().await.len(), 2);
+    assert_eq!(rig.state.send_message_calls.lock().await.len(), 2);
 }


### PR DESCRIPTION
## Context

PR #1331 (BRO-1142) shipped the `POST /v1/messages` Anthropic SSE route. The Strata B adversarial cross-review on that PR (https://github.com/broomva/life/pull/1331#issuecomment-4479193674) returned **CONDITIONAL** with 2 critical findings and 6 secondary concerns. PR #1331 merged before the fix-round 1 commit landed, so the fixes ship here as a follow-up.

## Scope

Fix-round 1 addresses both criticals + 5 of the 6 concerns. I-6 is deferred to **BRO-1143** with a documented rationale (the broader history-management story lands when tool flows wire `AnthropicArcan` into production traffic).

## Findings addressed

### C-1 — Rate limiter now applies to /v1/messages (CRITICAL)

`/v1/messages` is a 600 s streaming endpoint serving Claude Code; being outside the AuthLayer's rate-limit path is strictly worse than the `agent_http` precedent (10 s unary).

- `AnthropicMessagesState` now carries `Option<TokenBucketLimiter>`.
- `bootstrap.rs` threads the same `rate_limiter` instance the tonic stack uses into the route — **single shared budget per user across `/v1/agent/*` and `/v1/messages`**.
- The handler consults the limiter post-Tier-1-verify and pre-Tier-2-mint, mirroring the AuthLayer's order so over-budget traffic doesn't pay the JWS-mint CPU cost or hold a streaming slot.
- Over-budget responses are HTTP 429 + Anthropic-shape `rate_limit_error` body.
- New integration test `rate_limit_engaged_returns_429_on_messages_route` wires a capacity-2 / no-refill limiter, fires 3 requests, and asserts the 3rd returns 429 AND the upstream saga did not fire for it.

### C-2 — `AnthropicArcanConfig.api_key` no longer leaks via Debug (CRITICAL)

- `#[derive(Debug)]` removed.
- Manual `impl Debug` prints `api_key: "<redacted>"`; other fields pass through.
- New unit test `debug_impl_redacts_api_key` asserts `<redacted>` appears and the literal `secret-key-value` does not.

### I-1 — Docstring corrected

`req.model` is used only for SSE framing (encoder + `message_start` envelope + `gen_ai.response.model`). The field is NOT forwarded to lifed — `CreateSessionReq` / `SendMessageReq` have no `model` field. Backend selection is J-Sub-F's surface. Docstring updated.

### I-2 — Misnamed test renamed; documented placeholder added

- `connection_drop_resume` renamed to `deterministic_sid_across_turns` (honest naming — the body asserts sid determinism via `synthesize_sid`, NOT mid-stream drop + `from_sequence` replay).
- New `connection_drop_resume_replays_from_sequence` placeholder added, marked `#[ignore]` with a rationale referencing **BRO-1144** (J-Sub-G E2E owns the real drop+resume case).

### I-3 — SSE wire-shape ordering pinned

`simple_chat_completion` previously used `body.contains("event: X")` per-frame which is order-independent. The new helper `sse_event_names(...)` extracts event names in document order; `assert_canonical_sse_order(...)` walks them through a state machine asserting `message_start → content_block_start → content_block_delta+ → content_block_stop → message_delta → message_stop`. Pings interspersed anywhere are tolerated.

### I-4 — `MAX_BODY_BYTES` enforced at stream-time, not post-buffer

- `DefaultBodyLimit::max(MAX_BODY_BYTES)` layer on the router — axum rejects oversize bodies during the body read, not after full buffering.
- Post-extract size check removed as redundant.
- New `oversize_body_returns_413` test asserts a 9 MiB body (above 8 MiB cap) returns 413 and the upstream saga did not fire.

### I-5 — SendMessage drain task tied to response lifecycle

- `CancellationToken` threaded through `send_message` into the drain spawn.
- `StreamState` owns a matching `DropGuard`. When axum drops the SSE body (client disconnect / hyper teardown / error), `cancel()` fires.
- Drain loop uses `tokio::select! { biased; cancel.cancelled() => break, next = s.next() => … }` so cancellation wakes immediately.
- `HARD_STREAM_TIMEOUT` retained as a backstop for pathologically slow upstreams that never close.
- `tokio-util` added as a direct dependency on lifegw (workspace pin, `rt` feature already present).

### I-6 — DEFERRED to BRO-1143

`AnthropicArcan.history: HashMap<sid, Vec<ChatMessage>>` has per-sid bounds (`MAX_HISTORY_MESSAGES = 20`) but no cross-sid eviction. The crate is currently unconsumed on main (Q2 fold rationale); J-Sub-D wires `AnthropicArcan` into lifed as a real `ArcanCall` impl alongside production tool flows — that is when an LRU / TTL eviction story across sids becomes load-bearing. Single-line `TODO(BRO-1143)` doc-comment added at the field site.

## Acceptance gates

| Gate | Status |
|---|---|
| `cargo build -p arcan-proxy -p lifegw -p lifegw-anthropic-codec` | clean |
| `cargo test -p arcan-proxy` (incl. `debug_impl_redacts_api_key`) | 26 → 27 green |
| `cargo test -p lifegw --test anthropic_messages_integration` | 9 → 12 (11 green + 1 documented `#[ignore]`) |
| `cargo clippy -p lifegw -p arcan-proxy --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |

## Test plan

- [x] `cargo test -p arcan-proxy` — secret-redaction test green
- [x] `cargo test -p lifegw -- anthropic_messages` — 11 green + 1 ignored with rationale
- [x] `cargo test -p lifegw` (full) — no regressions
- [x] `cargo clippy -p lifegw -p arcan-proxy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — clean

## Pre-existing CI lane note

The Strata B reviewer flagged `bash scripts/verify_dependencies_lifegw.sh` failing on main due to `life-kernel-proto`. CI ran "Verify lifegw dependency rules" green on #1331; this PR does not touch the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)