### PR TITLE
fix(caddy/lifegw): correctly forward Sec-WebSocket-Protocol upstream + bearer-extraction trace [BRO-1228]

### DIFF
--- a/crates/life-runtime/lifegw/src/auth/middleware.rs
+++ b/crates/life-runtime/lifegw/src/auth/middleware.rs
@@ -218,6 +218,25 @@ where
             // Authorization wins when both are present so a forwarded
             // chain that copies the bearer twice always trusts the
             // canonical header form.
+            //
+            // BRO-1228 defense-in-depth (PR #1435): debug-level trace of
+            // what auth carriers actually arrived. Browser-WS upgrades
+            // ride `Sec-WebSocket-Protocol: bearer.<jwt>`; if any L7 in
+            // front strips that header (Caddy mis-config, Railway edge,
+            // Vercel rewrite), the only diagnostic was a generic
+            // "missing Tier-1 bearer token" grpc message. With this
+            // trace, `RUST_LOG=lifegw::auth=debug` surfaces the exact
+            // header state per request so future regressions are
+            // grepable in Railway logs without re-deploying instrumented
+            // builds.
+            tracing::debug!(
+                has_authorization = req.headers().contains_key("authorization"),
+                has_subprotocol = req.headers().contains_key("sec-websocket-protocol"),
+                subprotocol_value = ?req.headers().get("sec-websocket-protocol").and_then(|v| v.to_str().ok()),
+                path = req.uri().path(),
+                method = %req.method(),
+                "tier1 bearer extraction"
+            );
             let bearer = bearer_from_authorization(&req).or_else(|| bearer_from_subprotocol(&req));
 
             // `dev_signer_enabled` is informational here — both code

--- a/deploy/railway/lifegw-stack/Caddyfile
+++ b/deploy/railway/lifegw-stack/Caddyfile
@@ -54,14 +54,32 @@
 	reverse_proxy @websocket https://127.0.0.1:8443 {
 		header_up Connection Upgrade
 		header_up Upgrade websocket
-		# Explicitly forward Sec-WebSocket-Protocol upstream. Caddy's
-		# default reverse_proxy strips some hop-by-hop headers during a
-		# WebSocket upgrade; the bearer carrier MUST reach lifegw's
-		# auth middleware (see crates/life-runtime/lifegw/src/auth/
-		# middleware.rs:bearer_from_subprotocol, BRO-1228) or browser-
-		# style WS upgrades degrade to "missing Tier-1 bearer token"
-		# even when the client offered bearer.<jwt> as a sub-protocol.
-		header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
+		# Sec-WebSocket-Protocol passes through automatically.
+		#
+		# BRO-1228 PR #1434 tried to make this explicit with
+		# `header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}`,
+		# but `{>Header-Name}` is NOT a documented Caddyfile placeholder
+		# (https://caddyserver.com/docs/caddyfile/concepts §Placeholders
+		# lists `{header.*}` → `{http.request.header.*}` as the only
+		# header shorthand; `>` is a `header` directive prefix meaning
+		# "set with defer", never a placeholder operator). The undefined
+		# placeholder resolved to empty string, and the `header_up`
+		# directive *overwrote* the header that Caddy already forwards
+		# by default — producing the empty-bearer outcome the original
+		# PR was trying to prevent.
+		#
+		# Caddy's reverse_proxy preserves Sec-WebSocket-Protocol natively:
+		# the hop-by-hop strip in `modules/caddyhttp/reverseproxy/
+		# reverseproxy.go` removes Connection/Keep-Alive/Proxy-* but
+		# explicitly normalizes WebSocket headers (including
+		# Sec-WebSocket-Protocol) to RFC 6455 casing on the way through.
+		# The right fix is to remove the broken directive entirely.
+		#
+		# Diagnostic helper if this regresses: enable
+		# `RUST_LOG=lifegw::auth=debug` on lifegw to log
+		# `has_subprotocol` / `subprotocol_value` per inbound request
+		# (see crates/life-runtime/lifegw/src/auth/middleware.rs
+		# bearer-extraction tracing).
 		transport http {
 			tls_insecure_skip_verify
 			versions 1.1


### PR DESCRIPTION
## Summary — completes BRO-1228 prod-broken thread (after PR #1433 + #1434)

PR [#1433](https://github.com/broomva/life/pull/1433) extended lifegw's auth middleware to extract the Tier-1 bearer from `Sec-WebSocket-Protocol: bearer.<jwt>` on browser-style WS upgrades. PR [#1434](https://github.com/broomva/life/pull/1434) tried to make Caddy's forwarding of that header explicit. **Both merged, Railway deployed `5a5e6ef9`, but the fix was still incomplete** — the empirical probe still returns `missing Tier-1 bearer token` instead of `invalid Tier-1 bearer`.

## Root cause

PR #1434 used `header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}`. The `{>Header-Name}` form is **NOT a documented Caddyfile placeholder**.

Per [Caddyfile Concepts §Placeholders](https://caddyserver.com/docs/caddyfile/concepts), the only documented shorthand for reading a request header is:

> `{header.X}` → `{http.request.header.X}`

The `>` character is a directive prefix on the `header` directive ("set with defer"), never a placeholder operator. PR #1434's `{>Sec-WebSocket-Protocol}` resolved to an **undefined placeholder** which produced an empty string — and `header_up` then *overwrote* the value Caddy already forwards by default, producing the exact empty-bearer outcome the PR was trying to prevent.

## Why removing the directive is the right fix (not switching to `{header.X}`)

Caddy's `reverse_proxy` already preserves `Sec-WebSocket-Protocol` natively. From [`modules/caddyhttp/reverseproxy/reverseproxy.go`](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/reverseproxy.go):

- Hop-by-hop strip removes `Connection` / `Keep-Alive` / `Proxy-*` only.
- A normalization map explicitly preserves WebSocket headers and rewrites them to RFC 6455 casing: `"Sec-Websocket-Protocol": "Sec-WebSocket-Protocol"`.

So `Sec-WebSocket-Protocol` is **never stripped**. The PR #1434 `header_up` line was solving a non-problem and broke the natural pass-through. Removing it restores correct behavior. Adding `header_up Sec-WebSocket-Protocol {header.Sec-WebSocket-Protocol}` (the documented form) would also work but is redundant noise — strictly less code is the cleaner fix.

## Defense in depth: tracing at the bearer-extraction site

Adds a `tracing::debug!` call inside `AuthService::call` in `crates/life-runtime/lifegw/src/auth/middleware.rs`. The next time a fronting L7 strips this header, operators can grep Railway logs with `RUST_LOG=lifegw::auth=debug` and see exactly what arrived:

```
tier1 bearer extraction has_authorization=true has_subprotocol=false subprotocol_value=None path=/v1/agent/stream method=GET
```

Debug-level (not info) — won't spam prod by default but is grepable when toggled.

## Test plan

- [ ] CI green (Cargo build, test, clippy, fmt — covers Rust diff)
- [ ] Railway auto-redeploys lifegw-stack (Caddyfile + Rust diff; Docker layer rebuilds)
- [ ] Post-deploy probe:
  ```bash
  curl -i --http1.1 \
    -H "Connection: Upgrade" -H "Upgrade: websocket" \
    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
    -H "Sec-WebSocket-Version: 13" \
    -H "Sec-WebSocket-Protocol: bearer.junk-token-payload" \
    https://life.broomva.tech/v1/agent/stream
  ```
  Expect `Grpc-Message: invalid Tier-1 bearer` (NOT `missing`)
- [ ] Anon dogfood through `broomva.tech /api/chat` → SSE stream of real tokens (not `lifed-ws.transport_error`)

## Files changed

- `deploy/railway/lifegw-stack/Caddyfile` — remove broken `header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}`; add inline comment with the diagnosis so future agents don't re-add it
- `crates/life-runtime/lifegw/src/auth/middleware.rs` — add `tracing::debug!` at bearer extraction

## Local validation

- `cargo fmt -p lifegw --check` — clean
- `cargo check -p lifegw` — clean (full compile)
- `cargo test -p lifegw --lib` — couldn't run locally (disk exhaustion in env), but existing 9 BRO-1228 bearer-extraction tests in `middleware.rs` cover the affected code; CI will validate

Closes the BRO-1228 follow-up. Unblocks BRO-1208 final anon dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)