### PR TITLE
feat(arcan-proxy): per-chunk + per-emit tracing on VercelAiGatewayArcan [BRO-1234 PR-2]

### DIFF
--- a/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
+++ b/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
@@ -232,6 +232,27 @@ impl ArcanCall for VercelAiGatewayArcan {
         // BRO-1206: per-call model override → outbound request body.
         // `None` / empty falls back to `self.cfg.model` (env-bound).
         let body = self.build_request_body(content, model);
+
+        // BRO-1234: trace the substrate boundary so a silent gateway
+        // hang is distinguishable from a substrate-never-fires hang in
+        // production logs. The previous incarnation of this module
+        // emitted no log on entry / response → the broomva.tech-side
+        // dogfood saw "3 frames then silence" with no upstream signal
+        // to disambiguate H4 (gateway stalls) / H5 (parser bug) /
+        // H6 (ws-pump drops). These info lines + the per-chunk +
+        // per-emit logs in `parse_sse_token_stream` give every step
+        // of the body pump a name.
+        let t_start = std::time::Instant::now();
+        let resolved_model = model
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or(&self.cfg.model);
+        tracing::info!(
+            sid = sid,
+            model = resolved_model,
+            content_len = content.len(),
+            url = %url,
+            "arcan.dispatch_message: starting",
+        );
         let resp = self
             .client
             .post(&url)
@@ -240,16 +261,38 @@ impl ArcanCall for VercelAiGatewayArcan {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ArcanProxyError::Transport(format!("POST {url}: {e}")))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
+            .map_err(|e| {
+                tracing::warn!(
+                    sid = sid,
+                    elapsed_ms = t_start.elapsed().as_millis() as u64,
+                    error = %e,
+                    "arcan.dispatch_message: gateway send failed",
+                );
+                ArcanProxyError::Transport(format!("POST {url}: {e}"))
+            })?;
+        let resp_elapsed_ms = t_start.elapsed().as_millis() as u64;
+        let status = resp.status();
+        if !status.is_success() {
             let bytes = resp.bytes().await.unwrap_or_default();
             let body_preview = String::from_utf8_lossy(&bytes);
+            tracing::warn!(
+                sid = sid,
+                status = status.as_u16(),
+                elapsed_ms = resp_elapsed_ms,
+                body_preview = %truncate_body(&body_preview, 128),
+                "arcan.dispatch_message: gateway returned non-2xx",
+            );
             return Err(ArcanProxyError::Transport(format!(
                 "POST {url} returned HTTP {status}: {}",
                 truncate_body(&body_preview, 256)
             )));
         }
+        tracing::info!(
+            sid = sid,
+            status = status.as_u16(),
+            elapsed_ms = resp_elapsed_ms,
+            "arcan.dispatch_message: gateway responded — attaching SSE parser",
+        );
 
         // Stream parser: SSE-style lines `data: {json}\n\n` with
         // `data: [DONE]\n\n` as the terminal marker.
@@ -286,6 +329,56 @@ struct ChatCompletionDelta {
     content: Option<String>,
 }
 
+/// Per-stream observability state threaded through the unfold
+/// closure. BRO-1234: gives every body-pump + emit boundary a named
+/// log line so a production dogfood can distinguish "gateway stops
+/// sending bytes" from "parser stops emitting events" from
+/// "downstream ws pump drops frames."
+struct ParserMetrics {
+    /// `sid` extracted from `session_id.value` so every log line
+    /// correlates with the lifegw saga / WS upgrade for the same chat.
+    sid: String,
+    /// Wall clock at which `parse_sse_token_stream` started consuming.
+    /// `Instant::elapsed()` measures time-to-first-chunk and time
+    /// between chunks — the key signal for distinguishing a gateway-
+    /// side stall from a parser bug.
+    t_start: std::time::Instant,
+    /// Set on each `body.next() → Some(Ok(chunk))`. `None` before the
+    /// first chunk arrives. The `pre-await` log line surfaces
+    /// `ms_since_last_chunk` so a long gap is immediately visible
+    /// even if the await itself never resolves.
+    last_chunk_at: Option<std::time::Instant>,
+    chunk_count: u64,
+    emit_count: u64,
+    total_bytes: u64,
+}
+
+impl ParserMetrics {
+    fn new(sid: String) -> Self {
+        Self {
+            sid,
+            t_start: std::time::Instant::now(),
+            last_chunk_at: None,
+            chunk_count: 0,
+            emit_count: 0,
+            total_bytes: 0,
+        }
+    }
+
+    fn ms_since_start(&self) -> u64 {
+        self.t_start.elapsed().as_millis() as u64
+    }
+
+    /// Returns `ms_since_last_chunk` when at least one chunk has
+    /// arrived, otherwise `ms_since_start` (so the first pre-await
+    /// log still shows useful elapsed time).
+    fn ms_since_last_chunk_or_start(&self) -> u64 {
+        self.last_chunk_at
+            .map(|t| t.elapsed().as_millis() as u64)
+            .unwrap_or_else(|| self.ms_since_start())
+    }
+}
+
 /// Convert a streaming HTTP body into a stream of `AgentEvent`s.
 ///
 /// SSE framing: `\n\n`-delimited records, each line beginning with
@@ -303,12 +396,13 @@ where
     let buffer = Vec::new();
     let sequence: u64 = 0;
     let done = false;
+    let metrics = ParserMetrics::new(session_id.value.clone());
     let body: Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send>> =
         Box::pin(body);
 
     Box::pin(stream::unfold(
-        (body, buffer, sequence, done, session_id),
-        move |(mut body, mut buffer, mut sequence, mut done, session_id)| async move {
+        (body, buffer, sequence, done, session_id, metrics),
+        move |(mut body, mut buffer, mut sequence, mut done, session_id, mut metrics)| async move {
             if done {
                 return None;
             }
@@ -329,6 +423,16 @@ where
                         if payload == "[DONE]" {
                             done = true;
                             sequence += 1;
+                            metrics.emit_count += 1;
+                            tracing::info!(
+                                sid = %metrics.sid,
+                                seq = sequence,
+                                emit_count = metrics.emit_count,
+                                chunk_count = metrics.chunk_count,
+                                total_bytes = metrics.total_bytes,
+                                elapsed_ms = metrics.ms_since_start(),
+                                "arcan.parse: emit FINISH (reason=stop, [DONE] sentinel)",
+                            );
                             let finish_event = AgentEvent {
                                 record: Some(EventRecord {
                                     session_id: Some(session_id.clone()),
@@ -344,7 +448,7 @@ where
                             };
                             return Some((
                                 Ok(finish_event),
-                                (body, buffer, sequence, done, session_id),
+                                (body, buffer, sequence, done, session_id, metrics),
                             ));
                         }
                         if payload.is_empty() {
@@ -364,6 +468,18 @@ where
                                 }
                                 if !delta_text.is_empty() {
                                     sequence += 1;
+                                    metrics.emit_count += 1;
+                                    let delta_len = delta_text.len();
+                                    tracing::info!(
+                                        sid = %metrics.sid,
+                                        seq = sequence,
+                                        emit_count = metrics.emit_count,
+                                        delta_len,
+                                        chunk_count = metrics.chunk_count,
+                                        total_bytes = metrics.total_bytes,
+                                        elapsed_ms = metrics.ms_since_start(),
+                                        "arcan.parse: emit TOKEN",
+                                    );
                                     let token_event = AgentEvent {
                                         record: Some(EventRecord {
                                             session_id: Some(session_id.clone()),
@@ -379,12 +495,23 @@ where
                                     };
                                     return Some((
                                         Ok(token_event),
-                                        (body, buffer, sequence, done, session_id),
+                                        (body, buffer, sequence, done, session_id, metrics),
                                     ));
                                 }
                                 if let Some(reason) = finish_reason {
                                     done = true;
                                     sequence += 1;
+                                    metrics.emit_count += 1;
+                                    tracing::info!(
+                                        sid = %metrics.sid,
+                                        seq = sequence,
+                                        emit_count = metrics.emit_count,
+                                        reason = %reason,
+                                        chunk_count = metrics.chunk_count,
+                                        total_bytes = metrics.total_bytes,
+                                        elapsed_ms = metrics.ms_since_start(),
+                                        "arcan.parse: emit FINISH (finish_reason from delta)",
+                                    );
                                     let finish_event = AgentEvent {
                                         record: Some(EventRecord {
                                             session_id: Some(session_id.clone()),
@@ -400,15 +527,18 @@ where
                                     };
                                     return Some((
                                         Ok(finish_event),
-                                        (body, buffer, sequence, done, session_id),
+                                        (body, buffer, sequence, done, session_id, metrics),
                                     ));
                                 }
                             }
                             Err(err) => {
                                 tracing::warn!(
+                                    sid = %metrics.sid,
                                     error = %err,
                                     payload = %truncate_body(payload, 128),
-                                    "VercelAiGatewayArcan: skip malformed SSE chunk",
+                                    chunk_count = metrics.chunk_count,
+                                    total_bytes = metrics.total_bytes,
+                                    "arcan.parse: skip malformed SSE chunk",
                                 );
                             }
                         }
@@ -416,29 +546,69 @@ where
                     // Record consumed but produced no event (e.g. only role-only delta) — loop.
                     continue;
                 }
-                // No full record yet — pull more bytes.
+                // No full record yet — pull more bytes. The `pre-await`
+                // log line is the smoking-gun signal for H4 (gateway
+                // stops sending bytes): if logs show this line but the
+                // matching "got chunk" / "closed" / "stream error" log
+                // never follows, the `body.next().await` future is
+                // blocked indefinitely on upstream silence.
+                tracing::info!(
+                    sid = %metrics.sid,
+                    chunk_count = metrics.chunk_count,
+                    emit_count = metrics.emit_count,
+                    total_bytes = metrics.total_bytes,
+                    buffer_len = buffer.len(),
+                    ms_since_last_chunk = metrics.ms_since_last_chunk_or_start(),
+                    "arcan.parse: awaiting next upstream body chunk",
+                );
                 match body.next().await {
                     Some(Ok(chunk)) => {
+                        let bytes = chunk.len() as u64;
+                        metrics.chunk_count += 1;
+                        metrics.total_bytes += bytes;
+                        metrics.last_chunk_at = Some(std::time::Instant::now());
+                        tracing::info!(
+                            sid = %metrics.sid,
+                            chunk_count = metrics.chunk_count,
+                            bytes,
+                            total_bytes = metrics.total_bytes,
+                            emit_count = metrics.emit_count,
+                            elapsed_ms = metrics.ms_since_start(),
+                            "arcan.parse: got upstream body chunk",
+                        );
                         buffer.extend_from_slice(&chunk);
                     }
                     Some(Err(err)) => {
+                        tracing::warn!(
+                            sid = %metrics.sid,
+                            chunk_count = metrics.chunk_count,
+                            total_bytes = metrics.total_bytes,
+                            emit_count = metrics.emit_count,
+                            elapsed_ms = metrics.ms_since_start(),
+                            error = %err,
+                            "arcan.parse: upstream body stream error",
+                        );
                         return Some((
                             Err(tonic::Status::internal(format!(
                                 "VercelAiGatewayArcan: stream read error: {err}"
                             ))),
-                            (body, buffer, sequence, true, session_id),
+                            (body, buffer, sequence, true, session_id, metrics),
                         ));
                     }
                     None => {
                         // Upstream closed without [DONE] — synthesize a finish so
                         // the downstream pump exits cleanly.
-                        if !buffer.is_empty() {
-                            tracing::debug!(
-                                bytes_remaining = buffer.len(),
-                                "VercelAiGatewayArcan: upstream closed mid-record",
-                            );
-                        }
+                        tracing::info!(
+                            sid = %metrics.sid,
+                            chunk_count = metrics.chunk_count,
+                            total_bytes = metrics.total_bytes,
+                            emit_count = metrics.emit_count,
+                            elapsed_ms = metrics.ms_since_start(),
+                            bytes_remaining = buffer.len(),
+                            "arcan.parse: upstream closed (synthesising FINISH reason=upstream_closed)",
+                        );
                         sequence += 1;
+                        metrics.emit_count += 1;
                         let finish = AgentEvent {
                             record: Some(EventRecord {
                                 session_id: Some(session_id.clone()),
@@ -452,7 +622,10 @@ where
                             }),
                             kind: AgentEventKind::Finish as i32,
                         };
-                        return Some((Ok(finish), (body, buffer, sequence, true, session_id)));
+                        return Some((
+                            Ok(finish),
+                            (body, buffer, sequence, true, session_id, metrics),
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Adds `tracing::info!` instrumentation at every body-pump + emit boundary in `VercelAiGatewayArcan::dispatch_message` and `parse_sse_token_stream`. Threads a `ParserMetrics` struct (sid, t_start, chunk_count, emit_count, total_bytes, last_chunk_at) through the unfold state so every log line carries the same correlation fields.

Linear: **BRO-1234** PR-2 (second of two). PR-1 = broomva/broomva.tech#203 (already merged + deployed).

## Why

Per BRO-1234's post-PR-1 dogfood probe, broomva.tech-side `wrapWithFrameDeadline` returned:

```
data: {"type":"error","errorText":"lifed.stream.frame-deadline: No frame from lifegw within 30000ms after frame 3"}
```

3 canonical agent_event frames reach broomva.tech, then silence. lifegw's internal ws heartbeat closed the WS with code 1011 at 60995ms (visible in `lifegw::services::ws` logs). But the WHY behind the post-frame-3 silence isn't determinable today because `VercelAiGatewayArcan` had only **2 tracing calls in 785 LOC** (warn for malformed SSE, debug for upstream-closed-mid-record) — the entire success path is silent.

This PR adds names to every state transition the body pump goes through, so a single post-merge dogfood discriminates the three open hypotheses end-to-end:

| Pattern in logs | Hypothesis |
|---|---|
| `awaiting next upstream body chunk` fires but matching `got upstream body chunk` / `upstream closed` / `body stream error` never does | **H4** — Vercel AI Gateway hangs on `body.next().await` (gateway-side stall) |
| `got upstream body chunk` fires N>3 times but `emit TOKEN` capped at 3 | **H5** — `parse_sse_token_stream` parser bug: chunks arrive but no events emitted |
| `emit TOKEN` fires >3 times, but broomva.tech still receives only 3 frames | **H6** — lifed → lifegw → WS pump drops AgentEvents downstream of the parser |

## Diff

**`crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs`** (+191 / -18, single file):

- `dispatch_message`:
  - `info!` at entry — `sid`, resolved `model`, `content_len`, `url`
  - `warn!` on `.send()` failure — `sid`, `elapsed_ms`, `error`
  - `info!` after successful response — `sid`, `status`, `elapsed_ms`
  - `warn!` on non-2xx — `sid`, `status`, `elapsed_ms`, `body_preview`
- New `ParserMetrics` struct (sid, t_start, last_chunk_at, chunk_count, emit_count, total_bytes) + `ms_since_start` / `ms_since_last_chunk_or_start` helpers
- `parse_sse_token_stream`:
  - `info!` per-emit (TOKEN, FINISH via finish_reason, [DONE] sentinel, upstream_closed) — carries `seq`, `emit_count`, `chunk_count`, `total_bytes`, `elapsed_ms`
  - `info!` pre-await (`awaiting next upstream body chunk`) — `buffer_len`, `ms_since_last_chunk` — **smoking-gun signal for H4** (if pre-await fires but the matching got-chunk/closed/error never follows, body.next().await is blocked on upstream silence)
  - `info!` on body chunk received — `bytes`, `total_bytes`, `chunk_count`
  - `warn!` on body stream error (was silent before — error propagated upward without log)
  - Existing malformed-SSE warn extended with sid + counters

Unfold state extended from 5-tuple to 6-tuple to thread `metrics` through. All return-from-unfold sites updated.

## P11 validation

- [x] `cargo build -p arcan-proxy` clean (16.86s, no warnings)
- [x] `cargo test -p arcan-proxy` — **34/34 pass** including the 14 vercel_ai_gateway parser + dispatch tests (the new struct + log lines do not change any return shape)
- [x] `cargo fmt --package arcan-proxy --check` clean
- [x] `cargo clippy -p arcan-proxy --no-deps` clean

## Post-merge dogfood (per autonomous-flow-lessons rule #1 + rule #2)

After Railway auto-redeploys this commit, one anon probe leaves a definitive log fingerprint:

```bash
cd /Users/broomva/broomva/core/life && railway logs --service lifegw \
  | grep --line-buffered -E "arcan\.(dispatch_message|parse)"

# In another shell:
curl -sS -i -N -X POST https://broomva.tech/api/chat \
  -H 'Content-Type: application/json' -H 'Origin: https://broomva.tech' --max-time 60 \
  -d '{"id":"dogfood-pr2","message":{"id":"msg","role":"user","parts":[{"type":"text","text":"ping"}],"metadata":{"selectedModel":"anthropic/claude-haiku-4.5"}},"prevMessages":[]}'
```

Expected log sequence on a healthy response: `dispatch_message: starting` → `gateway responded` → N × (`awaiting next upstream body chunk` → `got upstream body chunk` → `emit TOKEN`) → `emit FINISH ([DONE] sentinel)`. Any deviation collapses the hypothesis space.

## P14 dep-chain

**Upstream:**
- `reqwest::Client::builder().timeout(120s)` (line 152) — the only existing guard against gateway hang; if it ever does fire, the new send-failed warn surfaces it explicitly
- BRO-1206 per-call `model: Option<&str>` override — preserved exactly; the new entry log surfaces the resolved model name so override + env-fallback decisions are visible

**Downstream:**
- `lifed::services::agent::stream_session` — consumes the `AgentEvent` stream from `dispatch_message`; the per-emit logs here line up 1:1 with what lifed forwards downstream
- `lifegw::services::ws::drive_upstream_tail` — packs each `AgentEvent` as a JSON ws frame; H6 (frames emitted here but lost before the ws send) becomes a third PR if the post-deploy dogfood rules out H4 + H5
- broomva.tech `LifedWsAgentSessionClient.stream()` + the `wrapWithFrameDeadline` from PR-1 — already shipped, no change required for this PR

## Linear

BRO-1234 second PR. PR-1 (broomva.tech#203) is live in production and surfaced the "after frame 3" signature that this PR's logs will explain end-to-end.

## Handoff continuity

Continues `~/broomva/docs/handoffs/2026-05-22-bro-1208-streaming-hang-handoff.md` §"Suggested second PR (broomva/life)" — narrower than the original plan because PR-1's dogfood already identified the "post-frame-3" surface area as the focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)