### PR TITLE
fix(lifegw-stack): UDS connect-probe instead of `-S` check (BRO-1193)

### DIFF
--- a/deploy/railway/lifegw-stack/Dockerfile
+++ b/deploy/railway/lifegw-stack/Dockerfile
@@ -54,10 +54,16 @@ FROM debian:bookworm-slim AS runtime
 
 # Caddy via the official .deb (small, current). openssl for self-signed cert
 # generation at boot. tini reaps zombies cleanly when caddy is PID 1.
+# netcat-openbsd provides `nc -zU <socket>` — a real UDS connect probe used
+# by entrypoint.sh to verify lifed has both bind()ed AND listen()ed before
+# lifegw starts dialing. `[[ -S … ]]` alone is insufficient because bind()
+# creates the socket file before listen() makes the kernel ready to queue
+# connections. See BRO-1193.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg debian-keyring debian-archive-keyring \
         apt-transport-https openssl tini \
+        netcat-openbsd \
  && curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
       | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
  && curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -102,10 +102,24 @@ runuser --preserve-environment -u life -g life-runtime -- \
   &
 LIFED_PID=$!
 
+# BRO-1193: probe the socket with `nc -zU` instead of only checking
+# whether the file is a socket. `[[ -S ... ]]` passes the instant
+# lifed `bind()`s the UDS, but `bind()` happens *before* `listen()` +
+# `accept()` make the kernel ready to queue connections. lifegw boots
+# 1-2ms after the file appears, tries to `connect()`, and gets a
+# `transport error` against an unlistening socket. The fix forces an
+# actual UDS connect: kernel only succeeds when the listen backlog is
+# up. See `lifegw::bootstrap` "Error: upstream: dial uds: transport
+# error" → "[entrypoint] FATAL: lifegw exited before binding 127.0.0.1:8443"
+# crash loop in production (2026-05-20T04:18:40 onward).
 echo "[entrypoint] waiting for lifed UDS at ${LIFE_RUNTIME_DIR}/life.sock"
 for i in $(seq 1 60); do
-  if [[ -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
-    echo "[entrypoint] lifed UDS ready (after ${i} half-seconds)"
+  # Belt-and-suspenders: cheap file-existence check first; only attempt
+  # the nc probe once the file is a socket. nc -zU returns 0 only when
+  # connect() succeeds — i.e., listen backlog is ready.
+  if [[ -S "${LIFE_RUNTIME_DIR}/life.sock" ]] \
+     && nc -zU "${LIFE_RUNTIME_DIR}/life.sock" 2>/dev/null; then
+    echo "[entrypoint] lifed UDS accepting connections (after ${i} half-seconds)"
     break
   fi
   if ! kill -0 "${LIFED_PID}" 2>/dev/null; then
@@ -115,8 +129,8 @@ for i in $(seq 1 60); do
   fi
   sleep 0.5
 done
-if [[ ! -S "${LIFE_RUNTIME_DIR}/life.sock" ]]; then
-  echo "[entrypoint] FATAL: lifed did not bind UDS within 30s" >&2
+if ! nc -zU "${LIFE_RUNTIME_DIR}/life.sock" 2>/dev/null; then
+  echo "[entrypoint] FATAL: lifed did not accept UDS connections within 30s" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Production `lifegw-production` (Railway deployment `974f754c-...`, 2026-05-06) has been crash-looping since 2026-05-20 04:18 UTC. Both `lifegw-production.up.railway.app/healthz` and `life.broomva.tech/healthz` time out with 0 bytes received. This PR fixes the root cause.

## Why it crashed

Runtime logs ([Railway service 4a5d266b-...](https://railway.com/project/f9c70d38-7fac-406e-beb4-dc05a5af73d9/service/4a5d266b-b826-4ea9-9145-3b30c56da750)):

```
04:18:40.456  lifed::bootstrap     lifed starting … public_socket=/run/life/life.sock
04:18:40.457  lifegw::bootstrap    lifegw starting … upstream=/run/life/life.sock   ← +1ms
04:18:40.458  lifegw::bootstrap    published lifegw JWKS
Error: upstream: dial uds: transport error                                          ← race lost
04:18:40.512  lifed::listener::public  unix_socket_group honored                    ← +56ms
[entrypoint] FATAL: lifegw exited before binding 127.0.0.1:8443
```

Root cause: TOCTOU between `[[ -S "${LIFE_RUNTIME_DIR}/life.sock" ]]` (line 107 of `entrypoint.sh`) and an actual UDS connection. `-S` passes the instant lifed calls `bind()` — but `bind()` creates the socket file *before* `listen()` makes the kernel ready to queue connections. lifegw boots, immediately tries `connect()`, gets ENOTCONN-equivalent, crashes. Entrypoint declares fatal → Railway container restart → race repeats indefinitely.

Stage 2 (#1087) added the `-S` check thinking it would fix the race; it doesn't.

## Fix

Probe the socket with `nc -zU` from `netcat-openbsd`. `nc -zU` returns 0 only when `connect()` succeeds — i.e., listen backlog is up. The file-existence check stays as a cheap pre-condition so we don't shell out to nc on a non-existent path.

Two files:
- `deploy/railway/lifegw-stack/entrypoint.sh` — replace `-S` with `[[ -S ... ]] && nc -zU ...`
- `deploy/railway/lifegw-stack/Dockerfile` — `apt-get install netcat-openbsd` (~150KB)

## Impact

- Production chat (`/v1/agent/create_session`, WS `/v1/agent/stream`) unblocks once redeployed
- Let's Encrypt cert for `life.broomva.tech` will issue automatically (HTTP-01 challenge endpoint comes back up)
- `lifegw-production.up.railway.app` becomes healthy again

## Linear

[BRO-1193](https://linear.app/broomva/issue/BRO-1193) (Urgent)

## Test plan

- [x] `bash -n entrypoint.sh` — syntax clean
- [x] `nc -zU /tmp/socket` returns 0 only when listener accepts (manually verified on local lumen-smoke)
- [ ] Image rebuild succeeds in Railway CI
- [ ] Post-deploy: `curl https://lifegw-production.up.railway.app/healthz` returns 200 within 30s of container start
- [ ] Post-deploy: `life.broomva.tech` Let's Encrypt cert provisions (status transitions from `ISSUING` to issued)

## Note on Railway deploy state

Project-wide deploys are currently paused on Railway (`serviceInstanceRedeploy` mutation returns "Deploys have been paused temporarily"). Merging this PR alone won't redeploy the service — operator must unpause deploys via Railway dashboard, then trigger a fresh image build (auto on push to main, or manual via the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced startup verification to confirm that services are fully operational and accepting connections before the application proceeds, improving initialization reliability and preventing potential connection failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->