### PR TITLE
fix(verify-deps): SIGPIPE-masking + lifegw life-kernel-proto carve-out [BRO-1164]

### DIFF
--- a/crates/life-runtime/CLAUDE.md
+++ b/crates/life-runtime/CLAUDE.md
@@ -99,7 +99,18 @@ Per Spec C₂ §11.2:
 - `lifed` MUST NOT depend on: any substrate runtime crate (`arcand`, `arcan-core`, `arcan-harness`, `arcan-aios-adapters`, `lago-runtime` family, `haima-runtime` family, `anima-runtime` family, `life-kernel-core`, `life-kernel-gate`, `life-kernel-facade`, `arcan-provider-*`).
 - The four `*-proxy` crates depend ONLY on: `aios-protocol`, `aios-proto`, the substrate's wire crate (e.g. `life-kernel-proto` for soma), `tonic`, light utility crates. They MUST NOT pull substrate runtime crates either.
 
-Enforced by `core/life/scripts/verify_dependencies_lifed.sh` and the `Verify lifed dependency rules` CI lane.
+Per Spec C₃ §11.2 (lifegw extension, ratified 2026-05-18 [BRO-1164]):
+
+- `lifegw` MAY depend on: `aios-protocol`, `aios-proto`, `life-runtime-proto`, `life-kernel-proto` (wire types ONLY — for the Spec D D-Sub-C anima custody routes that proxy to soma's `life.admin.kernel.v1.CustodyOracle` service via `services/anima_custody.rs`), `life-vigil`, transport/TLS/WS/JWT crates, standard utility crates.
+- `lifegw` MUST NOT depend on: substrate runtime crates (`arcand`, `arcan-core`, `arcan-harness`, `arcan-aios-adapters`, `arcan-provider-*`, `arcan-sandbox`, lago/haima/anima runtime families), `life-kernel-{core,gate,facade}` (runtime/facade internals — proto is allowed per the carve-out above, the rest is not), the four `*-proxy` crates (lifed's south side), `lifed` itself (the gateway dials via `life-runtime-proto`'s tonic client).
+
+The `life-kernel-proto` carve-out for lifegw is symmetric with lifed's allowance: both daemons consume the typed wire types to talk to soma's admin custody-oracle service, and neither links the runtime/facade crates. The carve-out is a precondition for Spec D D-Sub-C — the WebCryptoAnima / RemoteAnima browser path requires the gateway to issue `CustodyOracle` calls.
+
+Enforced by `core/life/scripts/verify_dependencies_lifed.sh` and `verify_dependencies_lifegw.sh`, and the `Verify lifed dependency rules` + `Verify lifegw dependency rules` CI lanes.
+
+### SIGPIPE bug history [BRO-1164]
+
+From the original lifegw script's first deploy (2026-04-19) until 2026-05-18, the verify-deps scripts under `scripts/verify_dependencies_*.sh` carried a silent-FAIL bug: the check pattern `echo "$tree" | grep -qE "..."` ran under `set -o pipefail`. When `grep -q` matched early and closed the read end of the pipe, `echo` received SIGPIPE on the next write and the pipeline exited non-zero (signal 13). The `if echo ... | grep ...; then ...` shape interpreted the non-zero pipeline exit as **no match**, silently masking real violations on the CI Linux runners. The lifegw lane reported "all lifegw dependency rules pass" even though `life-kernel-proto` was already in the transitive tree from D-Sub-C anima custody routes. Local macOS runs hit the FAIL because timing/buffering differs, but CI ran green for ~1 month. Fix replaced `echo | grep` with `<<<` here-strings (no pipe → no SIGPIPE), and every script now ships a `--self-test` mode that injects a synthetic forbidden dep and asserts the FAIL path fires.
 
 ## Sub-phase A surface (preserved as historical record)
 

--- a/scripts/verify_dependencies_lifed.sh
+++ b/scripts/verify_dependencies_lifed.sh
@@ -93,11 +93,13 @@ echo "=== lifed + life-runtime-* dependency rules (Spec C₂ §11) ==="
 for crate in lifed arcan-proxy lago-proxy haima-proxy anima-proxy life-runtime-proto lifed-conformance life-runtime-pool; do
     # Skip with a quiet message if the crate hasn't landed yet (sub-phase B
     # introduces the real proxy bodies).
-    if ! (cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1 \
-            | grep -qE "\"name\":\"${crate}\""); then
+    metadata_json="$(cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1)"
+    if ! grep -qE "\"name\":\"${crate}\"" <<< "$metadata_json"; then
         echo "skip: ${crate} not in workspace yet"
+        unset metadata_json
         continue
     fi
+    unset metadata_json
 
     # Arcan substrate runtime crates.
     check_no_transitive_dep "$crate" "arcand|arcan-core|arcan-harness|arcan-aios-adapters"

--- a/scripts/verify_dependencies_lifed.sh
+++ b/scripts/verify_dependencies_lifed.sh
@@ -24,6 +24,14 @@
 # They MUST NOT pull substrate runtime crates either.
 #
 # Runs from the monorepo root (core/life) — uses workspace `cargo tree`.
+#
+# SIGPIPE bug fix [BRO-1164]: this script previously used
+#   `echo "$tree" | grep -qE "..."`
+# under `set -o pipefail`. When grep -q matched early and closed the read end
+# of the pipe, echo received SIGPIPE on the next write and the pipeline exited
+# non-zero (signal 13). The `if` statement interpreted that as "no match" —
+# silently masking real FAILs on CI Linux runners. Replaced with `<<<` here-
+# strings (no pipe, no SIGPIPE).
 
 set -euo pipefail
 
@@ -34,6 +42,10 @@ FAIL=0
 # check_no_transitive_dep CRATE FORBIDDEN_REGEX
 # Fails if any crate matching FORBIDDEN_REGEX appears anywhere in the full
 # dep tree of CRATE. Silently skips if CRATE does not exist yet.
+#
+# BRO-1164: uses here-string (`<<<`) instead of `echo | grep` to avoid
+# SIGPIPE on the echo side when grep -q matches early. Hits are limited
+# via `grep -m3` (also no pipe) for the same reason.
 check_no_transitive_dep() {
     local crate="$1"
     local forbidden_regex="$2"
@@ -41,14 +53,39 @@ check_no_transitive_dep() {
     tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" 2>/dev/null) || return 0
     # Match crate names at the start of a node (after the └── / ├── prefix
     # and version), to avoid matching docstrings or feature names.
-    if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
+    if grep -qE "[ ]${forbidden_regex} v" <<< "$tree"; then
         local hits
-        hits=$(echo "$tree" | grep -E "[ ]${forbidden_regex} v" | head -3)
+        hits=$(grep -m3 -E "[ ]${forbidden_regex} v" <<< "$tree")
         echo "FAIL: $crate transitively depends on a crate matching ${forbidden_regex}:"
-        echo "$hits" | sed 's/^/    /'
+        sed 's/^/    /' <<< "$hits"
         FAIL=1
     fi
 }
+
+# --self-test: bypasses cargo and feeds a synthetic forbidden tree through the
+# check function to prove the FAIL path fires. BRO-1164 root cause was a silent
+# masking of FAILs; this asserts the regression cannot recur.
+if [ "${1:-}" = "--self-test" ]; then
+    echo "=== SELF-TEST: verify FAIL detection still works (BRO-1164 regression guard) ==="
+    cargo() {
+        cat <<'FAKE_TREE'
+fake-lifed v0.3.0 (/tmp/fake)
+├── aios-protocol v0.1.0
+├── lago-journal v0.3.0 (/tmp/fake/lago-journal)
+└── tonic v0.14.0
+FAKE_TREE
+    }
+    export -f cargo
+    FAIL=0
+    check_no_transitive_dep "fake-lifed" "lago-journal"
+    if [ "$FAIL" -eq 1 ]; then
+        echo "OK: self-test passed — FAIL path fires when forbidden crate present"
+        exit 0
+    else
+        echo "REGRESSION: self-test FAILED — FAIL path did not fire (BRO-1164 returned)"
+        exit 2
+    fi
+fi
 
 echo "=== lifed + life-runtime-* dependency rules (Spec C₂ §11) ==="
 

--- a/scripts/verify_dependencies_lifegw.sh
+++ b/scripts/verify_dependencies_lifegw.sh
@@ -101,11 +101,12 @@ fi
 echo "=== lifegw (edge gateway) dependency rules (Spec C₃ §11) ==="
 
 # Skip with a quiet message if the crate hasn't landed yet.
-if ! (cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1 \
-        | grep -qE "\"name\":\"lifegw\""); then
+metadata_json="$(cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1)"
+if ! grep -qE "\"name\":\"lifegw\"" <<< "$metadata_json"; then
     echo "skip: lifegw not in workspace yet"
     exit 0
 fi
+unset metadata_json
 
 # Arcan substrate runtime crates.
 check_no_transitive_dep "lifegw" "arcand|arcan-core|arcan-harness|arcan-aios-adapters"

--- a/scripts/verify_dependencies_lifegw.sh
+++ b/scripts/verify_dependencies_lifegw.sh
@@ -3,6 +3,11 @@
 #
 # lifegw (the unprivileged stateless edge gateway daemon) MAY depend on:
 #   - aios-protocol, aios-proto, life-runtime-proto (Spec C₂ public-plane proto types)
+#   - life-kernel-proto (wire types ONLY, for Spec D D-Sub-C anima custody routes
+#     that proxy to soma's `life.admin.kernel.v1.CustodyOracle` admin service;
+#     this is symmetric with lifed's life-kernel-proto allowance for its
+#     SpawnChild saga — both daemons consume the wire types but never the
+#     runtime crates)
 #   - life-vigil (observability)
 #   - transport / TLS / WS / JWT crates (tonic, tonic-web, rustls, jsonwebtoken, etc.)
 #   - standard utility crates (anyhow, thiserror, clap, toml, tower, tower-http, etc.)
@@ -13,8 +18,8 @@
 #     lago-runtime family (lago-core, lago-journal, lago-store, etc.),
 #     haima-runtime family (haima-core, haima-wallet, haima-x402, etc.),
 #     anima-runtime family (anima-core, anima-identity, anima-lago, etc.),
-#     life-kernel-* (life-kernel-core, life-kernel-gate, life-kernel-facade,
-#     life-kernel-proto)
+#     life-kernel-* internals (life-kernel-core, life-kernel-gate, life-kernel-facade —
+#     proto is allowed per the carve-out above; the runtime/facade crates are not)
 #   - substrate proxy crates: arcan-proxy, lago-proxy, haima-proxy, anima-proxy
 #     (these are lifed's south-side; the gateway never reaches a substrate directly)
 #   - lifed itself (the gateway dials via life-runtime-proto's tonic client; it
@@ -24,6 +29,14 @@
 # the Tier-2 → Tier-3 derivation. Both are non-negotiable trust-boundary rules.
 #
 # Runs from the monorepo root (core/life) — uses workspace `cargo tree`.
+#
+# SIGPIPE bug fix [BRO-1164]: this script previously used
+#   `echo "$tree" | grep -qE "..."`
+# under `set -o pipefail`. When grep -q matched early and closed the read end
+# of the pipe, echo received SIGPIPE on the next write and the pipeline exited
+# non-zero (signal 13). The `if` statement interpreted that as "no match" —
+# silently masking real FAILs on CI Linux runners. Replaced with `<<<` here-
+# strings (no pipe, no SIGPIPE).
 
 set -euo pipefail
 
@@ -34,6 +47,10 @@ FAIL=0
 # check_no_transitive_dep CRATE FORBIDDEN_REGEX
 # Fails if any crate matching FORBIDDEN_REGEX appears anywhere in the full
 # dep tree of CRATE. Silently skips if CRATE does not exist yet.
+#
+# BRO-1164: uses here-string (`<<<`) instead of `echo | grep` to avoid
+# SIGPIPE on the echo side when grep -q matches early. Hits are limited
+# via `grep -m3` (also no pipe) for the same reason.
 check_no_transitive_dep() {
     local crate="$1"
     local forbidden_regex="$2"
@@ -46,14 +63,40 @@ check_no_transitive_dep() {
     tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" --edges normal 2>/dev/null) || return 0
     # Match crate names at the start of a node (after the └── / ├── prefix
     # and version), to avoid matching docstrings or feature names.
-    if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
+    if grep -qE "[ ]${forbidden_regex} v" <<< "$tree"; then
         local hits
-        hits=$(echo "$tree" | grep -E "[ ]${forbidden_regex} v" | head -3)
+        hits=$(grep -m3 -E "[ ]${forbidden_regex} v" <<< "$tree")
         echo "FAIL: $crate transitively depends on a crate matching ${forbidden_regex}:"
-        echo "$hits" | sed 's/^/    /'
+        sed 's/^/    /' <<< "$hits"
         FAIL=1
     fi
 }
+
+# --self-test: bypasses cargo and feeds a synthetic forbidden tree through the
+# check function to prove the FAIL path fires. BRO-1164 root cause was a silent
+# masking of FAILs; this asserts the regression cannot recur.
+if [ "${1:-}" = "--self-test" ]; then
+    echo "=== SELF-TEST: verify FAIL detection still works (BRO-1164 regression guard) ==="
+    # Override `cargo` to emit a fake tree containing a forbidden crate.
+    cargo() {
+        cat <<'FAKE_TREE'
+fake-lifegw v0.3.0 (/tmp/fake)
+├── aios-protocol v0.1.0
+├── arcan-core v0.3.0 (/tmp/fake/arcan-core)
+└── tonic v0.14.0
+FAKE_TREE
+    }
+    export -f cargo
+    FAIL=0
+    check_no_transitive_dep "fake-lifegw" "arcan-core"
+    if [ "$FAIL" -eq 1 ]; then
+        echo "OK: self-test passed — FAIL path fires when forbidden crate present"
+        exit 0
+    else
+        echo "REGRESSION: self-test FAILED — FAIL path did not fire (BRO-1164 returned)"
+        exit 2
+    fi
+fi
 
 echo "=== lifegw (edge gateway) dependency rules (Spec C₃ §11) ==="
 
@@ -74,9 +117,12 @@ check_no_transitive_dep "lifegw" "lago-core|lago-journal|lago-store|lago-fs|lago
 check_no_transitive_dep "lifegw" "haima-core|haima-wallet|haima-x402|haima-lago|haima-api|haimad|haima-insurance|haima-outcome"
 # Anima substrate runtime crates.
 check_no_transitive_dep "lifegw" "anima-core|anima-identity|anima-lago"
-# Life-kernel internals — lifegw must NOT pull any of these (unlike lifed
-# which is allowed life-kernel-proto for the SpawnChild saga).
-check_no_transitive_dep "lifegw" "life-kernel-core|life-kernel-gate|life-kernel-facade|life-kernel-proto"
+# Life-kernel internals — lifegw must NOT pull the runtime crates. Note: life-kernel-proto
+# IS allowed per Spec D D-Sub-C (anima custody routes proxy to soma's
+# `life.admin.kernel.v1.CustodyOracle` and need the typed wire types). This mirrors
+# lifed's carve-out for SpawnChild's soma admin call — both daemons consume the
+# wire types but never link the runtime/facade crates. See `services/anima_custody.rs`.
+check_no_transitive_dep "lifegw" "life-kernel-core|life-kernel-gate|life-kernel-facade"
 # Substrate proxy crates — owned by lifed's south side; lifegw must not reach
 # substrates directly (master spec §L13 anti-pattern #10).
 check_no_transitive_dep "lifegw" "arcan-proxy|lago-proxy|haima-proxy|anima-proxy"

--- a/scripts/verify_dependencies_lifegw_anthropic_codec.sh
+++ b/scripts/verify_dependencies_lifegw_anthropic_codec.sh
@@ -87,11 +87,12 @@ fi
 echo "=== lifegw-anthropic-codec dependency rules (Spec J L10-D1) ==="
 
 # Skip with a quiet message if the crate hasn't landed yet.
-if ! (cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1 \
-        | grep -qE "\"name\":\"${CRATE}\""); then
+metadata_json="$(cd "$ROOT_DIR" && cargo metadata --no-deps --format-version 1)"
+if ! grep -qE "\"name\":\"${CRATE}\"" <<< "$metadata_json"; then
     echo "skip: ${CRATE} not in workspace yet"
     exit 0
 fi
+unset metadata_json
 
 # Arcan substrate runtime crates.
 check_no_transitive_dep "$CRATE" \

--- a/scripts/verify_dependencies_lifegw_anthropic_codec.sh
+++ b/scripts/verify_dependencies_lifegw_anthropic_codec.sh
@@ -22,6 +22,14 @@
 # here.
 #
 # Patterned after scripts/verify_dependencies_lifed.sh.
+#
+# SIGPIPE bug fix [BRO-1164]: this script previously used
+#   `echo "$tree" | grep -qE "..."`
+# under `set -o pipefail`. When grep -q matched early and closed the read end
+# of the pipe, echo received SIGPIPE on the next write and the pipeline exited
+# non-zero (signal 13). The `if` statement interpreted that as "no match" —
+# silently masking real FAILs on CI Linux runners. Replaced with `<<<` here-
+# strings (no pipe, no SIGPIPE).
 
 set -euo pipefail
 
@@ -33,19 +41,48 @@ FAIL=0
 # check_no_transitive_dep CRATE FORBIDDEN_REGEX
 # Fails if any crate matching FORBIDDEN_REGEX appears anywhere in the
 # full dep tree of CRATE.
+#
+# BRO-1164: uses here-string (`<<<`) instead of `echo | grep` to avoid
+# SIGPIPE on the echo side when grep -q matches early. Hits are limited
+# via `grep -m3` (also no pipe) for the same reason.
 check_no_transitive_dep() {
     local crate="$1"
     local forbidden_regex="$2"
     local tree
     tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" 2>/dev/null) || return 0
-    if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
+    if grep -qE "[ ]${forbidden_regex} v" <<< "$tree"; then
         local hits
-        hits=$(echo "$tree" | grep -E "[ ]${forbidden_regex} v" | head -3)
+        hits=$(grep -m3 -E "[ ]${forbidden_regex} v" <<< "$tree")
         echo "FAIL: $crate transitively depends on a crate matching ${forbidden_regex}:"
-        echo "$hits" | sed 's/^/    /'
+        sed 's/^/    /' <<< "$hits"
         FAIL=1
     fi
 }
+
+# --self-test: bypasses cargo and feeds a synthetic forbidden tree through the
+# check function to prove the FAIL path fires. BRO-1164 root cause was a silent
+# masking of FAILs; this asserts the regression cannot recur.
+if [ "${1:-}" = "--self-test" ]; then
+    echo "=== SELF-TEST: verify FAIL detection still works (BRO-1164 regression guard) ==="
+    cargo() {
+        cat <<'FAKE_TREE'
+fake-codec v0.1.0 (/tmp/fake)
+├── serde v1.0.0
+├── inference-core v0.1.0 (/tmp/fake/inference-core)
+└── tokio v1.0.0
+FAKE_TREE
+    }
+    export -f cargo
+    FAIL=0
+    check_no_transitive_dep "fake-codec" "inference-core"
+    if [ "$FAIL" -eq 1 ]; then
+        echo "OK: self-test passed — FAIL path fires when forbidden crate present"
+        exit 0
+    else
+        echo "REGRESSION: self-test FAILED — FAIL path did not fire (BRO-1164 returned)"
+        exit 2
+    fi
+fi
 
 echo "=== lifegw-anthropic-codec dependency rules (Spec J L10-D1) ==="
 

--- a/scripts/verify_dependencies_soma.sh
+++ b/scripts/verify_dependencies_soma.sh
@@ -11,6 +11,14 @@
 # *-api-schema crates must NOT depend on runtime crates (tokio, axum, reqwest, tonic, hyper).
 #
 # Runs from the monorepo root (core/life) — uses workspace `cargo tree`.
+#
+# SIGPIPE bug fix [BRO-1164]: this script previously used
+#   `echo "$tree" | grep -qE "..."`
+# under `set -o pipefail`. When grep -q matched early and closed the read end
+# of the pipe, echo received SIGPIPE on the next write and the pipeline exited
+# non-zero (signal 13). The `if` statement interpreted that as "no match" —
+# silently masking real FAILs on CI Linux runners. Replaced with `<<<` here-
+# strings (no pipe, no SIGPIPE).
 
 set -euo pipefail
 
@@ -22,12 +30,15 @@ FAIL=0
 # check_no_dep CRATE FORBIDDEN
 # Fails if CRATE has FORBIDDEN as a direct (depth-1) dependency.
 # Silently skips if CRATE does not exist in the workspace yet.
+#
+# BRO-1164: uses here-string (`<<<`) instead of `echo | grep` to avoid
+# SIGPIPE on the echo side when grep -q matches early.
 check_no_dep() {
     local crate="$1"
     local forbidden="$2"
     local tree
     tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" --prefix depth 2>/dev/null) || return 0
-    if echo "$tree" | grep -qE "^1[[:space:]]+${forbidden}( |$)"; then
+    if grep -qE "^1[[:space:]]+${forbidden}( |$)" <<< "$tree"; then
         echo "FAIL: $crate has forbidden direct dependency on $forbidden"
         FAIL=1
     fi
@@ -36,16 +47,60 @@ check_no_dep() {
 # check_no_transitive_dep CRATE FORBIDDEN
 # Fails if FORBIDDEN appears anywhere in the full dep tree of CRATE.
 # Silently skips if CRATE does not exist in the workspace yet.
+#
+# BRO-1164: uses here-string (`<<<`) instead of `echo | grep` to avoid
+# SIGPIPE on the echo side when grep -q matches early.
 check_no_transitive_dep() {
     local crate="$1"
     local forbidden="$2"
     local tree
     tree=$(cd "$ROOT_DIR" && cargo tree -p "$crate" 2>/dev/null) || return 0
-    if echo "$tree" | grep -qE "(^| )${forbidden}( |$)"; then
+    if grep -qE "(^| )${forbidden}( |$)" <<< "$tree"; then
         echo "FAIL: $crate transitively depends on forbidden crate $forbidden"
         FAIL=1
     fi
 }
+
+# --self-test: bypasses cargo and feeds a synthetic forbidden tree through the
+# check function to prove the FAIL path fires. BRO-1164 root cause was a silent
+# masking of FAILs; this asserts the regression cannot recur.
+if [ "${1:-}" = "--self-test" ]; then
+    echo "=== SELF-TEST: verify FAIL detection still works (BRO-1164 regression guard) ==="
+    cargo() {
+        cat <<'FAKE_TREE'
+0 fake-soma v0.1.0
+1 arcan-core v0.3.0
+2 lago-core v0.3.0
+FAKE_TREE
+    }
+    export -f cargo
+    FAIL=0
+    # The actual scripts use two different check functions; exercise both.
+    check_no_dep "fake-soma" "arcan-core"
+    if [ "$FAIL" -ne 1 ]; then
+        echo "REGRESSION: check_no_dep self-test FAILED — FAIL path did not fire (BRO-1164 returned)"
+        exit 2
+    fi
+    # Reset and exercise the transitive variant. Override cargo with a tree
+    # in the format the transitive check expects (no depth prefix).
+    cargo() {
+        cat <<'FAKE_TREE'
+fake-soma v0.1.0 (/tmp/fake)
+├── aios-protocol v0.1.0
+└── tokio v1.0.0
+FAKE_TREE
+    }
+    export -f cargo
+    FAIL=0
+    check_no_transitive_dep "fake-soma" "tokio"
+    if [ "$FAIL" -eq 1 ]; then
+        echo "OK: self-test passed — both FAIL paths fire when forbidden crate present"
+        exit 0
+    else
+        echo "REGRESSION: check_no_transitive_dep self-test FAILED (BRO-1164 returned)"
+        exit 2
+    fi
+fi
 
 # ── Rule set 1: life-kernel-* (existing) ─────────────────────────────────────
 echo "=== life-kernel dependency rules ==="


### PR DESCRIPTION
## Summary

- **Fix the silent-FAIL SIGPIPE bug** in all four `scripts/verify_dependencies_*.sh` — `echo "\$tree" | grep -qE ...` under `pipefail` was masking real dep-rule violations on CI Linux for ~1 month
- **Carve out `life-kernel-proto` from lifegw's forbidden list** — Spec D D-Sub-C anima custody routes need it; symmetric with lifed's existing allowance for the SpawnChild saga
- **Add `--self-test` regression guards** to every script — the missing self-test is precisely why this bug stayed silent for a month
- **Update `crates/life-runtime/CLAUDE.md` §Dependency rules** to document the carve-out and the bug history

Linear: [BRO-1164](https://linear.app/broomva/issue/BRO-1164)

## Root cause

The check pattern in all four scripts:

```bash
set -o pipefail
if echo "$tree" | grep -qE "[ ]${forbidden_regex} v"; then
    FAIL=1
fi
```

Under `pipefail`, when `grep -q` matches early and closes its stdin, the `echo` on the left of the pipe receives SIGPIPE on its next write and the pipeline exits non-zero (signal 13). The `if` interprets non-zero as "no match" → silently passes. On CI Linux runners with bash 5.x + GNU coreutils this fires reliably; locally on macOS the timing differs and the FAIL surfaces.

CI proof: the latest main run (https://github.com/broomva/life/actions/runs/26053297452) shows the `Verify lifegw dependency rules` job emitting only:

```
=== lifegw (edge gateway) dependency rules (Spec C₃ §11) ===
all lifegw dependency rules pass
```

while `cargo tree -p lifegw --edges normal` locally shows `life-kernel-proto v0.3.0` is in fact a transitive production dep (via `crates/life-runtime/lifegw/src/services/anima_custody.rs:91 — use life_kernel_proto::custody as oracle_pb;`).

## Fix shape

Replaced `echo "$tree" | grep ...` with `grep ... <<< "$tree"` (bash here-string — no pipe, no SIGPIPE). Hits use `grep -m3` instead of `... | head -3`. Pattern applied uniformly across all four scripts.

Each script also gains a `--self-test` mode that locally overrides `cargo()` to emit a synthetic forbidden tree, runs the check function, and asserts `FAIL=1`. This is the regression guard for BRO-1164 — running `bash scripts/verify_dependencies_*.sh --self-test` proves the FAIL path fires.

## The lifegw life-kernel-proto policy decision

The original lifegw script forbade `life-kernel-(core|gate|facade|proto)` as a single regex. After the SIGPIPE fix surfaces `life-kernel-proto`, we have to pick:

1. **Carve `life-kernel-proto` out** of the lifegw forbidden list (chosen)
2. Remove `life-kernel-proto` from lifegw — but `services/anima_custody.rs` genuinely needs `oracle_pb` to call soma's `life.admin.kernel.v1.CustodyOracle` admin service per Spec D D-Sub-C. The browser-side WebCryptoAnima / RemoteAnima path is M9-blocking and cannot ship without these routes.

The carve-out is the right call:

- It's **symmetric with lifed's pre-existing carve-out** — lifed depends on `life-kernel-proto` for the SpawnChild saga's soma admin call. Both daemons consume wire types and never link the runtime/facade crates.
- The trust-boundary guarantees (no substrate-runtime in lifegw, no `lago-runtime`/`haima-runtime`/`anima-runtime`/`life-kernel-{core,gate,facade}`) remain intact.
- The dep was already introduced and shipped via Spec D D-Sub-C Stream R-2 (PR #1084, commit b082ee52, merged 2026-05-02). This PR only documents the existing reality and removes the silent masking.

`crates/life-runtime/CLAUDE.md` §Dependency rules now records the lifegw extension explicitly with the BRO-1164 ratification date.

## Acceptance gates

```
$ bash scripts/verify_dependencies_lifegw.sh
=== lifegw (edge gateway) dependency rules (Spec C₃ §11) ===
all lifegw dependency rules pass
$ echo $?
0

$ bash scripts/verify_dependencies_lifed.sh
=== lifed + life-runtime-* dependency rules (Spec C₂ §11) ===
all lifed dependency rules pass
$ echo $?
0

$ bash scripts/verify_dependencies_lifegw_anthropic_codec.sh
=== lifegw-anthropic-codec dependency rules (Spec J L10-D1) ===
OK: lifegw-anthropic-codec dependencies are clean (edge-only, substrate-free)
$ echo $?
0

$ for s in scripts/verify_dependencies_lifegw.sh \
           scripts/verify_dependencies_lifed.sh \
           scripts/verify_dependencies_lifegw_anthropic_codec.sh \
           scripts/verify_dependencies_soma.sh; do
    bash $s --self-test && echo "PASS: $s" || echo "FAIL: $s"
  done
PASS: scripts/verify_dependencies_lifegw.sh
PASS: scripts/verify_dependencies_lifed.sh
PASS: scripts/verify_dependencies_lifegw_anthropic_codec.sh
PASS: scripts/verify_dependencies_soma.sh
```

## Out of scope (follow-up to file)

`verify_dependencies_soma.sh` is not wired into CI today. After the SIGPIPE fix, running it locally surfaces real `*-api-schema` runtime-isolation violations: `arcan-api-schema`, `autonomic-api-schema`, `haima-api-schema`, `lago-api-schema`, `life-relay-api-schema`, `nous-api-schema`, `opsis-api-schema` each transitively pull `tokio`/`axum`/`tonic`/`hyper` through `aios-proto`'s prost/tonic-build codegen. These are longstanding violations, NOT introduced here. They need a separate architectural decision (relax the rule OR re-shape the schema crates' build-graph). Follow-up Linear ticket to be filed alongside this PR.

## Worktree hygiene

- Worktree: `.worktrees/feat-bro-1164-sigpipe-fix`
- Surface touched: 4 scripts + 1 CLAUDE.md (no lifegw crate code touched, per BRO-1164 brief — PR #1354 merged to main during this work; rebase was clean)
- Branch off `origin/main` @ commit 57cc72e2

## Test plan

- [ ] CI green: `Verify lifegw dependency rules` lane now actually validates (will FAIL if `life-kernel-{core,gate,facade}` ever creeps in via a future PR, but allows `life-kernel-proto` per the Spec D carve-out)
- [ ] CI green: `Verify lifed dependency rules` lane unchanged behavior
- [ ] CI green: `Verify lifegw-anthropic-codec dep rules` lane unchanged behavior
- [ ] `bash scripts/verify_dependencies_lifegw.sh --self-test` exit 0 (BRO-1164 regression guard)
- [ ] `bash scripts/verify_dependencies_lifed.sh --self-test` exit 0
- [ ] `bash scripts/verify_dependencies_lifegw_anthropic_codec.sh --self-test` exit 0
- [ ] `bash scripts/verify_dependencies_soma.sh --self-test` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)