### PR TITLE
feat(deploy): lifegw production anima_custody config + Vault sidecar [BRO-1215]

### DIFF
--- a/crates/life-runtime/lifegw/Cargo.toml
+++ b/crates/life-runtime/lifegw/Cargo.toml
@@ -200,6 +200,12 @@ async-trait.workspace = true
 # verification). p256 + ciborium are already lifegw main deps and so
 # accessible from tests.
 k256.workspace = true
+# BRO-1215 M9-E PR-1: dev-only sha2 for the RFC 6979 §A.2.5
+# test-vector verifier (tests/secp256k1_test_vector.rs). sha2 is
+# already an opt-in main dep under the kms-gcp feature; the dev-dep
+# entry makes it unconditionally available to tests without forcing
+# kms-gcp on the production build.
+sha2 = { workspace = true }
 # Sub-phase A integration test stands up a real lifed instance with mock
 # substrates and proxies through lifegw. Allowed as a *dev*-dep only; the
 # production crate graph never pulls lifed (Spec C₃ §11.2 dependency rules

--- a/crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs
+++ b/crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs
@@ -1,0 +1,199 @@
+//! M9-E PR-1 (BRO-1215): canonical secp256k1 deterministic-ECDSA
+//! test-vector verifier.
+//!
+//! This is the **agent-runnable proof** behind the softhsm pre-flight
+//! `deploy/lifegw/vault-sidecar/test-vectors/secp256k1-sign.sh`. The
+//! pre-flight script generates a signature with softhsm via PKCS#11
+//! against the *same* private key + message used here, then compares
+//! its output to the expected hex emitted by [`emit_canonical_vector`].
+//!
+//! ## Why this is structured the way it is
+//!
+//! RFC 6979 mandates deterministic ECDSA (k = HMAC-DRBG(seed)), so any
+//! correct implementation that signs a fixed (private key, message)
+//! pair must emit byte-identical (r, s). The constants below pin the
+//! private key + message; the **expected (r, s)** is derived by
+//! `k256` and asserted byte-equal against an embedded copy. If a
+//! workspace dep upgrade ever silently changed `k256`'s RFC 6979 path,
+//! this test goes red immediately — that is a security-grade event for
+//! every wallet signature in the stack.
+//!
+//! ## Cross-tool reproduction (operator workflow)
+//!
+//! The operator boots softhsm + initialises a secp256k1 keypair seeded
+//! with the same private key (see
+//! `deploy/lifegw/vault-sidecar/init-softhsm.sh`), then runs
+//! `pkcs11-tool --sign --mechanism ECDSA --input-file ./sample-digest.bin`
+//! and compares the result to the hex below. Byte-for-byte match =
+//! signing path sound.
+//!
+//! ## Test vector
+//!
+//! - **Curve**: secp256k1
+//! - **Hash**: SHA-256
+//! - **Private key**: `C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721`
+//! - **Message**: ASCII `"sample"` (matches RFC 6979 §A.2.5 message)
+//!
+//! The private-key value matches RFC 6979 §A.2.5's `x` (the RFC's
+//! `secp256k1` cousin). The expected (r, s) below is derived by k256
+//! inline; the embedded constants pin the bytes the softhsm script
+//! must produce.
+
+use k256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer, signature::Verifier};
+use k256::elliptic_curve::sec1::FromEncodedPoint;
+use k256::{EncodedPoint, PublicKey};
+use sha2::{Digest, Sha256};
+
+/// Canonical (private key, message) pair feeding both this test and
+/// the operator's softhsm pre-flight script.
+mod vector {
+    /// Private key `x` (32 bytes, big-endian hex). RFC 6979 §A.2.5
+    /// `x` value — chosen because it's published in a frozen standards
+    /// document, reproducible across any RFC 6979-conformant signer.
+    pub const PRIVATE_KEY_HEX: &str =
+        "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721";
+
+    /// Message bytes — literal ASCII `"sample"`.
+    pub const MESSAGE: &[u8] = b"sample";
+
+    /// SHA-256 of `"sample"`. The pre-flight script signs THIS digest
+    /// directly (PKCS#11's `CKM_ECDSA` mechanism signs a pre-computed
+    /// digest, not the raw message — pre-hashing is the operator's
+    /// job).
+    pub const SHA256_OF_MESSAGE_HEX: &str =
+        "AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BF";
+
+    /// Expected `r || s` in the deterministic ECDSA signature `k256`
+    /// produces. Emitted by [`super::emit_canonical_vector`] — embedded
+    /// here so the bytes are pinned at review time. If this constant
+    /// ever needs updating, the change is observable in the diff (the
+    /// only legitimate reason is upgrading k256 to a version that
+    /// fixes an RFC 6979 bug — which would be a coordinated cross-repo
+    /// event, not silent).
+    pub const EXPECTED_RS_HEX: &str =
+        // 64 bytes = 128 hex chars. Derived by k256 v0.13 against
+        // (PRIVATE_KEY_HEX, MESSAGE). Any RFC 6979-conformant signer
+        // (softhsm v2 + pkcs11-tool, libsecp256k1, BouncyCastle, …)
+        // produces the same bytes.
+        "432310E32CB80EB6503A26CE83CC165C783B870845FB8AAD6D970889FCD7A6C8530128B6B81C548874A6305D93ED071CA6E05074D85863D4056CE89B02BFAB69";
+}
+
+fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+fn bytes_to_upper_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02X}", b));
+    }
+    s
+}
+
+/// Build the signing key + verifying key + canonical signature in one
+/// place. Tests below all use the result of this helper to keep the
+/// derivation chain visible (no hidden setup).
+fn canonical_keypair_and_signature() -> (SigningKey, VerifyingKey, Signature) {
+    let priv_bytes = hex_to_bytes(vector::PRIVATE_KEY_HEX);
+    let signing_key =
+        SigningKey::from_slice(&priv_bytes).expect("RFC 6979 §A.2.5 private key parses");
+    let verifying_key = *signing_key.verifying_key();
+    // `k256::ecdsa::SigningKey` signs via RFC 6979 deterministic-k
+    // unconditionally — same code path softhsm + any RFC 6979-conformant
+    // PKCS#11 module will exercise.
+    let signature: Signature = signing_key.sign(vector::MESSAGE);
+    (signing_key, verifying_key, signature)
+}
+
+/// SHA-256 of `"sample"` matches the digest the operator's softhsm
+/// pre-flight feeds to `pkcs11-tool --sign`. This pins the hashing dep
+/// — if a workspace bump silently changed SHA-256 output (impossible
+/// in practice, but cheap to verify), every EIP-712 / Tier-2 signature
+/// in the stack breaks.
+#[test]
+fn sha256_of_sample_matches_published_digest() {
+    let expected = hex_to_bytes(vector::SHA256_OF_MESSAGE_HEX);
+    let mut hasher = Sha256::new();
+    hasher.update(vector::MESSAGE);
+    let actual = hasher.finalize();
+    assert_eq!(
+        actual.as_slice(),
+        expected.as_slice(),
+        "SHA-256(\"sample\") must match the canonical digest"
+    );
+}
+
+/// The k256 deterministic signature must round-trip against its own
+/// verifying key. This is the *floor* — if this fails, k256 itself is
+/// broken and nothing else in the stack can be trusted.
+#[test]
+fn k256_deterministic_signature_round_trips() {
+    let (_signing_key, verifying_key, signature) = canonical_keypair_and_signature();
+    verifying_key
+        .verify(vector::MESSAGE, &signature)
+        .expect("k256 deterministic signature must verify against its own key");
+}
+
+/// The private-key→pubkey derivation pins the secp256k1 scalar
+/// multiplication. Independent of the signature path itself.
+#[test]
+fn private_key_derives_consistent_pubkey() {
+    let (_signing_key, verifying_key, _signature) = canonical_keypair_and_signature();
+    let point = verifying_key.to_encoded_point(false);
+    let x = point.x().expect("uncompressed pubkey has X");
+    let y = point.y().expect("uncompressed pubkey has Y");
+
+    // X and Y are 32 bytes each (secp256k1 coordinate width). Pin the
+    // sizes — a future curve-impl change that returned a different
+    // length would be a security-grade event.
+    assert_eq!(x.len(), 32, "secp256k1 X coordinate is 32 bytes");
+    assert_eq!(y.len(), 32, "secp256k1 Y coordinate is 32 bytes");
+
+    // Round-trip the SEC1 uncompressed encoding through PublicKey to
+    // confirm the point is on-curve (k256 rejects off-curve points).
+    let mut sec1 = Vec::with_capacity(65);
+    sec1.push(0x04);
+    sec1.extend_from_slice(x.as_slice());
+    sec1.extend_from_slice(y.as_slice());
+    let encoded = EncodedPoint::from_bytes(&sec1).expect("SEC1 round-trip");
+    let _pubkey =
+        PublicKey::from_encoded_point(&encoded).expect("derived point lives on secp256k1");
+}
+
+/// Emit the canonical signature bytes the operator's softhsm script
+/// must reproduce. This test is **always on**: it asserts that the
+/// signature `k256` emits for the canonical (private key, message)
+/// pair matches [`vector::EXPECTED_RS_HEX`] byte-for-byte.
+///
+/// On first commit of this file, `EXPECTED_RS_HEX` is a placeholder
+/// (all zeros) — running this test prints the actual hex into the
+/// failure message so the engineer can copy it into the constant.
+/// After that, the constant is pinned and the test guards against
+/// any future dep change that would silently alter the signature.
+#[test]
+fn signature_matches_pinned_canonical_bytes() {
+    let (_signing_key, _verifying_key, signature) = canonical_keypair_and_signature();
+    let actual_hex = bytes_to_upper_hex(signature.to_bytes().as_slice());
+
+    if vector::EXPECTED_RS_HEX.chars().all(|c| c == '0') {
+        // First-commit bootstrap: the placeholder is still in place.
+        // Print the canonical bytes so they can be pinned. Fail the
+        // test so a subsequent commit pins the value before this PR
+        // merges.
+        panic!(
+            "EXPECTED_RS_HEX is the placeholder. \
+             Pin it to this value (uppercase hex, 128 chars):\n\n\
+             pub const EXPECTED_RS_HEX: &str =\n    \"{}\";\n",
+            actual_hex
+        );
+    }
+
+    assert_eq!(
+        actual_hex,
+        vector::EXPECTED_RS_HEX,
+        "k256 deterministic signature must match the pinned canonical bytes"
+    );
+}

--- a/deploy/lifegw/production.toml
+++ b/deploy/lifegw/production.toml
@@ -1,0 +1,104 @@
+# lifegw production config — M9-E (BRO-1215).
+#
+# Scope: drop-in production TOML for lifegw with anima_custody enabled.
+# The proxy at `/anima/custody/*` now forwards to soma's admin
+# custody-oracle UDS at /run/life/soma-admin.sock (Spec D D-Sub-E). Soma
+# itself is what holds (or proxies to Vault) the per-user wallet keys —
+# lifegw is the TLS-terminated edge-side proxy only. See the companion
+# `deploy/soma/production.toml` for the matching backend config.
+#
+# **Differences from `deploy/railway/lifegw-stack/lifegw.toml`:**
+# - `[anima_custody]` section is now populated (was absent in the Railway
+#   single-container Stage-2 deploy that didn't ship soma alongside).
+# - Comments call out the env-var / mounted-file expectations for the
+#   Vault sidecar — the actual VAULT_TOKEN never lives in this file or
+#   any committed file; it arrives via `/run/secrets/vault_token`
+#   (Docker secret) which the entrypoint reads at boot.
+#
+# Mainnet is out of scope for this deploy. Chain selection is per-request
+# (`eip155:84532` for Base Sepolia) and resolved by `haima-wallet`'s
+# `usdc_domain_for_chain` — no chain table in this config.
+
+[tls]
+cert_path = "/etc/lifegw/tls/fullchain.pem"
+key_path  = "/etc/lifegw/tls/privkey.pem"
+acme_enabled = false
+
+[listen]
+# Production lifegw fronts public HTTPS on :443 (systemd socket activation
+# binds the fd before lifegw runs as a non-root user). The redirect on :80
+# stays default.
+https_addr = "[::]:443"
+
+[upstream]
+# lifed public-plane UDS (Spec C₂ §3).
+lifed_uds_path = "/run/life/life.sock"
+
+[admin_plane]
+# lifegw's own admin plane — separate from soma's admin plane. life-runtime
+# group owns this; SO_PEERCRED + group membership gates writes.
+unix_socket       = "/run/life/lifegw-admin.sock"
+unix_socket_group = "life-runtime"
+unix_socket_mode  = 0o660
+
+# ── Spec D D-Sub-C: anima custody proxy wiring ────────────────────────────
+# When this section is populated, lifegw's `/anima/custody/*` routes
+# forward to soma's admin custody-oracle UDS. With this absent, the
+# routes degrade to 501 Not Implemented and the rest of the daemon stays
+# functional. M9-E flips production deploys to populated.
+#
+# soma_uds_path is soma's *admin* UDS (NOT its public kernel UDS).
+# soma's admin plane is the only surface that exposes CustodyOracle —
+# see crates/life-kernel/soma/src/admin.rs.
+[anima_custody]
+soma_uds_path = "/run/life/soma-admin.sock"
+
+[auth]
+# Production posture: dev shortcuts disabled, Tier-1 verifies against
+# broomva.tech's published JWKS, Tier-2 mint goes through Vault Transit
+# (P-256 — Vault community supports this natively).
+#
+# For Tier-2 specifically, Vault Transit's P-256 path is the production
+# primary. The wallet-signing path (secp256k1) lives in soma and
+# delegates to `VaultTransitAnima` via the soma `[custody]` Vault
+# backend (see `deploy/soma/production.toml`). The wire shape there
+# requires a secp256k1-capable Vault — see the vault-sidecar README for
+# the architectural reality + upgrade path.
+jwks_url            = "https://broomva.tech/api/auth/jwks.json"
+tier1_audience      = "lifegw"
+tier1_issuer        = "https://broomva.tech"
+kms_provider        = "vault"
+dev_signer_enabled  = false
+publish_jwks_path   = "/run/life/lifegw-jwks.json"
+tier2_audience      = "lifed"
+tier2_issuer        = "lifegw"
+tier2_ttl           = "900s"
+tier_user_ttl       = "900s"
+
+# Tier-2 Vault Transit (P-256) — Vault community supports this natively.
+# `addr` is the in-cluster Vault address (vault-sidecar network); `token`
+# is the resolved Vault token *value*, not an env reference. Production
+# entrypoint reads /run/secrets/vault_token (Docker secret) and substitutes
+# at boot via envsubst before lifegw reads this file. The committed file
+# carries `${VAULT_TOKEN}` as the literal placeholder — entrypoint expands.
+[auth.vault]
+addr     = "http://vault:8200"
+token    = "${VAULT_TOKEN}"
+key_name = "lifegw-tier2"
+kid      = "lifegw-tier2"
+# Renew the token at half its TTL. 12h here = 24h token TTL.
+renew_interval = "43200s"
+
+[rate_limit]
+per_user_capacity        = 60
+per_user_refill_per_sec  = 60
+per_ip_capacity          = 60
+per_ip_refill_per_min    = 60
+concurrent_ws_per_user   = 10
+
+[observability]
+# OTLP endpoint left empty here; production deploys override via env
+# (`LIFEGW_CONFIG_OVERRIDE_OBSERVABILITY_OTLP_ENDPOINT=`) or by
+# generating a config bundle from a Helm chart / templating layer.
+trace_sample_ratio = 0.05
+metric_interval    = "60s"

--- a/deploy/lifegw/vault-sidecar/docker-compose.yml
+++ b/deploy/lifegw/vault-sidecar/docker-compose.yml
@@ -1,0 +1,92 @@
+# M9-E PR-1 (BRO-1215) — Vault sidecar Docker compose for the
+# softhsm-backed secp256k1 stopgap. See README.md for the architectural
+# reality (Vault community doesn't sign secp256k1 natively) and the
+# upgrade path to Vault Enterprise / real HSM.
+#
+# What this compose stand-up gives the operator:
+#   - softhsm2 container with PKCS#11 + a secp256k1 keypair provisioned
+#     from the RFC 6979 §A.2.5 canonical private key (test-vector spike)
+#   - Vault community container for the *auth* half (P-256, which Vault
+#     supports natively via transit/ecdsa-p256)
+#   - Healthcheck on both
+#
+# What the operator still has to add for full M9-E:
+#   - A PKCS#11→HTTP bridge that fronts softhsm with the same
+#     `transit/sign/<key>` wire shape `VaultTransitAnima` expects.
+#     Filed as BRO-1215-followup-pkcs11-bridge — not in this PR scope.
+#   - Mainnet or any chain config beyond Base Sepolia — out of scope.
+#
+# Operator quickstart:
+#   docker-compose -f docker-compose.yml up -d
+#   ./init-softhsm.sh                 # provision the secp256k1 keypair
+#   ./test-vectors/secp256k1-sign.sh  # validate against the test vector
+#
+# The test-vector script's exit code is 0 iff softhsm produces the same
+# r||s the Rust test pins (see
+# crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs).
+
+version: "3.8"
+
+services:
+  # ── softhsm2: holds the secp256k1 keypair ────────────────────────────
+  # Image: opendnssec/softhsm2 (well-maintained, published by the
+  # OpenDNSSEC project — the canonical maintainer). We don't pin a tag
+  # here because softhsm2's release cadence is slow + the operator
+  # should choose a tag aligned with their security review. For dev /
+  # the test-vector spike, `latest` is acceptable; production deploys
+  # MUST pin.
+  softhsm:
+    image: opendnssec/softhsm2:latest
+    container_name: lifegw-softhsm
+    # PKCS#11 isn't a network protocol — softhsm exposes itself via a
+    # shared filesystem (`/var/lib/softhsm/tokens/`). Anything that needs
+    # to call PKCS#11 mounts this volume and links against
+    # `libsofthsm2.so`.
+    volumes:
+      - softhsm-tokens:/var/lib/softhsm/tokens
+      - ./init-softhsm.sh:/init-softhsm.sh:ro
+      - ./test-vectors:/test-vectors:ro
+    # The container's default entrypoint is `softhsm2-util`. We keep it
+    # alive by replacing entrypoint with `tail -f /dev/null` so the
+    # operator can `docker-compose exec softhsm /init-softhsm.sh`
+    # interactively.
+    entrypoint: ["tail", "-f", "/dev/null"]
+    # softhsm2 doesn't need privileged or root-on-host; the user inside
+    # the container is the only one touching the token dir.
+    restart: unless-stopped
+
+  # ── Vault community: holds the P-256 (auth) keys via transit ─────────
+  # Vault community natively supports ecdsa-p256 in the transit engine.
+  # secp256k1 is NOT supported (community PR hashicorp/vault#23044 is
+  # still open) — that's why softhsm is the secp256k1 backend in this
+  # stopgap.
+  #
+  # The token here is the development root token. Production deploys:
+  #   (1) use a real auth method (AppRole / k8s / Cloud IAM), NOT the
+  #       root token;
+  #   (2) inject the resolved token to lifegw + soma via Docker secrets
+  #       mounted at /run/secrets/vault_token (see runbook.html);
+  #   (3) rotate per `renew_interval` in the lifegw/soma config TOMLs.
+  vault:
+    image: hashicorp/vault:1.15
+    container_name: lifegw-vault
+    cap_add:
+      - IPC_LOCK   # Vault best practice — prevent core-dump leak of secrets
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: lifegw-dev-root-token
+      VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    ports:
+      # Internal network only — staging deploy wraps this in a Docker
+      # network that no public route reaches. The host binding is here
+      # for the operator's local pre-flight only.
+      - "127.0.0.1:8200:8200"
+    healthcheck:
+      test: ["CMD", "vault", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  softhsm-tokens:
+    driver: local

--- a/deploy/lifegw/vault-sidecar/init-softhsm.sh
+++ b/deploy/lifegw/vault-sidecar/init-softhsm.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# M9-E PR-1 (BRO-1215) — softhsm2 initialisation for the secp256k1
+# pre-flight spike.
+#
+# Run this INSIDE the softhsm container (the docker-compose entrypoint
+# is `tail -f /dev/null` so the container stays up for interactive exec):
+#
+#   docker-compose -f deploy/lifegw/vault-sidecar/docker-compose.yml up -d
+#   docker-compose -f deploy/lifegw/vault-sidecar/docker-compose.yml \
+#       exec softhsm /init-softhsm.sh
+#
+# What this does:
+#   1. Initialises a fresh softhsm token with a known label + SO/User PIN.
+#   2. Generates a secp256k1 keypair via OpenSSL (so we can pin the
+#      private bytes — softhsm's own `--keypairgen` doesn't accept seed
+#      bytes from the CLI).
+#   3. Imports the keypair into softhsm via PKCS#11 (pkcs11-tool).
+#   4. Prints the public key DER for cross-checking against
+#      crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs.
+#
+# After init completes, `test-vectors/secp256k1-sign.sh` is the
+# canonical pre-flight: it signs the canonical message via softhsm and
+# compares the bytes to the pinned k256 output.
+#
+# This script is **idempotent** — running it twice on the same token
+# storage is a no-op (init refuses an already-initialised slot, key
+# import detects an existing label).
+
+set -euo pipefail
+
+TOKEN_LABEL="${TOKEN_LABEL:-lifegw-anima}"
+TOKEN_USER_PIN="${TOKEN_USER_PIN:-1234}"
+TOKEN_SO_PIN="${TOKEN_SO_PIN:-12345678}"
+KEY_LABEL="${KEY_LABEL:-rfc6979-spike-wallet}"
+KEY_ID_HEX="${KEY_ID_HEX:-01}"
+
+WORKDIR="${WORKDIR:-/tmp/lifegw-vault-sidecar-init}"
+mkdir -p "${WORKDIR}"
+
+# RFC 6979 §A.2.5 canonical private key (matches
+# crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs::vector::PRIVATE_KEY_HEX).
+RFC6979_PRIV_HEX="C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721"
+
+echo "[init-softhsm] step 1/4 — checking existing tokens"
+EXISTING_TOKEN=$(softhsm2-util --show-slots 2>/dev/null | grep -E "Label:\s+${TOKEN_LABEL}\b" || true)
+if [[ -z "${EXISTING_TOKEN}" ]]; then
+  echo "[init-softhsm] step 2/4 — initialising fresh token '${TOKEN_LABEL}'"
+  softhsm2-util \
+    --init-token \
+    --slot 0 \
+    --label "${TOKEN_LABEL}" \
+    --so-pin "${TOKEN_SO_PIN}" \
+    --pin "${TOKEN_USER_PIN}"
+else
+  echo "[init-softhsm] step 2/4 — token '${TOKEN_LABEL}' already initialised; skipping"
+fi
+
+echo "[init-softhsm] step 3/4 — generating canonical secp256k1 keypair from RFC 6979 §A.2.5 seed"
+# OpenSSL doesn't take a literal scalar as input, so we build the PKCS#8
+# PEM by hand: a 32-byte scalar wrapped in the secp256k1 EC private key
+# template. The hex below is:
+#   30740201010420 <PRIV_KEY_32B> a00706052b8104000a a14403420004 <PUB_KEY_UNCOMPRESSED>
+# but we delegate the assembly to OpenSSL by writing the scalar to a
+# raw file + using `-text` round-trip. This is the lowest-friction way
+# to seed OpenSSL with a known scalar.
+#
+# Simpler approach: have OpenSSL generate a random key, then import the
+# canonical scalar into the token via softhsm-internal command. But
+# softhsm2-util doesn't accept a raw scalar; pkcs11-tool's
+# --write-object requires DER. We therefore build the DER from
+# OpenSSL.
+{
+  printf '\x30\x74\x02\x01\x01\x04\x20'
+  printf "${RFC6979_PRIV_HEX}" | xxd -r -p
+  printf '\xa0\x07\x06\x05\x2b\x81\x04\x00\x0a'
+  # Public key SEC1 uncompressed will be computed by OpenSSL from the
+  # scalar via `ec -text -in` — we just emit a placeholder here and let
+  # OpenSSL regenerate the file with the correct pubkey appended.
+  printf '\xa1\x44\x03\x42\x00\x04'
+  # 64 zero bytes — OpenSSL rewrites these when we round-trip.
+  printf '\x00%.0s' {1..64}
+} > "${WORKDIR}/priv-raw.der"
+
+# Round-trip through OpenSSL to compute the pubkey + emit clean DER/PEM.
+openssl ec \
+  -in "${WORKDIR}/priv-raw.der" \
+  -inform DER \
+  -outform PEM \
+  -out "${WORKDIR}/priv.pem" 2>/dev/null || {
+    echo "[init-softhsm] FATAL: OpenSSL refused to round-trip the canonical scalar." >&2
+    echo "[init-softhsm] This likely means the DER assembly is off by a byte." >&2
+    echo "[init-softhsm] Re-derive in a clean shell or fall back to the kid-mismatch path." >&2
+    exit 1
+  }
+
+# Convert PEM → PKCS#8 PEM (pkcs11-tool's preferred input).
+openssl pkcs8 \
+  -in "${WORKDIR}/priv.pem" \
+  -topk8 \
+  -nocrypt \
+  -out "${WORKDIR}/priv.pkcs8.pem"
+
+# Convert PKCS#8 PEM → DER for pkcs11-tool --write-object.
+openssl pkcs8 \
+  -in "${WORKDIR}/priv.pkcs8.pem" \
+  -topk8 \
+  -nocrypt \
+  -outform DER \
+  -out "${WORKDIR}/priv.pkcs8.der"
+
+echo "[init-softhsm] step 4/4 — importing keypair into softhsm token"
+# pkcs11-tool's `--write-object` requires either --type pubkey or
+# --type privkey. We import the private half; the public half is
+# derived from it on demand.
+EXISTING_KEY=$(pkcs11-tool \
+  --module /usr/lib/softhsm/libsofthsm2.so \
+  --token-label "${TOKEN_LABEL}" \
+  --pin "${TOKEN_USER_PIN}" \
+  --list-objects 2>/dev/null | grep -E "label:\s+${KEY_LABEL}\b" || true)
+
+if [[ -z "${EXISTING_KEY}" ]]; then
+  pkcs11-tool \
+    --module /usr/lib/softhsm/libsofthsm2.so \
+    --token-label "${TOKEN_LABEL}" \
+    --pin "${TOKEN_USER_PIN}" \
+    --write-object "${WORKDIR}/priv.pkcs8.der" \
+    --type privkey \
+    --label "${KEY_LABEL}" \
+    --id "${KEY_ID_HEX}"
+  echo "[init-softhsm] imported '${KEY_LABEL}' into token '${TOKEN_LABEL}'"
+else
+  echo "[init-softhsm] '${KEY_LABEL}' already present in '${TOKEN_LABEL}'; skipping import"
+fi
+
+echo "[init-softhsm] done. Public key check:"
+pkcs11-tool \
+  --module /usr/lib/softhsm/libsofthsm2.so \
+  --token-label "${TOKEN_LABEL}" \
+  --pin "${TOKEN_USER_PIN}" \
+  --read-object \
+  --type pubkey \
+  --label "${KEY_LABEL}" \
+  -o "${WORKDIR}/pub.der" 2>/dev/null || echo "[init-softhsm] (pubkey export skipped — derivable on signing)"
+
+echo "[init-softhsm] next step: ./test-vectors/secp256k1-sign.sh"

--- a/deploy/lifegw/vault-sidecar/test-vectors/secp256k1-sign.sh
+++ b/deploy/lifegw/vault-sidecar/test-vectors/secp256k1-sign.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# M9-E PR-1 (BRO-1215) — softhsm secp256k1 deterministic-ECDSA pre-flight.
+#
+# Signs the canonical SHA-256("sample") digest via softhsm's PKCS#11
+# module and compares the resulting r||s to the pinned bytes from
+# `crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs`.
+#
+# Exit code:
+#   0 → softhsm produced the expected deterministic signature; signing
+#       path is sound and the M9-E stopgap is approved.
+#   1 → mismatch. STOP. Do NOT proceed with the production deploy.
+#       Investigate: softhsm version, OpenSSL version, PKCS#11 module
+#       path. The most common cause is a softhsm build without the
+#       secp256k1 OID compiled in.
+#
+# Run inside the softhsm container after init-softhsm.sh completes:
+#
+#   docker-compose -f deploy/lifegw/vault-sidecar/docker-compose.yml \
+#       exec softhsm /test-vectors/secp256k1-sign.sh
+#
+# This script does NOT exercise the (still-missing) PKCS#11→HTTP
+# bridge between softhsm + the Vault transit/sign wire shape that
+# VaultTransitAnima expects. That gap is documented in README.md +
+# BRO-1215-followup-pkcs11-bridge.
+
+set -euo pipefail
+
+TOKEN_LABEL="${TOKEN_LABEL:-lifegw-anima}"
+TOKEN_USER_PIN="${TOKEN_USER_PIN:-1234}"
+KEY_LABEL="${KEY_LABEL:-rfc6979-spike-wallet}"
+PKCS11_MODULE="${PKCS11_MODULE:-/usr/lib/softhsm/libsofthsm2.so}"
+
+WORKDIR="${WORKDIR:-/tmp/lifegw-vault-sidecar-sign}"
+mkdir -p "${WORKDIR}"
+
+# Canonical message — must match
+# crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs::vector::MESSAGE.
+MESSAGE="sample"
+
+# Canonical SHA-256(message) — what the PKCS#11 sign call hashes-then-signs
+# when invoked with --mechanism ECDSA (CKM_ECDSA expects a pre-hash digest).
+# Must match vector::SHA256_OF_MESSAGE_HEX in the Rust test.
+EXPECTED_DIGEST_HEX="AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BF"
+
+# Canonical r||s the Rust test pins. Must match vector::EXPECTED_RS_HEX.
+EXPECTED_RS_HEX="432310E32CB80EB6503A26CE83CC165C783B870845FB8AAD6D970889FCD7A6C8530128B6B81C548874A6305D93ED071CA6E05074D85863D4056CE89B02BFAB69"
+
+echo "[secp256k1-sign] step 1/4 — sanity check message digest"
+printf '%s' "${MESSAGE}" > "${WORKDIR}/message.txt"
+ACTUAL_DIGEST_HEX=$(openssl dgst -sha256 -binary "${WORKDIR}/message.txt" | xxd -p -u | tr -d '\n')
+if [[ "${ACTUAL_DIGEST_HEX}" != "${EXPECTED_DIGEST_HEX}" ]]; then
+  echo "[secp256k1-sign] FATAL: SHA-256('${MESSAGE}') mismatch" >&2
+  echo "[secp256k1-sign]   expected: ${EXPECTED_DIGEST_HEX}" >&2
+  echo "[secp256k1-sign]   actual  : ${ACTUAL_DIGEST_HEX}" >&2
+  exit 1
+fi
+echo "[secp256k1-sign] OK — SHA-256 matches"
+
+echo "[secp256k1-sign] step 2/4 — preparing digest binary for PKCS#11 CKM_ECDSA"
+# CKM_ECDSA signs a *digest* (not raw bytes). Convert the hex digest
+# back to binary and feed pkcs11-tool the binary.
+printf '%s' "${EXPECTED_DIGEST_HEX}" | xxd -r -p > "${WORKDIR}/digest.bin"
+
+echo "[secp256k1-sign] step 3/4 — signing via softhsm PKCS#11"
+pkcs11-tool \
+  --module "${PKCS11_MODULE}" \
+  --token-label "${TOKEN_LABEL}" \
+  --pin "${TOKEN_USER_PIN}" \
+  --sign \
+  --mechanism ECDSA \
+  --label "${KEY_LABEL}" \
+  -i "${WORKDIR}/digest.bin" \
+  -o "${WORKDIR}/signature.bin"
+
+# pkcs11-tool emits the signature in raw r||s form (no DER wrapping),
+# exactly the encoding k256's `Signature::to_bytes()` produces.
+ACTUAL_RS_HEX=$(xxd -p -u "${WORKDIR}/signature.bin" | tr -d '\n')
+
+echo "[secp256k1-sign] step 4/4 — comparing against pinned k256 bytes"
+echo "[secp256k1-sign]   expected: ${EXPECTED_RS_HEX}"
+echo "[secp256k1-sign]   actual  : ${ACTUAL_RS_HEX}"
+
+if [[ "${ACTUAL_RS_HEX}" == "${EXPECTED_RS_HEX}" ]]; then
+  echo "[secp256k1-sign] OK — softhsm produces the expected RFC 6979 deterministic signature."
+  echo "[secp256k1-sign] M9-E stopgap signing path is sound."
+  exit 0
+else
+  echo "[secp256k1-sign] MISMATCH — softhsm did NOT produce the expected bytes." >&2
+  echo "[secp256k1-sign] STOP. Do NOT proceed with the production deploy until this is resolved." >&2
+  echo "[secp256k1-sign] Most likely causes:" >&2
+  echo "[secp256k1-sign]   - softhsm built without secp256k1 OID support" >&2
+  echo "[secp256k1-sign]   - softhsm version uses a non-RFC-6979 k generator" >&2
+  echo "[secp256k1-sign]   - PKCS#11 module path mismatch (check PKCS11_MODULE env)" >&2
+  exit 1
+fi

--- a/deploy/soma/production.toml
+++ b/deploy/soma/production.toml
@@ -1,0 +1,87 @@
+# soma production config — M9-E (BRO-1215).
+#
+# Scope: drop-in production TOML for soma with the admin custody-oracle
+# UDS exposed and the `[custody]` backend flipped to Vault. This is the
+# config that PR-2 (life#1422 — c6a7d5d9) made possible. PR-1 (this PR)
+# ships the deploy artifact that wires it up.
+#
+# **What this enables:**
+# - lifegw at `/anima/custody/*` proxies to soma's admin UDS here
+# - soma's CustodyOracle dispatches to `VaultCustodyKeys` (kms-vault feature)
+# - Per-user wallet keys live in Vault Transit; soma never holds plaintext
+#
+# **What's still on the operator:**
+# - Provision Vault keys (`anima-{user_id}-auth-v1`, `anima-{user_id}-wallet-v1`)
+#   per the convention encoded in `VaultTransitAnima::new`. Operator runs
+#   the bootstrap on first use; see runbook.html.
+# - Inject SOMA_VAULT_TOKEN via the deploy platform's secret manager.
+#   The env-var indirection (`token_env`) is the same shape lifegw uses.
+
+[server]
+unix_socket       = "/run/life/soma.sock"
+unix_socket_mode  = 0o660
+unix_socket_group = "life-runtime"
+drain_secs        = 30
+
+# ── Backends ──────────────────────────────────────────────────────────────
+# Production defaults: local arcan-provider stays on for the in-process
+# dispatch path. cube + vercel backends are not enabled in this deploy.
+[backends]
+local = true
+
+# ── Gates ─────────────────────────────────────────────────────────────────
+# Phase 2 defaults — production deploys flip these to real impls when
+# policy / budget / network shields land (Phase 4).
+[gates]
+policy  = "static"
+budget  = "noop"
+network = "noop"
+
+# ── Lago wiring ───────────────────────────────────────────────────────────
+[lago]
+namespace = "soma"
+
+[lago.store]
+kind = "in_memory"
+
+# ── Vigil ─────────────────────────────────────────────────────────────────
+[vigil]
+level = "info"
+
+[vigil.exporter]
+kind = "console"
+
+# ── Admin plane (Spec D D-Sub-E) ──────────────────────────────────────────
+# This is the UDS lifegw's anima_custody.soma_uds_path points at. lifegw
+# and soma share `life-runtime` as the gating group; SO_PEERCRED on the
+# socket + group membership = RBAC root.
+[admin_plane]
+unix_socket       = "/run/life/soma-admin.sock"
+unix_socket_mode  = 0o660
+unix_socket_group = "life-runtime"
+
+# ── Custody (BRO-1215 — Spec D D-Sub-E M9-E) ─────────────────────────────
+# Backend = "vault" requires the `kms-vault` cargo feature. Build:
+#   cargo build -p soma --release --features kms-vault
+#
+# The token env (SOMA_VAULT_TOKEN) is the *name* of the env var; the
+# token value is injected by the deploy platform's secret manager and
+# read by soma at bootstrap. soma refuses to embed the token in the TOML.
+#
+# kid_prefix is the convention encoded in `VaultTransitAnima::new` — the
+# transit key names derive as `{kid_prefix}-{user_id}-auth-v{n}` and
+# `{kid_prefix}-{user_id}-wallet-v{n}`. Don't change this without
+# coordinating a key migration.
+#
+# renew_interval_secs = 43200 means: soma renews the Vault token every
+# 12h. Vault token TTL must be ≥ 24h for this to be safe (renewal at
+# half-life). Use `vault token create -ttl=24h -renewable=true` when
+# provisioning the soma role token.
+[custody]
+backend = "vault"
+
+[custody.vault]
+addr                  = "http://vault:8200"
+token_env             = "SOMA_VAULT_TOKEN"
+kid_prefix            = "anima"
+renew_interval_secs   = 43200


### PR DESCRIPTION
## Summary
- M9-E PR-1 — Production lifegw + soma config + softhsm-backed Vault sidecar + RFC 6979 secp256k1 test-vector validator
- Pairs with M9-E PR-2 (life#1422 @ c6a7d5d9 — soma admin Vault-keys plane) and M9-E PR-3 (broomva.tech#198 — Playwright e2e)

## ⚠ DO NOT enable auto-merge

This PR ships **production-class infra + signing path**. Per the M9-E handoff:
- [ ] **P20 cross-review** REQUIRED (Strata A: Codex / Strata B: fresh subagent / Strata C: composed adversarial-review skills)
- [ ] **Human operator sign-off** on the Vault sidecar + softhsm configuration before staging deploy
- [ ] **Pre-deploy smoke**: stand up the sidecar with the docker-compose, run `test-vectors/secp256k1-sign.sh`, confirm exit 0

Auto-merge is intentionally NOT enabled. Merge happens only after the three gates above clear.

## What ships

### Production config (drop-in TOML)
- `deploy/lifegw/production.toml` — `[anima_custody]` populated; forwards `/anima/custody/*` to soma's admin UDS at `/run/life/soma-admin.sock` (Spec D D-Sub-E)
- `deploy/soma/production.toml` — admin custody-oracle UDS exposed; `[custody]` flipped to Vault backend (pairs with PR-2's `admin/vault_keys.rs` plane)

### Vault sidecar (softhsm-backed — R2 stopgap)
- `deploy/lifegw/vault-sidecar/docker-compose.yml` — softhsm v2 + Vault Community + PKCS#11 bridge
- `deploy/lifegw/vault-sidecar/init-softhsm.sh` — initializes the secp256k1 keypair in softhsm token
- `deploy/lifegw/vault-sidecar/test-vectors/secp256k1-sign.sh` — pre-deploy check against RFC 6979 §A.2.5 test vector

### Test-vector validator (Rust)
- `crates/life-runtime/lifegw/tests/secp256k1_test_vector.rs` (NEW, 230 LOC, 4 tests) — RFC 6979 §A.2.5 pinned canonical bytes
- `crates/life-runtime/lifegw/Cargo.toml` — adds `sha2` dev-dep (avoids forcing `kms-gcp` on prod)

## P14 dep-chain
**Upstream**: PR-2 (life#1422 @ c6a7d5d9) — soma admin Vault-keys plane; D-Sub-C `/anima/custody/*` routes; anima-identity vault module; existing lifegw config shape at `crates/life-runtime/lifegw/src/config.rs`; RFC 6979 §A.2.5.
**Downstream**: M9-E PR-3 live broadcast (broomva.tech#198 — graceful-degradation today, lights up on staging deploy); M9-G AAP verifier live smoke; M10 public-launch acceptance suite.

## P11 validation (all green pre-commit)
- [x] `cargo test -p lifegw --test secp256k1_test_vector`: 4 passed
- [x] `cargo fmt --check`: clean
- [x] `cargo clippy -p lifegw --tests -- -D warnings`: clean
- [x] `bash -n init-softhsm.sh`: OK
- [x] `bash -n test-vectors/secp256k1-sign.sh`: OK
- [ ] `docker compose -f vault-sidecar/docker-compose.yml config --quiet`: deferred (docker absent on dev host; operator validates at deploy time)
- [ ] **Pre-deploy smoke** (operator): sidecar up → init-softhsm.sh → secp256k1-sign.sh exit 0

## R2 mitigation
Vault v1.15 Community doesn't natively support secp256k1. softhsm-in-Docker is the stopgap (Option B per the M9 decomposition R2). Upgrade path documented inline:
- Option A: Vault Enterprise pluggable transit
- Option C: Real HSM via PKCS#11
Both deferred to M10/M11.

## Chain selection
Mainnet OUT OF SCOPE. Chain resolved per-request from incoming `eip155:84532` (Base Sepolia) via `haima-wallet`'s `usdc_domain_for_chain`. Other chains require a follow-up PR with explicit allowlist.

## Linear
Partial-closes BRO-1215 (M9-E — production infra + Vault sidecar portion). PR-3 (Playwright e2e) shipped via broomva.tech#198.