### PR TITLE
feat(lifegw): J-Sub-D tool-use bridge — arcan-proxy SSE parser + encoder tests [BRO-1143]

### DIFF
--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -263,6 +263,28 @@ fn record_response(
     ))
 }
 
+/// State carried across SSE parse iterations.
+///
+/// Tracks upstream content-block indices that are bound to `tool_use`
+/// blocks so that subsequent `content_block_delta` / `content_block_stop`
+/// frames can look up the tool_use id without re-parsing the original
+/// start frame.
+///
+/// J-Sub-D (BRO-1143) extension: previously this parser was text-only;
+/// for the Anthropic tool-use bridge it must thread `(index → tool_use_id)`
+/// state across frames so that `input_json_delta` events know which tool
+/// the partial JSON belongs to.
+#[derive(Default)]
+struct ParserState {
+    /// Maps upstream `content_block` index → Anthropic `tool_use_id` for
+    /// every currently-open tool_use block.
+    tool_use_by_index: std::collections::HashMap<u64, String>,
+    /// Most recent stop_reason carried on `message_delta`. Surfaces in
+    /// the synthesized `Finish` event so the encoder downstream can
+    /// emit Anthropic's `message_delta {stop_reason: "tool_use"}`.
+    last_stop_reason: Option<String>,
+}
+
 fn parse_sse<S>(
     body: S,
     session_id: aios_proto::aios::v1::SessionId,
@@ -274,8 +296,15 @@ where
     let body: Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send>> =
         Box::pin(body);
     Box::pin(stream::unfold(
-        (body, Vec::new(), 0_u64, false, session_id),
-        |(mut body, mut buffer, mut sequence, done, session_id)| async move {
+        (
+            body,
+            Vec::new(),
+            0_u64,
+            false,
+            session_id,
+            ParserState::default(),
+        ),
+        |(mut body, mut buffer, mut sequence, done, session_id, mut state)| async move {
             if done {
                 return None;
             }
@@ -295,7 +324,33 @@ where
                             continue;
                         };
                         match v.get("type").and_then(|t| t.as_str()) {
+                            Some("content_block_start") => {
+                                // J-Sub-D: tool_use blocks open here.
+                                // Track the upstream index → id mapping
+                                // and synthesize a `ToolCallPending`
+                                // event the encoder uses to open the
+                                // Anthropic-side tool_use content block.
+                                if let Some((idx, id, name)) = parse_tool_use_start(&v) {
+                                    state.tool_use_by_index.insert(idx, id.clone());
+                                    sequence += 1;
+                                    return Some((
+                                        Ok(event(
+                                            AgentEventKind::ToolCallPending,
+                                            "TOOL_CALL_PENDING",
+                                            &session_id,
+                                            sequence,
+                                            serde_json::json!({
+                                                "id": id,
+                                                "name": name,
+                                                "input": {},
+                                            }),
+                                        )),
+                                        (body, buffer, sequence, false, session_id, state),
+                                    ));
+                                }
+                            }
                             Some("content_block_delta") => {
+                                // Text deltas — existing path.
                                 if let Some(text) = v
                                     .get("delta")
                                     .and_then(|d| d.get("text"))
@@ -311,11 +366,91 @@ where
                                             sequence,
                                             serde_json::json!({"text": text}),
                                         )),
-                                        (body, buffer, sequence, false, session_id),
+                                        (body, buffer, sequence, false, session_id, state),
+                                    ));
+                                }
+                                // J-Sub-D: `input_json_delta` carries the
+                                // streamed tool_use input JSON. Look up
+                                // the tool_use id by the upstream index
+                                // (stashed at content_block_start) and
+                                // emit a ToolCallPending event with the
+                                // partial JSON fragment.
+                                //
+                                // If the index is unknown (upstream is
+                                // misbehaving) the delta is dropped
+                                // silently rather than panicking — keep
+                                // the stream healthy.
+                                if let Some((idx, partial)) = parse_input_json_delta(&v)
+                                    && let Some(id) = state.tool_use_by_index.get(&idx)
+                                {
+                                    sequence += 1;
+                                    let id = id.clone();
+                                    return Some((
+                                        Ok(event(
+                                            AgentEventKind::ToolCallPending,
+                                            "TOOL_CALL_PENDING",
+                                            &session_id,
+                                            sequence,
+                                            serde_json::json!({
+                                                "id": id,
+                                                "name": "",
+                                                "partial_json": partial,
+                                            }),
+                                        )),
+                                        (body, buffer, sequence, false, session_id, state),
                                     ));
                                 }
                             }
+                            Some("content_block_stop") => {
+                                // J-Sub-D: close tool_use block. Emit
+                                // ToolCallPending with `done: true` so
+                                // the encoder closes the Anthropic-side
+                                // content block. Text/thinking block
+                                // boundaries are synthesized at the
+                                // encoder layer, not here.
+                                if let Some(idx) = v.get("index").and_then(|i| i.as_u64())
+                                    && let Some(id) = state.tool_use_by_index.remove(&idx)
+                                {
+                                    sequence += 1;
+                                    return Some((
+                                        Ok(event(
+                                            AgentEventKind::ToolCallPending,
+                                            "TOOL_CALL_PENDING",
+                                            &session_id,
+                                            sequence,
+                                            serde_json::json!({
+                                                "id": id,
+                                                "name": "",
+                                                "done": true,
+                                            }),
+                                        )),
+                                        (body, buffer, sequence, false, session_id, state),
+                                    ));
+                                }
+                            }
+                            Some("message_delta") => {
+                                // J-Sub-D: capture stop_reason so the
+                                // synthesized Finish event downstream
+                                // carries it. Anthropic's upstream emits
+                                // `stop_reason: "tool_use"` on a
+                                // tool_use-terminated turn.
+                                if let Some(reason) = v
+                                    .get("delta")
+                                    .and_then(|d| d.get("stop_reason"))
+                                    .and_then(|s| s.as_str())
+                                {
+                                    state.last_stop_reason = Some(reason.to_string());
+                                }
+                                // message_delta itself produces no
+                                // synthesized AgentEvent — the Finish
+                                // event on `message_stop` carries the
+                                // reason.
+                            }
                             Some("message_stop") => {
+                                let reason = state
+                                    .last_stop_reason
+                                    .clone()
+                                    .unwrap_or_else(|| "stop".to_string());
                                 sequence += 1;
                                 return Some((
                                     Ok(event(
@@ -323,9 +458,9 @@ where
                                         "FINISH",
                                         &session_id,
                                         sequence,
-                                        serde_json::json!({"reason": "stop"}),
+                                        serde_json::json!({"reason": reason}),
                                     )),
-                                    (body, buffer, sequence, true, session_id),
+                                    (body, buffer, sequence, true, session_id, state),
                                 ));
                             }
                             _ => {}
@@ -340,7 +475,7 @@ where
                             Err(tonic::Status::internal(format!(
                                 "AnthropicArcan: stream read error: {err}"
                             ))),
-                            (body, buffer, sequence, true, session_id),
+                            (body, buffer, sequence, true, session_id, state),
                         ));
                     }
                     None => {
@@ -353,13 +488,44 @@ where
                                 sequence,
                                 serde_json::json!({"reason": "upstream_closed"}),
                             )),
-                            (body, buffer, sequence, true, session_id),
+                            (body, buffer, sequence, true, session_id, state),
                         ));
                     }
                 }
             }
         },
     ))
+}
+
+/// Extract `(index, id, name)` from a `content_block_start` event whose
+/// `content_block.type == "tool_use"`. Returns `None` for non-tool_use
+/// block_start frames (text / thinking are synthesized at the encoder,
+/// not parsed from upstream).
+fn parse_tool_use_start(v: &serde_json::Value) -> Option<(u64, String, String)> {
+    let idx = v.get("index").and_then(|i| i.as_u64())?;
+    let block = v.get("content_block")?;
+    if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+        return None;
+    }
+    let id = block.get("id").and_then(|s| s.as_str())?.to_string();
+    let name = block.get("name").and_then(|s| s.as_str())?.to_string();
+    Some((idx, id, name))
+}
+
+/// Extract `(index, partial_json)` from a `content_block_delta` whose
+/// `delta.type == "input_json_delta"`. Returns `None` for non-tool_use
+/// deltas.
+fn parse_input_json_delta(v: &serde_json::Value) -> Option<(u64, String)> {
+    let idx = v.get("index").and_then(|i| i.as_u64())?;
+    let delta = v.get("delta")?;
+    if delta.get("type").and_then(|t| t.as_str()) != Some("input_json_delta") {
+        return None;
+    }
+    let partial = delta
+        .get("partial_json")
+        .and_then(|s| s.as_str())?
+        .to_string();
+    Some((idx, partial))
 }
 
 fn event(
@@ -458,5 +624,152 @@ mod tests {
             s.next().await.unwrap().unwrap().kind(),
             AgentEventKind::Finish
         );
+    }
+
+    /// J-Sub-D (BRO-1143): upstream `content_block_start` for a tool_use
+    /// block must emit a `ToolCallPending` event carrying `{id, name}`.
+    #[tokio::test]
+    async fn parses_tool_use_start() {
+        let body = b"event: content_block_start\n\
+                     data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"read_file\",\"input\":{}}}\n\n\
+                     event: message_stop\n\
+                     data: {\"type\":\"message_stop\"}\n\n";
+        let mut s = parse_sse(
+            stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::from(body.to_vec()))]),
+            aios_proto::aios::v1::SessionId { value: "s".into() },
+        );
+        let first = s.next().await.unwrap().unwrap();
+        assert_eq!(first.kind(), AgentEventKind::ToolCallPending);
+        let record = first.record.as_ref().unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_slice(&record.payload).expect("payload is valid json");
+        assert_eq!(payload["id"], "toolu_01");
+        assert_eq!(payload["name"], "read_file");
+        // Finish closes the stream.
+        let second = s.next().await.unwrap().unwrap();
+        assert_eq!(second.kind(), AgentEventKind::Finish);
+    }
+
+    /// J-Sub-D (BRO-1143): `content_block_delta` carrying
+    /// `input_json_delta` re-uses the index → tool_use_id binding to
+    /// emit one event per partial-JSON chunk.
+    #[tokio::test]
+    async fn parses_input_json_delta_chunks() {
+        let body = b"event: content_block_start\n\
+                     data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"read_file\",\"input\":{}}}\n\n\
+                     event: content_block_delta\n\
+                     data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\"}}\n\n\
+                     event: content_block_delta\n\
+                     data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\" \\\"foo.txt\\\"}\"}}\n\n\
+                     event: content_block_stop\n\
+                     data: {\"type\":\"content_block_stop\",\"index\":1}\n\n\
+                     event: message_stop\n\
+                     data: {\"type\":\"message_stop\"}\n\n";
+        let mut s = parse_sse(
+            stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::from(body.to_vec()))]),
+            aios_proto::aios::v1::SessionId { value: "s".into() },
+        );
+        // Open: id + name carried.
+        let open = s.next().await.unwrap().unwrap();
+        assert_eq!(open.kind(), AgentEventKind::ToolCallPending);
+        // Partial 1.
+        let p1 = s.next().await.unwrap().unwrap();
+        assert_eq!(p1.kind(), AgentEventKind::ToolCallPending);
+        let v1: serde_json::Value =
+            serde_json::from_slice(&p1.record.as_ref().unwrap().payload).unwrap();
+        assert_eq!(v1["id"], "toolu_01");
+        assert_eq!(v1["partial_json"], "{\"path\":");
+        // Partial 2.
+        let p2 = s.next().await.unwrap().unwrap();
+        let v2: serde_json::Value =
+            serde_json::from_slice(&p2.record.as_ref().unwrap().payload).unwrap();
+        assert_eq!(v2["id"], "toolu_01");
+        assert_eq!(v2["partial_json"], " \"foo.txt\"}");
+        // Stop: done=true.
+        let stop = s.next().await.unwrap().unwrap();
+        let vs: serde_json::Value =
+            serde_json::from_slice(&stop.record.as_ref().unwrap().payload).unwrap();
+        assert_eq!(vs["id"], "toolu_01");
+        assert_eq!(vs["done"], true);
+        // Finish at message_stop.
+        let fin = s.next().await.unwrap().unwrap();
+        assert_eq!(fin.kind(), AgentEventKind::Finish);
+    }
+
+    /// J-Sub-D (BRO-1143): `message_delta {stop_reason: "tool_use"}`
+    /// propagates into the synthesized `Finish` event so the encoder
+    /// can render Anthropic's `message_delta {stop_reason: "tool_use"}`.
+    #[tokio::test]
+    async fn parses_message_delta_stop_reason_tool_use() {
+        let body = b"event: content_block_start\n\
+                     data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_02\",\"name\":\"do_x\",\"input\":{}}}\n\n\
+                     event: content_block_stop\n\
+                     data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+                     event: message_delta\n\
+                     data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":47}}\n\n\
+                     event: message_stop\n\
+                     data: {\"type\":\"message_stop\"}\n\n";
+        let mut s = parse_sse(
+            stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::from(body.to_vec()))]),
+            aios_proto::aios::v1::SessionId { value: "s".into() },
+        );
+        // open + stop + (no message_delta event surfaced) + finish.
+        let mut events = Vec::new();
+        while let Some(item) = s.next().await {
+            events.push(item.unwrap());
+        }
+        let kinds: Vec<AgentEventKind> = events.iter().map(|e| e.kind()).collect();
+        // Two ToolCallPending (open + done) + one Finish.
+        assert_eq!(
+            kinds,
+            vec![
+                AgentEventKind::ToolCallPending,
+                AgentEventKind::ToolCallPending,
+                AgentEventKind::Finish,
+            ]
+        );
+        // The Finish event carries reason="tool_use" from message_delta.
+        let finish = events.last().unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_slice(&finish.record.as_ref().unwrap().payload).unwrap();
+        assert_eq!(payload["reason"], "tool_use");
+    }
+
+    /// J-Sub-D (BRO-1143): two interleaved tool_use blocks (parallel
+    /// tool_use is rare from Anthropic today but the protocol allows
+    /// it). Verify that index→id state stays correctly partitioned.
+    #[tokio::test]
+    async fn parses_multi_tool_use_with_distinct_indices() {
+        let body = b"event: content_block_start\n\
+                     data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_A\",\"name\":\"a\",\"input\":{}}}\n\n\
+                     event: content_block_start\n\
+                     data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_B\",\"name\":\"b\",\"input\":{}}}\n\n\
+                     event: content_block_delta\n\
+                     data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n\
+                     event: content_block_delta\n\
+                     data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n\
+                     event: message_stop\n\
+                     data: {\"type\":\"message_stop\"}\n\n";
+        let mut s = parse_sse(
+            stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::from(body.to_vec()))]),
+            aios_proto::aios::v1::SessionId { value: "s".into() },
+        );
+        let mut events = Vec::new();
+        while let Some(item) = s.next().await {
+            events.push(item.unwrap());
+        }
+        // 2 starts + 2 deltas + 1 finish = 5 events.
+        assert_eq!(events.len(), 5);
+        let payload = |i: usize| -> serde_json::Value {
+            serde_json::from_slice(&events[i].record.as_ref().unwrap().payload).unwrap()
+        };
+        assert_eq!(payload(0)["id"], "toolu_A");
+        assert_eq!(payload(0)["name"], "a");
+        assert_eq!(payload(1)["id"], "toolu_B");
+        assert_eq!(payload(1)["name"], "b");
+        // Order of partial deltas: index 1 first (toolu_B), then index 0.
+        assert_eq!(payload(2)["id"], "toolu_B");
+        assert_eq!(payload(3)["id"], "toolu_A");
+        assert_eq!(events[4].kind(), AgentEventKind::Finish);
     }
 }

--- a/crates/life-runtime/lifegw-anthropic-codec/src/encoder.rs
+++ b/crates/life-runtime/lifegw-anthropic-codec/src/encoder.rs
@@ -1277,4 +1277,103 @@ mod tests {
         // Message_start is still unsent.
         assert!(e.emit_message_start().is_some());
     }
+
+    /// J-Sub-D (BRO-1143): a tool_use event missing the required `id`
+    /// must produce a typed `CodecError::Upstream` rather than panic or
+    /// silently corrupting the stream.
+    #[test]
+    fn tool_call_pending_without_id_returns_upstream_error() {
+        let mut e = Encoder::new("msg_test", "m");
+        let bad = AgentEvent {
+            record: Some(EventRecord {
+                session_id: None,
+                sequence: 1,
+                at: None,
+                kind: "TOOL_CALL_PENDING".into(),
+                payload: serde_json::to_vec(&serde_json::json!({"name": "f"})).unwrap(),
+            }),
+            kind: AgentEventKind::ToolCallPending as i32,
+        };
+        let err = e.encode(&bad).unwrap_err();
+        assert!(
+            matches!(err, crate::errors::CodecError::Upstream(ref m) if m.contains("id")),
+            "expected CodecError::Upstream mentioning id, got {err:?}"
+        );
+    }
+
+    /// J-Sub-D (BRO-1143): a tool_use event missing the required `name`
+    /// likewise surfaces a typed `CodecError::Upstream`.
+    #[test]
+    fn tool_call_pending_without_name_returns_upstream_error() {
+        let mut e = Encoder::new("msg_test", "m");
+        let bad = AgentEvent {
+            record: Some(EventRecord {
+                session_id: None,
+                sequence: 1,
+                at: None,
+                kind: "TOOL_CALL_PENDING".into(),
+                payload: serde_json::to_vec(&serde_json::json!({"id": "toolu_01"})).unwrap(),
+            }),
+            kind: AgentEventKind::ToolCallPending as i32,
+        };
+        let err = e.encode(&bad).unwrap_err();
+        assert!(
+            matches!(err, crate::errors::CodecError::Upstream(ref m) if m.contains("name")),
+            "expected CodecError::Upstream mentioning name, got {err:?}"
+        );
+    }
+
+    /// J-Sub-D (BRO-1143): the `done: true` signal on a tool_call event
+    /// closes the tool_use block at the correct index; subsequent
+    /// tool_call events for a new id allocate a fresh index.
+    #[test]
+    fn tool_call_pending_done_closes_block_at_correct_index() {
+        let mut e = Encoder::new("msg_test", "m");
+        let mut out = Vec::new();
+        out.extend(
+            e.encode(&tool_call_event(
+                1,
+                serde_json::json!({"id":"toolu_A","name":"a","partial_json":"{}","done":true}),
+            ))
+            .unwrap(),
+        );
+        // First tool_use opened + closed at index 0.
+        let opens: Vec<_> = out
+            .iter()
+            .filter_map(|ev| match ev {
+                AnthropicSseEvent::ContentBlockStart(p) => match &p.content_block {
+                    ContentBlockInit::ToolUse { id, .. } => Some((p.index, id.clone())),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(opens, vec![(0, "toolu_A".to_string())]);
+        let closes: Vec<_> = out
+            .iter()
+            .filter_map(|ev| match ev {
+                AnthropicSseEvent::ContentBlockStop(p) => Some(p.index),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(closes, vec![0]);
+
+        // Now open a second tool_use — it gets a fresh index (1).
+        out.clear();
+        out.extend(
+            e.encode(&tool_call_event(
+                2,
+                serde_json::json!({"id":"toolu_B","name":"b","input":{}}),
+            ))
+            .unwrap(),
+        );
+        let second_idx = out
+            .iter()
+            .find_map(|ev| match ev {
+                AnthropicSseEvent::ContentBlockStart(p) => Some(p.index),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(second_idx, 1, "second tool_use must get a fresh index");
+    }
 }

--- a/crates/life-runtime/lifegw-anthropic-codec/tests/encoder_wire_shape.rs
+++ b/crates/life-runtime/lifegw-anthropic-codec/tests/encoder_wire_shape.rs
@@ -283,3 +283,395 @@ fn anthropic_error_helper_renders_top_level_event() {
     assert!(frame.contains("\"billing_error\""));
     assert!(frame.contains("Insufficient credits"));
 }
+
+// ─── J-Sub-D (BRO-1143) tool-use bridge integration tests ───────────
+//
+// Six tests exercise the full SSE wire-shape contract for the tool-use
+// round-trip: single-tool, two-round resume, multi-tool simultaneous,
+// streamed partial-JSON input, tool_use after a thinking block, and
+// error mid-tool_use. Together they assert the encoder emits the
+// `content_block_start → input_json_delta+ → content_block_stop`
+// sequence per Spec J §[Tool use] and finalizes with
+// `message_delta {stop_reason: "tool_use"}` + `message_stop`.
+
+/// J-Sub-D: one tool_use round produces the canonical
+/// content_block_start (with tool_use init) → input_json_delta
+/// (the streamed JSON) → content_block_stop sequence, terminated by
+/// message_delta {stop_reason: "tool_use"} + message_stop.
+#[test]
+fn tool_use_single_round_emits_correct_sse() {
+    let out = drive(&[
+        token(1, "I'll read it."),
+        tool_call(
+            2,
+            serde_json::json!({"id":"toolu_01","name":"read_file","input":{}}),
+        ),
+        tool_call(
+            3,
+            serde_json::json!({"id":"toolu_01","name":"read_file","partial_json":"{\"path\": \"foo.txt\"}", "done": true}),
+        ),
+        finish(4, "tool_use"),
+    ]);
+    assert_wire_shape(&out);
+
+    // 1) tool_use ContentBlockStart carries id + name.
+    let tool_start = out
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::ContentBlockStart(p) => match &p.content_block {
+                ContentBlockInit::ToolUse { id, name, input } => {
+                    Some((p.index, id.clone(), name.clone(), input.clone()))
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("tool_use content_block_start must be emitted");
+    assert_eq!(tool_start.1, "toolu_01");
+    assert_eq!(tool_start.2, "read_file");
+    // input is `{}` at start — the JSON streams via deltas.
+    assert_eq!(tool_start.3, serde_json::json!({}));
+
+    // 2) The accumulated partial_json fragments concatenate to valid JSON.
+    let fragments: Vec<String> = out
+        .iter()
+        .filter_map(|e| match e {
+            AnthropicSseEvent::ContentBlockDelta(p) => match &p.delta {
+                lifegw_anthropic_codec::encoder::BlockDelta::InputJsonDelta { partial_json } => {
+                    Some(partial_json.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    let concatenated = fragments.concat();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&concatenated).expect("concatenated partial_json must be valid JSON");
+    assert_eq!(parsed, serde_json::json!({"path": "foo.txt"}));
+
+    // 3) message_delta carries stop_reason = "tool_use".
+    let md = out
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::MessageDelta(p) => Some(p),
+            _ => None,
+        })
+        .expect("message_delta is emitted");
+    assert_eq!(md.delta.stop_reason, "tool_use");
+}
+
+/// J-Sub-D: two-rounds. The first request emits tool_use; the second
+/// request (carrying tool_result in messages[-1]) re-derives the same
+/// sid and continues the assistant turn against the resumed session.
+///
+/// The codec layer doesn't own the sid resolution or the resume — that
+/// lives in the lifegw handler (J-Sub-G E2E). What the codec MUST
+/// guarantee is that the same `(did, canon)` pair synthesizes the same
+/// sid across both requests so the substrate sees one continuous
+/// session.
+#[test]
+fn tool_use_two_rounds_resumes_session() {
+    use lifegw_anthropic_codec::canonicalize_first_user_message;
+
+    // Round 1: user("read foo.txt") → assistant emits tool_use.
+    let round_1_body = r#"{
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 100,
+        "messages": [{"role": "user", "content": "read foo.txt"}]
+    }"#;
+    let round_1: AnthropicMessagesRequest = serde_json::from_str(round_1_body).unwrap();
+    let sid_1 = synthesize_sid(&round_1, "did:life:abc").unwrap();
+    let canon_1 = canonicalize_first_user_message(&round_1.messages[0].content);
+
+    // Round 2: same user + assistant tool_use + user tool_result.
+    let round_2_body = r#"{
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 100,
+        "messages": [
+            {"role": "user", "content": "read foo.txt"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "I'll read it."},
+                {"type": "tool_use", "id": "toolu_01", "name": "read_file", "input": {"path": "foo.txt"}}
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_01", "content": "hello world"}
+            ]}
+        ]
+    }"#;
+    let round_2: AnthropicMessagesRequest = serde_json::from_str(round_2_body).unwrap();
+    let sid_2 = synthesize_sid(&round_2, "did:life:abc").unwrap();
+    let canon_2 = canonicalize_first_user_message(&round_2.messages[0].content);
+
+    // Sid stability: same DID + canon first user message → same sid.
+    assert_eq!(canon_1, canon_2, "canonical first user message must match");
+    assert_eq!(sid_1, sid_2, "sid must be stable across the round-trip");
+
+    // Round 2's encoder reads back the same encoder state via lago tail
+    // (production path); here we simulate by running fresh encoders for
+    // each round and checking each independently produces wire-valid
+    // SSE.
+    let out_1 = drive(&[
+        token(1, "I'll read it."),
+        tool_call(
+            2,
+            serde_json::json!({"id":"toolu_01","name":"read_file","partial_json":"{\"path\":\"foo.txt\"}", "done": true}),
+        ),
+        finish(3, "tool_use"),
+    ]);
+    assert_wire_shape(&out_1);
+    let out_2 = drive(&[
+        token(1, "The file says: hello world"),
+        finish(2, "end_turn"),
+    ]);
+    assert_wire_shape(&out_2);
+
+    // Round 1 finalizes with stop_reason=tool_use; round 2 with end_turn.
+    let r1_reason = out_1
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::MessageDelta(p) => Some(p.delta.stop_reason.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let r2_reason = out_2
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::MessageDelta(p) => Some(p.delta.stop_reason.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(r1_reason, "tool_use");
+    assert_eq!(r2_reason, "end_turn");
+}
+
+/// J-Sub-D: two parallel tool_use blocks open in the same response.
+/// Anthropic's protocol allows this; the codec must allocate distinct
+/// content-block indices and emit input_json_delta for each that
+/// reference the correct id.
+#[test]
+fn tool_use_multi_tool_simultaneous() {
+    let out = drive(&[
+        tool_call(1, serde_json::json!({"id":"toolu_A","name":"a","input":{}})),
+        tool_call(2, serde_json::json!({"id":"toolu_B","name":"b","input":{}})),
+        tool_call(
+            3,
+            serde_json::json!({"id":"toolu_A","name":"a","partial_json":"{\"x\":1}", "done": true}),
+        ),
+        tool_call(
+            4,
+            serde_json::json!({"id":"toolu_B","name":"b","partial_json":"{\"y\":2}", "done": true}),
+        ),
+        finish(5, "tool_use"),
+    ]);
+    assert_wire_shape(&out);
+
+    // Two distinct ContentBlockStart frames for tool_use, with distinct
+    // indices.
+    let tool_starts: Vec<_> = out
+        .iter()
+        .filter_map(|e| match e {
+            AnthropicSseEvent::ContentBlockStart(p) => match &p.content_block {
+                ContentBlockInit::ToolUse { id, .. } => Some((p.index, id.clone())),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tool_starts.len(), 2);
+    assert_ne!(
+        tool_starts[0].0, tool_starts[1].0,
+        "two tool_use blocks must have distinct indices, got {tool_starts:?}"
+    );
+    let ids: Vec<_> = tool_starts.iter().map(|(_, id)| id.clone()).collect();
+    assert!(ids.contains(&"toolu_A".to_string()));
+    assert!(ids.contains(&"toolu_B".to_string()));
+}
+
+/// J-Sub-D: input JSON arrives across many small partial_json chunks;
+/// the concatenation must produce valid JSON and each chunk emits a
+/// distinct input_json_delta with the correct (matching) block index.
+#[test]
+fn tool_use_with_partial_json() {
+    let chunks = ["{\"path\":", " \"foo", ".txt\",", " \"mode\":", " \"r\"}"];
+    let mut events = vec![tool_call(
+        1,
+        serde_json::json!({"id":"toolu_01","name":"read_file","input":{}}),
+    )];
+    for (i, c) in chunks.iter().enumerate() {
+        let seq = (i + 2) as u64;
+        let done = i == chunks.len() - 1;
+        events.push(tool_call(
+            seq,
+            serde_json::json!({"id":"toolu_01","name":"read_file","partial_json": c, "done": done}),
+        ));
+    }
+    events.push(finish((events.len() + 1) as u64, "tool_use"));
+
+    let out = drive(&events);
+    assert_wire_shape(&out);
+
+    // Each chunk produces an input_json_delta.
+    let fragments: Vec<String> = out
+        .iter()
+        .filter_map(|e| match e {
+            AnthropicSseEvent::ContentBlockDelta(p) => match &p.delta {
+                lifegw_anthropic_codec::encoder::BlockDelta::InputJsonDelta { partial_json } => {
+                    Some(partial_json.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        fragments.len(),
+        chunks.len(),
+        "one input_json_delta per chunk; got {fragments:?}"
+    );
+    let concatenated = fragments.concat();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&concatenated).expect("concatenated JSON must be valid");
+    assert_eq!(parsed, serde_json::json!({"path": "foo.txt", "mode": "r"}));
+}
+
+/// J-Sub-D: a thinking block precedes a tool_use block. The encoder
+/// must close the thinking block (content_block_stop) before opening
+/// the tool_use block. The Anthropic protocol forbids overlapping
+/// blocks within a message.
+#[test]
+fn tool_use_after_thinking() {
+    let out = drive(&[
+        thinking_token(1, "Let me consider..."),
+        thinking_token(2, " I should read the file."),
+        tool_call(
+            3,
+            serde_json::json!({"id":"toolu_01","name":"read_file","partial_json":"{\"path\":\"foo.txt\"}", "done": true}),
+        ),
+        finish(4, "tool_use"),
+    ]);
+    assert_wire_shape(&out);
+
+    // The thinking block opens first (index 0), then closes BEFORE
+    // tool_use opens (index 1).
+    let starts: Vec<(u32, &ContentBlockInit)> = out
+        .iter()
+        .filter_map(|e| match e {
+            AnthropicSseEvent::ContentBlockStart(p) => Some((p.index, &p.content_block)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(starts.len(), 2);
+    assert!(matches!(starts[0].1, ContentBlockInit::Thinking { .. }));
+    assert!(matches!(starts[1].1, ContentBlockInit::ToolUse { .. }));
+    assert_ne!(starts[0].0, starts[1].0);
+
+    // Find positions: thinking stop must come before tool_use start.
+    let thinking_index = starts[0].0;
+    let tool_index = starts[1].0;
+    let thinking_stop_pos = out
+        .iter()
+        .position(|e| {
+            matches!(
+                e,
+                AnthropicSseEvent::ContentBlockStop(p) if p.index == thinking_index
+            )
+        })
+        .expect("thinking block must be closed");
+    let tool_start_pos = out
+        .iter()
+        .position(|e| {
+            matches!(
+                e,
+                AnthropicSseEvent::ContentBlockStart(p) if p.index == tool_index
+            )
+        })
+        .expect("tool_use must be opened");
+    assert!(
+        thinking_stop_pos < tool_start_pos,
+        "thinking block must close before tool_use opens (got thinking_stop={thinking_stop_pos}, tool_start={tool_start_pos})"
+    );
+
+    // message_delta carries stop_reason=tool_use.
+    let md = out
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::MessageDelta(p) => Some(p),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(md.delta.stop_reason, "tool_use");
+}
+
+/// J-Sub-D: upstream errors mid-tool_use must close the stream cleanly
+/// — emit the inline error event AND finalize (close blocks + emit
+/// message_delta + message_stop). No panic; no malformed wire.
+#[test]
+fn tool_use_with_error() {
+    // Open a tool_use block, then hit an upstream Error mid-stream.
+    let out = drive(&[
+        tool_call(
+            1,
+            serde_json::json!({"id":"toolu_01","name":"read_file","input":{}}),
+        ),
+        tool_call(
+            2,
+            serde_json::json!({"id":"toolu_01","name":"read_file","partial_json":"{\"pa"}),
+        ),
+        AgentEvent {
+            record: Some(EventRecord {
+                session_id: None,
+                sequence: 3,
+                at: None,
+                kind: "ERROR".into(),
+                payload: serde_json::to_vec(&serde_json::json!({
+                    "kind": "overloaded_error",
+                    "message": "upstream overloaded mid-tool_use",
+                }))
+                .unwrap(),
+            }),
+            kind: AgentEventKind::Error as i32,
+        },
+    ]);
+    assert_wire_shape(&out);
+
+    // Inline error event is emitted.
+    let has_error = out
+        .iter()
+        .any(|e| matches!(e, AnthropicSseEvent::Error(p) if p.error.kind == "overloaded_error"));
+    assert!(has_error, "inline error event must be present");
+
+    // Stream closes cleanly: message_stop is the last event.
+    assert!(
+        matches!(out.last(), Some(AnthropicSseEvent::MessageStop)),
+        "stream must close cleanly with message_stop"
+    );
+
+    // The mid-stream tool_use block must be closed before message_stop —
+    // the wire-shape contract enforces this; assert_wire_shape above
+    // would have failed if a tool_use block were left dangling. Verify
+    // explicitly:
+    let tool_use_index = out
+        .iter()
+        .find_map(|e| match e {
+            AnthropicSseEvent::ContentBlockStart(p) => match &p.content_block {
+                ContentBlockInit::ToolUse { .. } => Some(p.index),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("tool_use must have opened");
+    let stop_count = out
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AnthropicSseEvent::ContentBlockStop(p) if p.index == tool_use_index
+            )
+        })
+        .count();
+    assert_eq!(
+        stop_count, 1,
+        "tool_use block must be closed exactly once (got {stop_count} stops for index {tool_use_index})"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **J-Sub-D** of Spec J Phase 1 — the tool-use bridge for the
Anthropic Messages route. Phase 1 supports only Claude-Code-host tools
(BYOT — bring-your-own-tool); Praxis-side tools are deferred to Phase 2
J-Sub-I per Spec J §[Tool use].

- **arcan-proxy SSE parser** extended to round-trip Anthropic `tool_use`
  blocks (was text-only). Stashes `(upstream_content_block_index →
  tool_use_id)` in a new `ParserState` so `input_json_delta` frames can
  look up the tool id without re-parsing the start frame.
- **lifegw-anthropic-codec encoder** stays as-is — it already handled
  `AgentEventKind::ToolCallPending` per J-Sub-A's documented substitute
  for the missing `ToolCallEmit` / `Thinking` proto variants. This PR
  adds the test coverage that locks the contract in.

Linear: [BRO-1143](https://linear.app/broomva/issue/BRO-1143)
Spec: `docs/superpowers/specs/2026-05-18-spec-j-claude-code-interop.md` §[Tool use] + L10-D3
Plan: `docs/superpowers/plans/2026-05-18-spec-j-phase-1-lifegw-edge.md` §J-Sub-D

## What changed

**`crates/life-runtime/arcan-proxy/src/anthropic.rs`** — extended `parse_sse(...)`:
- `content_block_start { content_block.type == "tool_use" }` → emit `ToolCallPending { id, name, input: {} }`.
- `content_block_delta { delta.type == "input_json_delta" }` → emit `ToolCallPending { id, partial_json }` using the stashed index→id binding.
- `content_block_stop { index }` (when index is bound to a tool_use) → emit `ToolCallPending { id, done: true }`.
- `message_delta { delta.stop_reason }` → captured into `ParserState.last_stop_reason`; surfaces in the synthesized `Finish { reason }` emitted on `message_stop`.
- Unknown index for `input_json_delta` is dropped silently — keep stream healthy on misbehaving upstreams.
- Existing text_delta path untouched.

**`crates/life-runtime/lifegw-anthropic-codec/src/encoder.rs`** — added 3 unit tests:
- `tool_call_pending_without_id_returns_upstream_error`
- `tool_call_pending_without_name_returns_upstream_error`
- `tool_call_pending_done_closes_block_at_correct_index`

**`crates/life-runtime/lifegw-anthropic-codec/tests/encoder_wire_shape.rs`** — added 6 integration tests per spec:
- `tool_use_single_round_emits_correct_sse` — full content_block_start/delta/stop sequence with valid JSON reconstruction.
- `tool_use_two_rounds_resumes_session` — verifies sid stability across the tool_use→tool_result round-trip (the codec contract — the wire-level resume is J-Sub-G E2E's surface).
- `tool_use_multi_tool_simultaneous` — two parallel tool_use blocks with distinct content-block indices.
- `tool_use_with_partial_json` — 5 small partial_json chunks concatenate to valid JSON.
- `tool_use_after_thinking` — thinking block closes BEFORE tool_use opens (Anthropic protocol forbids overlapping blocks).
- `tool_use_with_error` — upstream error mid-tool_use closes the stream cleanly (no panic, no dangling block, in-band `event: error` + finalize).

**`crates/life-runtime/arcan-proxy/src/anthropic.rs::tests`** — added 4 parser tests:
- `parses_tool_use_start`
- `parses_input_json_delta_chunks`
- `parses_message_delta_stop_reason_tool_use`
- `parses_multi_tool_use_with_distinct_indices`

## Proto-bump decision: NO

Per the task spec's explicit fallback option: continuing to use
`AgentEventKind::ToolCallPending` as the substitute for the
non-existent `ToolCallEmit` variant. Disambiguated by payload-field
shapes drawn from the upstream:

| Phase | Payload shape | Effect |
|---|---|---|
| tool_use open | `{id, name, input: {}}` | encoder opens `content_block_start` with type `tool_use` |
| tool_use delta | `{id, partial_json}` | encoder emits `content_block_delta` with `input_json_delta` |
| tool_use done | `{id, done: true}` | encoder emits `content_block_stop` |

Reasons:
1. The encoder already implements this substitute path per J-Sub-A's documented decision.
2. A proto bump would cascade through codegen + arcand + lago + downstream consumers — out of scope for a tool-use bridge PR.
3. The substitute is documented in `encoder.rs` crate-level docs.

A clean follow-up could add `ToolCallEmit` + `Thinking` variants in a precursor for J-Sub-I (Phase 2 Praxis-side tools) without touching this PR's surface.

## Spec ambiguity surfaced (J-Sub-G E2E's problem)

`lifed.Agent.SendMessage` today carries a `string content` field. The
Anthropic-shape `tool_result` block from `messages[-1]` on round-2
needs to be serialized into that string (or `attachment_blob_ref`).
That wire-shape decision belongs to the **handler**
(`services/anthropic_messages.rs` in J-Sub-G E2E), not the codec.
The encoder + parser layers are unaffected.

## Test plan

- [x] `cargo build -p lifegw-anthropic-codec -p arcan-proxy -p lifegw` clean
- [x] `cargo test -p lifegw-anthropic-codec` — **97 tests** (was 88; +9: 6 integration + 3 unit); target ≥95 met
- [x] `cargo test -p arcan-proxy` — **30 tests** (was 26; +4 parser tests); target ≥30 met
- [x] `cargo clippy -p lifegw-anthropic-codec -p arcan-proxy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `bash scripts/verify_dependencies_lifegw_anthropic_codec.sh` exits 0 (codec stays substrate-free per L10-D1)
- [x] `cargo test -p lifegw` — all 45 tests still green (no consumer regressions)
- [ ] Manual smoke with `claude --tool-use` round-trip — deferred to J-Sub-G E2E (full handler integration)

## Out of scope

- Praxis-side tools (J-Sub-I, Phase 2). Phase 1 is BYOT only.
- Handler extension at `services/anthropic_messages.rs` — encoder is the right surface for this work; handler stays untouched.
- Round-2 `tool_result` → `lifed.Agent.SendMessage` wire mapping — J-Sub-G E2E's surface.
- Proto bump for `ToolCallEmit` / `Thinking` variants — documented `ToolCallPending` substitute remains in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)