### PR TITLE
docs(spec-j): mark Phase 1 (6/6) SHIPPED + surface three test paths

### DIFF
--- a/docs/superpowers/specs/2026-05-18-spec-j-claude-code-interop.md
+++ b/docs/superpowers/specs/2026-05-18-spec-j-claude-code-interop.md
@@ -1,7 +1,7 @@
 # Spec J — Claude Code Interoperability (Anthropic Messages ↔ lifegw)
 
 **Date**: 2026-05-18
-**Status**: Phase 1 (5/6) shipped 2026-05-18; E2E smoke prep landed for operator execution (BRO-1146). J-Sub-A..F merged on `main`; in-process E2E scaffold + operator runbook + deploy script ride this PR. Runbook + script target the `lifegw-stack` Dockerfile (Option A, Topology A, mock-substrate fallback); they edit the baked `lifegw.toml` in place because lifegw reads TOML only.
+**Status**: **Phase 1 (6/6) SHIPPED 2026-05-18.** J-Sub-A..G all merged on `main`. Three test paths available: (1) `cargo test -p lifegw --test spec_j_e2e_smoke` in-process E2E, (2) `cargo run -p lifegw --example local_smoke` interactive local TCP, (3) Railway staging deploy via `scripts/deploy_lifegw_staging.sh` + operator runbook at `docs/conformance/2026-05-18-claude-code-smoke-runbook.md`. Live operator smoke session (BRO-1146 follow-up) remains as human-only step to close Phase 1 conformance evidence. Phase 2 candidates documented under `## Phase 2 backlog` in the ticket [BRO-1140](https://linear.app/broomva/issue/BRO-1140).
 **Sibling of**: Spec C₃ (lifegw edge gateway) — same wire-shape-at-the-edge pattern, applied to Anthropic Messages instead of native lifed gRPC/WS.
 **Owner**: `crates/life-runtime/lifegw/` + new `crates/life-runtime/lifegw-anthropic-codec/`
 **Linear umbrella**: [BRO-1140](https://linear.app/broomva/issue/BRO-1140/spec-j-claude-code-interoperability-anthropic-messages-lifegw)


### PR DESCRIPTION
## Summary

Tiny doc-only PR. Updates the Spec J header to reflect Phase 1 (6/6) shipped honestly:

- J-Sub-A through J-Sub-G all merged on \`main\`
- Bonus local_smoke example merged (#1354)
- Governance SIGPIPE verify-deps fix merged (#1355)

The status line was downgraded to \`5/6 + prep landed\` during J-Sub-G fix-round 1 (the operator runbook had legit fixes needed). All those fixes shipped; the count is now 6/6.

## Three test paths surfaced

The new header points readers at all three use-paths:

1. \`cargo test -p lifegw --test spec_j_e2e_smoke\` — in-process E2E (~30 s)
2. \`cargo run -p lifegw --example local_smoke\` — interactive local TCP (~10 min)
3. Railway staging via \`scripts/deploy_lifegw_staging.sh\` + \`docs/conformance/2026-05-18-claude-code-smoke-runbook.md\` (30-60 min)

## What's NOT closed

BRO-1146 live operator smoke session — human-only Railway deploy + real Claude Code conformance run. Tracked as a follow-up.

## Linear

[BRO-1140](https://linear.app/broomva/issue/BRO-1140) (Spec J umbrella, already Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 1 completion status and clarified available testing approaches for the AI code interoperability specification. Documented that manual operator validation remains required to finalize Phase 1 conformance. Identified Phase 2 candidates for future work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->