### PR TITLE
chore(ergon): cargo fmt new adapter crates (post-#1441)

### DIFF
--- a/crates/ergon/ergon-anima-adapter/src/lib.rs
+++ b/crates/ergon/ergon-anima-adapter/src/lib.rs
@@ -28,10 +28,7 @@ pub trait AgentAttestationSigner: Send + Sync {
     /// Sign a step receipt. The receipt is opaque to this trait — the
     /// adapter chooses how to canonicalize before signing. Errors are
     /// non-fatal at the hook layer (same contract as `SoulAttester`).
-    async fn sign_step_receipt(
-        &self,
-        receipt: &Value,
-    ) -> std::result::Result<String, String>;
+    async fn sign_step_receipt(&self, receipt: &Value) -> std::result::Result<String, String>;
 }
 
 /// Adapter — wraps an `Arc<dyn AnimaCustody>` and implements both
@@ -62,10 +59,7 @@ impl AgentAttestationAdapter {
 
 #[async_trait]
 impl AgentAttestationSigner for AgentAttestationAdapter {
-    async fn sign_step_receipt(
-        &self,
-        _receipt: &Value,
-    ) -> std::result::Result<String, String> {
+    async fn sign_step_receipt(&self, _receipt: &Value) -> std::result::Result<String, String> {
         // Implementation follow-up tracked in BRO-1226 implementation
         // ticket (filed after the ADR review pass).
         //

--- a/crates/ergon/ergon-nous-adapter/src/lib.rs
+++ b/crates/ergon/ergon-nous-adapter/src/lib.rs
@@ -57,10 +57,7 @@ impl NousAdapter {
 
 #[async_trait]
 impl ResponseScorer for NousAdapter {
-    async fn score(
-        &self,
-        _response: &ModelResponse,
-    ) -> Result<Value, String> {
+    async fn score(&self, _response: &ModelResponse) -> Result<Value, String> {
         // Implementation follow-up tracked in BRO-1225 implementation
         // ticket (filed after the ADR review pass).
         //


### PR DESCRIPTION
Trivial follow-up to PR #1441. The Format CI check flagged 3 multi-line async-fn signatures in the new `ergon-nous-adapter` and `ergon-anima-adapter` skeleton crates — rustfmt prefers single-line for these.

PR #1441 merged via auto-merge before Format completed (Format isn't a required check in this repo, so the merge proceeded). This restores green Format CI on main.

## Diff

```
crates/ergon/ergon-anima-adapter/src/lib.rs   2 multi-line → single-line async fn signatures
crates/ergon/ergon-nous-adapter/src/lib.rs    1 multi-line → single-line async fn signature
```

## Validation

```
cargo fmt --check -p ergon-nous-adapter -p ergon-anima-adapter  # OK
```

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)