### PR TITLE
feat(lifegw+lifed+arcan-proxy): per-request model selection (BRO-1206)

### DIFF
--- a/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
+++ b/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
@@ -196,8 +196,13 @@ async fn dispatch_message_streams_real_substrate_events() {
     let sid = "bro-1016-dispatch";
     let _ = proxy.create_agent(sid).await.expect("create_agent");
 
+    // BRO-1206: `dispatch_message` accepts an optional per-call model
+    // override. The arcan substrate gRPC wire ignores it (the substrate
+    // proto doesn't carry a `model` field); HTTP-backed backends honour
+    // it. This Topology B e2e test exercises the gRPC path so the
+    // override is irrelevant — pass `None`.
     let mut stream = proxy
-        .dispatch_message(sid, "Hello, substrate!")
+        .dispatch_message(sid, "Hello, substrate!", None)
         .await
         .expect("dispatch_message");
 

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -127,7 +127,19 @@ impl AnthropicArcan {
         Self::new(AnthropicArcanConfig::from_env()?)
     }
 
-    fn request_body(&self, sid: &str, content: &str) -> serde_json::Value {
+    /// Build the Anthropic Messages API request body.
+    ///
+    /// BRO-1206: when `model_override` is `Some(non_empty)` the override
+    /// wins over `self.cfg.model` (env-bound default — `ANTHROPIC_MODEL`
+    /// or [`DEFAULT_MODEL`]). Empty / whitespace / `None` falls back to
+    /// the env default. Per-call override means a single backend can
+    /// serve sessions on different Claude models without re-construction.
+    fn request_body(
+        &self,
+        sid: &str,
+        content: &str,
+        model_override: Option<&str>,
+    ) -> serde_json::Value {
         let prior = self
             .history
             .lock()
@@ -139,8 +151,12 @@ impl AnthropicArcan {
             .map(|m| serde_json::json!({"role": m.role, "content": m.content}))
             .collect();
         messages.push(serde_json::json!({"role": "user", "content": content}));
+        let model: &str = model_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(self.cfg.model.as_str());
         let mut body = serde_json::json!({
-            "model": self.cfg.model,
+            "model": model,
             "max_tokens": self.cfg.max_tokens,
             "messages": messages,
             "stream": true
@@ -188,6 +204,7 @@ impl ArcanCall for AnthropicArcan {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>>
     {
         let url = format!("{}/v1/messages", self.cfg.base_url);
@@ -198,7 +215,9 @@ impl ArcanCall for AnthropicArcan {
             .header("content-type", "application/json")
             .header("accept", "text/event-stream")
             .header("x-api-key", &self.cfg.api_key)
-            .json(&self.request_body(sid, content))
+            // BRO-1206: per-call override or env-bound default in the
+            // outbound `model` field.
+            .json(&self.request_body(sid, content, model))
             .send()
             .await
             .map_err(|e| ArcanProxyError::Transport(format!("POST {url}: {e}")))?;
@@ -604,6 +623,33 @@ mod tests {
         // Non-secret fields still appear.
         assert!(rendered.contains(DEFAULT_MODEL));
         assert!(rendered.contains("helpful assistant"));
+    }
+
+    /// BRO-1206: `request_body` honors model overrides per-call.
+    /// Empty / whitespace / `None` falls back to `cfg.model`.
+    #[test]
+    fn request_body_honors_model_override() {
+        let cfg = AnthropicArcanConfig {
+            api_key: "k".to_string(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: "claude-sonnet-4-5-default".to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            system_prompt: None,
+        };
+        let arc = AnthropicArcan::new(cfg).expect("build");
+        // Override wins.
+        let body = arc.request_body("sid", "hi", Some("claude-opus-4-7"));
+        assert_eq!(body["model"], "claude-opus-4-7");
+        // Empty override falls back to cfg.model.
+        let body = arc.request_body("sid", "hi", Some(""));
+        assert_eq!(body["model"], "claude-sonnet-4-5-default");
+        // Whitespace falls back too.
+        let body = arc.request_body("sid", "hi", Some("   "));
+        assert_eq!(body["model"], "claude-sonnet-4-5-default");
+        // None falls back.
+        let body = arc.request_body("sid", "hi", None);
+        assert_eq!(body["model"], "claude-sonnet-4-5-default");
     }
 
     #[tokio::test]

--- a/crates/life-runtime/arcan-proxy/src/client.rs
+++ b/crates/life-runtime/arcan-proxy/src/client.rs
@@ -175,10 +175,19 @@ impl ArcanProxy {
     /// `arcan.v1.AgentSubstrate.DispatchMessage` and translates the
     /// substrate-plane events into the public-plane shape (Phase 1
     /// maps TOKEN/FINISH/ERROR; tool kinds remain Phase 2 work).
+    ///
+    /// BRO-1206: `model` is accepted at the trait boundary so callers
+    /// (lifed) can plumb a per-session override end-to-end without a
+    /// trait signature change downstream. The arcan substrate wire
+    /// (`arcan.v1.AgentSubstrate.DispatchMessage`) does NOT yet carry a
+    /// `model` field — this proxy ignores the override when forwarding
+    /// to a real arcand. Override-or-env-fallback is honored by the
+    /// `VercelAiGatewayArcan` and `AnthropicArcan` HTTP-backed impls.
     pub async fn dispatch_message(
         &self,
         sid: &str,
         content: &str,
+        _model: Option<&str>,
     ) -> ArcanProxyResult<
         Pin<
             Box<
@@ -258,6 +267,14 @@ fn record_outcome(guard: Option<PoolGuard>, success_or_permanent: bool) {
 /// Object-safe trait covering the lifed-relevant subset of arcan operations.
 /// Used in `lifed::services::agent` so the integration tests can swap the
 /// real proxy for a mock under test.
+///
+/// BRO-1206: `dispatch_message` takes an optional `model` override that
+/// flows from `POST /v1/agent/create_session`'s `model` field through
+/// lifed's routing cache. `None` means "use the backend's env default"
+/// (`OPENAI_MODEL` / `ANTHROPIC_MODEL`). Mocks accept and ignore it; the
+/// substrate-gRPC `ArcanProxy` accepts and ignores it (the arcan
+/// substrate wire doesn't carry a model field yet); HTTP-backed impls
+/// (`VercelAiGatewayArcan`, `AnthropicArcan`) honour the override.
 #[async_trait]
 pub trait ArcanCall: Send + Sync {
     async fn create_agent(&self, sid: &str) -> ArcanProxyResult<String>;
@@ -266,6 +283,7 @@ pub trait ArcanCall: Send + Sync {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<
         Pin<
             Box<
@@ -288,6 +306,7 @@ impl ArcanCall for ArcanProxy {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<
         Pin<
             Box<
@@ -296,7 +315,7 @@ impl ArcanCall for ArcanProxy {
             >,
         >,
     > {
-        ArcanProxy::dispatch_message(self, sid, content).await
+        ArcanProxy::dispatch_message(self, sid, content, model).await
     }
 }
 
@@ -362,6 +381,7 @@ impl<C: ArcanCall> ArcanCall for Pooled<C> {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<
         Pin<
             Box<
@@ -372,7 +392,7 @@ impl<C: ArcanCall> ArcanCall for Pooled<C> {
     > {
         // Streams hold the guard until the inner stream terminates.
         let guard = self.pool.acquire().await.map_err(ArcanProxyError::from)?;
-        match self.inner.dispatch_message(sid, content).await {
+        match self.inner.dispatch_message(sid, content, model).await {
             Ok(stream) => Ok(Box::pin(PoolGuardedStream::new(stream, Some(guard)))),
             Err(e) => {
                 if e.is_retryable() {
@@ -498,6 +518,7 @@ mod tests {
                 &self,
                 _sid: &str,
                 _content: &str,
+                _model: Option<&str>,
             ) -> ArcanProxyResult<
                 Pin<
                     Box<
@@ -546,6 +567,7 @@ mod tests {
                 &self,
                 _sid: &str,
                 _content: &str,
+                _model: Option<&str>,
             ) -> ArcanProxyResult<
                 Pin<
                     Box<

--- a/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
+++ b/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
@@ -169,7 +169,18 @@ impl VercelAiGatewayArcan {
 
     /// Build the chat-completions request body for a single user
     /// dispatch. The system prompt (if any) is prepended.
-    fn build_request_body(&self, user_message: &str) -> serde_json::Value {
+    ///
+    /// BRO-1206: when `model_override` is `Some(non_empty)` the override
+    /// wins; otherwise we fall back to `self.cfg.model` (today's behavior
+    /// — derived at construction from `OPENAI_MODEL` env or
+    /// [`DEFAULT_MODEL`]). The override is per-call (per-session in
+    /// practice) so a single backend can serve users on different
+    /// models without rebuilding.
+    fn build_request_body(
+        &self,
+        user_message: &str,
+        model_override: Option<&str>,
+    ) -> serde_json::Value {
         let mut messages: Vec<serde_json::Value> = Vec::with_capacity(2);
         if let Some(sys) = &self.cfg.system_prompt
             && !sys.trim().is_empty()
@@ -183,8 +194,12 @@ impl VercelAiGatewayArcan {
             "role": "user",
             "content": user_message,
         }));
+        let model: &str = model_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(self.cfg.model.as_str());
         serde_json::json!({
-            "model": self.cfg.model,
+            "model": model,
             "messages": messages,
             "stream": true,
         })
@@ -210,10 +225,13 @@ impl ArcanCall for VercelAiGatewayArcan {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>>
     {
         let url = format!("{}/chat/completions", self.cfg.base_url);
-        let body = self.build_request_body(content);
+        // BRO-1206: per-call model override → outbound request body.
+        // `None` / empty falls back to `self.cfg.model` (env-bound).
+        let body = self.build_request_body(content, model);
         let resp = self
             .client
             .post(&url)
@@ -477,7 +495,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::stream;
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn cfg(base_url: String) -> VercelAiGatewayConfig {
@@ -522,7 +540,7 @@ mod tests {
     fn build_request_body_contains_model_and_user_message() {
         let arc =
             VercelAiGatewayArcan::new(cfg("http://localhost:8080".to_string())).expect("build");
-        let body = arc.build_request_body("hello world");
+        let body = arc.build_request_body("hello world", None);
         assert_eq!(body["model"], "test-model");
         assert_eq!(body["stream"], true);
         let messages = body["messages"].as_array().expect("messages");
@@ -536,12 +554,28 @@ mod tests {
         let mut c = cfg("http://localhost:8080".to_string());
         c.system_prompt = Some("be helpful".to_string());
         let arc = VercelAiGatewayArcan::new(c).expect("build");
-        let body = arc.build_request_body("hello");
+        let body = arc.build_request_body("hello", None);
         let messages = body["messages"].as_array().expect("messages");
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[0]["content"], "be helpful");
         assert_eq!(messages[1]["role"], "user");
+    }
+
+    /// BRO-1206: per-call model override wins over `cfg.model`.
+    #[test]
+    fn build_request_body_honors_model_override() {
+        let arc =
+            VercelAiGatewayArcan::new(cfg("http://localhost:8080".to_string())).expect("build");
+        // Override wins.
+        let body = arc.build_request_body("hi", Some("openai/gpt-4o-mini"));
+        assert_eq!(body["model"], "openai/gpt-4o-mini");
+        // Empty override falls back to cfg.model.
+        let body = arc.build_request_body("hi", Some("   "));
+        assert_eq!(body["model"], "test-model");
+        // None falls back to cfg.model.
+        let body = arc.build_request_body("hi", None);
+        assert_eq!(body["model"], "test-model");
     }
 
     #[tokio::test]
@@ -668,7 +702,7 @@ mod tests {
 
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
         let stream = arc
-            .dispatch_message("sess_x", "hello?")
+            .dispatch_message("sess_x", "hello?", None)
             .await
             .expect("dispatch");
         let mut tokens = Vec::new();
@@ -692,6 +726,73 @@ mod tests {
         assert!(finish_seen);
     }
 
+    /// BRO-1206: when `dispatch_message` is called with `Some(model)`,
+    /// the outbound HTTP body's `model` field MUST equal the override.
+    /// Verified via `wiremock::matchers::body_partial_json` — wiremock
+    /// only serves the mock when the `model` field matches the override,
+    /// proving the wire shape end-to-end.
+    #[tokio::test]
+    async fn dispatch_message_override_reaches_outbound_body() {
+        let server = MockServer::start().await;
+        let sse_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n\
+                        data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "openai/gpt-4o-mini"
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
+        // Override should win over `cfg.model = "test-model"`.
+        let stream = arc
+            .dispatch_message("sess_x", "hi", Some("openai/gpt-4o-mini"))
+            .await
+            .expect("override reaches body");
+        let mut s = Box::pin(stream);
+        let first = s.next().await.expect("event").expect("ok");
+        assert_eq!(first.kind(), AgentEventKind::Token);
+    }
+
+    /// BRO-1206: when `dispatch_message` is called with `None` (or empty
+    /// override), the outbound HTTP body's `model` field MUST equal
+    /// `cfg.model` — i.e. the env-bound default. Mock will only respond
+    /// when the env-default flows through.
+    #[tokio::test]
+    async fn dispatch_message_env_fallback_reaches_outbound_body() {
+        let server = MockServer::start().await;
+        let sse_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n\
+                        data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "test-model"
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
+        // No override → cfg.model is "test-model" (from `cfg(...)` helper).
+        let stream = arc
+            .dispatch_message("sess_x", "hi", None)
+            .await
+            .expect("env fallback reaches body");
+        let mut s = Box::pin(stream);
+        let first = s.next().await.expect("event").expect("ok");
+        assert_eq!(first.kind(), AgentEventKind::Token);
+    }
+
     #[tokio::test]
     async fn dispatch_propagates_http_errors_with_actionable_message() {
         let server = MockServer::start().await;
@@ -702,7 +803,7 @@ mod tests {
             .await;
 
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
-        match arc.dispatch_message("sess_x", "hi").await {
+        match arc.dispatch_message("sess_x", "hi", None).await {
             Ok(_) => panic!("must surface 401"),
             Err(ArcanProxyError::Transport(m)) => {
                 assert!(m.contains("401"), "msg: {m}");

--- a/crates/life-runtime/lifed/src/dev_mocks.rs
+++ b/crates/life-runtime/lifed/src/dev_mocks.rs
@@ -31,6 +31,13 @@ pub struct MockArcan {
     pub create_agent_calls: Arc<Mutex<Vec<String>>>,
     pub destroy_agent_calls: Arc<Mutex<Vec<String>>>,
     pub dispatch_calls: Arc<Mutex<Vec<(String, String)>>>,
+    /// BRO-1206: captures the per-call `model` override passed to
+    /// `dispatch_message`. Tests assert this to prove the override
+    /// travels end-to-end from `Agent.CreateSession` (stored on the
+    /// routing-cache entry) through `Agent.SendMessage` to the
+    /// substrate-call boundary.
+    #[allow(clippy::type_complexity)]
+    pub dispatch_models: Arc<Mutex<Vec<(String, Option<String>)>>>,
     /// When set, the next `create_agent` returns an error (then resets).
     pub fail_next: Arc<AtomicBool>,
     /// Sub-phase D: sustained failure mode for chaos tests.
@@ -115,11 +122,19 @@ impl ArcanCall for MockArcan {
         &self,
         sid: &str,
         content: &str,
+        model: Option<&str>,
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, tonic::Status>> + Send>>>
     {
+        // BRO-1206: mock records the dispatch (sid, content) — model
+        // override is captured separately on `dispatch_models` so
+        // tests can assert plumbing without changing existing
+        // `dispatch_calls` semantics.
         self.dispatch_calls
             .lock()
             .push((sid.to_string(), content.to_string()));
+        self.dispatch_models
+            .lock()
+            .push((sid.to_string(), model.map(str::to_string)));
         if let Some(s) = self.force_fail_status() {
             return Err(ArcanProxyError::Substrate(s));
         }

--- a/crates/life-runtime/lifed/src/routing/cache.rs
+++ b/crates/life-runtime/lifed/src/routing/cache.rs
@@ -36,6 +36,15 @@ pub struct RouteEntry {
     pub status: SessionStatus,
     /// Per-session multi-tab fan-out registry. Spec C₂ §6.4.
     pub fanout: Arc<FanoutRegistry>,
+    /// BRO-1206: per-request LLM model override carried from
+    /// `Agent.CreateSession`. When `Some(non_empty)`, every subsequent
+    /// `SendMessage` for this sid passes it to
+    /// `ArcanCall::dispatch_message`. When `None` or empty, the backend
+    /// falls back to its env-bound default (`OPENAI_MODEL` /
+    /// `ANTHROPIC_MODEL`). Stored on the routing-cache entry so the
+    /// override survives multi-tab fan-out without requiring it on
+    /// every `SendMessage` body.
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,7 +83,29 @@ impl RoutingCache {
     /// Insert a minimal entry. Each entry owns a fresh `FanoutRegistry`
     /// so SendMessage and StreamSession can broadcast to all attached
     /// tabs.
+    ///
+    /// BRO-1206: defaults `model: None` — backend env fallback applies.
+    /// Use [`Self::insert_with_model`] when `Agent.CreateSession` carries
+    /// a per-request override.
     pub fn insert_minimal(&self, sid: &aios_v1::SessionId, user_id: &str, project_id: &str) {
+        self.insert_with_model(sid, user_id, project_id, None);
+    }
+
+    /// BRO-1206: insert a routing entry with an optional per-session
+    /// LLM model override. The override is carried on subsequent
+    /// `Agent.SendMessage` dispatches via `ArcanCall::dispatch_message`.
+    pub fn insert_with_model(
+        &self,
+        sid: &aios_v1::SessionId,
+        user_id: &str,
+        project_id: &str,
+        model: Option<String>,
+    ) {
+        // Normalize empty / whitespace to None so downstream backends
+        // see a single "not set" representation.
+        let model = model
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         let entry = RouteEntry {
             sid: sid.clone(),
             user_id: user_id.to_string(),
@@ -86,6 +117,7 @@ impl RoutingCache {
             last_touched: Instant::now(),
             status: SessionStatus::Active,
             fanout: Arc::new(FanoutRegistry::new()),
+            model,
         };
         self.by_sid
             .insert(sid.value.clone(), Arc::new(RwLock::new(entry)));
@@ -97,6 +129,15 @@ impl RoutingCache {
         crate::observability::metrics::record_session_created("Tier-2");
         crate::observability::metrics::set_cache_size(self.by_sid.len() as i64);
         crate::observability::metrics::set_session_active(self.by_sid.len() as i64, "Tier-2");
+    }
+
+    /// BRO-1206: read the per-session model override (if any). Returns
+    /// `None` when the session was created without a `model` field on
+    /// `Agent.CreateSession` (or with an empty override).
+    pub fn lookup_model(&self, sid: &aios_v1::SessionId) -> Option<String> {
+        self.by_sid
+            .get(&sid.value)
+            .and_then(|e| e.read().model.clone())
     }
 
     /// Return the per-session fan-out registry. Sub-phase B's

--- a/crates/life-runtime/lifed/src/services/agent.rs
+++ b/crates/life-runtime/lifed/src/services/agent.rs
@@ -150,11 +150,17 @@ impl Drop for PumpGuard {
 /// a `PoolGuardedStream` that records the breaker outcome on terminal
 /// poll. The `PumpGuard` retained here only governs the
 /// one-pump-per-session invariant. Drop is panic-safe (RAII).
+///
+/// BRO-1206: `model` carries the per-session LLM model override (looked
+/// up from the routing-cache entry's `model` field by the caller). Mocks
+/// + the substrate gRPC proxy accept and ignore it; the HTTP-backed
+///   `VercelAiGatewayArcan` / `AnthropicArcan` impls honour it.
 fn spawn_or_attach_fanout_pump(
     fanout: &Arc<FanoutRegistry>,
     arcan: Arc<dyn ArcanCall>,
     sid: String,
     content: String,
+    model: Option<String>,
 ) {
     let Some(pump_guard) = PumpGuard::try_claim(Arc::clone(fanout), sid.clone()) else {
         // A pump is already running for this session — the new
@@ -170,7 +176,10 @@ fn spawn_or_attach_fanout_pump(
         // lifetime. If the spawned future panics, Drop releases the
         // slot — Spec C₂ §6.4 invariant preserved.
         let _pump_guard = pump_guard;
-        match arcan.dispatch_message(&sid, &content).await {
+        match arcan
+            .dispatch_message(&sid, &content, model.as_deref())
+            .await
+        {
             Ok(mut up) => {
                 use futures::StreamExt;
                 while let Some(evt) = up.next().await {
@@ -309,8 +318,13 @@ impl pb::agent_server::Agent for AgentService {
             .run(ctx, steps)
             .await
             .map_err(|e| e.into_status())?;
+        // BRO-1206: persist optional per-request model override on the
+        // routing-cache entry. Empty / whitespace is normalised to None
+        // inside `insert_with_model`. The override flows out via
+        // `send_message` → `spawn_or_attach_fanout_pump` →
+        // `ArcanCall::dispatch_message`.
         self.routing
-            .insert_minimal(&sid, &body.user_id, &body.project_id);
+            .insert_with_model(&sid, &body.user_id, &body.project_id, body.model.clone());
         Ok(Response::new(pb::Session {
             sid: Some(sid),
             agent_id: Some(aios_v1::AgentId {
@@ -377,13 +391,21 @@ impl pb::agent_server::Agent for AgentService {
             .ok_or_else(|| Status::invalid_argument("missing sid"))?
             .value
             .clone();
+        let sid_proto = aios_v1::SessionId {
+            value: sid_value.clone(),
+        };
         let fanout = self
             .routing
-            .lookup_fanout(&aios_v1::SessionId {
-                value: sid_value.clone(),
-            })
+            .lookup_fanout(&sid_proto)
             .ok_or_else(|| Status::not_found("session not found"))?;
         let stream = fanout.attach(64);
+        // BRO-1206: lift the per-session model override from the
+        // routing-cache entry (None when `Agent.CreateSession` carried no
+        // `model` field — backends apply env fallback). Cached lookup is
+        // a single DashMap read + RwLock read; cheap enough on the
+        // hot path that an explicit per-`SendMessage` model field is
+        // unnecessary.
+        let model = self.routing.lookup_model(&sid_proto);
         // Sub-phase E: pool bracketing is inside the arcan-proxy `Pooled`
         // adapter; the pump only manages the one-pump-per-session slot
         // via `PumpGuard` (RAII).
@@ -392,6 +414,7 @@ impl pb::agent_server::Agent for AgentService {
             Arc::clone(&self.arcan_call),
             sid_value,
             body.content,
+            model,
         );
         Ok(Response::new(Box::pin(stream)))
     }

--- a/crates/life-runtime/lifed/tests/_support/test_env.rs
+++ b/crates/life-runtime/lifed/tests/_support/test_env.rs
@@ -163,6 +163,20 @@ impl TestEnv {
         project_id: &str,
         label: &str,
     ) -> Result<Session, tonic::Status> {
+        self.create_session_dev_with_model(user_id, project_id, label, None)
+            .await
+    }
+
+    /// BRO-1206: build a `CreateSessionReq` with an optional `model`
+    /// override and dispatch it. Used by the per-request-model selection
+    /// integration tests to prove the field travels end-to-end.
+    pub async fn create_session_dev_with_model(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        label: &str,
+        model: Option<&str>,
+    ) -> Result<Session, tonic::Status> {
         let mut client = self.agent_client().await;
         let mut req = tonic::Request::new(CreateSessionReq {
             user_id: user_id.to_string(),
@@ -170,6 +184,7 @@ impl TestEnv {
             label: label.to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: model.map(str::to_string),
         });
         // Sub-phase A: the dev signer accepts a deterministic test token whose
         // body is `bearer test-token-for-{user_id}`. Real ES256 lands in B5.

--- a/crates/life-runtime/lifed/tests/integration_send_message.rs
+++ b/crates/life-runtime/lifed/tests/integration_send_message.rs
@@ -98,6 +98,153 @@ async fn stream_session_returns_canned_events() {
     env.shutdown().await;
 }
 
+/// BRO-1206: end-to-end model-override plumbing through lifed.
+///
+/// 1. `Agent.CreateSession` with `model: Some("anthropic/claude-opus-4-7")`
+///    persists the override on the routing-cache entry.
+/// 2. `Agent.SendMessage` looks it up and passes it to
+///    `MockArcan::dispatch_message`.
+/// 3. The mock records `(sid, Some("anthropic/claude-opus-4-7"))` on
+///    `dispatch_models`, proving the wire path is closed.
+#[tokio::test]
+async fn send_message_passes_per_session_model_override_to_arcan() {
+    let env = TestEnv::start_with_mocks().await;
+    let session = env
+        .create_session_dev_with_model(
+            "alice",
+            "project-demo",
+            "model-override",
+            Some("anthropic/claude-opus-4-7"),
+        )
+        .await
+        .expect("create_session");
+    let sid = session.sid.expect("sid");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SendMessageReq {
+        sid: Some(sid.clone()),
+        content: "hi".to_string(),
+        attachment_blob_ref: vec![],
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let mut stream = client
+        .send_message(req)
+        .await
+        .expect("send_message")
+        .into_inner();
+    // Drain a few events so the pump task has run dispatch_message.
+    for _ in 0..2 {
+        if stream.next().await.is_none() {
+            break;
+        }
+    }
+    // Give the spawned pump a moment to record the dispatch.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let models = env.mocks.arcan.dispatch_models.lock().clone();
+    assert!(
+        !models.is_empty(),
+        "expected at least one dispatch_message call recorded"
+    );
+    assert_eq!(models[0].0, sid.value);
+    assert_eq!(
+        models[0].1.as_deref(),
+        Some("anthropic/claude-opus-4-7"),
+        "model override should travel from CreateSession through routing cache to dispatch_message"
+    );
+
+    env.shutdown().await;
+}
+
+/// BRO-1206: no `model` field on `Agent.CreateSession` → backends see
+/// `None` on `dispatch_message` → env fallback applies.
+#[tokio::test]
+async fn send_message_passes_none_when_no_model_override() {
+    let env = TestEnv::start_with_mocks().await;
+    let session = env
+        .create_session_dev("alice", "project-demo", "no-override")
+        .await
+        .expect("create_session");
+    let sid = session.sid.expect("sid");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SendMessageReq {
+        sid: Some(sid.clone()),
+        content: "hi".to_string(),
+        attachment_blob_ref: vec![],
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let mut stream = client
+        .send_message(req)
+        .await
+        .expect("send_message")
+        .into_inner();
+    for _ in 0..2 {
+        if stream.next().await.is_none() {
+            break;
+        }
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let models = env.mocks.arcan.dispatch_models.lock().clone();
+    assert!(!models.is_empty());
+    assert!(
+        models[0].1.is_none(),
+        "no model on CreateSession → None on dispatch_message (env fallback)"
+    );
+
+    env.shutdown().await;
+}
+
+/// BRO-1206: empty / whitespace `model` is normalised to None at the
+/// routing-cache layer so backends see a single "not set" representation.
+#[tokio::test]
+async fn empty_model_field_normalises_to_none() {
+    let env = TestEnv::start_with_mocks().await;
+    let session = env
+        .create_session_dev_with_model("alice", "project-demo", "empty-model", Some("   "))
+        .await
+        .expect("create_session");
+    let sid = session.sid.expect("sid");
+
+    let mut client = env.agent_client().await;
+    let mut req = tonic::Request::new(SendMessageReq {
+        sid: Some(sid.clone()),
+        content: "hi".to_string(),
+        attachment_blob_ref: vec![],
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let mut stream = client
+        .send_message(req)
+        .await
+        .expect("send_message")
+        .into_inner();
+    for _ in 0..2 {
+        if stream.next().await.is_none() {
+            break;
+        }
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let models = env.mocks.arcan.dispatch_models.lock().clone();
+    assert!(!models.is_empty());
+    assert!(
+        models[0].1.is_none(),
+        "whitespace-only model should normalise to None at the routing-cache boundary"
+    );
+
+    env.shutdown().await;
+}
+
 /// M5 sub-phase B Task B12 acceptance — Spec C₂ §6.4.
 ///
 /// Multi-tab fanout: two clients attach to `stream_session` and a single

--- a/crates/life-runtime/lifed/tests/integration_spawn_child_stub.rs
+++ b/crates/life-runtime/lifed/tests/integration_spawn_child_stub.rs
@@ -23,6 +23,7 @@ async fn spawn_child_returns_unimplemented() {
             label: "child".to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         }),
         budget_cap_micros: 100_000,
         inherit_policy: Some(ChildPolicy {

--- a/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
+++ b/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
@@ -247,9 +247,13 @@ impl Agent for AnthropicProxyAgentService {
         // bookkeeps multi-turn history per-sid internally
         // (`append_exchange` on `Finish`), so successive turns on the
         // same sid carry conversation context.
+        // BRO-1206: this local-smoke harness predates per-request model
+        // selection; it always uses the env-bound default by passing
+        // `None`. A production lifed wires the per-session override here
+        // from its routing-cache entry.
         let stream = self
             .arcan
-            .dispatch_message(&sid, &content)
+            .dispatch_message(&sid, &content, None)
             .await
             .map_err(|e| tonic::Status::internal(format!("AnthropicArcan dispatch failed: {e}")))?;
         Ok(tonic::Response::new(stream))

--- a/crates/life-runtime/lifegw/src/services/agent_http.rs
+++ b/crates/life-runtime/lifegw/src/services/agent_http.rs
@@ -118,6 +118,15 @@ pub struct CreateSessionBody {
     /// again.
     #[serde(default)]
     pub resume_sid: Option<String>,
+    /// BRO-1206: optional per-request LLM model override. When set,
+    /// forwarded to `life.v1.Agent.CreateSession.model` and stored on
+    /// lifed's routing-cache entry; every subsequent
+    /// `Agent.SendMessage` for this sid passes it to
+    /// `ArcanCall::dispatch_message`. When unset / empty, the backend
+    /// falls back to its env-bound default (`OPENAI_MODEL` /
+    /// `ANTHROPIC_MODEL`). Backwards-compatible (additive `Option`).
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -186,6 +195,20 @@ async fn create_session_handler(
             }),
         ));
     }
+    // BRO-1206: bound `model` at the same MAX_FIELD_LEN. Vendor-prefixed
+    // identifiers like `anthropic/claude-opus-4-7` or
+    // `openai/gpt-4o-mini` are well under 128 chars; anything longer
+    // is almost certainly malformed input.
+    if let Some(ref m) = body.model
+        && m.len() > MAX_FIELD_LEN
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrJson {
+                error: format!("model must be ≤ {MAX_FIELD_LEN} characters"),
+            }),
+        ));
+    }
     // sub/user_id binding (same pattern as anima_custody): the Tier-1
     // bearer's subject MUST match the body's user_id. Without this, a
     // Tier-1 cap minted for user X could be replayed to create a
@@ -214,6 +237,15 @@ async fn create_session_handler(
 
     // 4. Forward to lifed with the Tier-2 cap.
     let mut client = AgentClient::new(state.upstream.clone());
+    // BRO-1206: normalize the optional `model` override before forwarding.
+    // Empty / whitespace-only strings are dropped so lifed sees a single
+    // "not set" representation (matching `RoutingCache::insert_with_model`).
+    let model = body
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     let mut tonic_req = tonic::Request::new(pb::CreateSessionReq {
         user_id: body.user_id.clone(),
         project_id: body.project_id.clone(),
@@ -226,6 +258,7 @@ async fn create_session_handler(
                 value: s.to_string(),
             }),
         inherit_policy: None,
+        model,
     });
     let bearer_value: tonic::metadata::MetadataValue<_> = format!("Bearer {tier2}")
         .parse()
@@ -497,6 +530,48 @@ mod tests {
             post_create_session(state, &[("authorization", auth.as_str())], &body_json).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(body.contains("characters"), "body: {body}");
+    }
+
+    /// BRO-1206: `model` field is accepted at the boundary and not
+    /// flagged as unknown by `deny_unknown_fields`. The handler reaches
+    /// the upstream call (which fails because the lazy connector is
+    /// unreachable — see `happy_path_reaches_upstream_call`). What
+    /// matters here is that the body deserializes cleanly.
+    #[tokio::test]
+    async fn accepts_optional_model_field() {
+        let state = dev_state().await;
+        let auth = format!("Bearer {}", dev_tier1_token("alice"));
+        let (status, body) = post_create_session(
+            state,
+            &[("authorization", auth.as_str())],
+            r#"{"user_id":"alice","project_id":"sentinel","model":"anthropic/claude-opus-4-7"}"#,
+        )
+        .await;
+        // Same shape as `happy_path_reaches_upstream_call`: we passed
+        // body validation + Tier-1 verify + Tier-2 mint and reached
+        // the upstream call. If `model` were rejected by serde, status
+        // would be 422 Unprocessable Entity.
+        assert!(
+            status == StatusCode::BAD_GATEWAY
+                || status == StatusCode::GATEWAY_TIMEOUT
+                || status == StatusCode::INTERNAL_SERVER_ERROR,
+            "unexpected status {status}, body: {body}",
+        );
+    }
+
+    /// BRO-1206: oversized `model` is rejected with 400 (mirrors the
+    /// other `MAX_FIELD_LEN`-bounded fields).
+    #[tokio::test]
+    async fn rejects_oversized_model() {
+        let state = dev_state().await;
+        let auth = format!("Bearer {}", dev_tier1_token("alice"));
+        let oversized = "m".repeat(MAX_FIELD_LEN + 1);
+        let body_json =
+            format!(r#"{{"user_id":"alice","project_id":"sentinel","model":"{oversized}"}}"#);
+        let (status, body) =
+            post_create_session(state, &[("authorization", auth.as_str())], &body_json).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("model"), "body: {body}");
     }
 
     #[tokio::test]

--- a/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
+++ b/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
@@ -790,6 +790,10 @@ async fn create_session(
             value: sid.to_string(),
         }),
         inherit_policy: None,
+        // BRO-1206: Spec J / Claude Code path passes the model per-turn
+        // via the Anthropic Messages API request body itself — the
+        // session-level override is intentionally not set here.
+        model: None,
     });
     attach_tier2(&mut req, tier2)?;
 

--- a/crates/life-runtime/lifegw/tests/integration_jwks_round_trip.rs
+++ b/crates/life-runtime/lifegw/tests/integration_jwks_round_trip.rs
@@ -69,6 +69,7 @@ async fn jwks_round_trip_suite() {
             label: "real-jwks-roundtrip".to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         });
         req.metadata_mut().insert(
             "authorization",
@@ -100,6 +101,7 @@ async fn jwks_round_trip_suite() {
             label: "alg-none".to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         });
         req.metadata_mut().insert(
             "authorization",
@@ -139,6 +141,7 @@ async fn jwks_round_trip_suite() {
             label: "rotation".to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         });
         req.metadata_mut().insert(
             "authorization",

--- a/crates/life-runtime/lifegw/tests/integration_proxy_passthrough.rs
+++ b/crates/life-runtime/lifegw/tests/integration_proxy_passthrough.rs
@@ -43,6 +43,7 @@ async fn proxy_forwards_create_session() {
         label: "lifegw-roundtrip".to_string(),
         resume_sid: None,
         inherit_policy: None,
+        model: None,
     });
     req.metadata_mut().insert(
         "authorization",
@@ -90,6 +91,7 @@ async fn missing_bearer_returns_unauthenticated() {
         label: "no-auth".to_string(),
         resume_sid: None,
         inherit_policy: None,
+        model: None,
     });
     let err = client
         .create_session(req)

--- a/crates/life-runtime/lifegw/tests/integration_rate_limit.rs
+++ b/crates/life-runtime/lifegw/tests/integration_rate_limit.rs
@@ -38,6 +38,7 @@ async fn rate_limit_returns_resource_exhausted_after_burst() {
             label: format!("attempt-{i}"),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         });
         req.metadata_mut().insert(
             "authorization",
@@ -55,6 +56,7 @@ async fn rate_limit_returns_resource_exhausted_after_burst() {
         label: "attempt-3-rejected".to_string(),
         resume_sid: None,
         inherit_policy: None,
+        model: None,
     });
     req3.metadata_mut().insert(
         "authorization",

--- a/crates/life-runtime/lifegw/tests/integration_ws_bidi.rs
+++ b/crates/life-runtime/lifegw/tests/integration_ws_bidi.rs
@@ -459,6 +459,7 @@ impl TestEnv {
             label: "ws-test".to_string(),
             resume_sid: None,
             inherit_policy: None,
+            model: None,
         });
         let bearer = format!("Bearer dev-token-for-{user_id}");
         req.metadata_mut()

--- a/proto/life/v1/agent.proto
+++ b/proto/life/v1/agent.proto
@@ -46,6 +46,16 @@ message CreateSessionReq {
   string label = 3;
   aios.v1.SessionId resume_sid = 4;
   ChildPolicy inherit_policy = 5;
+  // BRO-1206: optional per-request LLM model override. When set, lifed
+  // stores the value on the routing-cache entry and passes it to
+  // `ArcanCall::dispatch_message` on every subsequent `SendMessage` for
+  // this sid. When unset (None / empty), backends fall back to their
+  // env-bound default (`OPENAI_MODEL` / `ANTHROPIC_MODEL`).
+  //
+  // `optional` keeps the wire shape backwards-compatible: pre-1206
+  // clients and servers don't carry the field; new clients can send it
+  // safely against legacy servers (they'll ignore it).
+  optional string model = 6;
 }
 
 message Session {


### PR DESCRIPTION
## Summary

Stream A of the per-request LLM model selection arc. Allows CLI/clients to specify which LLM model to use per chat session via an optional `model` field on `POST /v1/agent/create_session`. When unset, lifed falls back to today's env-bound default (`OPENAI_MODEL` / `ANTHROPIC_MODEL`) — backward-compatible (additive `Option`).

Closes [BRO-1206](https://linear.app/broomva/issue/BRO-1206/per-request-model-selection-stream-a-life-lifegw-lifed-backends). Stream B ([BRO-1207](https://linear.app/broomva/issue/BRO-1207/per-request-model-selection-stream-b-broomva-cli-docs), broomva-cli + docs) consumes this.

## Wire-shape investigation

HTTP/JSON at the lifegw boundary (`agent_http.rs` axum handler), tonic gRPC over UDS between lifegw and lifed (`life.v1.Agent.CreateSession`). Proto-bumped — `optional string model = 6;` on `CreateSessionReq` keeps the wire backwards-compatible (any pre-1206 client/server pair stays valid).

The `arcan-proxy::ArcanCall` trait is the substrate-call boundary; the `model` field is added to `dispatch_message(sid, content, model)`. The arcan-substrate gRPC wire (`arcan.v1.AgentSubstrate.DispatchMessage`) is **not** touched — the substrate proto doesn't carry `model` today; HTTP-backed impls (`VercelAiGatewayArcan`, `AnthropicArcan`) honour the override.

## Dep-chain (4 layers, all touched)

1. **lifegw HTTP boundary** (`crates/life-runtime/lifegw/src/services/agent_http.rs`)
   - `CreateSessionBody.model: Option<String>` (under `#[serde(deny_unknown_fields)]`)
   - `MAX_FIELD_LEN` bound + empty/whitespace normalisation
2. **Proto bump** (`proto/life/v1/agent.proto`)
   - `optional string model = 6;` on `CreateSessionReq`
3. **lifed receiver** (`crates/life-runtime/lifed/src/`)
   - `routing/cache.rs::RouteEntry.model: Option<String>` + new `insert_with_model` + `lookup_model`
   - `services/agent.rs::create_session` persists to routing cache
   - `services/agent.rs::send_message` looks up + threads to pump
4. **ArcanCall trait + 3 impls** (`crates/life-runtime/arcan-proxy/src/`)
   - `client.rs::ArcanCall::dispatch_message` signature extended
   - `vercel_ai_gateway.rs` — override-or-`cfg.model` in outbound OpenAI body
   - `anthropic.rs` — override-or-`cfg.model` in outbound Messages body
   - `client.rs::ArcanProxy` (substrate gRPC) accepts + ignores
   - `lifed::dev_mocks::MockArcan` records on new `dispatch_models` field

## Tests added (+10 unit/integration)

- **`arcan-proxy`**:
  - `vercel_ai_gateway::build_request_body_honors_model_override`
  - `vercel_ai_gateway::dispatch_message_override_reaches_outbound_body` (wiremock `body_partial_json` verifies the override reaches the outbound HTTP body)
  - `vercel_ai_gateway::dispatch_message_env_fallback_reaches_outbound_body`
  - `anthropic::request_body_honors_model_override`
- **`lifegw`**:
  - `agent_http::accepts_optional_model_field` (proves `deny_unknown_fields` doesn't reject)
  - `agent_http::rejects_oversized_model`
- **`lifed`** (end-to-end through routing-cache):
  - `send_message_passes_per_session_model_override_to_arcan`
  - `send_message_passes_none_when_no_model_override`
  - `empty_model_field_normalises_to_none`

## Verify

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                   # 4455 passed, 0 failed, 28 ignored
```

## Deferred (per ticket scope)

- **Per-turn model swap** — Stream B follow-up (wire change on `WireOutbound::SendMessage`)
- **Cost ceiling per-tier** — Phase B+ (Spec D wallet integration); document as known limitation
- **Per-tier model allowlists** — auth-side enforcement; deferred

## Test plan

- [x] HTTP body with `model` field deserializes (no 422)
- [x] HTTP body without `model` field still works (backward-compat)
- [x] Oversized `model` rejected with 400
- [x] Empty/whitespace `model` normalised to `None`
- [x] VercelAiGateway: outbound `model` field == override when set
- [x] VercelAiGateway: outbound `model` field == `cfg.model` when None
- [x] Anthropic: outbound `model` field == override when set
- [x] Anthropic: outbound `model` field == `cfg.model` when None
- [x] lifed: end-to-end — CreateSession with model → routing cache → SendMessage → ArcanCall sees `Some(model)`
- [x] lifed: end-to-end — CreateSession without model → ArcanCall sees `None`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 4455 passed, 0 failed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-session LLM model override. Users can now specify an alternative language model when creating a session, which will be applied to all messages within that session.

* **Tests**
  * Added integration tests verifying model override behavior and proper fallback to default configuration when no override is specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->