### PR TITLE
feat(lifegw): local_smoke_anthropic — real-Anthropic local smoke example [BRO-1185]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,6 +6562,7 @@ dependencies = [
  "aios-protocol",
  "anyhow",
  "arc-swap",
+ "arcan-proxy",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",

--- a/crates/life-runtime/lifegw/Cargo.toml
+++ b/crates/life-runtime/lifegw/Cargo.toml
@@ -206,6 +206,11 @@ k256.workspace = true
 # apply to the production graph, not test rigs — verify_dependencies_lifegw.sh
 # checks `cargo tree`, which excludes dev-deps).
 lifed = { path = "../lifed" }
+# Spec J real-Anthropic local smoke example (`examples/local_smoke_anthropic.rs`).
+# Dev-only: the production graph never pulls arcan-proxy (Spec C₃ §11.2
+# LOCKED L4-D13). Same carve-out as the `lifed` dev-dep above — dev tooling
+# needs a real upstream; the production graph does not.
+arcan-proxy = { path = "../arcan-proxy" }
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }

--- a/crates/life-runtime/lifegw/examples/README.md
+++ b/crates/life-runtime/lifegw/examples/README.md
@@ -5,6 +5,7 @@ Dev-tooling examples for the lifegw edge gateway. Currently:
 | Example | Purpose | Linear |
 |---|---|---|
 | `local_smoke` | Boot lifegw locally against an in-process mock lifed for ~30 s interactive smoke. Zero deploy, zero Railway slot. | [BRO-1165](https://linear.app/broomva/issue/BRO-1165) |
+| `local_smoke_anthropic` | Real-Anthropic local smoke — daily dogfooding, no Railway slot. Same shape as `local_smoke`, but the upstream forwards to `api.anthropic.com` via `arcan_proxy::AnthropicArcan`. Requires `ANTHROPIC_API_KEY`. | [BRO-1185](https://linear.app/broomva/issue/BRO-1185) |
 
 ## `local_smoke`
 
@@ -176,13 +177,215 @@ production gateway uses.
 
 ### Relation to the other test paths
 
-Spec J Phase 1 ships three escalating test surfaces:
+Spec J Phase 1 ships four escalating test surfaces:
 
-| Path | Command / artefact | What it certifies |
+| Path | Command / artefact | Upstream | What it certifies |
+|---|---|---|---|
+| 1 | `cargo test -p lifegw --test spec_j_e2e_smoke` | mock | In-process E2E — codec, route, auth, recording haima, mock lifed; 5 scenarios. |
+| 2 | This example (`cargo run -p lifegw --example local_smoke`) | mock | Real TCP socket, interactive — operator-driven probe of the edge wire over HTTP. |
+| 3 | Railway staging deploy per `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` | real (full saga) | Live conformance evidence — Loom + Vigil traces + lago replay + haima ledger. |
+| 4 | `cargo run -p lifegw --example local_smoke_anthropic` | real (no saga) | Daily dogfooding — real Claude responses on a `127.0.0.1` socket without burning a Railway slot. |
+
+Path 1 is automated; path 3 is the Phase 1 conformance gate;
+**path 2 is the iterating-engineer's loop on the gateway with no
+upstream cost**, and **path 4 is the iterating-engineer's loop with
+real Claude responses** (every call hits `api.anthropic.com` and costs
+real money). See the `local_smoke_anthropic` section below for the
+cost warning and recipes.
+
+## `local_smoke_anthropic`
+
+Same shape as `local_smoke`, with **one substantive change**: the
+upstream tonic `Agent` service forwards to
+`arcan_proxy::anthropic::AnthropicArcan` instead of returning canned
+events. Result: a real Claude Code ↔ lifegw ↔ `api.anthropic.com`
+round-trip on `127.0.0.1:<port>` with only `ANTHROPIC_API_KEY` set —
+no Railway deploy, no Vercel JWKS, no lifed saga, no haima ledger.
+
+### Cost warning — read this first
+
+Every `/v1/messages` call hits `api.anthropic.com` and is billed to
+your `ANTHROPIC_API_KEY`. The active model defaults to **Claude Sonnet
+4.5** (`claude-sonnet-4-5-20250929`); set `ANTHROPIC_MODEL` to
+override. Approximate pricing (live numbers vary — check
+[the Anthropic pricing page](https://www.anthropic.com/pricing) before
+extended runs):
+
+| Model | Tier | Cost posture |
 |---|---|---|
-| 1 | `cargo test -p lifegw --test spec_j_e2e_smoke` | In-process E2E — codec, route, auth, recording haima, mock lifed; 5 scenarios. |
-| 2 | This example (`cargo run -p lifegw --example local_smoke`) | Real TCP socket, interactive — operator-driven probe of the edge wire over HTTP. |
-| 3 | Railway staging deploy per `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` | Live evidence — Loom + Vigil traces + lago replay + haima ledger. |
+| `claude-haiku-4-5-20251001` | small / fast | Cheapest — recommended default for iteration. |
+| `claude-sonnet-4-5-20250929` | balanced | Moderate. The example's default if `ANTHROPIC_MODEL` is unset. |
+| `claude-opus-4-20250514` | high-end | Expensive. Avoid for routine dogfooding. |
 
-Path 1 is automated; path 3 is the Phase 1 conformance gate; **path 2 is
-the iterating-engineer's loop** between the two.
+The 600 s `HARD_STREAM_TIMEOUT` cap inside the production
+`anthropic_messages` router still applies — long thinking turns are
+bounded by the same backstop the production gateway uses.
+
+### Run
+
+```sh
+export ANTHROPIC_API_KEY=sk-...
+# Recommended — Haiku is the cheapest model for iteration.
+export ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+cargo run -p lifegw --example local_smoke_anthropic
+```
+
+Optional env knobs (consumed by `AnthropicArcanConfig::from_env()`):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | *(required)* | Your Anthropic API key. The example bails with a clean error if unset. |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-5-20250929` | Active model. Set to Haiku for cheap iteration. |
+| `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Override for proxy / VPC endpoints. |
+| `ANTHROPIC_MAX_TOKENS` | `4096` | Per-turn cap. Lower for tighter cost control. |
+
+On boot you get:
+
+```
+lifegw local smoke (real Anthropic upstream) ready:
+  URL:    http://127.0.0.1:<port>
+  Bearer: dev-token-for-broomva
+  Model:  claude-haiku-4-5-20251001
+
+WARNING: this binds to api.anthropic.com using your ANTHROPIC_API_KEY.
+         Every /v1/messages call costs real money on the active model.
+         Haiku (claude-haiku-4-5-20251001) is the cheapest; switch to
+         it for iteration via ANTHROPIC_MODEL=...
+
+Try:
+  curl http://127.0.0.1:<port>/v1/models | jq .
+
+  curl -N -H "Authorization: Bearer dev-token-for-broomva" \
+       -H "anthropic-version: 2023-06-01" \
+       -H "Content-Type: application/json" \
+       -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"reply with the single word OK"}],"max_tokens":20,"stream":true}' \
+       http://127.0.0.1:<port>/v1/messages
+
+Press Ctrl-C to exit.
+```
+
+### Three curl recipes
+
+#### 1. `GET /v1/models` — Anthropic-pinned static catalogue (unauthenticated)
+
+```sh
+curl http://127.0.0.1:<port>/v1/models | jq .
+```
+
+Identical posture to the mock-upstream example — the `/v1/models`
+route is served by lifegw's static catalogue and does not hit
+`api.anthropic.com`.
+
+#### 2. `POST /v1/messages/count_tokens` — edge token-count probe
+
+```sh
+curl -s -H "Authorization: Bearer dev-token-for-broomva" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Please write a unit test for the new module."}]}' \
+     http://127.0.0.1:<port>/v1/messages/count_tokens \
+     -i
+```
+
+Like the catalogue route, count_tokens runs at the edge and does not
+hit `api.anthropic.com` — it estimates tokens via the encoder's local
+heuristic and stamps the `X-Life-Cost-Estimate-Usd-Micros` header.
+
+#### 3. `POST /v1/messages` — streaming chat (SSE) — **real Claude response**
+
+```sh
+curl -N -H "Authorization: Bearer dev-token-for-broomva" \
+     -H "anthropic-version: 2023-06-01" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"reply with the single word OK"}],"max_tokens":20,"stream":true}' \
+     http://127.0.0.1:<port>/v1/messages
+```
+
+The SSE frame shape is canonical Anthropic (`message_start`,
+`content_block_start`, `content_block_delta`, `content_block_stop`,
+`message_delta`, `message_stop`); the content is whatever the active
+model actually generates. `max_tokens: 20` plus the "reply with the
+single word OK" prompt keeps the cost negligible for a smoke check.
+
+### Pointing Claude Code at the example
+
+```sh
+export ANTHROPIC_BASE_URL=http://127.0.0.1:<port>
+export ANTHROPIC_AUTH_TOKEN=dev-token-for-broomva
+claude
+```
+
+Claude Code's `/model` picker queries `/v1/models` at bootstrap
+against the static catalogue. Conversations route through
+`/v1/messages` and hit `api.anthropic.com` via lifegw, exercising the
+same codec + auth + rate-limit + Vigil span paths the production
+gateway uses. Set `ANTHROPIC_MODEL=claude-haiku-4-5-20251001` in
+*Claude Code*'s environment (or pick Haiku in the `/model` picker) to
+keep iteration cheap.
+
+### Honest divergence from production
+
+Production lifegw goes through:
+
+```
+lifegw → tonic UDS → lifed.Agent.StreamSession → real saga
+       → arcan-proxy → AnthropicArcan → api.anthropic.com
+```
+
+This example shortcuts the `lifed` layer entirely. The in-process
+tonic `Agent` service dispatches **directly** to `AnthropicArcan`:
+
+```
+lifegw → tonic UDS → AnthropicProxyAgentService (this example)
+       → AnthropicArcan → api.anthropic.com
+```
+
+What's exercised end-to-end (matches production):
+
+- Anthropic Messages codec (`lifegw_anthropic_codec`)
+- Auth (`JwksCache::dev_only()` + Tier-2 mint)
+- Rate limit (`TokenBucketLimiter`)
+- Vigil span emission (real spans on stderr, real GenAI semconv)
+- `StubHaimaClient` cost gate (no-op, identical to current production)
+- `AnthropicArcan` HTTP client + SSE parser
+- 600 s `HARD_STREAM_TIMEOUT` wall-clock cap
+
+What's NOT exercised (different from production):
+
+- `lifed` saga (Tier-2 → Tier-3 derivation)
+- `arcan-proxy` retry policy / circuit breaker
+- Real `lago` event durability
+- Real `haima` ledger settlement
+- Real `anima` identity wire
+
+For full-saga validation, use **Path 3** (the Railway operator
+runbook at `docs/conformance/2026-05-18-claude-code-smoke-runbook.md`).
+
+### Known limits
+
+- **No `lifed` saga.** See "Honest divergence" above.
+- **No tool-use round-trip.** The codec handles `tool_use` blocks, but
+  Anthropic only emits them when the request body declares tools. The
+  example doesn't inject a tool definition into the in-flight request
+  — for tool-use end-to-end use `tests/spec_j_e2e_smoke.rs` (mocked
+  upstream) or the Railway path (real saga). The `AnthropicArcan` SSE
+  parser does carry tool-use payloads through faithfully when the
+  upstream emits them.
+- **No `from_sequence` replay.** The in-process Agent has no lago to
+  replay against. Mid-stream drops surface as fresh requests.
+- **No TLS.** Plain HTTP on `127.0.0.1` (production lifegw terminates
+  TLS 1.3 via rustls; the example skips the bind dance because
+  operators are not testing TLS posture here).
+- **Per-sid history is `AnthropicArcan`'s in-memory map.** It survives
+  across `SendMessage` / `StreamSession` calls within one process run
+  but does NOT persist to lago.
+- **Cost is on you.** Every `/v1/messages` call is billed.
+
+### Substrate-free guarantee
+
+`arcan-proxy` is a `[dev-dependencies]` entry in
+`crates/life-runtime/lifegw/Cargo.toml`, not a production dep. The
+`scripts/verify_dependencies_lifegw.sh` script (Spec C₃ §11.2 LOCKED
+L4-D13 enforcement) uses `cargo tree --edges normal` which excludes
+dev-deps, so the production graph is unchanged. Same carve-out
+pattern as the `lifed` dev-dep used by
+`tests/integration_proxy_passthrough.rs`.

--- a/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
+++ b/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
@@ -1,0 +1,475 @@
+//! BRO-1185 — real-Anthropic local smoke for lifegw (zero deploy, zero
+//! Railway). The mirror of `local_smoke.rs` with one substantive change:
+//! the upstream tonic `Agent` service forwards to
+//! `arcan_proxy::anthropic::AnthropicArcan` instead of returning canned
+//! events. Result: a real Claude Code ↔ lifegw ↔ `api.anthropic.com`
+//! round-trip on `127.0.0.1:<port>` with only `ANTHROPIC_API_KEY` set.
+//!
+//! # Purpose
+//!
+//! Path 4 of the Spec J Phase 1 test-surface taxonomy (see
+//! `docs/conformance/2026-05-18-claude-code-smoke-runbook.md`):
+//!
+//! 1. In-process E2E test (`cargo test -p lifegw --test spec_j_e2e_smoke`)
+//!    — automated, mock upstream.
+//! 2. `local_smoke` example — interactive, mock upstream. Validates the
+//!    edge wire (codec / auth / rate-limit / Vigil) without burning a
+//!    Railway slot.
+//! 3. Railway staging deploy — live, real upstream, full saga. Produces
+//!    the Phase 1 conformance evidence.
+//! 4. **This example** — interactive, real upstream, no Railway slot.
+//!    Daily dogfooding loop for the iterating engineer: every call hits
+//!    `api.anthropic.com` and costs real money, but the iteration cycle
+//!    is `cargo run` rather than `railway up`.
+//!
+//! # Honest divergence from production
+//!
+//! Production lifegw goes through `lifed.Agent.StreamSession` → real
+//! saga (Tier-2 → Tier-3) → `arcan-proxy` → `AnthropicArcan`. This
+//! example **shortcuts the `lifed` layer entirely**: the in-process
+//! tonic `Agent` service built below dispatches directly to
+//! `AnthropicArcan`. Useful for iterating on the gateway (codec, route,
+//! Vigil) without paying Railway latency. **Does NOT validate** the
+//! full production saga / arcan-substrate dial / lago events / haima
+//! ledger. For that, run Path 3 (the Railway operator runbook).
+//!
+//! # What's real, what's not
+//!
+//! Real (in-process, same code as production):
+//!
+//! - the axum router built from `AnthropicMessagesState`,
+//! - the `lifegw_anthropic_codec::Encoder`,
+//! - the `JwksCache::dev_only()` Tier-1 verifier (dev-bearer shortcut),
+//! - the `Tier2Minter` capability minter,
+//! - the `TokenBucketLimiter` rate limiter,
+//! - the tonic Channel dialled to the in-process Agent UDS,
+//! - the `StubHaimaClient` cost gate (no-op, mirrors production today),
+//! - the `AnthropicArcan` HTTP client (POST `/v1/messages` against
+//!   `api.anthropic.com`, real SSE parse, real `Token`/`Finish` events).
+//!
+//! In-process (not mocked, but not lifed either):
+//!
+//! - `lifed.life.v1.Agent.{SendMessage, StreamSession}` is served by a
+//!   minimal `AnthropicProxyAgentService` that captures the user
+//!   content on `SendMessage` and replays it through
+//!   `AnthropicArcan::dispatch_message` on the matching
+//!   `StreamSession`. Multi-turn history is bookkept by
+//!   `AnthropicArcan` itself.
+//!
+//! Substrate-free per Spec C₃ §11.2 — `arcan-proxy` is a
+//! `[dev-dependencies]` entry, not a production dep. The
+//! `verify_dependencies_lifegw.sh` script uses `cargo tree --edges
+//! normal` which excludes dev-deps, so this remains compliant. The
+//! carve-out matches the existing `lifed` dev-dep entry (used by
+//! `tests/integration_proxy_passthrough.rs`).
+//!
+//! # 600 s SSE wall-clock cap
+//!
+//! The production `anthropic_messages::router` enforces
+//! `HARD_STREAM_TIMEOUT = 600 s` on the SSE response body (see
+//! `services/anthropic_messages.rs:272`). Because this example uses
+//! `anthropic_messages::router(state)` directly, that cap is inherited
+//! — no new timeout code at the example level. Long-running upstream
+//! calls (e.g. a multi-minute Sonnet thinking turn) are bounded by the
+//! same backstop the production gateway uses.
+//!
+//! # Lifecycle
+//!
+//! 1. Read `ANTHROPIC_API_KEY` from env (and `ANTHROPIC_MODEL`,
+//!    `ANTHROPIC_BASE_URL`, `ANTHROPIC_MAX_TOKENS` if present).
+//!    Bail fast with a clean error block if the key is missing.
+//! 2. Build a tempdir + UDS path `<tempdir>/lifed.sock`.
+//! 3. Spawn a tonic `Server` hosting the `AnthropicProxyAgentService`
+//!    on that UDS.
+//! 4. Dial a tonic `Channel` back over the UDS.
+//! 5. Build `AnthropicMessagesState` with real auth + rate-limit +
+//!    stub haima + the in-process channel.
+//! 6. Bind axum on `127.0.0.1:0` (kernel-picked port).
+//! 7. Print the URL + dev bearer + cost warning + curl recipes.
+//! 8. Serve until `SIGINT` (Ctrl-C).
+//! 9. Graceful drain: shut down axum, then the in-process UDS server,
+//!    then drop the tempdir.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::Stream;
+use tempfile::TempDir;
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+use tracing_subscriber::EnvFilter;
+
+// `ArcanCall` is the trait that provides `dispatch_message`; it's an
+// `async_trait` so the method-on-trait-object pattern requires the
+// trait to be in scope at the call site.
+use arcan_proxy::ArcanCall;
+use life_runtime_proto::life::v1::agent_server::{Agent, AgentServer};
+use life_runtime_proto::life::v1::{
+    AgentEvent, ApprovalReq, CreateSessionReq, DispatchRef, Empty, ListModelsReq, ListSkillsReq,
+    ListToolsReq, ModelCatalog, SendMessageReq, Session, SessionRef, SkillCatalog, SpawnChildReq,
+    SpawnChildResp, ToolCatalog,
+};
+
+use lifegw::auth::jwks::JwksCache;
+use lifegw::auth::kms::StaticKeystore;
+use lifegw::auth::tier2::Tier2Minter;
+use lifegw::config::{AuthConfig, RateLimitConfig};
+use lifegw::services::anthropic_messages::{
+    self, AnthropicMessagesState, HaimaClient, StubHaimaClient,
+};
+use lifegw::services::rate_limit::TokenBucketLimiter;
+
+// ─── In-process Anthropic-proxy Agent service ───────────────────────────
+//
+// Same shape as `tests/spec_j_e2e_smoke.rs::MockAgentService` and
+// `examples/local_smoke.rs::MockAgentService`, but the
+// `SendMessage` / `StreamSession` pair forwards real content to
+// `arcan_proxy::anthropic::AnthropicArcan`. The split mirrors lifegw's
+// production posture: lifegw calls `SendMessage` (no streaming), then
+// `StreamSession` to consume events — the example honours that ordering
+// by stashing the user content in `SendMessage` and replaying it through
+// `AnthropicArcan::dispatch_message` on `StreamSession`.
+
+#[derive(Clone)]
+struct AnthropicProxyAgentService {
+    /// Underlying real-upstream client. Cloned cheaply; the inner state
+    /// (per-sid history, reqwest client) is `Arc`-wrapped inside.
+    arcan: Arc<arcan_proxy::anthropic::AnthropicArcan>,
+    /// `sid -> last user message`. `SendMessage` inserts; `StreamSession`
+    /// removes and dispatches. A new `SendMessage` for the same sid
+    /// overwrites — matches the production "one in-flight message per
+    /// session" posture.
+    pending: Arc<Mutex<HashMap<String, String>>>,
+    /// Monotonic counter for synthesizing fresh `mock-sid-N` values when
+    /// the caller does not supply a `resume_sid`. Same naming as
+    /// `local_smoke.rs` so the operator's mental model is identical
+    /// across the two examples.
+    sequence: Arc<Mutex<u64>>,
+}
+
+#[tonic::async_trait]
+impl Agent for AnthropicProxyAgentService {
+    type SendMessageStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+    type StreamSessionStream =
+        Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send + 'static>>;
+
+    async fn create_session(
+        &self,
+        req: tonic::Request<CreateSessionReq>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        let body = req.into_inner();
+        let sid_val = match body.resume_sid.as_ref().map(|s| s.value.clone()) {
+            Some(v) if !v.is_empty() => v,
+            _ => {
+                let mut seq = self.sequence.lock().await;
+                *seq += 1;
+                format!("mock-sid-{}", *seq)
+            }
+        };
+        Ok(tonic::Response::new(Session {
+            sid: Some(aios_proto::aios::v1::SessionId { value: sid_val }),
+            agent_id: Some(aios_proto::aios::v1::AgentId {
+                value: "anthropic-arcan".to_string(),
+            }),
+            user_id: body.user_id,
+            project_id: body.project_id,
+            created_at: Some(prost_types::Timestamp {
+                seconds: 0,
+                nanos: 0,
+            }),
+        }))
+    }
+
+    async fn describe_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Session>, tonic::Status> {
+        Err(tonic::Status::unimplemented("anthropic-proxy"))
+    }
+
+    async fn close_session(
+        &self,
+        _: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn send_message(
+        &self,
+        req: tonic::Request<SendMessageReq>,
+    ) -> Result<tonic::Response<Self::SendMessageStream>, tonic::Status> {
+        // Stash the user content for the matching `StreamSession`.
+        // Production lifegw calls `SendMessage` (returns empty stream)
+        // immediately followed by `StreamSession`; the example matches
+        // that ordering.
+        let body = req.into_inner();
+        let sid = body
+            .sid
+            .as_ref()
+            .map(|s| s.value.clone())
+            .unwrap_or_default();
+        let content = body.content;
+        if !sid.is_empty() {
+            self.pending.lock().await.insert(sid, content);
+        }
+        // Empty stream — matches the mock's posture: the canonical event
+        // source is `StreamSession`, not `SendMessage`.
+        let s = futures::stream::empty::<Result<AgentEvent, tonic::Status>>();
+        Ok(tonic::Response::new(Box::pin(s)))
+    }
+
+    async fn stream_session(
+        &self,
+        req: tonic::Request<SessionRef>,
+    ) -> Result<tonic::Response<Self::StreamSessionStream>, tonic::Status> {
+        let sref = req.into_inner();
+        let sid = sref
+            .sid
+            .as_ref()
+            .map(|s| s.value.clone())
+            .unwrap_or_default();
+        let content = self.pending.lock().await.remove(&sid).unwrap_or_default();
+        if content.is_empty() {
+            // No content stashed — caller hit `StreamSession` before
+            // `SendMessage`, or the sid does not match a pending entry.
+            // Return an empty stream (matches the mock's posture for
+            // empty replay).
+            let s = futures::stream::empty::<Result<AgentEvent, tonic::Status>>();
+            return Ok(tonic::Response::new(Box::pin(s)));
+        }
+        // Dispatch into the real Anthropic upstream. `AnthropicArcan`
+        // bookkeeps multi-turn history per-sid internally
+        // (`append_exchange` on `Finish`), so successive turns on the
+        // same sid carry conversation context.
+        let stream = self
+            .arcan
+            .dispatch_message(&sid, &content)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("AnthropicArcan dispatch failed: {e}")))?;
+        Ok(tonic::Response::new(stream))
+    }
+
+    async fn approve_dispatch(
+        &self,
+        _: tonic::Request<ApprovalReq>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn cancel_dispatch(
+        &self,
+        _: tonic::Request<DispatchRef>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Ok(tonic::Response::new(Empty {}))
+    }
+
+    async fn list_skills(
+        &self,
+        _: tonic::Request<ListSkillsReq>,
+    ) -> Result<tonic::Response<SkillCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("anthropic-proxy"))
+    }
+
+    async fn list_models(
+        &self,
+        _: tonic::Request<ListModelsReq>,
+    ) -> Result<tonic::Response<ModelCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("anthropic-proxy"))
+    }
+
+    async fn list_tools(
+        &self,
+        _: tonic::Request<ListToolsReq>,
+    ) -> Result<tonic::Response<ToolCatalog>, tonic::Status> {
+        Err(tonic::Status::unimplemented("anthropic-proxy"))
+    }
+
+    async fn spawn_child(
+        &self,
+        _: tonic::Request<SpawnChildReq>,
+    ) -> Result<tonic::Response<SpawnChildResp>, tonic::Status> {
+        Err(tonic::Status::unimplemented("anthropic-proxy"))
+    }
+}
+
+async fn dial_uds(path: &str) -> Channel {
+    let path = path.to_string();
+    let endpoint = Endpoint::try_from("http://[::]:0").expect("endpoint scheme");
+    endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let path = path.clone();
+            async move {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+            }
+        }))
+        .await
+        .expect("dial in-process Anthropic-proxy UDS")
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Logging — default to `lifegw=debug,info` so Vigil span emission is
+    // visible to the operator. `RUST_LOG` overrides the default.
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("lifegw=debug,info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .init();
+
+    // 0. Fail fast on missing API key. The error from
+    // `AnthropicArcan::from_env` already says "AnthropicArcan requires
+    // ANTHROPIC_API_KEY" (no key value in the message); the printed
+    // operator instructions never echo the key either.
+    let arcan = match arcan_proxy::anthropic::AnthropicArcan::from_env() {
+        Ok(a) => a,
+        Err(err) => {
+            eprintln!();
+            eprintln!("ERROR: {err}");
+            eprintln!();
+            eprintln!("local_smoke_anthropic requires ANTHROPIC_API_KEY in the environment.");
+            eprintln!("Set it (Haiku is the cheapest model for iteration) and re-run:");
+            eprintln!();
+            eprintln!("    export ANTHROPIC_API_KEY=sk-...");
+            eprintln!(
+                "    export ANTHROPIC_MODEL=claude-haiku-4-5-20251001  # optional, defaults to Sonnet 4.5"
+            );
+            eprintln!("    cargo run -p lifegw --example local_smoke_anthropic");
+            eprintln!();
+            std::process::exit(1);
+        }
+    };
+    let arcan = Arc::new(arcan);
+
+    // Surface which model is in use so the operator sees what they're
+    // about to pay for. `AnthropicArcan` itself parses `ANTHROPIC_MODEL`
+    // (defaulting to `claude-sonnet-4-5-20250929`); reading the env var
+    // here mirrors that derivation without touching the redacted Debug.
+    let active_model = std::env::var("ANTHROPIC_MODEL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| arcan_proxy::ANTHROPIC_DEFAULT_MODEL.to_string());
+
+    // 1. Stand up the in-process Anthropic-proxy Agent service over a
+    // tempdir UDS.
+    let temp: TempDir = tempfile::tempdir()?;
+    let socket_path = temp.path().join("lifed.sock");
+    let socket_path_str = socket_path.to_string_lossy().to_string();
+    let listener = UnixListener::bind(&socket_path)?;
+    let uds_stream = UnixListenerStream::new(listener);
+
+    tracing::info!(uds = %socket_path_str, "in-process Anthropic-proxy UDS bound");
+
+    let agent_svc = AnthropicProxyAgentService {
+        arcan: Arc::clone(&arcan),
+        pending: Arc::new(Mutex::new(HashMap::new())),
+        sequence: Arc::new(Mutex::new(0)),
+    };
+    let agent_server = AgentServer::new(agent_svc);
+
+    let (uds_shutdown_tx, uds_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let uds_handle = tokio::spawn(async move {
+        if let Err(err) = tonic::transport::Server::builder()
+            .add_service(agent_server)
+            .serve_with_incoming_shutdown(uds_stream, async move {
+                let _ = uds_shutdown_rx.await;
+            })
+            .await
+        {
+            tracing::warn!(error = %err, "in-process Anthropic-proxy server exited with error");
+        }
+    });
+
+    // Tiny grace for the listener to start accepting (mirrors the
+    // mock-upstream example — connect_with_connector retries once but a
+    // brief sleep makes the first dial deterministic).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // 2. Dial the in-process Anthropic-proxy over UDS.
+    let upstream = dial_uds(&socket_path_str).await;
+
+    // 3. Build the router state — same shape lifegw uses in production,
+    // with the dev JWKS shortcut + a freshly-generated keystore + a
+    // default-config rate limiter + the stub haima cost gate.
+    let auth_cfg = AuthConfig::default();
+    let jwks = Arc::new(JwksCache::dev_only());
+    let signer = Arc::new(StaticKeystore::generate_dev()?);
+    let minter = Arc::new(Tier2Minter::new(signer, &auth_cfg));
+    let rate_limiter = TokenBucketLimiter::from_config(&RateLimitConfig::default());
+    let haima: Arc<dyn HaimaClient> = Arc::new(StubHaimaClient);
+
+    let state = AnthropicMessagesState {
+        jwks,
+        minter,
+        upstream,
+        rate_limiter: Some(rate_limiter),
+        haima,
+        billing_enforce: false,
+    };
+    // The 600 s `HARD_STREAM_TIMEOUT` SSE wall-clock cap is enforced
+    // inside `anthropic_messages::router(state)` itself — see
+    // `services/anthropic_messages.rs:272`. The example inherits the
+    // production cap unchanged.
+    let app = anthropic_messages::router(state);
+
+    // 4. Bind axum on 127.0.0.1:0 — kernel picks the port so concurrent
+    // example runs don't collide.
+    let bind_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = bind_listener.local_addr()?;
+
+    let dev_bearer = "dev-token-for-broomva";
+
+    println!();
+    println!("lifegw local smoke (real Anthropic upstream) ready:");
+    println!("  URL:    http://{local_addr}");
+    println!("  Bearer: {dev_bearer}");
+    println!("  Model:  {active_model}");
+    println!();
+    println!("WARNING: this binds to api.anthropic.com using your ANTHROPIC_API_KEY.");
+    println!("         Every /v1/messages call costs real money on the active model.");
+    println!("         Haiku (claude-haiku-4-5-20251001) is the cheapest; switch to");
+    println!("         it for iteration via ANTHROPIC_MODEL=...");
+    println!();
+    println!("Try:");
+    println!("  curl http://{local_addr}/v1/models | jq .");
+    println!();
+    println!("  curl -N -H \"Authorization: Bearer {dev_bearer}\" \\");
+    println!("       -H \"anthropic-version: 2023-06-01\" \\");
+    println!("       -H \"Content-Type: application/json\" \\");
+    println!(
+        "       -d '{{\"model\":\"claude-haiku-4-5-20251001\",\"messages\":\
+[{{\"role\":\"user\",\"content\":\"reply with the single word OK\"}}],\"max_tokens\":20,\"stream\":true}}' \\"
+    );
+    println!("       http://{local_addr}/v1/messages");
+    println!();
+    println!("Press Ctrl-C to exit.");
+    println!();
+
+    // 5. Serve until SIGINT. axum::serve takes ownership of the listener
+    // and runs the connection accept loop; the shutdown future fires on
+    // Ctrl-C and the server drains in-flight requests.
+    let shutdown = async {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            tracing::warn!(error = %err, "ctrl_c handler failed; exiting anyway");
+        }
+        tracing::info!("Ctrl-C received; shutting down lifegw local smoke (real upstream)");
+    };
+
+    let serve_result = axum::serve(bind_listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await;
+
+    // 6. Tear down the in-process UDS server and the tempdir.
+    let _ = uds_shutdown_tx.send(());
+    let _ = tokio::time::timeout(Duration::from_secs(2), uds_handle).await;
+    drop(temp);
+
+    serve_result.map_err(Into::into)
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1572,6 +1572,17 @@ now covers Phase 1 end-to-end at the in-process level.
   `crates/life-runtime/lifegw/examples/README.md` for the full curl
   recipes.
 
+A fourth iteration-only surface (`cargo run -p lifegw --example
+local_smoke_anthropic`, [BRO-1185]) lands as a follow-up: same shape
+as Path 3, but the in-process Agent service forwards to
+`arcan_proxy::AnthropicArcan` so every `/v1/messages` call hits
+`api.anthropic.com` for real (requires `ANTHROPIC_API_KEY`; defaults
+to Sonnet 4.5 — switch to `claude-haiku-4-5-20251001` for cheap
+iteration). Daily dogfooding loop; does NOT validate the lifed saga
+(use Path 2 for full conformance evidence). See the runbook §"Path 4"
+callout and `crates/life-runtime/lifegw/examples/README.md` for full
+recipes and the honest divergence notes.
+
 **Operator runbook + deploy script (this PR's other deliverables):**
 
 - `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` — seven

--- a/docs/conformance/2026-05-18-claude-code-smoke-runbook.md
+++ b/docs/conformance/2026-05-18-claude-code-smoke-runbook.md
@@ -71,6 +71,49 @@ Phase 1 conformance evidence.
 
 ---
 
+## Path 4 — Real-Anthropic local smoke (daily dogfooding) [BRO-1185]
+
+> **For dev iteration, not conformance evidence.** Use this when you
+> want real Claude responses but don't want to burn a Railway slot.
+
+```sh
+export ANTHROPIC_API_KEY=sk-...
+export ANTHROPIC_MODEL=claude-haiku-4-5-20251001  # cheapest model for iteration
+cargo run -p lifegw --example local_smoke_anthropic
+```
+
+Prints a localhost URL + dev-bearer; point Claude Code at it exactly
+like Path 2 (the mock-upstream example), but every `/v1/messages`
+call hits `api.anthropic.com` via lifegw's real codec / auth /
+rate-limit / Vigil span paths. Same dev-bearer (`dev-token-for-broomva`)
+and same dev-mode JWKS shortcut as the mock example.
+
+**Cost warning**: every call is billed to your `ANTHROPIC_API_KEY`.
+Haiku is the cheapest model; default the example to it via
+`ANTHROPIC_MODEL=...` before sustained dogfooding.
+
+**Relation to the other paths**:
+
+| Path | Upstream | Saga | Use case |
+|---|---|---|---|
+| 1 (in-process E2E test) | mock | — | Automated regression gate. |
+| 2 (`local_smoke` example) | mock | — | Iterate on the gateway with zero upstream cost. |
+| 3 (Railway deploy, this runbook) | real | full lifed | **Conformance evidence** — Loom + Vigil + lago + haima. |
+| **4 (`local_smoke_anthropic` example)** | **real** | **no saga** | **Iterate with real Claude responses, no Railway slot.** |
+
+Paths 2 and 4 share the same edge wire (codec + auth + rate-limit +
+Vigil); they differ only in whether the in-process Agent service
+returns canned events (Path 2) or forwards to `AnthropicArcan` (Path
+4). Path 4 does NOT validate the full production saga / lago events /
+haima ledger — for that, the full Railway staging path below
+(Section 2 onwards) is the **conformance evidence** path. Path 4 is
+for iterating on the gateway without paying Railway latency.
+
+See `crates/life-runtime/lifegw/examples/README.md` for the full curl
+recipes, env-var knobs, and the honest divergence notes.
+
+---
+
 ## Section 1 — Prerequisites
 
 Before starting, verify the following are installed and configured on


### PR DESCRIPTION
## Summary

Adds **Path 4** of the Spec J Phase 1 test-surface taxonomy: a runnable `cargo run -p lifegw --example local_smoke_anthropic` that boots lifegw locally against an in-process tonic `Agent` service which forwards calls to `arcan_proxy::anthropic::AnthropicArcan`. Result: real Claude Code ↔ Life ↔ `api.anthropic.com` round-trip on `127.0.0.1:<port>` with only `ANTHROPIC_API_KEY` set — **no Railway slot**.

| Path | Upstream | Saga | Use case |
|---|---|---|---|
| 1 (in-process E2E) | mock | — | Automated regression gate |
| 2 (`local_smoke`) | mock | — | Iterate on gateway with zero upstream cost |
| 3 (Railway runbook) | real | full lifed | Conformance evidence (Loom/Vigil/lago/haima) |
| **4 (this — `local_smoke_anthropic`)** | **real** | **no saga** | **Daily dogfooding, no Railway slot** |

Resolves [BRO-1185](https://linear.app/broomva/issue/BRO-1185) (child of [BRO-1140](https://linear.app/broomva/issue/BRO-1140)).
Handoff doc: `docs/conversations/HANDOFF-2026-05-19-spec-j-real-anthropic-smoke.md`

## What's in the diff

| File | Δ | Purpose |
|---|---|---|
| `crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs` | NEW (~475 LOC) | The example itself: mirror of `local_smoke.rs` with `AnthropicProxyAgentService` replacing `MockAgentService` |
| `crates/life-runtime/lifegw/Cargo.toml` | +5 | `arcan-proxy` as `[dev-dependencies]` with carve-out comment matching the existing `lifed` dev-dep |
| `crates/life-runtime/lifegw/examples/README.md` | +217/-7 | New table row + full `local_smoke_anthropic` section (run, cost warning, 3 curl recipes, Claude Code wiring, honest divergence, 4-path relation table) |
| `docs/conformance/2026-05-18-claude-code-smoke-runbook.md` | +43 | Path 4 callout above Section 2 (deploy) with 4-path comparison table |
| `docs/STATUS.md` | +11 | 2026-05-18 entry mentions the fourth iteration surface |
| `Cargo.lock` | +1 | Auto-regen from new dev-dep edge |

## The implementation pattern

`AnthropicProxyAgentService` mirrors the mock's shape but the `SendMessage`/`StreamSession` pair forwards real content:

```rust
// Stash content on SendMessage (returns empty stream — matches mock posture)
async fn send_message(&self, req) -> ... {
    let body = req.into_inner();
    let sid = body.sid.as_ref().map(|s| s.value.clone()).unwrap_or_default();
    if !sid.is_empty() {
        self.pending.lock().await.insert(sid, body.content);
    }
    Ok(tonic::Response::new(Box::pin(futures::stream::empty())))
}

// Dispatch on StreamSession (the canonical event source for the codec)
async fn stream_session(&self, req) -> ... {
    let sid = req.into_inner().sid.as_ref().map(|s| s.value.clone()).unwrap_or_default();
    let content = self.pending.lock().await.remove(&sid).unwrap_or_default();
    if content.is_empty() { return Ok(empty_stream); }
    let stream = self.arcan.dispatch_message(&sid, &content).await
        .map_err(|e| tonic::Status::internal(format!("AnthropicArcan dispatch failed: {e}")))?;
    Ok(tonic::Response::new(stream))
}
```

Multi-turn history is bookkept inside `AnthropicArcan` (per-sid `append_exchange` on `Finish`), so successive turns on the same sid carry conversation context without any HashMap state on the proxy side.

## Honest divergence from production

Production lifegw goes through `lifed.Agent.StreamSession` → real saga (Tier-2 → Tier-3) → `arcan-proxy` → `AnthropicArcan`. This example **shortcuts the `lifed` layer entirely** — the in-process Agent service dispatches directly to `AnthropicArcan`. Documented in the example's module rustdoc and the README, with a pointer to Path 3 (Railway runbook) for full-saga validation.

## Dep-chain compliance

`arcan-proxy` lands as a `[dev-dependencies]` entry. Production graph never pulls it (Spec C₃ §11.2 LOCKED L4-D13). `scripts/verify_dependencies_lifegw.sh` uses `cargo tree --edges normal` which excludes dev-deps — verified clean. Same carve-out logic as the existing `lifed` dev-dep used by `tests/integration_proxy_passthrough.rs`.

## Security

- `ANTHROPIC_API_KEY` Debug redaction preserved from BRO-1144 fix-round
- Negative-path error message uses the redaction-safe `ArcanProxyError::Transport` payload (just states the var is required)
- No `println!`/`tracing::debug!`/`eprintln!` of the raw key value anywhere in the new code

## 600s SSE wall-clock cap

The production `anthropic_messages::router` enforces `HARD_STREAM_TIMEOUT = Duration::from_secs(600)` on the SSE response body (`services/anthropic_messages.rs:272`). The example uses `anthropic_messages::router(state)` directly, so the cap is inherited unchanged — no new timeout code at the example level. Documented in the example's module rustdoc.

## Acceptance gates (all green)

| Gate | Result |
|---|---|
| `cargo build -p lifegw --examples` | ✅ |
| `cargo clippy -p lifegw --all-targets --examples -- -D warnings` | ✅ no warnings |
| `cargo fmt --all -- --check` | ✅ clean |
| `bash scripts/verify_dependencies_lifegw.sh` | ✅ exit 0 |
| Negative-path smoke (no `ANTHROPIC_API_KEY`) | ✅ exit 1, clean error block, no panic, no key value in output |

### Negative-path smoke evidence

```
$ unset ANTHROPIC_API_KEY && cargo run -p lifegw --example local_smoke_anthropic

ERROR: transport: AnthropicArcan requires ANTHROPIC_API_KEY

local_smoke_anthropic requires ANTHROPIC_API_KEY in the environment.
Set it (Haiku is the cheapest model for iteration) and re-run:

    export ANTHROPIC_API_KEY=sk-...
    export ANTHROPIC_MODEL=claude-haiku-4-5-20251001  # optional, defaults to Sonnet 4.5
    cargo run -p lifegw --example local_smoke_anthropic

# exit code: 1
```

## Test plan

### Positive path — real Anthropic round-trip (operator-driven)

This PR's negative-path bail is verified inline. The positive-path real-upstream smoke requires an operator-provided `ANTHROPIC_API_KEY`:

- [ ] `export ANTHROPIC_API_KEY=sk-...` + `export ANTHROPIC_MODEL=claude-haiku-4-5-20251001`
- [ ] `cargo run -p lifegw --example local_smoke_anthropic` boots, prints URL + dev-bearer + active model + cost warning
- [ ] In another shell:
      ```
      curl -N -H "Authorization: Bearer dev-token-for-broomva" \
           -H "anthropic-version: 2023-06-01" \
           -H "Content-Type: application/json" \
           -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"reply with the single word OK"}],"max_tokens":20,"stream":true}' \
           http://127.0.0.1:<port>/v1/messages
      ```
      Expect canonical Anthropic SSE shape (`message_start` → `content_block_start` → `content_block_delta*` → `content_block_stop` → `message_delta` → `message_stop`) with `Vigil` span emission visible on stderr.
- [ ] Ctrl-C drains cleanly (axum graceful shutdown + tonic UDS server stop + tempdir cleanup)
- [ ] Point Claude Code at `localhost:<port>` (`ANTHROPIC_BASE_URL=...` + `ANTHROPIC_AUTH_TOKEN=dev-token-for-broomva`) for end-to-end CLI dogfooding

### P20 cross-review (Strata B)

- [ ] Fresh-context `pr-review-toolkit:code-reviewer` adversarial pass with brief from handoff §P20
- [ ] Verdict ≥7/10, zero criticals before auto-merge

## P20 cross-review brief (for the Strata B reviewer)

Specific verification targets:

1. **`ANTHROPIC_API_KEY` not logged** — Debug redacted per BRO-1144; verify no new `println!`/`eprintln!`/`tracing::*` site echoes the raw key value
2. **SIGINT cleanup** — graceful axum drain + tonic UDS server stop + tempdir teardown matches `local_smoke.rs` shape
3. **600s hard timeout** — confirmed inherited from `anthropic_messages::router` (`HARD_STREAM_TIMEOUT = 600 s` at `services/anthropic_messages.rs:272`); no new ceiling at the example layer
4. **Cost warning prominence** — README + printed banner; recommends Haiku as default for iteration
5. **Substrate-free guarantee** — `arcan-proxy` is `[dev-dependencies]`; production `cargo tree --edges normal` stays clean
6. **Honest divergence note** — module rustdoc + README + runbook + STATUS.md all flag that the example shortcuts the `lifed` saga layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new local smoke testing example that enables testing against real Anthropic API with live Claude responses for iterative development.

* **Documentation**
  * Expanded example guides and runbook with setup instructions, curl recipes, and cost warnings for the new real-API testing path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->