### PR TITLE
fix(lifegw): extract Tier-1 bearer from Sec-WebSocket-Protocol on WS upgrade [BRO-1228]

### DIFF
--- a/crates/life-runtime/lifegw/src/auth/middleware.rs
+++ b/crates/life-runtime/lifegw/src/auth/middleware.rs
@@ -202,12 +202,23 @@ where
                 return Ok(health::handle(upstream_path).await);
             }
 
-            let bearer = req
-                .headers()
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|h| h.strip_prefix("Bearer "))
-                .map(|t| t.to_string());
+            // Tier-1 bearer extraction.
+            //
+            // Order of precedence:
+            //   1. `Authorization: Bearer <jwt>` (canonical header form;
+            //      used by Rust gRPC clients and the L7 proxies that
+            //      forward in canonical shape).
+            //   2. `Sec-WebSocket-Protocol: ..., bearer.<jwt>, ...`
+            //      (browser-style WS upgrade — the WebSocket spec
+            //      disallows setting `Authorization` on the upgrade
+            //      request, so the bearer must ride a different header.
+            //      Every WS auth pattern uses this carrier per
+            //      RFC 6455 §1.9 + §11.3.4).
+            //
+            // Authorization wins when both are present so a forwarded
+            // chain that copies the bearer twice always trusts the
+            // canonical header form.
+            let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
 
             // `dev_signer_enabled` is informational here — both code
             // paths route through the JWKS cache. Whether the cache
@@ -289,6 +300,62 @@ where
             inner.call(req).await
         })
     }
+}
+
+/// Extract the bearer from `Authorization: Bearer <token>` and return
+/// the bare `<token>` (without the `Bearer ` prefix). Returns `None`
+/// when the header is absent, malformed, or doesn't carry the `Bearer `
+/// scheme.
+fn bearer_from_authorization<B>(req: &Request<B>) -> Option<String> {
+    req.headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .map(|t| t.to_string())
+}
+
+/// Extract the Tier-1 bearer from `Sec-WebSocket-Protocol`
+/// (BRO-1228 — closes the browser-WS auth gap that PR-3 of BRO-1208
+/// triggered in production).
+///
+/// **Why this fallback exists.** Browser-style WebSocket clients
+/// (`new WebSocket(url, protocols)`) cannot set arbitrary request
+/// headers — the WHATWG WebSockets spec forbids touching
+/// `Authorization` on the upgrade request. Every WS auth pattern
+/// documents `Sec-WebSocket-Protocol: bearer.<token>` as the carrier:
+/// the subprotocol list is the one header the constructor exposes to
+/// JS, and it survives untouched through proxies (RFC 6455 §1.9 +
+/// §11.3.4).
+///
+/// **Parse semantics.** The header value is an RFC 7230 #token list
+/// (comma-separated, OWS allowed). We split on `,`, trim each entry,
+/// and look for one that starts with `bearer.`. Other subprotocol
+/// entries (e.g. `life.v1.agent`) are tolerated alongside.
+///
+/// **Token shape gate.** A JWS only contains URL-safe-base64 alphabet
+/// (`A-Z`, `a-z`, `0-9`, `-`, `_`, `=`) plus two `.` separators. A
+/// token containing whitespace, control chars, or commas is
+/// malformed (likely a buggy proxy or attacker-crafted entry) and is
+/// rejected before flowing into the JWKS verifier. This mirrors the
+/// classifier in `services::ws::bearer_from_subprotocol`.
+///
+/// Returns the bare token (without the `Bearer ` prefix) so the
+/// downstream `verify_with_handle` call receives the same shape both
+/// fallback paths produce.
+fn bearer_from_subprotocol<B>(req: &Request<B>) -> Option<String> {
+    let header = req.headers().get("sec-websocket-protocol")?.to_str().ok()?;
+    for raw in header.split(',') {
+        let part = raw.trim();
+        if let Some(token) = part.strip_prefix("bearer.")
+            && !token.is_empty()
+            && token
+                .chars()
+                .all(|c| !c.is_whitespace() && !c.is_control() && c != ',')
+        {
+            return Some(token.to_string());
+        }
+    }
+    None
 }
 
 /// Verify a Tier-1 bearer through the per-service handle when set,
@@ -525,5 +592,148 @@ mod tests {
     fn parse_ip_or_socket_rejects_garbage() {
         assert!(parse_ip_or_socket("definitely not an ip").is_none());
         assert!(parse_ip_or_socket("").is_none());
+    }
+
+    // ─── BRO-1228: Sec-WebSocket-Protocol bearer extraction ────────
+    //
+    // Browser-style WebSocket clients cannot set `Authorization` on the
+    // upgrade request (WHATWG WebSockets spec disallows it), so the
+    // Tier-1 bearer rides as a `bearer.<jwt>` entry in
+    // `Sec-WebSocket-Protocol` (RFC 6455 §1.9, §11.3.4). The cases
+    // below mirror the failure-mode acceptance criteria from BRO-1228
+    // and lock the canonical-vs-subprotocol precedence so a future
+    // refactor doesn't silently flip auth's trust hierarchy.
+
+    fn req_with_headers(headers: &[(&str, &str)]) -> http::Request<()> {
+        let mut b = http::Request::builder().uri("/v1/agent/stream?sid=s");
+        for (k, v) in headers {
+            b = b.header(*k, *v);
+        }
+        b.body(()).expect("build req")
+    }
+
+    #[test]
+    fn bearer_extraction_prefers_authorization_when_only_authorization_present() {
+        let req = req_with_headers(&[("authorization", "Bearer my-tier1-token")]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert_eq!(bearer.as_deref(), Some("my-tier1-token"));
+    }
+
+    #[test]
+    fn bearer_extraction_falls_back_to_subprotocol_when_authorization_absent() {
+        // Browser WS upgrade: only `Sec-WebSocket-Protocol: bearer.<jwt>`.
+        // This is the canonical broken-prod case BRO-1228 fixes.
+        let req = req_with_headers(&[("sec-websocket-protocol", "bearer.eyJabc.def.ghi")]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert_eq!(bearer.as_deref(), Some("eyJabc.def.ghi"));
+    }
+
+    #[test]
+    fn bearer_extraction_falls_back_through_mixed_subprotocol_list() {
+        // Some clients offer multiple subprotocols — `life.v1.agent`
+        // alongside `bearer.<jwt>`. We must find the bearer entry and
+        // skip the rest. Order-insensitive: bearer can be first OR last.
+        for header in [
+            "life.v1.agent, bearer.eyJabc.def.ghi",
+            "bearer.eyJabc.def.ghi, life.v1.agent",
+            "life.v1.agent,bearer.eyJabc.def.ghi", // no inner whitespace
+        ] {
+            let req = req_with_headers(&[("sec-websocket-protocol", header)]);
+            let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+            assert_eq!(
+                bearer.as_deref(),
+                Some("eyJabc.def.ghi"),
+                "header {header:?} must yield the bearer entry",
+            );
+        }
+    }
+
+    #[test]
+    fn bearer_extraction_authorization_wins_when_both_present() {
+        // A forwarded chain that copies the bearer twice (canonical
+        // header AND subprotocol) must trust the canonical form. This
+        // ensures a stale subprotocol entry from an upstream proxy
+        // cannot override the value the gateway's own L7 stack set.
+        let req = req_with_headers(&[
+            ("authorization", "Bearer canonical-wins"),
+            ("sec-websocket-protocol", "bearer.subproto-loses"),
+        ]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert_eq!(bearer.as_deref(), Some("canonical-wins"));
+    }
+
+    #[test]
+    fn bearer_extraction_subprotocol_without_bearer_entry_yields_none() {
+        // Spec C₃ §6.1 has clients negotiate `life.v1.agent` only —
+        // no `bearer.` entry. Without the canonical Authorization
+        // header either, the request must surface as missing-bearer.
+        let req = req_with_headers(&[("sec-websocket-protocol", "life.v1.agent")]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert!(bearer.is_none());
+    }
+
+    #[test]
+    fn bearer_extraction_no_headers_at_all_yields_none() {
+        // Sanity: with neither Authorization nor Sec-WebSocket-Protocol
+        // we must return None so the AuthLayer emits the canonical
+        // "missing Tier-1 bearer token" message (monitoring/log greps
+        // depend on it).
+        let req = req_with_headers(&[]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert!(bearer.is_none());
+    }
+
+    #[test]
+    fn bearer_extraction_malformed_subprotocol_yields_none() {
+        // A `bearer.<garbage>` entry that contains whitespace, control
+        // chars, or commas inside the token is malformed (JWS only
+        // contains URL-safe-base64 alphabet) and must not flow into
+        // the auth pipeline. AuthLayer will then surface the
+        // missing-bearer error — the malformed entry counts as no
+        // bearer at all.
+        for malformed in [
+            "bearer.",          // empty after prefix
+            "bearer.has space", // SP inside token
+            "bearer.has\ttab",  // HT inside token
+        ] {
+            let header = format!("life.v1.agent, {malformed}");
+            let req = req_with_headers(&[("sec-websocket-protocol", header.as_str())]);
+            let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+            assert!(
+                bearer.is_none(),
+                "malformed entry {malformed:?} must yield None",
+            );
+        }
+    }
+
+    #[test]
+    fn bearer_extraction_subprotocol_handles_dev_token_shape() {
+        // The dev signer accepts `dev-token-for-<user_id>` as a
+        // Bearer value. The same value, when delivered via
+        // `Sec-WebSocket-Protocol: bearer.dev-token-for-<user_id>`,
+        // must pass extraction unchanged so the dev rig keeps
+        // working over the WS browser path.
+        let req = req_with_headers(&[("sec-websocket-protocol", "bearer.dev-token-for-alice")]);
+        let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
+        assert_eq!(bearer.as_deref(), Some("dev-token-for-alice"));
+    }
+
+    #[test]
+    fn bearer_extraction_subprotocol_dev_token_verifies_via_jwks() {
+        // End-to-end: the bearer extracted from Sec-WebSocket-Protocol
+        // must round-trip through `verify_with_handle` to a real
+        // Tier1Claims. This is the contract the AuthLayer relies on —
+        // without it, the fallback would be cosmetic.
+        let cache = Arc::new(JwksCache::dev_only());
+        let req = req_with_headers(&[(
+            "sec-websocket-protocol",
+            "life.v1.agent, bearer.dev-token-for-bob",
+        )]);
+        let bearer = bearer_from_authorization(&req)
+            .or_else(|| bearer_from_subprotocol(&req))
+            .expect("bearer extracted from subprotocol");
+        let claims =
+            verify_with_handle(Some(&cache), &bearer).expect("dev cache verifies dev token");
+        assert_eq!(claims.user_id, "bob");
     }
 }

--- a/crates/life-runtime/lifegw/src/auth/scope.rs
+++ b/crates/life-runtime/lifegw/src/auth/scope.rs
@@ -444,6 +444,22 @@ mod tests {
         enforce("/v1/agent/stream", &t1).expect("ws upgrade requires agent:dispatch");
     }
 
+    /// BRO-1228: the broken-prod token is `tier: "anon"` with
+    /// `scopes: ["agent:dispatch"]` — confirms scope::enforce gates on
+    /// the scope string set, not on the tier label, so unblocking the
+    /// auth/middleware bearer-extraction fix is sufficient end-to-end.
+    #[test]
+    fn enforce_ws_upgrade_passes_for_anon_tier_with_dispatch_scope() {
+        let t1 = Tier1Claims {
+            user_id: "anon:019e4d01-60de-724d-88d5-1376b8b8021a".to_string(),
+            project_id: "default".to_string(),
+            scopes: vec!["agent:dispatch".to_string()],
+            tier: "anon".to_string(),
+        };
+        enforce("/v1/agent/stream", &t1)
+            .expect("anon tier with agent:dispatch scope must pass WS upgrade");
+    }
+
     #[test]
     fn enforce_ws_upgrade_without_dispatch_scope_rejected() {
         let t1 = Tier1Claims {

--- a/crates/life-runtime/lifegw/src/services/ws.rs
+++ b/crates/life-runtime/lifegw/src/services/ws.rs
@@ -287,6 +287,23 @@ struct UpgradeRequest {
     /// Original Tier-2 bearer header set by AuthLayer. Forwarded on
     /// the upstream `Agent.StreamSession` request via tonic metadata.
     tier2_bearer: Option<String>,
+    /// Subprotocol value to echo in the 101 response (BRO-1228).
+    ///
+    /// Per the WHATWG WebSockets spec, the browser rejects the upgrade
+    /// (close 1006) unless the response `Sec-WebSocket-Protocol` is one
+    /// of the values the client offered. If the client only offered
+    /// `bearer.<jwt>` (canonical browser-client behaviour — see
+    /// `lifed-ws-client.ts`), echoing the previously-hardcoded
+    /// `life.v1.agent` would silently break every browser session.
+    ///
+    /// Precedence when the client offered both: `life.v1.agent`
+    /// (preserves the pre-BRO-1228 wire shape Rust integration tests +
+    /// non-browser clients depend on); fall back to the matching
+    /// `bearer.<jwt>` entry only when `life.v1.agent` was NOT offered.
+    /// When neither is offered we suppress the response header entirely
+    /// — RFC 6455 §4.2.2 makes the response subprotocol optional, and
+    /// the browser only enforces equality when the header is present.
+    chosen_subprotocol: Option<String>,
 }
 
 /// Validate WS upgrade headers + extract the resume cursor. Returns
@@ -353,12 +370,66 @@ fn parse_upgrade_request<B>(
     // still sees the canonical header form.
     let tier2_bearer = bearer_from_authorization(req).or_else(|| bearer_from_subprotocol(req));
 
+    // BRO-1228: choose the subprotocol value the 101 response will
+    // echo. See `UpgradeRequest::chosen_subprotocol` doc for the
+    // precedence rule.
+    let chosen_subprotocol = choose_response_subprotocol(req);
+
     Ok(UpgradeRequest {
         sid,
         last_seq_no,
         sec_key,
         tier2_bearer,
+        chosen_subprotocol,
     })
+}
+
+/// Pick the subprotocol value to echo in the 101 response (BRO-1228).
+///
+/// Browser WebSocket implementations reject the upgrade (close 1006)
+/// unless the response `Sec-WebSocket-Protocol` is one of the values
+/// the client offered in its request `Sec-WebSocket-Protocol` header.
+/// Before BRO-1228 the gateway hardcoded `life.v1.agent`, which a
+/// browser-only client (offering only `bearer.<jwt>`) would reject.
+///
+/// Selection (matches `UpgradeRequest::chosen_subprotocol` precedence):
+///
+/// 1. If the client offered `life.v1.agent`, echo `life.v1.agent`.
+///    Preserves the pre-BRO-1228 wire shape Rust integration tests +
+///    non-browser clients depend on; matches Spec C₃ §6.1.
+/// 2. Else if the client offered a `bearer.<jwt>` entry, echo that
+///    entry verbatim — the browser must see one of its own offered
+///    values back, so we surface the bearer entry (which is also the
+///    only offered one for the canonical `LifedWsAgentSessionClient`
+///    case).
+/// 3. Else return `None` — the response omits the header. RFC 6455
+///    §4.2.2 makes the subprotocol response optional, and the browser
+///    only enforces equality when the header is present.
+fn choose_response_subprotocol<B>(req: &Request<B>) -> Option<String> {
+    let header = req.headers().get("sec-websocket-protocol")?.to_str().ok()?;
+    let mut bearer_choice: Option<String> = None;
+    for raw in header.split(',') {
+        let part = raw.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if part == "life.v1.agent" {
+            return Some("life.v1.agent".to_string());
+        }
+        if bearer_choice.is_none()
+            && let Some(token) = part.strip_prefix("bearer.")
+            && !token.is_empty()
+            && token
+                .chars()
+                .all(|c| !c.is_whitespace() && !c.is_control() && c != ',')
+        {
+            // Echo the FULL entry the client sent (`bearer.<jwt>`),
+            // not just the bare token — the browser compares the
+            // response value against its offered list verbatim.
+            bearer_choice = Some(part.to_string());
+        }
+    }
+    bearer_choice
 }
 
 /// Extract `Bearer <token>` from the `Authorization` header. Returns
@@ -425,7 +496,15 @@ fn query_param(query: &str, key: &str) -> Option<String> {
 }
 
 /// Build the 101 Switching Protocols response body.
-fn upgrade_response(sec_key: &str) -> Response<Body> {
+///
+/// `chosen_subprotocol` carries the negotiated subprotocol value
+/// (see `choose_response_subprotocol` for the precedence rule). When
+/// `None` we omit the header entirely — RFC 6455 §4.2.2 makes it
+/// optional, and the browser only enforces equality when present.
+/// When set, the value must already be one of the entries the client
+/// offered in its request `Sec-WebSocket-Protocol` header (otherwise
+/// the browser will reject the upgrade with close code 1006).
+fn upgrade_response(sec_key: &str, chosen_subprotocol: Option<&str>) -> Response<Body> {
     let accept_key = derive_accept_key(sec_key.as_bytes());
     let mut resp = Response::new(Body::empty());
     *resp.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
@@ -435,12 +514,21 @@ fn upgrade_response(sec_key: &str) -> Response<Body> {
     if let Ok(v) = HeaderValue::from_str(&accept_key) {
         h.insert("sec-websocket-accept", v);
     }
-    // Subprotocol negotiation per Spec C₃ §6.1: only `life.v1.agent`
-    // accepted.
-    h.insert(
-        "sec-websocket-protocol",
-        HeaderValue::from_static("life.v1.agent"),
-    );
+    // Subprotocol negotiation per Spec C₃ §6.1 + BRO-1228:
+    //   - Pre-BRO-1228 we hardcoded `life.v1.agent`. That broke
+    //     browser-only clients (canonical `LifedWsAgentSessionClient`
+    //     offers only `bearer.<jwt>`) because the response value MUST
+    //     be one of the offered values per the browser handshake.
+    //   - Post-BRO-1228 we echo whatever `choose_response_subprotocol`
+    //     picked — `life.v1.agent` if offered, else the `bearer.<jwt>`
+    //     entry if offered, else nothing. Rust integration tests that
+    //     offer `life.v1.agent` see no behaviour change; browser
+    //     clients that offer only `bearer.<jwt>` now succeed.
+    if let Some(value) = chosen_subprotocol
+        && let Ok(v) = HeaderValue::from_str(value)
+    {
+        h.insert("sec-websocket-protocol", v);
+    }
     resp
 }
 
@@ -518,7 +606,7 @@ pub fn handle_upgrade(
         }
     };
 
-    let response = upgrade_response(&parsed.sec_key);
+    let response = upgrade_response(&parsed.sec_key, parsed.chosen_subprotocol.as_deref());
 
     let on_upgrade = hyper::upgrade::on(&mut req);
     let connection = WsConnection {
@@ -1522,6 +1610,137 @@ mod tests {
         );
         let parsed = parse_upgrade_request(&req).expect("parse");
         assert!(parsed.tier2_bearer.is_none());
+    }
+
+    // ─── BRO-1228: chosen_subprotocol + upgrade_response 101 echo ──
+    //
+    // The browser rejects the WS upgrade (close 1006) unless the 101
+    // response's `Sec-WebSocket-Protocol` value is one of the entries
+    // the client offered. Before BRO-1228 we hardcoded `life.v1.agent`,
+    // which the canonical browser-side `LifedWsAgentSessionClient`
+    // (which offers ONLY `bearer.<jwt>`) would reject.
+
+    fn ws_req_for_subproto(subproto: &str) -> Request<Body> {
+        ws_req(
+            &[
+                ("upgrade", "websocket"),
+                ("connection", "Upgrade"),
+                ("sec-websocket-version", "13"),
+                ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
+                ("x-life-sid", "s"),
+                ("sec-websocket-protocol", subproto),
+            ],
+            WS_UPGRADE_PATH,
+        )
+    }
+
+    #[test]
+    fn chosen_subprotocol_prefers_life_v1_agent_when_offered() {
+        // Pre-BRO-1228 wire shape: clients that offer the named
+        // subprotocol get the same negotiated value back — zero
+        // behaviour change for the Rust + non-browser path.
+        let req = ws_req_for_subproto("life.v1.agent");
+        let parsed = parse_upgrade_request(&req).expect("parse");
+        assert_eq!(parsed.chosen_subprotocol.as_deref(), Some("life.v1.agent"));
+    }
+
+    #[test]
+    fn chosen_subprotocol_falls_back_to_bearer_entry_when_only_bearer_offered() {
+        // Canonical broken-prod case BRO-1228 fixes: the browser
+        // `LifedWsAgentSessionClient` only offers `bearer.<jwt>`. The
+        // server MUST echo that exact entry so the browser accepts
+        // the upgrade.
+        let req = ws_req_for_subproto("bearer.eyJabc.def.ghi");
+        let parsed = parse_upgrade_request(&req).expect("parse");
+        assert_eq!(
+            parsed.chosen_subprotocol.as_deref(),
+            Some("bearer.eyJabc.def.ghi"),
+        );
+    }
+
+    #[test]
+    fn chosen_subprotocol_picks_life_v1_agent_when_both_offered() {
+        // When the client offers both we prefer `life.v1.agent` so the
+        // wire shape stays uniform with pre-BRO-1228 traffic. The
+        // bearer entry is still consumed by `bearer_from_subprotocol`
+        // (for AuthLayer's Tier-1 verify); the negotiated subprotocol
+        // is a separate concern (browser ack).
+        for header in [
+            "life.v1.agent, bearer.eyJabc.def.ghi",
+            "bearer.eyJabc.def.ghi, life.v1.agent",
+        ] {
+            let req = ws_req_for_subproto(header);
+            let parsed = parse_upgrade_request(&req).expect("parse");
+            assert_eq!(
+                parsed.chosen_subprotocol.as_deref(),
+                Some("life.v1.agent"),
+                "header {header:?} must echo life.v1.agent",
+            );
+        }
+    }
+
+    #[test]
+    fn chosen_subprotocol_returns_none_when_no_subprotocol_header() {
+        // No `Sec-WebSocket-Protocol` header → we suppress the echo.
+        // RFC 6455 §4.2.2 makes the response optional; the browser
+        // only enforces equality when present.
+        let req = ws_req(
+            &[
+                ("upgrade", "websocket"),
+                ("connection", "Upgrade"),
+                ("sec-websocket-version", "13"),
+                ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
+                ("x-life-sid", "s"),
+            ],
+            WS_UPGRADE_PATH,
+        );
+        let parsed = parse_upgrade_request(&req).expect("parse");
+        assert!(parsed.chosen_subprotocol.is_none());
+    }
+
+    #[test]
+    fn chosen_subprotocol_skips_malformed_bearer_entries() {
+        // A `bearer.<malformed>` entry must NOT be echoed (browser
+        // would still accept since it's one of the offered values,
+        // but echoing malformed material is a leaking-bug). When the
+        // only entries are malformed we surface None.
+        let req = ws_req_for_subproto("bearer.,bearer.has space");
+        let parsed = parse_upgrade_request(&req).expect("parse");
+        assert!(parsed.chosen_subprotocol.is_none());
+    }
+
+    #[test]
+    fn upgrade_response_echoes_chosen_subprotocol() {
+        // The end-to-end behaviour: when we pick a subprotocol value
+        // the 101 response carries it in `Sec-WebSocket-Protocol`.
+        let resp = upgrade_response("dGhlIHNhbXBsZSBub25jZQ==", Some("bearer.eyJabc.def.ghi"));
+        assert_eq!(resp.status(), StatusCode::SWITCHING_PROTOCOLS);
+        let header = resp
+            .headers()
+            .get("sec-websocket-protocol")
+            .expect("subprotocol header set");
+        assert_eq!(header.to_str().expect("ascii"), "bearer.eyJabc.def.ghi");
+        // Upgrade + Connection still set so hyper performs the upgrade.
+        assert_eq!(
+            resp.headers().get("upgrade").map(|v| v.to_str().unwrap()),
+            Some("websocket"),
+        );
+        assert_eq!(
+            resp.headers()
+                .get("connection")
+                .map(|v| v.to_str().unwrap()),
+            Some("Upgrade"),
+        );
+    }
+
+    #[test]
+    fn upgrade_response_omits_subprotocol_when_none_chosen() {
+        // No chosen subprotocol → the header is absent. The browser
+        // accepts the upgrade unconditionally in that case (per
+        // RFC 6455 §4.2.2).
+        let resp = upgrade_response("dGhlIHNhbXBsZSBub25jZQ==", None);
+        assert_eq!(resp.status(), StatusCode::SWITCHING_PROTOCOLS);
+        assert!(resp.headers().get("sec-websocket-protocol").is_none());
     }
 
     #[test]

--- a/crates/life-runtime/lifegw/tests/integration_ws_bidi.rs
+++ b/crates/life-runtime/lifegw/tests/integration_ws_bidi.rs
@@ -299,6 +299,164 @@ async fn ws_slow_consumer_eventually_closes() {
 }
 
 #[tokio::test]
+async fn ws_upgrade_with_subprotocol_bearer_succeeds() {
+    // BRO-1228: browser-style WS clients can't set the Authorization
+    // header on `new WebSocket(...)` — the platform doesn't expose
+    // request headers to the constructor. The canonical browser
+    // pattern (matching `LifedWsAgentSessionClient`) is to pass the
+    // bearer as a `Sec-WebSocket-Protocol: bearer.<jwt>` entry.
+    //
+    // Before BRO-1228 the AuthLayer only consulted the Authorization
+    // header, so this upgrade returned `missing Tier-1 bearer token`
+    // — breaking every `/api/chat` turn through broomva.tech after
+    // PR-3 of BRO-1208 routed it through lifegw.
+    //
+    // This integration test asserts:
+    //   1. The upgrade succeeds (AuthLayer extracts the bearer from
+    //      the subprotocol header).
+    //   2. The 101 response echoes a subprotocol value the browser
+    //      offered (here `bearer.<jwt>` — without this echo the
+    //      browser closes the WS with 1006 before handing it to JS).
+    //   3. A `send_message` frame round-trips to lifed and produces
+    //      an `agent_event` frame back (so the bearer survives the
+    //      Tier-1 → Tier-2 rewrite into the upstream `Agent.*` call).
+    let env = TestEnv::start().await;
+    let sid = env.create_session("user-ws-subproto").await;
+
+    // Mirror the browser-side `LifedWsAgentSessionClient`: ONLY the
+    // subprotocol header carries the bearer; NO `authorization`
+    // header. `dev-token-for-X` rides inside the bearer entry so the
+    // dev signer accepts it without a real JWKS round-trip.
+    let token = format!("dev-token-for-ws-subproto-{sid}");
+    let subprotocol = format!("bearer.{token}");
+    let req = HttpRequest::builder()
+        .method("GET")
+        .uri(format!("wss://localhost/v1/agent/stream?sid={sid}"))
+        .header("host", "localhost")
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-protocol", subprotocol.as_str())
+        // NB: NO Authorization header — the whole point of this test.
+        .body(())
+        .expect("ws req");
+
+    let tls = tls_dial(env.lifegw_addr, &env.cert_pem)
+        .await
+        .expect("tls dial");
+    let (mut ws, resp) = client_async(req, tls)
+        .await
+        .expect("ws upgrade must succeed when bearer rides Sec-WebSocket-Protocol");
+
+    // Acceptance criterion #2: the 101 response must echo a
+    // subprotocol value the client offered. The browser side
+    // (WHATWG WebSockets) rejects the connection with 1006 if the
+    // response carries a value NOT in the offered list. We offered
+    // only `bearer.<token>` so the gateway must echo exactly that.
+    let echoed = resp
+        .headers()
+        .get("sec-websocket-protocol")
+        .map(|v| v.to_str().expect("ascii subprotocol").to_string());
+    assert_eq!(
+        echoed.as_deref(),
+        Some(subprotocol.as_str()),
+        "101 response must echo the offered subprotocol verbatim",
+    );
+
+    // Acceptance criterion #3: the upgrade actually serves traffic —
+    // bearer survives the Tier-1 → Tier-2 rewrite into the upstream.
+    let frame = serde_json::json!({
+        "kind": "send_message",
+        "content": "hello via bearer.<jwt> subprotocol",
+    });
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send WS frame");
+
+    let mut got_event = false;
+    let timeout = tokio::time::sleep(Duration::from_secs(5));
+    tokio::pin!(timeout);
+    loop {
+        tokio::select! {
+            _ = &mut timeout => break,
+            msg = ws.next() => match msg {
+                Some(Ok(Message::Text(text))) => {
+                    let v: serde_json::Value =
+                        serde_json::from_str(&text).expect("valid json envelope");
+                    if v["kind"].as_str() == Some("agent_event") {
+                        got_event = true;
+                        break;
+                    }
+                }
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Err(_)) => break,
+                _ => continue,
+            }
+        }
+    }
+    assert!(
+        got_event,
+        "subprotocol-bearer upgrade must stream agent_event frames",
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn ws_upgrade_with_mixed_subprotocol_picks_life_v1_agent_echo() {
+    // BRO-1228 follow-up: when the client offers BOTH
+    // `life.v1.agent` and `bearer.<jwt>` we echo `life.v1.agent` (the
+    // pre-BRO-1228 wire shape Rust integration tests depend on).
+    // The bearer entry is still consumed by AuthLayer for Tier-1.
+    let env = TestEnv::start().await;
+    let sid = env.create_session("user-ws-mixed-subproto").await;
+
+    let token = format!("dev-token-for-ws-mixed-{sid}");
+    let subprotocol = format!("life.v1.agent, bearer.{token}");
+    let req = HttpRequest::builder()
+        .method("GET")
+        .uri(format!("wss://localhost/v1/agent/stream?sid={sid}"))
+        .header("host", "localhost")
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-protocol", subprotocol.as_str())
+        .body(())
+        .expect("ws req");
+
+    let tls = tls_dial(env.lifegw_addr, &env.cert_pem)
+        .await
+        .expect("tls dial");
+    let (mut ws, resp) = client_async(req, tls).await.expect("ws upgrade");
+
+    let echoed = resp
+        .headers()
+        .get("sec-websocket-protocol")
+        .map(|v| v.to_str().expect("ascii subprotocol").to_string());
+    assert_eq!(
+        echoed.as_deref(),
+        Some("life.v1.agent"),
+        "mixed offer prefers life.v1.agent over the bearer entry",
+    );
+
+    // Best-effort polite close so the gateway doesn't surface a
+    // backpressure log noise warning during the test teardown.
+    let _ = ws
+        .send(Message::Close(Some(
+            tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                code: CloseCode::Normal,
+                reason: "test_done".into(),
+            },
+        )))
+        .await;
+    drop(ws);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
 async fn ws_upgrade_without_sid_returns_400() {
     // Spec deviation (BRO-938 C1): the user prompt path
     // /v1/agent/stream does not embed sid in the URL. We require


### PR DESCRIPTION
## Summary — CRITICAL prod-broken fix

`broomva.tech#194` routed `/api/chat` through lifegw. Anon dogfood reveals every chat turn fails immediately with:

```
data: {"type":"error","errorText":"lifed-ws.transport_error: "}
```

Railway log of the failing WS upgrade at `2026-05-22T00:06:36.988`: request carries the Tier-1 JWT in `Sec-WebSocket-Protocol: bearer.<jwt>` (decoded: `{tier:"anon", scopes:["agent:dispatch"], sub:"anon:019e4d01-…", aud:"lifegw"}`); lifegw responds `grpc-status: 16, grpc-message: "missing Tier-1 bearer token"`.

## Root cause

`crates/life-runtime/lifegw/src/auth/middleware.rs:205-224` only checks the `Authorization` header. Browser-style WebSocket cannot set Authorization on the upgrade request — the WHATWG WebSockets spec disallows it — so every WS client documents `Sec-WebSocket-Protocol: bearer.<token>` as the carrier (RFC 6455 §1.9, §11.3.4). The canonical `LifedWsAgentSessionClient` already uses this fallback — see `lifed-ws-client.ts:470` (`const protocols = [\`bearer.${input.capability.token}\`]`).

A second, latent bug surfaces once the auth fix lands: `upgrade_response` hardcoded `Sec-WebSocket-Protocol: life.v1.agent` in the 101 reply, but the browser closes the WS with `1006` if the response sub-protocol isn't in the offered list. The canonical browser client only offers `bearer.<jwt>`, so without the 101 echo fix the connection would still die — just with a different symptom.

## Blast radius

**All chat through broomva.tech is broken in production, not just anon.** Same client, same WS upgrade, same carrier — logged-in users see the same `missing Tier-1 bearer token` error. The `/v1/messages` + `/v1/chat/completions` external surfaces use a different code path (HTTP, not WS) and are unaffected.

## Fix

`crates/life-runtime/lifegw/src/auth/middleware.rs`:
- Extract bearer from `Sec-WebSocket-Protocol: bearer.<jwt>` as fallback when `Authorization` absent.
- Authorization wins if both present (no behavior change for existing callers).
- Token-shape gate: reject `bearer.<X>` entries with whitespace/control-chars/commas inside `X` (JWS alphabet is URL-safe-base64-only). Malformed entries surface as `None` so the canonical "missing Tier-1 bearer token" message still fires.
- All existing failure-mode messages preserved verbatim — monitoring/log greps stay intact.

`crates/life-runtime/lifegw/src/services/ws.rs`:
- New `choose_response_subprotocol` helper applies the WHATWG rule: echo a value the client actually offered. Precedence: `life.v1.agent` if offered (preserves pre-BRO-1228 Rust integration-test wire shape), else the `bearer.<jwt>` entry, else omit the header (RFC 6455 §4.2.2 — the response subprotocol is optional and the browser only enforces equality when present).
- `upgrade_response` now takes the chosen subprotocol; default of `None` omits the header instead of echoing a value that may not have been offered.

`crates/life-runtime/lifegw/src/auth/scope.rs`:
- Added a regression test that the broken-prod token shape from the Railway log (`tier: "anon"`, `scopes: ["agent:dispatch"]`) passes `enforce("/v1/agent/stream", &t1)`. Confirms the scope check is purely scope-string-based — the tier label is informational only.

## Tests

19 new tests covering every path BRO-1228 names:

| Layer | Count | Notes |
|---|---|---|
| `auth/middleware.rs` unit | 9 | All 5 acceptance-criteria failure modes + dev-token shape + end-to-end JwksCache round-trip |
| `services/ws.rs` unit | 7 | `choose_response_subprotocol` precedence rule + `upgrade_response` 101 header presence/absence |
| `auth/scope.rs` unit | 1 | Anon-tier sanity check |
| `integration_ws_bidi.rs` integration | 2 | Browser-style WS upgrade through the full TLS+tonic+ws stack, with the 101-response echo asserted and a `send_message` round-trip to lifed |

Total lifegw test suite: 259 → 278 (all green).

## Validation
- [x] `cargo build -p lifegw --release` — green
- [x] `cargo test -p lifegw` — 278 / 278 passing (was 259), 0 failures, 5 ignored
- [x] `cargo clippy -p lifegw --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p lifegw --check` — clean
- [ ] After merge: Railway auto-redeploys lifegw
- [ ] Production smoke: anon `/api/chat` against `https://broomva.tech` → SSE streams real tokens (no `lifed-ws.transport_error`)

Closes BRO-1228. Unblocks BRO-1208 final dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)