### PR TITLE
feat(control): wire the RCS control-loop substrate on life

### DIFF
--- a/.control/arcs.yaml
+++ b/.control/arcs.yaml
@@ -1,0 +1,98 @@
+# =============================================================================
+# bstack — Closure-Contract Arcs (the (X, U, h, Π, T) 5-tuple, generalized)
+# =============================================================================
+#
+# A closure-contract *arc* lifts the same 5-tuple already used at the 4 hard-
+# coded RCS layers (see assets/templates/rcs-parameters.toml.template) to the
+# N user-declared domain arcs the workspace actually runs every day. Each arc
+# names one feedback loop the workspace promises to close:
+#
+#     (plant_surfaces, sensor, actuator, termination, tau_a)
+#
+# read as:
+#
+#     "for these plant surfaces, observe via this sensor, act via this
+#      actuator, terminate when this condition holds, within tau_a seconds."
+#
+# The agent's reasoning is the universal Π (controller). When
+# actuator.kind == "agent_reasoning" the controller binding is implicit —
+# the agent loop closes the arc by reading the sensor, deciding, and acting.
+# Script / mcp_tool / http actuators bind specific mechanisms while keeping
+# the agent in the supervisory role.
+#
+# Read by:
+#   - scripts/compute-arc-status.sh   (per-arc verdict reader; mirrors
+#                                      compute-budget-status.sh shape)
+#   - scripts/doctor.sh §20            (arcs-declared health)
+#   - schemas/arcs.v1.json             (declarative shape; bstack doctor
+#                                      runs json-schema validation in §10)
+#
+# Editing rules:
+#   - Bump schema_version below when adding/removing fields.
+#   - Run `bash scripts/compute-arc-status.sh --human` after edits to verify
+#     each arc still resolves to a verdict.
+#   - tau_a is in seconds (per-arc switching cost denominator). Keep it
+#     proportional to the natural cadence of the loop: PR CI is ~1800s,
+#     bookkeeping promotion-quality is ~86400s, etc.
+#   - Workspace files override this template: copy to .control/arcs.yaml,
+#     edit, and compute-arc-status.sh will prefer the workspace file.
+
+schema_version: 1
+
+arcs:
+  # ---------------------------------------------------------------------------
+  # Arc 1 — code-pr-greenflow
+  # ---------------------------------------------------------------------------
+  # Closes the loop: "every PR I open ends up merged with all checks green."
+  # Plant: GitHub PR checks. Sensor: `gh pr checks --json`. Actuator: agent
+  # reasoning (which calls heal-recipes from .control/policy.yaml ci_heal:
+  # block). Termination: predicate over checks_green AND merged. Window:
+  # 30 minutes (PR CI ceiling — beyond this the human steps in).
+  - id: code-pr-greenflow
+    description: PR CI greenflow — open, watch, heal, merge.
+    plant_surfaces:
+      - gh://${repo}/pulls
+      - fs://.github/workflows/
+    sensor:
+      kind: json_path
+      source: gh pr checks --json conclusion,name --jq '[.[] | select(.conclusion != null)]'
+      expr: all(.conclusion == "SUCCESS")
+    actuator:
+      kind: agent_reasoning
+      tools:
+        - gh
+        - skills/p9/scripts/p9.py
+        - skills/bookkeeping/scripts/bookkeeping.py
+    termination:
+      kind: predicate
+      expr: checks_green AND merged
+    tau_a: 1800
+    shield_ref: gates.hard.G-PR-MERGE
+
+  # ---------------------------------------------------------------------------
+  # Arc 2 — bookkeeping-promotion-quality
+  # ---------------------------------------------------------------------------
+  # Closes the loop: "every Layer-2 raw extract that ends up an entity page
+  # in research/entities/ scored ≥7/9 on the Nous gate." Plant: research/
+  # notes/ + research/entities/. Sensor: a hypothetical eval script that
+  # exits 0 when the most recent promotion run scored ≥ threshold.
+  # Actuator: agent reasoning (the agent re-runs bookkeeping replay if the
+  # score dips). Termination: score_threshold. Window: 1 day (matches the
+  # bookkeeping cadence and the L3 governance budget).
+  - id: bookkeeping-promotion-quality
+    description: Bookkeeping promotion quality — every entity page meets the Nous gate.
+    plant_surfaces:
+      - fs://research/entities/
+      - fs://research/notes/
+    sensor:
+      kind: exit_code
+      source: skills/bookkeeping/scripts/eval-promotion-quality.sh
+    actuator:
+      kind: agent_reasoning
+      tools:
+        - skills/bookkeeping/scripts/bookkeeping.py
+    termination:
+      kind: score_threshold
+      expr: score >= 7
+    tau_a: 86400
+    shield_ref: gates.governed.G-PROMOTION-NOUS

--- a/.control/audit/.gitkeep
+++ b/.control/audit/.gitkeep
@@ -1,0 +1,1 @@
+# RCS audit logs are machine-local runtime telemetry — not committed.

--- a/.control/policy.yaml
+++ b/.control/policy.yaml
@@ -1,0 +1,208 @@
+# Agentic Control Kernel — bstack workspace policy
+# Installed by `bstack bootstrap` when .control/policy.yaml is absent.
+# Customize for your workspace; bstack doctor will validate required blocks.
+
+version: "1.0"
+profile: governed  # baseline | governed | autonomous
+
+setpoints:
+  - id: S1
+    name: "gate_pass_rate"
+    target: 0.85
+    alert_below: 0.70
+    severity: blocking
+
+  - id: S2
+    name: "audit_pass_rate"
+    target: 1.0
+    alert_below: 0.95
+    severity: blocking
+
+gates:
+  governed:
+    - id: G1
+      rule: "No force-push to protected branches"
+      severity: blocking
+
+    - id: G2
+      rule: "No `git reset --hard` without backup branch"
+      severity: blocking
+
+    - id: G3
+      rule: "No `rm -rf` on protected paths"
+      severity: blocking
+
+    - id: G4
+      rule: "No staging .env, credentials, secrets"
+      severity: blocking
+
+    - id: G5
+      rule: "Verify tests pass before push"
+      severity: warn
+
+    - id: G6
+      rule: "Run smoke before commit"
+      severity: warn
+
+# === P9 CI Watcher + Productive-Wait Primitive ===
+# Required by skills/p9 (bstack P9 primitive — name matches number). Fails closed if absent.
+
+ci_watch:
+  enabled: true
+  max_concurrent_prs: 1
+  isolation_tier_map:
+    research: none
+    docs: none
+    code_independent: worktree
+    code_dependent: stacked_branch
+    governance: blocked
+
+ci_heal:
+  enabled: true
+  max_attempts: 5
+  stability_floor: 0.3
+  classified_failure_types: [lint, format, test_flaky, codegen_drift, import_missing]
+  escalation_channel:
+    linear_team: BRO
+    linear_label: ci-heal-escalation
+    notify_hook: skills/p9/scripts/p9-escalate-notify.sh
+
+# === P9 Auto-merge actuator ===
+# Closes the MERGE_READY → merged gap. Default-disabled; opt-in branch class.
+
+auto_merge:
+  enabled: false
+  require_no_requested_changes: true
+  require_branch_up_to_date: true
+  merge_method: squash
+  delete_branch: true
+  rules:
+    # Governance paths ALWAYS block (matcher pre-pass enforces this regardless
+    # of rule order; listing them first protects against future reshuffles)
+    - path_touched: CLAUDE.md
+      action: require_human
+    - path_touched: AGENTS.md
+      action: require_human
+    - path_touched: METALAYER.md
+      action: require_human
+    - path_touched: .control/policy.yaml
+      action: require_human
+    # === Indirect-prompt-injection defense — editor-config paths (2026-05-15) ===
+    # Spec: specs/2026-05-15-indirect-prompt-injection-defense.md §4 Tier 1.
+    # Rationale: every documented incident in 2024-2026 that turned indirect prompt
+    # injection into RCE pivoted through a silent write to one of these paths:
+    #   - .vscode/tasks.json + .vscode/settings.json  (CVE-2025-53773 Copilot YOLO-Mode;
+    #                                                   blockchain-C2 gist 2026-05-06)
+    #   - .cursor/mcp.json                            (CurXecute CVE-2025-54135; MCPoison
+    #                                                   CVE-2025-54136)
+    #   - .claude/settings.json                       (Claudy Day Claude.ai exfil)
+    #   - .gitignore (removal)                        (blockchain-C2 gist stage 5)
+    - path_touched: .vscode/*
+      action: require_human
+    - path_touched: .cursor/*
+      action: require_human
+    - path_touched: .idea/*
+      action: require_human
+    - path_touched: .continue/*
+      action: require_human
+    - path_touched: .aider/*
+      action: require_human
+    - path_touched: .claude/settings.json
+      action: require_human
+    - path_touched: .gitignore
+      action: require_human
+    # Auto-merge classes (uncomment to enable per branch pattern)
+    # - branch_pattern: "docs/*"
+    #   action: auto
+    # - branch_pattern: "research/*"
+    #   action: auto
+  default_action: notify
+
+# === Indirect-prompt-injection defense — PreToolUse write gate (2026-05-15) ===
+# Spec: specs/2026-05-15-indirect-prompt-injection-defense.md §4 Tier 1.
+# Consumed by ~/broomva/scripts/check-file-write-safety.py (workspace-side, ships
+# as PR #2 against broomva/workspace). This block defines the schema; the runtime
+# is a separate concern. Schema lands first so the runtime can pin to a stable
+# contract.
+#
+# Three sub-blocks:
+#   write_gate.content_patterns: regex refusal on dangerous content substrings.
+#   write_gate.magic_bytes_check: refuses files whose extension claims one type but
+#                                 whose magic bytes are script/executable.
+#   write_gate.gitignore_modification: refuses .gitignore edits that REMOVE patterns
+#                                       (additions are normal; removals enable silent
+#                                       commits of malicious files).
+#
+# Default state: enabled. Override per-workspace by setting
+#   write_gate.enabled: false  in .control/policy.yaml — but the bstack-doctor
+# command will warn loudly when this is off.
+
+write_gate:
+  enabled: true
+  content_patterns:
+    # Each pattern is a Python `re` regex matched against the file content being
+    # written or edited. severity=blocking refuses the write with exit code 8
+    # (analogue to the marketing-shape detector in broomva/social-intelligence
+    # PR #2 — same refuse-to-send substrate pattern). severity=warn logs but
+    # allows.
+    - pattern: "runOn:\\s*folderOpen"
+      severity: blocking
+      rationale: "VS Code autoexec primitive. Universal trigger across Jamf Threat Labs Dec 2025 North Korea campaign, Tenable/ThreatLocker advisories, mihai-r-lupu blockchain-C2 gist 2026-05-06. https://github.com/microsoft/vscode/issues/309406"
+    - pattern: "task\\.allowAutomaticTasks:\\s*true"
+      severity: blocking
+      rationale: "VS Code autoexec-bypass key — blockchain-C2 gist used this exact setting to skip the 'Do you want to allow automatic tasks?' confirmation"
+    - pattern: "chat\\.tools\\.autoApprove:\\s*true"
+      severity: blocking
+      rationale: "GitHub Copilot YOLO-Mode (CVE-2025-53773, CVSS 7.8) — prompt injection writes this exact key to .vscode/settings.json then shell-exec auto-approves"
+    - pattern: "--dangerously-skip-permissions"
+      severity: blocking
+      rationale: "Claude Code unsafe-flag bypass — used by Nx s1ngularity (CISA-advisory) postinstall scripts to weaponize AI CLIs as recon"
+    - pattern: "api\\.trongrid\\.io|fullnode\\.mainnet\\.aptoslabs|bsc-dataseed\\.binance|bsc-rpc\\.publicnode"
+      severity: blocking
+      rationale: "Public-blockchain RPCs in non-blockchain code = dead-drop C2 signal (blockchain-C2 gist used TRON for XOR key + Aptos + BSC fallback)"
+    - pattern: "child_process\\.spawn\\([^)]*detached:\\s*true"
+      severity: warn
+      rationale: "Detached spawn in JS/TS = persistence primitive (blockchain-C2 gist Layer 4 used this to keep payload alive after parent exits)"
+  magic_bytes_check:
+    enabled: true
+    # Maps a forbidden file-extension family to a list of magic-byte / start-of-content
+    # signatures that MUST NOT appear at the file head. Catches the font-file-with-JS
+    # disguise from the blockchain-C2 gist (stage 4).
+    #
+    # Signatures are matched against the first 256 bytes of content (utf-8 decoded for
+    # text-style sigs; raw bytes for binary sigs). String signatures match literally.
+    rules:
+      - extension_match: [".woff2", ".woff", ".ttf", ".otf", ".eot"]
+        forbid_signatures_starting_with:
+          - "function"
+          - "(function"
+          - "const "
+          - "var "
+          - "let "
+          - "import "
+          - "module.exports"
+          - "#!/"
+        rationale: "Font file with script content = blockchain-C2 stage 4 (fa-solid-400.woff2 disguise)"
+      - extension_match: [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico"]
+        forbid_signatures_starting_with:
+          - "function"
+          - "(function"
+          - "<?php"
+          - "<script"
+          - "#!/"
+        rationale: "Image file with script content = steganography/disguise class"
+      - extension_match: [".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".ini"]
+        forbid_signatures_starting_with:
+          - "MZ"
+          - "\\x7fELF"
+          - "\\xca\\xfe\\xba\\xbe"
+          - "\\xfe\\xed\\xfa"
+        rationale: "Text/config file with PE/ELF/Mach-O magic = binary disguise class"
+  gitignore_modification:
+    enabled: true
+    removed_patterns_require_human: true
+    # Modifications that ADD patterns to .gitignore are normal and unaffected.
+    # Modifications that REMOVE patterns trigger require_human because removing
+    # e.g. `.vscode/*` from .gitignore enables silent commit of attacker-injected
+    # editor config (blockchain-C2 gist stage 5).
+    rationale: "blockchain-C2 gist (mihai-r-lupu 2026-05-06) explicitly removed .vscode/* from .gitignore to enable committing the malicious tasks.json"

--- a/.control/rcs-parameters.toml
+++ b/.control/rcs-parameters.toml
@@ -1,0 +1,155 @@
+# =============================================================================
+# RCS — Workspace Stability Parameters (bstack default)
+# =============================================================================
+#
+# Per-level parameters for the Recursive Controlled Systems (RCS) stability
+# budget. These values are read by bstack/scripts/compute-lambda.sh and by
+# bstack doctor §14 to verify the composite system is exponentially stable.
+#
+# Formula (papers/p0-foundations/main.tex, Theorem 1):
+#
+#     lambda_i = gamma_i
+#              - L_theta_i * rho_i        (adaptation cost)
+#              - L_d_i * eta_i            (design evolution cost)
+#              - beta_i * tau_bar_i       (delay cost)
+#              - ln(nu_i) / tau_a_i       (switching cost)
+#
+# A level is stable iff lambda_i > 0. The composite hierarchy is exponentially
+# stable iff every level is individually stable.
+#
+# Defaults below are calibrated from broomva's Life runtime (research/rcs/
+# data/parameters.toml). For a generic bstack repo without Life, customize:
+#   - L0 (plant): match your runtime's inner loop (sub-second tool execution)
+#   - L1 (autonomic): match your agent's hysteresis / mode-transition layer
+#   - L2 (meta-control): match your EGRI / promotion cadence (default: hours)
+#   - L3 (governance): KEEP CONSERVATIVE — tau_a = 86400s (1 day) is the
+#     stability budget's load-bearing assumption. Faster governance churn
+#     destabilizes the whole hierarchy.
+#
+# Editing rules:
+#   - Bump schema_version below when adding/removing fields.
+#   - bstack doctor --strict verifies the cached [derived.lambda] block
+#     matches recomputed values; CI will fail if they drift.
+#   - Run `bash scripts/compute-lambda.sh --human` after edits to see the
+#     per-level impact before committing.
+
+schema_version = 1
+
+# -----------------------------------------------------------------------------
+# L0 — Plant (agent inner loop)
+# -----------------------------------------------------------------------------
+# Sub-second timescale: tool execution, streaming output, immediate response.
+# Source: Arcan agent loop default (or your equivalent).
+
+[[levels]]
+id             = "L0"
+name           = "plant"
+system         = "Agent loop / tool execution"
+gamma          = 2.0
+L_theta        = 0.3
+rho            = 0.5
+L_d            = 0.1
+eta            = 0.2
+beta           = 1.0
+tau_bar        = 0.01
+nu             = 1.2
+tau_a          = 0.5
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L1 — Autonomic (per-session reasoning + hysteresis)
+# -----------------------------------------------------------------------------
+# Seconds timescale: hysteresis gates, mode transitions, validation backpressure.
+
+[[levels]]
+id             = "L1"
+name           = "autonomic"
+system         = "Agent reasoning / per-session loop"
+gamma          = 0.5
+L_theta        = 0.2
+rho            = 0.1
+L_d            = 0.1
+eta            = 0.05
+beta           = 0.5
+tau_bar        = 0.1
+nu             = 1.5
+tau_a          = 30.0
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L2 — EGRI / meta-control
+# -----------------------------------------------------------------------------
+# Hours timescale: cross-session synthesis, candidate promotion, evaluator runs.
+
+[[levels]]
+id             = "L2"
+name           = "EGRI"
+system         = "EGRI / Crystallize (P16) / Bookkeeping (P6)"
+gamma          = 0.1
+L_theta        = 0.05
+rho            = 0.01
+L_d            = 0.02
+eta            = 0.01
+beta           = 0.0005
+tau_bar        = 60.0
+nu             = 1.1
+tau_a          = 3600.0
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L3 — Governance
+# -----------------------------------------------------------------------------
+# Days timescale: CLAUDE.md / AGENTS.md / .control/policy.yaml mutations.
+#
+# CRITICAL: tau_a = 86400s (1 day) is the load-bearing assumption. Faster
+# governance churn destabilizes the entire RCS hierarchy. The bstack pre-commit
+# hook (`githook-pre-commit-l3-rate.sh`) enforces this rate by counting L3-class
+# commits in the last tau_a window.
+
+[[levels]]
+id             = "L3"
+name           = "governance"
+system         = "CLAUDE.md + AGENTS.md + .control/policy.yaml"
+gamma          = 0.01
+L_theta        = 0.001
+rho            = 0.001
+L_d            = 0.001
+eta            = 0.0005
+beta           = 0.000001
+tau_bar        = 3600.0
+nu             = 1.05
+tau_a          = 86400.0
+display_digits = 4
+
+# -----------------------------------------------------------------------------
+# Derived values — cached for human readers, verified by compute-lambda.sh
+# -----------------------------------------------------------------------------
+# scripts/compute-lambda.sh --strict recomputes these and fails if drift > 1e-4.
+
+[derived.lambda]
+L0 = 1.455357
+L1 = 0.411484
+L2 = 0.069274
+L3 = 0.006398
+
+[derived.omega]
+value = 0.006398
+level = "L3"
+
+# -----------------------------------------------------------------------------
+# Governance path patterns (read by l3-rate-gate.sh)
+# -----------------------------------------------------------------------------
+# Files that match these git-pathspec patterns count as L3 mutations.
+# Used by:
+#   - .githooks/pre-commit (pre-commit gate G1)
+#   - .github/workflows/l3-stability.yml (CI gate G2)
+#   - .claude/settings.json PreToolUse hook (Claude Code gate G0)
+
+[gates.l3_paths]
+patterns = [
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".control/policy.yaml",
+    ".control/rcs-parameters.toml",
+    "METALAYER.md",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ crates/opsis/web/docs/conversations/
 crates/opsis/web/scripts/conversation-history.py
 crates/opsis/web/scripts/conversation-bridge-hook.sh
 .worktrees/
+
+# bstack RCS control-loop machine-local telemetry (not committed)
+.control/audit/*.jsonl


### PR DESCRIPTION
## What

Adds the missing committable loop definitions so life's RCS control loop is fully wired. life was partially bstack'd (CLAUDE/AGENTS/METALAYER tracked + audit dir) but missing `.control/{policy,arcs,rcs-parameters}` — so the loop wasn't closeable.

## Scope: committable substrate only (the portable pattern)

life's `.claude/settings.json` is **tracked with repo-relative paths**. So the machine-local L0/L1 audit hooks (which carry absolute bstack paths) stay in the **gitignored `.claude/settings.local.json`** — never injected into the shared `settings.json`. (This is also why a raw `bstack onboard`/bootstrap isn't run here — it would pollute the tracked settings.json.)

## Committed
- `.control/policy.yaml`, `.control/arcs.yaml`, `.control/rcs-parameters.toml`
- `.control/audit/.gitkeep` + `.gitignore` ignores `.control/audit/*.jsonl` (logs are machine-local)

## Verification (P11)
- `bstack doctor` §23 → **`wired + running + closing`** (L0 hook fires → audit entry → arcs + composite-ω resolve).
- No secrets / absolute paths in committed files (the one "secrets" match is a gate *rule description*).
- The broader primitive-contract gaps (AGENTS.md P1–P20 sections + vendored mechanism scripts) are a separate, larger effort — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added workspace governance and control configurations for CI/PR automation and policy management.
  * Introduced workspace stability parameters and audit telemetry exclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/life/pull/1454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->