### PR TITLE
fix(caddy): explicitly forward Sec-WebSocket-Protocol upstream [BRO-1228]

### DIFF
--- a/deploy/railway/lifegw-stack/Caddyfile
+++ b/deploy/railway/lifegw-stack/Caddyfile
@@ -54,6 +54,14 @@
 	reverse_proxy @websocket https://127.0.0.1:8443 {
 		header_up Connection Upgrade
 		header_up Upgrade websocket
+		# Explicitly forward Sec-WebSocket-Protocol upstream. Caddy's
+		# default reverse_proxy strips some hop-by-hop headers during a
+		# WebSocket upgrade; the bearer carrier MUST reach lifegw's
+		# auth middleware (see crates/life-runtime/lifegw/src/auth/
+		# middleware.rs:bearer_from_subprotocol, BRO-1228) or browser-
+		# style WS upgrades degrade to "missing Tier-1 bearer token"
+		# even when the client offered bearer.<jwt> as a sub-protocol.
+		header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
 		transport http {
 			tls_insecure_skip_verify
 			versions 1.1


### PR DESCRIPTION
## Summary — completes BRO-1228 fix

[BRO-1228 / #1433](https://github.com/broomva/life/pull/1433) extended lifegw's auth middleware to extract the Tier-1 bearer from \`Sec-WebSocket-Protocol: bearer.<jwt>\` on browser-style WS upgrades. After the build deployed, **the middleware never sees the header** — Caddy's default reverse_proxy strips \`Sec-WebSocket-Protocol\` on the upstream hop during WS upgrade.

## Diagnostic probe

\`\`\`bash
$ curl -i --http1.1 \
    -H "Upgrade: websocket" -H "Connection: Upgrade" \
    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
    -H "Sec-WebSocket-Version: 13" \
    -H "Sec-WebSocket-Protocol: bearer.junk" \
    https://life.broomva.tech/v1/agent/stream

HTTP/1.1 200 OK
Grpc-Message: missing Tier-1 bearer token   ← expected: "invalid Tier-1 bearer"
Grpc-Status: 16
\`\`\`

The \`missing\` branch only fires when bearer is None. The new code path (\`or_else(bearer_from_subprotocol)\`) ran, the header lookup returned None — proving Caddy didn't forward Sec-WebSocket-Protocol to upstream lifegw.

## Fix

Single line in the @websocket reverse_proxy block:

\`\`\`caddy
header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
\`\`\`

Mirrors the existing \`header_up Connection Upgrade\` + \`header_up Upgrade websocket\` workarounds that exist because Railway's edge proxy also strips those headers on its way in.

## Test plan

- [ ] CI green
- [ ] Railway auto-redeploys lifegw-stack (Caddyfile-only diff; no Rust rebuild needed but Docker layer rebuilds from COPY)
- [ ] Post-deploy probe: same curl as above → \`Grpc-Message: "invalid Tier-1 bearer"\` (proves header passes through)
- [ ] Final anon dogfood: \`POST https://broomva.tech/api/chat\` (anon flow) → SSE streams real tokens, no \`lifed-ws.transport_error\`

Closes the BRO-1228 follow-up. Unblocks BRO-1208 final dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebSocket reverse-proxy configuration for agent streaming endpoints to properly forward required authentication protocol headers upstream. This resolves connection failures that previously occurred during WebSocket protocol upgrade negotiation. The proxy now correctly handles subprotocol header forwarding, ensuring reliable agent stream authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->