### PR TITLE
feat(lifegw): local interactive smoke example — zero-deploy iteration loop [BRO-1165]

### DIFF
--- a/crates/life-runtime/lifegw/examples/README.md
+++ b/crates/life-runtime/lifegw/examples/README.md
@@ -1,0 +1,188 @@
+# lifegw — examples
+
+Dev-tooling examples for the lifegw edge gateway. Currently:
+
+| Example | Purpose | Linear |
+|---|---|---|
+| `local_smoke` | Boot lifegw locally against an in-process mock lifed for ~30 s interactive smoke. Zero deploy, zero Railway slot. | [BRO-1165](https://linear.app/broomva/issue/BRO-1165) |
+
+## `local_smoke`
+
+Boots the real lifegw Anthropic Messages router (`/v1/messages`,
+`/v1/models`, `/v1/messages/count_tokens`) on a kernel-picked `127.0.0.1`
+port, wired against a mock `lifed.Agent` service running in-process over a
+tempdir UDS. Same code paths as production (codec, auth, rate-limit, vigil
+spans, stub haima) — only the substrate is mocked.
+
+### Run
+
+```sh
+cargo run -p lifegw --example local_smoke
+```
+
+On boot you get:
+
+```
+lifegw local smoke ready:
+  URL:    http://127.0.0.1:<port>
+  Bearer: dev-token-for-broomva
+
+Try:
+  curl http://127.0.0.1:<port>/v1/models | jq .
+
+  curl -N -H "Authorization: Bearer dev-token-for-broomva" \
+       -H "anthropic-version: 2023-06-01" \
+       -H "Content-Type: application/json" \
+       -d '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100,"stream":true}' \
+       http://127.0.0.1:<port>/v1/messages
+
+Press Ctrl-C to exit.
+```
+
+The port the kernel picks varies per run; copy the printed value.
+
+### Three curl recipes
+
+#### 1. `GET /v1/models` — Anthropic-pinned static catalogue (unauthenticated)
+
+```sh
+curl http://127.0.0.1:<port>/v1/models | jq .
+```
+
+Expected shape (truncated):
+
+```json
+{
+  "data": [
+    { "id": "claude-opus-4-20250514",     "type": "model", ... },
+    { "id": "claude-sonnet-4-20250514",   "type": "model", ... },
+    { "id": "claude-haiku-4-20250514",    "type": "model", ... },
+    { "id": "claude-sonnet-4-5-20250929", "type": "model", ... },
+    { "id": "claude-haiku-4-5-20251001",  "type": "model", ... }
+  ],
+  "first_id": "claude-opus-4-20250514",
+  "last_id":  "claude-haiku-4-5-20251001",
+  "has_more": false
+}
+```
+
+#### 2. `POST /v1/messages/count_tokens` — edge token-count probe
+
+```sh
+curl -s -H "Authorization: Bearer dev-token-for-broomva" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Please write a unit test for the new module."}]}' \
+     http://127.0.0.1:<port>/v1/messages/count_tokens \
+     -i
+```
+
+Expected:
+
+```
+HTTP/1.1 200 OK
+content-type: application/json
+x-life-cost-estimate-usd-micros: <positive integer>
+...
+
+{"input_tokens": <small integer>}
+```
+
+The `X-Life-Cost-Estimate-Usd-Micros` header is the prefetch hint Claude
+Code uses to budget its context window; it's positive whenever the model
+is in the Phase 1 pricing snapshot.
+
+#### 3. `POST /v1/messages` — streaming chat (SSE)
+
+```sh
+curl -N -H "Authorization: Bearer dev-token-for-broomva" \
+     -H "anthropic-version: 2023-06-01" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100,"stream":true}' \
+     http://127.0.0.1:<port>/v1/messages
+```
+
+Expected SSE order (`-N` disables curl's buffering):
+
+```
+event: message_start
+data: {...}
+
+event: content_block_start
+data: {...}
+
+event: content_block_delta
+data: {... "text": "Hello"}
+
+event: content_block_delta
+data: {... "text": " from"}
+
+event: content_block_delta
+data: {... "text": " lifegw"}
+
+event: content_block_delta
+data: {... "text": " local"}
+
+event: content_block_delta
+data: {... "text": " smoke!"}
+
+event: content_block_stop
+data: {...}
+
+event: message_delta
+data: {... "stop_reason": "end_turn"}
+
+event: message_stop
+data: {...}
+```
+
+Mock lifed emits the fixed token sequence
+`Hello`, ` from`, ` lifegw`, ` local`, ` smoke!` then a `stop` Finish. The
+real codec runs over it, producing the canonical Anthropic SSE wire shape.
+
+### Pointing Claude Code at the example
+
+```sh
+export ANTHROPIC_BASE_URL=http://127.0.0.1:<port>
+export ANTHROPIC_AUTH_TOKEN=dev-token-for-broomva
+claude
+```
+
+Claude Code's `/model` picker queries `/v1/models` at bootstrap (matches
+`api.anthropic.com`'s posture). Conversations route through `/v1/messages`
+and exercise the same codec + auth + rate-limit + Vigil span paths the
+production gateway uses.
+
+### Known limits
+
+- **Text-only mock.** Tool-use round-trips, drop+resume sid stability, and
+  haima cost-gate failures all live in `tests/spec_j_e2e_smoke.rs`. The
+  example is the *single happy-path* surface — if you need tool-use you
+  drive the codec via the real `/v1/messages` route and `tool_use` payload
+  shapes; this example's mock won't synthesise `tool_use` blocks.
+- **No real substrate.** No lago durability, no anima identity, no haima
+  ledger. The `StubHaimaClient` is wired (`billing_enforce = false`) so
+  `/v1/messages` and `/v1/messages/count_tokens` pass the cost gate
+  unconditionally. Production runs against haimad once that daemon
+  exposes a `check`/`settle` RPC (Phase 2+).
+- **Mocked `from_sequence` replay.** The mock returns an empty
+  `StreamSession` reply on resume; lago-side cursor replay is the Railway
+  staging path's responsibility (`docs/conformance/...claude-code-smoke-runbook.md`).
+- **No TLS.** Plain HTTP on `127.0.0.1`. Production lifegw terminates TLS
+  1.3 via rustls; the example skips the bind dance because operators are
+  not testing TLS posture here.
+- **Single mock session.** Each request creates a fresh `mock-sid-N`; the
+  mock doesn't persist session state between calls. Use the in-process
+  E2E test or Railway deploy to exercise resume / multi-turn semantics.
+
+### Relation to the other test paths
+
+Spec J Phase 1 ships three escalating test surfaces:
+
+| Path | Command / artefact | What it certifies |
+|---|---|---|
+| 1 | `cargo test -p lifegw --test spec_j_e2e_smoke` | In-process E2E — codec, route, auth, recording haima, mock lifed; 5 scenarios. |
+| 2 | This example (`cargo run -p lifegw --example local_smoke`) | Real TCP socket, interactive — operator-driven probe of the edge wire over HTTP. |
+| 3 | Railway staging deploy per `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` | Live evidence — Loom + Vigil traces + lago replay + haima ledger. |
+
+Path 1 is automated; path 3 is the Phase 1 conformance gate; **path 2 is
+the iterating-engineer's loop** between the two.

--- a/crates/life-runtime/lifegw/examples/local_smoke.rs
+++ b/crates/life-runtime/lifegw/examples/local_smoke.rs
@@ -1,0 +1,397 @@
+//! BRO-1165 — local interactive smoke for lifegw (zero deploy, zero Railway).
+//!
+//! Boots lifegw's Anthropic Messages router (and siblings: `/v1/models`,
+//! `/v1/messages/count_tokens`) on a kernel-picked `127.0.0.1` port, wired
+//! against an in-process mock lifed `Agent` service over a tempdir UDS. The
+//! operator runs:
+//!
+//! ```sh
+//! cargo run -p lifegw --example local_smoke
+//! ```
+//!
+//! …and gets a URL + dev bearer printed to stdout. `curl`, `claude`, or any
+//! Anthropic-compatible client can then exercise the route against a real
+//! TCP socket, end to end, with real Vigil span emission and the real codec
+//! pipeline.
+//!
+//! # Why this exists
+//!
+//! Spec J Phase 1 ships three test paths (`docs/STATUS.md` §J-Sub-G):
+//!
+//! 1. In-process E2E test (`cargo test -p lifegw --test spec_j_e2e_smoke`).
+//! 2. Railway staging deploy per the operator runbook
+//!    (`docs/conformance/2026-05-18-claude-code-smoke-runbook.md`).
+//! 3. **This example** — local interactive smoke, ~30 s setup, no Railway
+//!    slot burned.
+//!
+//! Path 3 is what an iterating engineer reaches for when validating a tweak
+//! to `services/anthropic_messages.rs`, the codec, or the Vigil spans. The
+//! full Railway deploy path is what produces the Phase 1 conformance
+//! evidence (Loom + Vigil traces + lago replay).
+//!
+//! # What's mocked, what's real
+//!
+//! Real (in-process, same code as production):
+//!
+//! - the axum router built from `AnthropicMessagesState`,
+//! - the `lifegw_anthropic_codec::Encoder`,
+//! - the `JwksCache::dev_only()` Tier-1 verifier (dev-bearer shortcut),
+//! - the `Tier2Minter` capability minter,
+//! - the `TokenBucketLimiter` rate limiter,
+//! - the tonic Channel dialled to the mock lifed UDS,
+//! - the `StubHaimaClient` cost gate (no-op, mirrors production today).
+//!
+//! Mocked (over UDS, by this file):
+//!
+//! - `lifed.life.v1.Agent` — `CreateSession`, `SendMessage`, `StreamSession`
+//!   produce a canned four-token chat reply per request, matching the
+//!   pattern used by `tests/spec_j_e2e_smoke.rs`.
+//!
+//! Substrate-free per Spec J L10-D1 — no real arcan/lago/anima/haima deps.
+//! Per the BRO-1165 scope-discipline rule, the mock is duplicated from
+//! `tests/spec_j_e2e_smoke.rs` (option 2) rather than refactored into a
+//! shared module: dev tooling has no business widening lifegw's public
+//! `src/` surface.
+//!
+//! # Lifecycle
+//!
+//! 1. Build a tempdir + UDS path `<tempdir>/lifed.sock`.
+//! 2. Spawn a tonic `Server` hosting the mock `Agent` on that UDS.
+//! 3. Dial a tonic `Channel` back over the UDS.
+//! 4. Build `AnthropicMessagesState` with real auth + rate-limit + stub
+//!    haima + the mock-backed channel.
+//! 5. Bind axum on `127.0.0.1:0` (kernel-picked port).
+//! 6. Print the URL + dev bearer + curl recipes.
+//! 7. Serve until `SIGINT` (Ctrl-C).
+//! 8. Graceful drain: shut down axum, then the mock UDS server, then drop
+//!    the tempdir.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::Stream;
+use tempfile::TempDir;
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+use tracing_subscriber::EnvFilter;
+
+use life_runtime_proto::life::v1::agent_server::{Agent, AgentServer};
+use life_runtime_proto::life::v1::{
+    AgentEvent, AgentEventKind, ApprovalReq, CreateSessionReq, DispatchRef, Empty, EventRecord,
+    ListModelsReq, ListSkillsReq, ListToolsReq, ModelCatalog, SendMessageReq, Session, SessionRef,
+    SkillCatalog, SpawnChildReq, SpawnChildResp, ToolCatalog,
+};
+
+use lifegw::auth::jwks::JwksCache;
+use lifegw::auth::kms::StaticKeystore;
+use lifegw::auth::tier2::Tier2Minter;
+use lifegw::config::{AuthConfig, RateLimitConfig};
+use lifegw::services::anthropic_messages::{
+    self, AnthropicMessagesState, HaimaClient, StubHaimaClient,
+};
+use lifegw::services::rate_limit::TokenBucketLimiter;
+
+// ─── Mock lifed Agent service ───────────────────────────────────────────
+//
+// Duplicated from `tests/spec_j_e2e_smoke.rs` (option 2 per BRO-1165 scope
+// discipline). Kept intentionally minimal: a single fixed token stream
+// (`Hello`, ` from`, ` lifegw`, ` local`, ` smoke!`) closing with a
+// `stop` Finish. Tool-use round-trips and richer scenarios stay in the
+// test suite — operators wanting to exercise those drive the example
+// against the codec via the real `/v1/messages` route.
+
+#[derive(Default)]
+struct MockAgentState {
+    /// Cumulative session-id counter so successive `CreateSession` calls
+    /// echo distinct sids when the caller doesn't supply a `resume_sid`.
+    sequence: Mutex<u64>,
+}
+
+#[derive(Clone)]
+struct MockAgentService {
+    state: Arc<MockAgentState>,
+}
+
+#[tonic::async_trait]
+impl Agent for MockAgentService {
+    type SendMessageStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+    type StreamSessionStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+
+    async fn create_session(
+        &self,
+        req: tonic::Request<CreateSessionReq>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        let body = req.into_inner();
+        let sid_val = match body.resume_sid.as_ref().map(|s| s.value.clone()) {
+            Some(v) if !v.is_empty() => v,
+            _ => {
+                let mut seq = self.state.sequence.lock().await;
+                *seq += 1;
+                format!("mock-sid-{}", *seq)
+            }
+        };
+        Ok(tonic::Response::new(Session {
+            sid: Some(aios_proto::aios::v1::SessionId { value: sid_val }),
+            agent_id: Some(aios_proto::aios::v1::AgentId {
+                value: "mock-agent".to_string(),
+            }),
+            user_id: body.user_id,
+            project_id: body.project_id,
+            created_at: Some(prost_types::Timestamp {
+                seconds: 0,
+                nanos: 0,
+            }),
+        }))
+    }
+
+    async fn describe_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn close_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn send_message(
+        &self,
+        _req: tonic::Request<SendMessageReq>,
+    ) -> Result<tonic::Response<Self::SendMessageStream>, tonic::Status> {
+        // Empty — the canonical event source is StreamSession (matches
+        // the in-process E2E test pattern).
+        let s = futures::stream::empty::<Result<AgentEvent, tonic::Status>>();
+        Ok(tonic::Response::new(Box::pin(s)))
+    }
+
+    async fn stream_session(
+        &self,
+        _req: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Self::StreamSessionStream>, tonic::Status> {
+        let events = default_chat_stream_events();
+        let s = futures::stream::iter(events.into_iter().map(Ok::<_, tonic::Status>));
+        Ok(tonic::Response::new(Box::pin(s)))
+    }
+
+    async fn approve_dispatch(
+        &self,
+        _: tonic::Request<ApprovalReq>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn cancel_dispatch(
+        &self,
+        _: tonic::Request<DispatchRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn list_skills(
+        &self,
+        _: tonic::Request<ListSkillsReq>,
+    ) -> Result<tonic::Response<SkillCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn list_models(
+        &self,
+        _: tonic::Request<ListModelsReq>,
+    ) -> Result<tonic::Response<ModelCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn list_tools(
+        &self,
+        _: tonic::Request<ListToolsReq>,
+    ) -> Result<tonic::Response<ToolCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+
+    async fn spawn_child(
+        &self,
+        _: tonic::Request<SpawnChildReq>,
+    ) -> Result<tonic::Response<SpawnChildResp>, tonic::Status> {
+        Err(tonic::Status::unimplemented("mock"))
+    }
+}
+
+fn default_chat_stream_events() -> Vec<AgentEvent> {
+    vec![
+        token_event(1, "Hello"),
+        token_event(2, " from"),
+        token_event(3, " lifegw"),
+        token_event(4, " local"),
+        token_event(5, " smoke!"),
+        finish_event(6, "stop"),
+    ]
+}
+
+fn token_event(seq: u64, text: &str) -> AgentEvent {
+    AgentEvent {
+        record: Some(EventRecord {
+            session_id: None,
+            sequence: seq,
+            at: None,
+            kind: "TOKEN".into(),
+            payload: serde_json::to_vec(&serde_json::json!({ "text": text }))
+                .expect("encode token payload"),
+        }),
+        kind: AgentEventKind::Token as i32,
+    }
+}
+
+fn finish_event(seq: u64, reason: &str) -> AgentEvent {
+    AgentEvent {
+        record: Some(EventRecord {
+            session_id: None,
+            sequence: seq,
+            at: None,
+            kind: "FINISH".into(),
+            payload: serde_json::to_vec(&serde_json::json!({ "reason": reason }))
+                .expect("encode finish payload"),
+        }),
+        kind: AgentEventKind::Finish as i32,
+    }
+}
+
+async fn dial_uds(path: &str) -> Channel {
+    let path = path.to_string();
+    let endpoint = Endpoint::try_from("http://[::]:0").expect("endpoint scheme");
+    endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let path = path.clone();
+            async move {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+            }
+        }))
+        .await
+        .expect("dial mock lifed UDS")
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Logging — default to `lifegw=debug,info` so Vigil span emission is
+    // visible to the operator. `RUST_LOG` overrides the default.
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("lifegw=debug,info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .init();
+
+    // 1. Stand up the mock lifed Agent service over a tempdir UDS.
+    let temp: TempDir = tempfile::tempdir()?;
+    let socket_path = temp.path().join("lifed.sock");
+    let socket_path_str = socket_path.to_string_lossy().to_string();
+    let listener = UnixListener::bind(&socket_path)?;
+    let uds_stream = UnixListenerStream::new(listener);
+
+    tracing::info!(uds = %socket_path_str, "mock lifed UDS bound");
+
+    let agent_state = Arc::new(MockAgentState::default());
+    let agent_svc = MockAgentService {
+        state: Arc::clone(&agent_state),
+    };
+    let agent_server = AgentServer::new(agent_svc);
+
+    let (uds_shutdown_tx, uds_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let uds_handle = tokio::spawn(async move {
+        if let Err(err) = tonic::transport::Server::builder()
+            .add_service(agent_server)
+            .serve_with_incoming_shutdown(uds_stream, async move {
+                let _ = uds_shutdown_rx.await;
+            })
+            .await
+        {
+            tracing::warn!(error = %err, "mock lifed server exited with error");
+        }
+    });
+
+    // Tiny grace for the listener to start accepting (mirrors the test rig
+    // — connect_with_connector retries once but a brief sleep makes the
+    // first dial deterministic).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // 2. Dial the mock lifed over UDS.
+    let upstream = dial_uds(&socket_path_str).await;
+
+    // 3. Build the router state — same shape lifegw uses in production,
+    // with the dev JWKS shortcut + a freshly-generated keystore + a
+    // default-config rate limiter + the stub haima cost gate.
+    let auth_cfg = AuthConfig::default();
+    let jwks = Arc::new(JwksCache::dev_only());
+    let signer = Arc::new(StaticKeystore::generate_dev()?);
+    let minter = Arc::new(Tier2Minter::new(signer, &auth_cfg));
+    let rate_limiter = TokenBucketLimiter::from_config(&RateLimitConfig::default());
+    let haima: Arc<dyn HaimaClient> = Arc::new(StubHaimaClient);
+
+    let state = AnthropicMessagesState {
+        jwks,
+        minter,
+        upstream,
+        rate_limiter: Some(rate_limiter),
+        haima,
+        billing_enforce: false,
+    };
+    let app = anthropic_messages::router(state);
+
+    // 4. Bind axum on 127.0.0.1:0 — kernel picks the port so concurrent
+    // example runs don't collide.
+    let bind_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = bind_listener.local_addr()?;
+
+    let dev_bearer = "dev-token-for-broomva";
+
+    println!();
+    println!("lifegw local smoke ready:");
+    println!("  URL:    http://{local_addr}");
+    println!("  Bearer: {dev_bearer}");
+    println!();
+    println!("Try:");
+    println!("  curl http://{local_addr}/v1/models | jq .");
+    println!();
+    println!("  curl -N -H \"Authorization: Bearer {dev_bearer}\" \\");
+    println!("       -H \"anthropic-version: 2023-06-01\" \\");
+    println!("       -H \"Content-Type: application/json\" \\");
+    println!(
+        "       -d '{{\"model\":\"claude-sonnet-4-20250514\",\"messages\":\
+[{{\"role\":\"user\",\"content\":\"hello\"}}],\"max_tokens\":100,\"stream\":true}}' \\"
+    );
+    println!("       http://{local_addr}/v1/messages");
+    println!();
+    println!("Press Ctrl-C to exit.");
+    println!();
+
+    // 5. Serve until SIGINT. axum::serve takes ownership of the listener
+    // and runs the connection accept loop; the shutdown future fires on
+    // Ctrl-C and the server drains in-flight requests.
+    let shutdown = async {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            tracing::warn!(error = %err, "ctrl_c handler failed; exiting anyway");
+        }
+        tracing::info!("Ctrl-C received; shutting down lifegw local smoke");
+    };
+
+    let serve_result = axum::serve(bind_listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await;
+
+    // 6. Tear down the mock UDS server and the tempdir.
+    let _ = uds_shutdown_tx.send(());
+    let _ = tokio::time::timeout(Duration::from_secs(2), uds_handle).await;
+    drop(temp);
+
+    serve_result.map_err(Into::into)
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1552,6 +1552,26 @@ All 5 pass green. Joined with the existing
 `anthropic_messages_integration.rs` tests, the lifegw test surface
 now covers Phase 1 end-to-end at the in-process level.
 
+**Three test paths for Phase 1:**
+
+- **Path 1 — in-process E2E** (`cargo test -p lifegw --test
+  spec_j_e2e_smoke`): the 5 scenarios above. Automated regression gate.
+- **Path 2 — Railway staging deploy**
+  (`docs/conformance/2026-05-18-claude-code-smoke-runbook.md`): live
+  Claude Code session against a Railway-hosted lifegw+lifed stack.
+  Produces the Phase 1 conformance evidence (Loom + Vigil traces + lago
+  replay + haima ledger).
+- **Path 3 — local interactive smoke** (`cargo run -p lifegw --example
+  local_smoke`, BRO-1165): boots the real lifegw router against an
+  in-process mock lifed UDS on a kernel-picked `127.0.0.1` port. Prints
+  the URL + dev bearer and serves until SIGINT. Same code paths as
+  production (codec, auth, rate-limit, Vigil) — only the substrate is
+  mocked. Used for iterating on the Anthropic Messages route, validating
+  Vigil span emission, and verifying the wire over a real TCP socket
+  without burning a Railway slot. See
+  `crates/life-runtime/lifegw/examples/README.md` for the full curl
+  recipes.
+
 **Operator runbook + deploy script (this PR's other deliverables):**
 
 - `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` — seven

--- a/docs/conformance/2026-05-18-claude-code-smoke-runbook.md
+++ b/docs/conformance/2026-05-18-claude-code-smoke-runbook.md
@@ -50,6 +50,27 @@ committing. See §2.2 below for the full mutation list.
 
 ---
 
+## Quick local smoke (zero deploy, zero Railway)
+
+Before the full staging deploy, you can run lifegw locally against a
+mock lifed for a ~30 second interactive smoke:
+
+```sh
+cargo run -p lifegw --example local_smoke
+```
+
+Prints a localhost URL + dev-bearer; `curl` or `claude` against it.
+Useful for iterating on the Anthropic Messages route, validating
+Vigil span emission, and verifying the wire over a real TCP socket
+without burning Railway slots. See
+`crates/life-runtime/lifegw/examples/README.md` for the full curl
+recipes.
+
+The full Railway staging path (below) is what produces the
+Phase 1 conformance evidence.
+
+---
+
 ## Section 1 — Prerequisites
 
 Before starting, verify the following are installed and configured on


### PR DESCRIPTION
## Summary

Boots the real lifegw Anthropic Messages router (`/v1/messages`,
`/v1/models`, `/v1/messages/count_tokens`) on a kernel-picked
`127.0.0.1` port, wired against an in-process mock lifed `Agent` service
over a tempdir UDS. Same code paths as production — codec, auth,
rate-limit, Vigil span emission, stub haima — only the substrate is
mocked. Per [BRO-1165](https://linear.app/broomva/issue/BRO-1165).

Adds **Path 3** to Spec J Phase 1's test surface:

| Path | Command | Cost | What it certifies |
|---|---|---|---|
| 1 | `cargo test -p lifegw --test spec_j_e2e_smoke` | seconds | in-process E2E — automated regression gate |
| **3 (new)** | **`cargo run -p lifegw --example local_smoke`** | **~30 s** | **interactive smoke over a real TCP socket — no Railway slot** |
| 2 | Railway staging deploy per runbook | minutes + Railway quota | Phase 1 conformance evidence — Loom + Vigil + lago replay |

Path 3 is the iterating-engineer's loop between Path 1 (automated) and
Path 2 (conformance gate).

## Files

- **New:** `crates/life-runtime/lifegw/examples/local_smoke.rs` —
  duplicates the minimal `MockAgentService` from
  `tests/spec_j_e2e_smoke.rs` (**option 2** per BRO-1165 scope discipline —
  dev tooling has no business widening lifegw's public `src/` surface).
  Boots → prints URL + bearer + three curl recipes → serves until
  `SIGINT` → graceful drain (axum then mock UDS server then tempdir).
- **New:** `crates/life-runtime/lifegw/examples/README.md` — what it
  does, three curl recipes (models / count_tokens / messages SSE),
  known limits, how to point Claude Code at it.
- **Updated:** `docs/conformance/2026-05-18-claude-code-smoke-runbook.md`
  §1.0 callout pointing operators at the local smoke before Railway.
- **Updated:** `docs/STATUS.md` Spec J row surfaces Path 3.

## Scope discipline (BRO-1165 anti-rationalization checklist)

- [x] **`MockAgentService` reuse**: chose option 2 (duplicate into example).
      The mock is ~150 LOC and the alternative (`pub(crate)` test_utils
      gated behind `feature = "test-utils"`) would widen the production
      crate's public API for a dev tool. The duplicate is documented
      in-file with the link back to the test.
- [x] **Substrate-free per Spec J L10-D1**: no real
      `lifed`/`arcan`/`lago`/`anima`/`haima` deps. Only `life-runtime-proto`
      (Agent service definitions) and `aios-proto` (`SessionId`/`AgentId`)
      types, both of which are already production deps of lifegw.
- [x] **No Spec J scope extension**: dev-tooling only.
- [x] **No production code touched**: zero edits to
      `src/services/anthropic_messages.rs`, `src/bootstrap.rs`,
      `src/auth/*`. The example imports the same public types
      production uses.

## Manual smoke evidence

Ran during PR preparation (kernel-picked port 54289):

```
=== /v1/models ===
{"data":[{"id":"claude-opus-4-20250514",...},{"id":"claude-sonnet-4-20250514",...},
 {"id":"claude-haiku-4-20250514",...},{"id":"claude-sonnet-4-5-20250929",...},
 {"id":"claude-haiku-4-5-20251001",...}]}

=== /v1/messages/count_tokens ===
HTTP/1.1 200 OK
content-type: application/json
x-life-cost-estimate-usd-micros: 33
{"input_tokens":11}

=== /v1/messages SSE ===
event: message_start ...
event: content_block_start ...
event: content_block_delta data: {... "text": "Hello"}
event: content_block_delta data: {... "text": " from"}
event: content_block_delta data: {... "text": " lifegw"}
event: content_block_delta data: {... "text": " local"}
event: content_block_delta data: {... "text": " smoke!"}
event: content_block_stop ...
event: message_delta data: {... "stop_reason": "end_turn"}
event: message_stop ...
```

`SIGINT` → `Ctrl-C received; shutting down lifegw local smoke` → axum
graceful drain → mock UDS server shutdown → tempdir cleanup.

Vigil span emission verified end-to-end (visible in the example's
default `lifegw=debug,info` log filter):

```
DEBUG life.anthropic.count_tokens{
  gen_ai.system=life gen_ai.operation.name=count_tokens
  gen_ai.usage.input_tokens=11 gen_ai.request.model=claude-sonnet-4-20250514
  life.anima.did=did:life:broomva life.estimated_cost_usd_micros=33
}: lifegw::services::anthropic_messages: count_tokens estimate ...
```

## Test plan

- [x] `cargo build -p lifegw --examples` clean (`Finished dev`).
- [x] `cargo run -p lifegw --example local_smoke` boots, prints URL +
      bearer, runs until SIGINT, graceful drain on exit.
- [x] Three-curl manual roundtrip — `/v1/models` returns 5 model IDs,
      `/v1/messages/count_tokens` returns plausible count + cost header,
      `/v1/messages` returns canonical Anthropic SSE order.
- [x] `cargo clippy -p lifegw --all-targets --examples -- -D warnings`
      clean.
- [x] `cargo fmt --all -- --check` clean.

## Linear

Closes BRO-1165. Child of BRO-1140 (Phase 1 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)