### PR TITLE
feat(chronos): M1 — agenda store + HTTP wake ingest [BRO-1069]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,6 +2236,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chronos-api"
+version = "0.3.0"
+dependencies = [
+ "axum 0.8.8",
+ "chronos-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
 name = "chronos-core"
 version = "0.3.0"
 dependencies = [
@@ -2254,6 +2267,7 @@ name = "chronos-lago"
 version = "0.3.0"
 dependencies = [
  "aios-protocol",
+ "async-trait",
  "chronos-core",
  "lago-core",
  "lago-journal",
@@ -2281,6 +2295,7 @@ version = "0.3.0"
 dependencies = [
  "aios-protocol",
  "anyhow",
+ "chronos-api",
  "chronos-core",
  "chronos-lago",
  "chronos-triggers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,11 @@ members = [
     "crates/autonomic/autonomic-core",
     "crates/autonomic/autonomic-lago",
     "crates/autonomic/autonomicd",
-    # Chronos — temporality (M0 scaffold; see docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md)
+    # Chronos — temporality (M0 scaffold + M1 agenda/HTTP; see docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md)
     "crates/chronos/chronos-core",
     "crates/chronos/chronos-triggers",
     "crates/chronos/chronos-lago",
+    "crates/chronos/chronos-api",
     "crates/chronos/chronosd",
     # Praxis — tool execution
     "crates/praxis/praxis-core",
@@ -213,6 +214,7 @@ autonomic-lago = { path = "crates/autonomic/autonomic-lago", version = "0.3.0" }
 chronos-core = { path = "crates/chronos/chronos-core", version = "0.3.0" }
 chronos-triggers = { path = "crates/chronos/chronos-triggers", version = "0.3.0" }
 chronos-lago = { path = "crates/chronos/chronos-lago", version = "0.3.0" }
+chronos-api = { path = "crates/chronos/chronos-api", version = "0.3.0" }
 haima-api = { path = "crates/haima/haima-api", version = "0.3.0" }
 haima-core = { path = "crates/haima/haima-core", version = "0.3.0" }
 haima-insurance = { path = "crates/haima/haima-insurance", version = "0.3.0" }

--- a/crates/chronos/CLAUDE.md
+++ b/crates/chronos/CLAUDE.md
@@ -3,21 +3,23 @@
 > *Chronos* (χρόνος, Greek: time) — the substrate that answers **when an agent should wake**
 > and **what it should do when it wakes**. Biological analogue: circadian rhythm.
 
-**Status**: M0 (scaffold + heartbeat trigger). M1–M3 planned per
-`docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md`.
+**Status**: M1 (agenda store + HTTP wake ingest). M2–M3 planned per
+`docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md` (the M1 spec also lives in
+Linear BRO-1069).
 
 ## Architecture
 
 ```
 chronos/
-├── chronos-core/         # Pure types + traits + WakeRouter (depends ONLY on aios-protocol)
-├── chronos-triggers/     # HeartbeatTrigger (real) + stubs for http/cron/fs/sub-agent/threshold/webhook
-├── chronos-lago/         # Lago bridge — record_wake → Custom("chronos.wake")
-└── chronosd/             # Daemon binary — lib + bin split, like haimad / autonomicd
+├── chronos-core/         # Pure types + traits + WakeRouter + AgendaStore (depends ONLY on aios-protocol)
+├── chronos-triggers/     # HeartbeatTrigger + HttpTrigger (real) + stubs for cron/fs/sub-agent/threshold/webhook
+├── chronos-lago/         # Lago bridge — record_wake + LagoAgendaStore (Custom("chronos.*") events)
+├── chronos-api/          # M1 axum HTTP API — POST /v1/wake, GET /v1/agenda/{session_id}, GET /v1/health
+└── chronosd/             # Daemon binary — lib + bin split, like haimad / autonomicd; --http-bind mounts the API
 ```
 
-`chronos-api`, `chronos-substrate-proto`, and `life-chronos` (Topology B + kernel adapter)
-are M3+ work and not scaffolded yet.
+`chronos-substrate-proto` and `life-chronos` (Topology B + kernel adapter) are M3+ work and not
+scaffolded yet. The M2 kernel wake handoff (`WakeEvent → tick_on_branch`) is also still planned.
 
 ## Core Types (chronos-core)
 
@@ -28,7 +30,11 @@ are M3+ work and not scaffolded yet.
 | `WakeSource` | `Heartbeat | Http | Cron | FsWatch | SubAgentReturn | Threshold | Webhook` |
 | `WakeTrigger` | `async fn next_wake(&mut self) -> Option<WakeEvent>; fn name(&self) -> &'static str` |
 | `WakeRouter` | Multiplexes triggers concurrently via tokio mpsc into a single stream |
-| `ChronosError` / `ChronosResult` | Crate-local error type |
+| `AgendaStore` | Trait: `add` / `complete` / `defer` / `cancel` / `list(session)` — the durable agenda (M1) |
+| `AgendaItem` | `{ id, session_id, intent, priority, state, source, created_at_unix_ms, not_before? }` |
+| `Priority` / `AgendaItemState` | `Urgent>Normal>Deferrable` (FIFO within band); `Pending\|Completed\|Deferred\|Cancelled` |
+| `InMemoryAgendaStore` | Reference `AgendaStore` for tests + the `chronos-api` suite (no lago needed) |
+| `ChronosError` / `ChronosResult` | Crate-local error type (adds `NotFound` / `Agenda` in M1) |
 
 ## Event Namespace
 
@@ -37,9 +43,15 @@ autonomic (`autonomic.*`) and haima (`finance.*`) convention.
 
 | event_type | When emitted |
 |------------|--------------|
-| `chronos.wake` | A trigger fired and produced a `WakeEvent`. (M0 — the only one for now.) |
-| `chronos.agenda.added` | An agenda item was created. (M1+) |
-| `chronos.agenda.completed` | An agenda item completed after the kernel ran it. (M2+) |
+| `chronos.wake` | A trigger fired and produced a `WakeEvent`. Routes to the wake's target session (M0). |
+| `chronos.agenda.added` | An agenda item was created (M1). Carries the full item snapshot. |
+| `chronos.agenda.completed` | An agenda item completed (M1 exposes the transition; M2 drives it from the kernel). |
+| `chronos.agenda.deferred` | An agenda item was deferred to a later time (M1). Carries `not_before_unix_ms`. |
+| `chronos.agenda.cancelled` | An agenda item was withdrawn before dispatch (M1). |
+
+All `chronos.agenda.*` events land in the dedicated **`chronos.agenda`** ledger session (the item's
+*target* session is a field in the payload), so `LagoAgendaStore::{complete,defer,cancel}` can
+address an item by id alone. `chronos.wake` events route to their target session, separately.
 
 The kernel does NOT yet ship a typed `EventKind::ChronosWake` variant — see the
 [plan](../../docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md) §"Constraints"
@@ -48,10 +60,11 @@ for the reasoning. Promote to a typed variant after M2-M3 stabilizes the payload
 ## Dependency Rules
 
 ```
-chronos-core → aios-protocol (ONLY internal dep) + tokio, serde, ulid, thiserror
-chronos-triggers → chronos-core (no other internal deps)
-chronos-lago → chronos-core + aios-protocol + lago-core (read), lago-journal (dev only)
-chronosd → all the above + lago-journal + anyhow + clap + tracing-subscriber
+chronos-core → aios-protocol (ONLY internal dep) + tokio, serde, ulid, thiserror, async-trait
+chronos-triggers → chronos-core (no other internal deps) + tokio mpsc, async-trait
+chronos-lago → chronos-core + aios-protocol + lago-core (read), lago-journal (dev only) + async-trait
+chronos-api → chronos-core (ONLY internal dep) + axum, serde, tokio  [concrete store + trigger injected]
+chronosd → all the above + chronos-api + lago-journal + anyhow + clap + tracing-subscriber
 ```
 
 Enforced by `scripts/architecture/verify_dependencies_chronos.sh`. The CI lane runs
@@ -61,6 +74,7 @@ Enforced by `scripts/architecture/verify_dependencies_chronos.sh`. The CI lane r
 
 ```
 chronosd --heartbeat-seconds 5 --data-dir /tmp/chronos-smoke
+chronosd --http-bind 127.0.0.1:3737 --heartbeat-seconds 60 --data-dir /tmp/chronos   # M1: HTTP wake ingest
 ```
 
 Flags:
@@ -71,6 +85,7 @@ Flags:
 | `--data-dir` | `/tmp/chronosd` | `CHRONOSD_DATA_DIR` | Holds the lago redb journal (created on startup). |
 | `--journal-filename` | `journal.redb` | `CHRONOSD_JOURNAL_FILENAME` | File name inside `--data-dir`. |
 | `--router-buffer` | 64 | `CHRONOSD_ROUTER_BUFFER` | Mpsc capacity for the router. ≥1. |
+| `--http-bind` | *(unset)* | `CHRONOSD_HTTP_BIND` | M1 wake-ingest API bind addr (e.g. `127.0.0.1:3737`). Unset ⇒ heartbeat-only. |
 
 SIGTERM and SIGINT trigger a clean shutdown that drains the router within ~2 seconds.
 
@@ -85,15 +100,39 @@ Constants exposed by `chronos-lago`:
 pub const CHRONOS_WAKE_EVENT_TYPE: &str = "chronos.wake";
 pub const CHRONOS_SYSTEM_SESSION: &str = "chronos.system";
 pub const CHRONOS_DEFAULT_BRANCH: &str = "main";
+// M1 — agenda ledger:
+pub const CHRONOS_AGENDA_SESSION: &str = "chronos.agenda";
+pub const CHRONOS_AGENDA_ADDED_EVENT_TYPE: &str = "chronos.agenda.added";
+// + chronos.agenda.{completed,deferred,cancelled}
 ```
+
+## HTTP API (M1 — `chronos-api`)
+
+Enabled with `chronosd --http-bind <addr>`. Localhost-only in M1 (auth lands when chronosd moves
+behind lifegw).
+
+| Method · Route | Body / Param | Effect |
+|---|---|---|
+| `POST /v1/wake` | `{ session_id?, intent, priority?, when_unix_ms?, source? }` | Adds an agenda item; fires a `chronos.wake` now unless `when_unix_ms` is in the future. → `202 { agenda_item_id, fired, session_id }` |
+| `GET /v1/agenda/{session_id}` | — | Lists the session's agenda items (dispatch order), folded from the lago journal. |
+| `GET /v1/health` | — | `{ "status": "ok", "service": "chronos-api" }` |
+
+`chronos-api` holds an `Arc<dyn AgendaStore>` + an `mpsc::Sender<WakeEvent>`, both injected by
+`chronosd` — it never names `chronos-lago` or `chronos-triggers` (clean dep graph).
 
 ## Commands
 
 ```bash
-# Build & test the four chronos crates
-cargo build  -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd
-cargo test   -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd
-cargo clippy -p chronos-core -p chronos-triggers -p chronos-lago -p chronosd -- -D warnings
+# Build & test the five chronos crates
+cargo build  -p chronos-core -p chronos-triggers -p chronos-lago -p chronos-api -p chronosd
+cargo test   -p chronos-core -p chronos-triggers -p chronos-lago -p chronos-api -p chronosd
+cargo clippy -p chronos-core -p chronos-triggers -p chronos-lago -p chronos-api -p chronosd -- -D warnings
+
+# M1 live smoke (HTTP wake ingest)
+cargo run -p chronosd -- --http-bind 127.0.0.1:3737 --heartbeat-seconds 60 --data-dir /tmp/chronos-m1 &
+curl -s -XPOST 127.0.0.1:3737/v1/wake -H 'content-type: application/json' -d '{"intent":"hello","session_id":"s"}'
+curl -s 127.0.0.1:3737/v1/agenda/s
+cargo run -p lago -- log --data-dir /tmp/chronos-m1 --session chronos.agenda   # shows chronos.agenda.added
 
 # Run the daemon (writes one chronos.wake every 5 seconds to /tmp/chronos-smoke/journal.redb)
 cargo run -p chronosd -- --heartbeat-seconds 5 --data-dir /tmp/chronos-smoke
@@ -106,9 +145,9 @@ cargo run -p lago-cli -- replay --tree --data /tmp/chronos-smoke/journal.redb
 
 | Milestone | Goal | Status |
 |-----------|------|--------|
-| M0 | Scaffold + heartbeat trigger writes `chronos.wake` events to lago | **shipped (this scaffold)** |
-| M1 | Agenda store + HTTP `POST /v1/wake` ingest | planned |
-| M2 | Kernel wake handoff — `WakeEvent → kernel.dispatch(session_id, intent)` | planned |
+| M0 | Scaffold + heartbeat trigger writes `chronos.wake` events to lago | **shipped** |
+| M1 | Agenda store + HTTP `POST /v1/wake` ingest | **shipped (BRO-1069)** |
+| M2 | Kernel wake handoff — `WakeEvent → kernel.dispatch(session_id, intent)` | planned (BRO-1080) |
 | M3 | File-watch + sub-agent return triggers | planned |
 | Beyond M3 | `chronos-substrate-proto`, cron, webhook, threshold triggers, multi-priority queue | planned |
 

--- a/crates/chronos/chronos-api/Cargo.toml
+++ b/crates/chronos/chronos-api/Cargo.toml
@@ -1,25 +1,23 @@
 [package]
-name = "chronos-lago"
+name = "chronos-api"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Lago bridge for Chronos — records wake events to the Life journal"
+description = "HTTP wake-ingest + agenda inspection API for Chronos (M1)"
 
 [dependencies]
 chronos-core.workspace = true
-aios-protocol.workspace = true
-lago-core.workspace = true
-async-trait.workspace = true
+axum.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "rt", "net", "macros"] }
 tracing.workspace = true
 
 [dev-dependencies]
-lago-journal.workspace = true
-tempfile.workspace = true
+tower = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/chronos/chronos-api/src/lib.rs
+++ b/crates/chronos/chronos-api/src/lib.rs
@@ -1,0 +1,438 @@
+//! chronos-api — HTTP wake ingest + agenda inspection for Chronos (M1).
+//!
+//! Two routes turn Chronos's wake stream from one source (heartbeat) into a multi-source surface:
+//!
+//! - `POST /v1/wake` — submit an intent. The intent is added to the durable agenda; if it is
+//!   ready to fire now (`when_unix_ms` absent or in the past) a [`chronos_core::WakeEvent`] is
+//!   pushed into the [`HttpTrigger`](chronos_core) via the wake channel.
+//! - `GET /v1/agenda/{session_id}` — list a session's agenda items, in dispatch order.
+//! - `GET /v1/health` — liveness probe.
+//!
+//! ## Dependency injection keeps this crate thin
+//!
+//! `chronos-api` depends only on `chronos-core` (plus axum/serde/tokio). It holds an
+//! `Arc<dyn AgendaStore>` and an `mpsc::Sender<WakeEvent>` — both injected by `chronosd`, which is
+//! the single place where the concrete `LagoAgendaStore` and the real `HttpTrigger` receiver are
+//! wired together. The API never names `chronos-lago` or `chronos-triggers`.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use chronos_core::{
+    AgendaItem, AgendaStore, ChronosError, NewAgendaItem, Priority, SessionId, WakeEvent,
+    WakeSource,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+/// Shared state for the chronos-api router. Cheaply cloneable (an `Arc` + a channel sender + an
+/// id), so axum can clone it per request.
+#[derive(Clone)]
+pub struct ApiState {
+    /// Durable agenda store. `InMemoryAgendaStore` in tests; `LagoAgendaStore` in `chronosd`.
+    pub agenda: Arc<dyn AgendaStore>,
+    /// Sender into the paired [`HttpTrigger`](chronos_core); pushing here fires a wake through the
+    /// router. (`chronos-core` re-exports the event type the channel carries.)
+    pub wake_tx: mpsc::Sender<WakeEvent>,
+    /// Session an item is routed to when the request omits `session_id`. `chronosd` injects the
+    /// `chronos.system` session so the API never hard-codes a routing constant.
+    pub default_session: SessionId,
+}
+
+/// Build the chronos-api router with the supplied state.
+pub fn router(state: ApiState) -> Router {
+    Router::new()
+        .route("/v1/wake", post(post_wake))
+        .route("/v1/agenda/{session_id}", get(get_agenda))
+        .route("/v1/health", get(health))
+        .with_state(state)
+}
+
+/// Bind to `addr` and serve until `shutdown` resolves (graceful drain).
+pub async fn serve<F>(addr: SocketAddr, state: ApiState, shutdown: F) -> std::io::Result<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let local = listener.local_addr()?;
+    info!(%local, "chronos-api listening");
+    axum::serve(listener, router(state))
+        .with_graceful_shutdown(shutdown)
+        .await
+}
+
+/// Request body for `POST /v1/wake`.
+#[derive(Debug, Deserialize)]
+pub struct WakeRequest {
+    /// Target session; if omitted, the item routes to the daemon's default (system) session.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// What the agent should do when it wakes. Must be non-empty.
+    pub intent: String,
+    /// Dispatch priority (`urgent` | `normal` | `deferrable`). Defaults to `normal`.
+    #[serde(default)]
+    pub priority: Priority,
+    /// Earliest fire time, ms since epoch. If set and in the future, the item is added to the
+    /// agenda (pending, `not_before` = this) but NOT fired now.
+    #[serde(default)]
+    pub when_unix_ms: Option<i64>,
+    /// Optional free-form source label, echoed into the wake payload (informational; the
+    /// [`WakeSource`] is always `Http`).
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+/// Response body for `POST /v1/wake`.
+#[derive(Debug, Serialize)]
+pub struct WakeResponse {
+    /// Id of the agenda item that was created.
+    pub agenda_item_id: String,
+    /// Whether a wake was fired now (`false` when the intent is scheduled for the future).
+    pub fired: bool,
+    /// Session the item was routed to.
+    pub session_id: String,
+}
+
+/// Response body for `GET /v1/agenda/{session_id}`.
+#[derive(Debug, Serialize)]
+pub struct AgendaListResponse {
+    /// The session whose agenda was listed.
+    pub session_id: String,
+    /// Number of items returned.
+    pub count: usize,
+    /// The items, in dispatch order.
+    pub items: Vec<AgendaItem>,
+}
+
+async fn post_wake(
+    State(state): State<ApiState>,
+    Json(req): Json<WakeRequest>,
+) -> Result<(StatusCode, Json<WakeResponse>), ApiError> {
+    if req.intent.trim().is_empty() {
+        return Err(ApiError::bad_request("intent must not be empty"));
+    }
+
+    // Resolve the target session: explicit non-empty value, else the injected default.
+    let target: Option<SessionId> = req
+        .session_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(SessionId::from_string);
+    let agenda_session = target
+        .clone()
+        .unwrap_or_else(|| state.default_session.clone());
+
+    let now = chronos_core::now_unix_ms();
+    let ready_now = req.when_unix_ms.map(|w| w <= now).unwrap_or(true);
+
+    // Add to the durable agenda (always Pending; not_before carries the schedule if any).
+    let mut new_item =
+        NewAgendaItem::new(agenda_session.clone(), req.intent.clone(), WakeSource::Http)
+            .with_priority(req.priority);
+    if let Some(when) = req.when_unix_ms {
+        new_item = new_item.with_not_before(when);
+    }
+    let item_id = state.agenda.add(new_item).await.map_err(ApiError::from)?;
+
+    // Fire the wake now only if the intent is ready.
+    let fired = if ready_now {
+        let mut wake = WakeEvent::new(WakeSource::Http).with_payload(serde_json::json!({
+            "intent": req.intent,
+            "agenda_item_id": item_id.as_str(),
+            "priority": req.priority.as_str(),
+            "source": req.source,
+        }));
+        if let Some(t) = target {
+            wake = wake.with_target_session(t);
+        }
+        match state.wake_tx.send(wake).await {
+            Ok(()) => true,
+            Err(err) => {
+                // Agenda item is durably recorded; only the immediate wake was lost. The
+                // heartbeat / a future scheduler can still pick the item up.
+                warn!(error = %err, "wake channel closed; item added but wake not fired");
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(WakeResponse {
+            agenda_item_id: item_id.0,
+            fired,
+            session_id: agenda_session.as_str().to_string(),
+        }),
+    ))
+}
+
+async fn get_agenda(
+    State(state): State<ApiState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<AgendaListResponse>, ApiError> {
+    let session = SessionId::from_string(&session_id);
+    let items = state.agenda.list(&session).await.map_err(ApiError::from)?;
+    Ok(Json(AgendaListResponse {
+        session_id,
+        count: items.len(),
+        items,
+    }))
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok", "service": "chronos-api" }))
+}
+
+/// API error → HTTP response mapping.
+#[derive(Debug)]
+pub enum ApiError {
+    /// Malformed request (400).
+    BadRequest(String),
+    /// Backing store / internal failure (500).
+    Internal(String),
+}
+
+impl ApiError {
+    fn bad_request(msg: impl Into<String>) -> Self {
+        Self::BadRequest(msg.into())
+    }
+}
+
+impl From<ChronosError> for ApiError {
+    fn from(err: ChronosError) -> Self {
+        match err {
+            ChronosError::NotFound(m) => ApiError::BadRequest(format!("not found: {m}")),
+            other => ApiError::Internal(other.to_string()),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            ApiError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
+        };
+        (status, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use chronos_core::{AgendaItemState, InMemoryAgendaStore, SessionId, WakeSource};
+    use tower::ServiceExt; // for `oneshot`
+
+    use super::*;
+
+    const DEFAULT_SESSION: &str = "chronos.system";
+
+    fn test_state() -> (ApiState, mpsc::Receiver<WakeEvent>) {
+        let (tx, rx) = mpsc::channel(16);
+        let state = ApiState {
+            agenda: Arc::new(InMemoryAgendaStore::new()),
+            wake_tx: tx,
+            default_session: SessionId::from_string(DEFAULT_SESSION),
+        };
+        (state, rx)
+    }
+
+    fn post(uri: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn post_wake_adds_pending_item_and_fires() {
+        let (state, mut rx) = test_state();
+        let agenda = state.agenda.clone();
+        let app = router(state);
+
+        let resp = app
+            .oneshot(post(
+                "/v1/wake",
+                serde_json::json!({ "intent": "rebuild index" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let json = body_json(resp).await;
+        assert_eq!(json["fired"], true);
+        assert_eq!(json["session_id"], DEFAULT_SESSION);
+
+        // A wake was pushed into the trigger channel.
+        let wake = rx.try_recv().expect("a wake was fired");
+        assert_eq!(wake.source, WakeSource::Http);
+        assert_eq!(wake.payload["intent"], "rebuild index");
+
+        // The agenda holds exactly one pending item in the default session.
+        let items = agenda
+            .list(&SessionId::from_string(DEFAULT_SESSION))
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].state, AgendaItemState::Pending);
+        assert_eq!(items[0].source, WakeSource::Http);
+    }
+
+    #[tokio::test]
+    async fn post_wake_routes_to_explicit_session() {
+        let (state, mut rx) = test_state();
+        let agenda = state.agenda.clone();
+        let app = router(state);
+
+        let resp = app
+            .oneshot(post(
+                "/v1/wake",
+                serde_json::json!({ "intent": "do it", "session_id": "user-7", "priority": "urgent" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let json = body_json(resp).await;
+        assert_eq!(json["session_id"], "user-7");
+
+        let wake = rx.try_recv().expect("fired");
+        assert_eq!(
+            wake.target_session.as_ref().map(|s| s.as_str()),
+            Some("user-7")
+        );
+        assert_eq!(
+            agenda
+                .list(&SessionId::from_string("user-7"))
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // Nothing leaked into the default session.
+        assert!(
+            agenda
+                .list(&SessionId::from_string(DEFAULT_SESSION))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn future_intent_is_added_but_not_fired() {
+        let (state, mut rx) = test_state();
+        let agenda = state.agenda.clone();
+        let app = router(state);
+
+        let future = chronos_core::now_unix_ms() + 60_000;
+        let resp = app
+            .oneshot(post(
+                "/v1/wake",
+                serde_json::json!({ "intent": "later", "when_unix_ms": future }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        assert_eq!(body_json(resp).await["fired"], false);
+
+        // No wake fired...
+        assert!(rx.try_recv().is_err(), "future intent must not fire now");
+        // ...but the item is durably scheduled (pending, not_before set).
+        let items = agenda
+            .list(&SessionId::from_string(DEFAULT_SESSION))
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].state, AgendaItemState::Pending);
+        assert_eq!(items[0].not_before_unix_ms, Some(future));
+        assert!(!items[0].is_ready(chronos_core::now_unix_ms()));
+    }
+
+    #[tokio::test]
+    async fn empty_intent_is_rejected() {
+        let (state, _rx) = test_state();
+        let app = router(state);
+        let resp = app
+            .oneshot(post("/v1/wake", serde_json::json!({ "intent": "   " })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_agenda_lists_items_in_dispatch_order() {
+        let (state, _rx) = test_state();
+        let app = router(state);
+
+        for (intent, priority) in [("low", "deferrable"), ("mid", "normal"), ("top", "urgent")] {
+            let r = app
+                .clone()
+                .oneshot(post(
+                    "/v1/wake",
+                    serde_json::json!({ "intent": intent, "session_id": "s", "priority": priority }),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(r.status(), StatusCode::ACCEPTED);
+        }
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/agenda/s")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["count"], 3);
+        let order: Vec<&str> = json["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["intent"].as_str().unwrap())
+            .collect();
+        assert_eq!(order, vec!["top", "mid", "low"]);
+    }
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let (state, _rx) = test_state();
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_json(resp).await["status"], "ok");
+    }
+}

--- a/crates/chronos/chronos-core/src/agenda.rs
+++ b/crates/chronos/chronos-core/src/agenda.rs
@@ -1,0 +1,469 @@
+//! The durable per-session **agenda** (M1).
+//!
+//! Where [`crate::WakeEvent`] answers *"when should an agent wake?"*, the agenda answers
+//! *"what should it do when it wakes?"* — a list of [`AgendaItem`]s, each carrying an
+//! `intent`, scoped to a session, surviving daemon restarts.
+//!
+//! ## The [`AgendaStore`] trait
+//!
+//! Two implementations exist:
+//!
+//! - [`InMemoryAgendaStore`] (this crate) — a `Mutex<HashMap<…>>`, used by tests and by the
+//!   `chronos-api` integration suite (so the API can be exercised without a lago journal).
+//! - `chronos_lago::LagoAgendaStore` — persists each mutation as a `Custom("chronos.agenda.*")`
+//!   lago event and rebuilds state by folding the journal (a *pure event projection*, matching
+//!   the `haima::FinancialState` / `autonomic::HomeostaticState` precedent). This is what makes
+//!   the agenda durable across restarts.
+//!
+//! The mutating methods (`complete` / `defer` / `cancel`) take only an [`AgendaItemId`], never a
+//! session. The lago projection therefore writes every agenda event to a single dedicated ledger
+//! stream and folds the whole stream on `list`, filtering by the item's `session_id` field —
+//! which is why an id alone is enough to address any item.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{ChronosError, ChronosResult, SessionId, WakeSource};
+
+/// Unique identifier for an agenda item.
+///
+/// ULID-based, so the string sorts by creation time — handy for FIFO tie-breaking within a
+/// priority band and for inspecting the journal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgendaItemId(pub String);
+
+impl AgendaItemId {
+    /// Mint a new ULID-based agenda item id.
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    /// View the underlying string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for AgendaItemId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for AgendaItemId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Dispatch priority for an agenda item.
+///
+/// Ordering (the M1 locked decision): `Urgent` > `Normal` > `Deferrable`, FIFO within a band.
+/// See [`AgendaItem::dispatch_cmp`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    /// Dispatched before everything else.
+    Urgent,
+    /// The default band.
+    #[default]
+    Normal,
+    /// Dispatched only once `Urgent` and `Normal` are drained.
+    Deferrable,
+}
+
+impl Priority {
+    /// Lowercase string identifier suitable for log fields and event payloads.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Priority::Urgent => "urgent",
+            Priority::Normal => "normal",
+            Priority::Deferrable => "deferrable",
+        }
+    }
+
+    /// Sort rank — lower dispatches first.
+    pub fn rank(self) -> u8 {
+        match self {
+            Priority::Urgent => 0,
+            Priority::Normal => 1,
+            Priority::Deferrable => 2,
+        }
+    }
+}
+
+/// Lifecycle state of an agenda item.
+///
+/// `Pending` items with a `not_before_unix_ms` in the future are scheduled but not yet ready
+/// (see [`AgendaItem::is_ready`]). `Completed` / `Cancelled` are terminal. `Deferred` is the
+/// result of an explicit [`AgendaStore::defer`] call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgendaItemState {
+    /// Awaiting dispatch (the M1 default for a freshly-added item).
+    Pending,
+    /// The kernel ran the item to completion (M2 marks this; M1 exposes the transition).
+    Completed,
+    /// Explicitly pushed to a later time via [`AgendaStore::defer`].
+    Deferred,
+    /// Withdrawn before dispatch.
+    Cancelled,
+}
+
+impl AgendaItemState {
+    /// Lowercase string identifier suitable for log fields and event payloads.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgendaItemState::Pending => "pending",
+            AgendaItemState::Completed => "completed",
+            AgendaItemState::Deferred => "deferred",
+            AgendaItemState::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether the state is terminal (no further transitions expected).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            AgendaItemState::Completed | AgendaItemState::Cancelled
+        )
+    }
+}
+
+/// Input to [`AgendaStore::add`]. The store assigns the `id`, the initial `Pending` state, and
+/// the `created_at_unix_ms` timestamp — callers supply only the intent + routing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewAgendaItem {
+    /// Session the item (and the wake it fires) is targeted at.
+    pub session_id: SessionId,
+    /// What the agent should do when it wakes (free-form; the kernel interprets it in M2).
+    pub intent: String,
+    /// Dispatch priority. Defaults to [`Priority::Normal`].
+    #[serde(default)]
+    pub priority: Priority,
+    /// Where the intent came from. `Http` for the M1 `POST /v1/wake` path.
+    pub source: WakeSource,
+    /// Earliest dispatch time (ms since epoch). `None` means "ready now".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before_unix_ms: Option<i64>,
+}
+
+impl NewAgendaItem {
+    /// Construct a normal-priority, ready-now item.
+    pub fn new(session_id: SessionId, intent: impl Into<String>, source: WakeSource) -> Self {
+        Self {
+            session_id,
+            intent: intent.into(),
+            priority: Priority::Normal,
+            source,
+            not_before_unix_ms: None,
+        }
+    }
+
+    /// Set the dispatch priority (builder).
+    #[must_use]
+    pub fn with_priority(mut self, priority: Priority) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Set the earliest-dispatch time in ms since epoch (builder).
+    #[must_use]
+    pub fn with_not_before(mut self, not_before_unix_ms: i64) -> Self {
+        self.not_before_unix_ms = Some(not_before_unix_ms);
+        self
+    }
+}
+
+/// A durable agenda item — the unit of work the kernel will eventually run on wake (M2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgendaItem {
+    /// Unique id, minted on add.
+    pub id: AgendaItemId,
+    /// Session this item belongs to (and the wake routes to).
+    pub session_id: SessionId,
+    /// What the agent should do when it wakes.
+    pub intent: String,
+    /// Dispatch priority.
+    pub priority: Priority,
+    /// Current lifecycle state.
+    pub state: AgendaItemState,
+    /// Where the intent came from.
+    pub source: WakeSource,
+    /// When the item was added (ms since epoch).
+    pub created_at_unix_ms: i64,
+    /// Earliest dispatch time (ms since epoch); `None` means "ready now".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before_unix_ms: Option<i64>,
+}
+
+impl AgendaItem {
+    /// Build a fresh `Pending` item from a [`NewAgendaItem`], minting an id and stamping the
+    /// creation time.
+    pub fn pending_from(new: NewAgendaItem) -> Self {
+        Self {
+            id: AgendaItemId::new(),
+            session_id: new.session_id,
+            intent: new.intent,
+            priority: new.priority,
+            state: AgendaItemState::Pending,
+            source: new.source,
+            created_at_unix_ms: crate::now_unix_ms(),
+            not_before_unix_ms: new.not_before_unix_ms,
+        }
+    }
+
+    /// Whether the item is ready to dispatch at `now_unix_ms`: `Pending` and either no
+    /// `not_before` constraint or one already in the past.
+    pub fn is_ready(&self, now_unix_ms: i64) -> bool {
+        matches!(self.state, AgendaItemState::Pending)
+            && self
+                .not_before_unix_ms
+                .map(|t| t <= now_unix_ms)
+                .unwrap_or(true)
+    }
+
+    /// Total dispatch ordering: by [`Priority::rank`], then creation time, then id (a stable
+    /// FIFO tie-break, since ULIDs are creation-ordered). Use with `slice::sort_by`.
+    pub fn dispatch_cmp(&self, other: &AgendaItem) -> Ordering {
+        self.priority
+            .rank()
+            .cmp(&other.priority.rank())
+            .then(self.created_at_unix_ms.cmp(&other.created_at_unix_ms))
+            .then_with(|| self.id.as_str().cmp(other.id.as_str()))
+    }
+}
+
+/// Sort a slice of agenda items into dispatch order (see [`AgendaItem::dispatch_cmp`]).
+///
+/// Shared by every [`AgendaStore::list`] implementation so the dispatch ordering is defined in
+/// exactly one place.
+pub fn sort_for_dispatch(items: &mut [AgendaItem]) {
+    items.sort_by(AgendaItem::dispatch_cmp);
+}
+
+/// Durable per-session store of [`AgendaItem`]s.
+///
+/// Implementations must be `Send + Sync` so they can live behind an `Arc<dyn AgendaStore>` shared
+/// across the daemon's HTTP handlers and wake loop. `#[async_trait]` boxes the returned futures
+/// for dyn-compatibility (the wake rate Chronos targets — ≤ 100/sec — makes the boxing cost
+/// negligible).
+#[async_trait]
+pub trait AgendaStore: Send + Sync {
+    /// Add a new item to the agenda. Returns the freshly-minted id.
+    async fn add(&self, item: NewAgendaItem) -> ChronosResult<AgendaItemId>;
+
+    /// Mark an item completed. Errors with [`ChronosError::NotFound`] if the id is unknown.
+    async fn complete(&self, id: &AgendaItemId) -> ChronosResult<()>;
+
+    /// Defer an item to a later time (`until_unix_ms`, ms since epoch). Sets state to
+    /// [`AgendaItemState::Deferred`] and updates `not_before_unix_ms`. Errors with
+    /// [`ChronosError::NotFound`] if the id is unknown.
+    async fn defer(&self, id: &AgendaItemId, until_unix_ms: i64) -> ChronosResult<()>;
+
+    /// Cancel an item. Errors with [`ChronosError::NotFound`] if the id is unknown.
+    async fn cancel(&self, id: &AgendaItemId) -> ChronosResult<()>;
+
+    /// List the items for a session, in dispatch order. Terminal (completed/cancelled) items are
+    /// included so callers can inspect history; filter on [`AgendaItem::state`] if undesired.
+    async fn list(&self, session: &SessionId) -> ChronosResult<Vec<AgendaItem>>;
+}
+
+/// In-memory [`AgendaStore`] — the reference implementation used by tests and by the
+/// `chronos-api` integration suite. Not durable across restarts; for that, use
+/// `chronos_lago::LagoAgendaStore`.
+#[derive(Default)]
+pub struct InMemoryAgendaStore {
+    items: Mutex<HashMap<AgendaItemId, AgendaItem>>,
+}
+
+impl InMemoryAgendaStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl AgendaStore for InMemoryAgendaStore {
+    async fn add(&self, item: NewAgendaItem) -> ChronosResult<AgendaItemId> {
+        let stored = AgendaItem::pending_from(item);
+        let id = stored.id.clone();
+        let mut guard = self.items.lock().expect("agenda mutex poisoned");
+        guard.insert(id.clone(), stored);
+        Ok(id)
+    }
+
+    async fn complete(&self, id: &AgendaItemId) -> ChronosResult<()> {
+        let mut guard = self.items.lock().expect("agenda mutex poisoned");
+        let item = guard
+            .get_mut(id)
+            .ok_or_else(|| ChronosError::NotFound(id.to_string()))?;
+        item.state = AgendaItemState::Completed;
+        Ok(())
+    }
+
+    async fn defer(&self, id: &AgendaItemId, until_unix_ms: i64) -> ChronosResult<()> {
+        let mut guard = self.items.lock().expect("agenda mutex poisoned");
+        let item = guard
+            .get_mut(id)
+            .ok_or_else(|| ChronosError::NotFound(id.to_string()))?;
+        item.state = AgendaItemState::Deferred;
+        item.not_before_unix_ms = Some(until_unix_ms);
+        Ok(())
+    }
+
+    async fn cancel(&self, id: &AgendaItemId) -> ChronosResult<()> {
+        let mut guard = self.items.lock().expect("agenda mutex poisoned");
+        let item = guard
+            .get_mut(id)
+            .ok_or_else(|| ChronosError::NotFound(id.to_string()))?;
+        item.state = AgendaItemState::Cancelled;
+        Ok(())
+    }
+
+    async fn list(&self, session: &SessionId) -> ChronosResult<Vec<AgendaItem>> {
+        let guard = self.items.lock().expect("agenda mutex poisoned");
+        let mut out: Vec<AgendaItem> = guard
+            .values()
+            .filter(|i| i.session_id.as_str() == session.as_str())
+            .cloned()
+            .collect();
+        sort_for_dispatch(&mut out);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sess(s: &str) -> SessionId {
+        SessionId::from_string(s)
+    }
+
+    fn new_item(session: &str, intent: &str) -> NewAgendaItem {
+        NewAgendaItem::new(sess(session), intent, WakeSource::Http)
+    }
+
+    #[tokio::test]
+    async fn add_then_list_returns_pending_item() {
+        let store = InMemoryAgendaStore::new();
+        let id = store.add(new_item("s1", "rebuild index")).await.unwrap();
+
+        let items = store.list(&sess("s1")).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, id);
+        assert_eq!(items[0].state, AgendaItemState::Pending);
+        assert_eq!(items[0].intent, "rebuild index");
+        assert_eq!(items[0].priority, Priority::Normal);
+        assert_eq!(items[0].source, WakeSource::Http);
+        assert!(items[0].created_at_unix_ms >= 0);
+        assert!(items[0].not_before_unix_ms.is_none());
+    }
+
+    #[tokio::test]
+    async fn complete_defer_cancel_transition_state() {
+        let store = InMemoryAgendaStore::new();
+        let a = store.add(new_item("s", "a")).await.unwrap();
+        let b = store.add(new_item("s", "b")).await.unwrap();
+        let c = store.add(new_item("s", "c")).await.unwrap();
+
+        store.complete(&a).await.unwrap();
+        store.defer(&b, 9_999).await.unwrap();
+        store.cancel(&c).await.unwrap();
+
+        let items = store.list(&sess("s")).await.unwrap();
+        let by_id: HashMap<_, _> = items.into_iter().map(|i| (i.id.clone(), i)).collect();
+        assert_eq!(by_id[&a].state, AgendaItemState::Completed);
+        assert_eq!(by_id[&b].state, AgendaItemState::Deferred);
+        assert_eq!(by_id[&b].not_before_unix_ms, Some(9_999));
+        assert_eq!(by_id[&c].state, AgendaItemState::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn mutations_on_unknown_id_error_not_found() {
+        let store = InMemoryAgendaStore::new();
+        let ghost = AgendaItemId("01J0000000000000000000GHOST".to_string());
+        assert!(matches!(
+            store.complete(&ghost).await,
+            Err(ChronosError::NotFound(_))
+        ));
+        assert!(matches!(
+            store.defer(&ghost, 1).await,
+            Err(ChronosError::NotFound(_))
+        ));
+        assert!(matches!(
+            store.cancel(&ghost).await,
+            Err(ChronosError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_session() {
+        let store = InMemoryAgendaStore::new();
+        store.add(new_item("alpha", "a1")).await.unwrap();
+        store.add(new_item("alpha", "a2")).await.unwrap();
+        store.add(new_item("beta", "b1")).await.unwrap();
+
+        assert_eq!(store.list(&sess("alpha")).await.unwrap().len(), 2);
+        assert_eq!(store.list(&sess("beta")).await.unwrap().len(), 1);
+        assert_eq!(store.list(&sess("gamma")).await.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn list_orders_by_priority_then_fifo() {
+        let store = InMemoryAgendaStore::new();
+        // Add in deliberately scrambled priority order.
+        let normal = store.add(new_item("s", "normal-1")).await.unwrap();
+        let deferrable = store
+            .add(new_item("s", "deferrable").into_priority(Priority::Deferrable))
+            .await
+            .unwrap();
+        let urgent = store
+            .add(new_item("s", "urgent").into_priority(Priority::Urgent))
+            .await
+            .unwrap();
+
+        let items = store.list(&sess("s")).await.unwrap();
+        let order: Vec<&AgendaItemId> = items.iter().map(|i| &i.id).collect();
+        assert_eq!(order, vec![&urgent, &normal, &deferrable]);
+    }
+
+    #[test]
+    fn agenda_item_roundtrips_through_json() {
+        let item = AgendaItem::pending_from(new_item("sX", "do the thing").with_not_before(123));
+        let json = serde_json::to_string(&item).expect("serialize");
+        let back: AgendaItem = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.id, item.id);
+        assert_eq!(back.intent, "do the thing");
+        assert_eq!(back.session_id.as_str(), "sX");
+        assert_eq!(back.not_before_unix_ms, Some(123));
+        assert_eq!(back.state, AgendaItemState::Pending);
+    }
+
+    #[test]
+    fn is_ready_respects_not_before_and_state() {
+        let mut item = AgendaItem::pending_from(new_item("s", "x"));
+        assert!(item.is_ready(0), "pending, no not_before => ready");
+
+        item.not_before_unix_ms = Some(1_000);
+        assert!(!item.is_ready(999), "not_before in the future => not ready");
+        assert!(item.is_ready(1_000), "not_before reached => ready");
+
+        item.state = AgendaItemState::Completed;
+        assert!(!item.is_ready(2_000), "terminal state => never ready");
+    }
+
+    // Tiny test-only ergonomic helper so the priority test reads cleanly.
+    impl NewAgendaItem {
+        fn into_priority(self, p: Priority) -> Self {
+            self.with_priority(p)
+        }
+    }
+}

--- a/crates/chronos/chronos-core/src/error.rs
+++ b/crates/chronos/chronos-core/src/error.rs
@@ -16,6 +16,16 @@ pub enum ChronosError {
     /// The router observed an invariant violation.
     #[error("chronos router error: {0}")]
     Router(String),
+
+    /// An agenda operation referenced an item id that does not exist in the store.
+    #[error("chronos agenda item not found: {0}")]
+    NotFound(String),
+
+    /// The agenda backing store failed (e.g. a lago journal append/read error in
+    /// `chronos-lago::LagoAgendaStore`). Carries the backend error rendered as a string so
+    /// `chronos-core` stays free of a `lago-core` dependency.
+    #[error("chronos agenda store error: {0}")]
+    Agenda(String),
 }
 
 /// Result alias used throughout chronos-core.

--- a/crates/chronos/chronos-core/src/lib.rs
+++ b/crates/chronos/chronos-core/src/lib.rs
@@ -5,20 +5,21 @@
 //! 1. **"When should an agent wake?"** — a unified surface that coalesces all wake sources
 //!    (HTTP `/runs`, cron, file changes, sub-agent completions, threshold crossings, webhooks,
 //!    heartbeats) into a single ordered event stream the kernel can subscribe to.
-//! 2. **"What should the agent do when it wakes?"** — a durable per-session agenda that survives
-//!    daemon restarts (introduced in M1; not in this crate's M0 surface).
+//! 2. **"What should the agent do when it wakes?"** — a durable per-session [`AgendaStore`] of
+//!    [`AgendaItem`]s that survives daemon restarts (introduced in M1).
 //!
 //! ## Dependency rule
 //!
 //! `chronos-core` depends ONLY on `aios-protocol` from the Life internal-crate graph. No lago,
 //! no arcan, no autonomic. Enforced by `scripts/architecture/verify_dependencies_chronos.sh`.
 //!
-//! ## Module shape (M0)
+//! ## Module shape
 //!
 //! - [`WakeEvent`] — universal wake shape (id, timestamp, source, payload, optional target session)
 //! - [`WakeSource`] — taxonomy of where a wake can come from
 //! - [`WakeTrigger`] — async trait every trigger implements (heartbeat, http, cron, fs, …)
 //! - [`WakeRouter`] — multiplexes triggers concurrently into a single stream
+//! - [`AgendaStore`] / [`AgendaItem`] / [`InMemoryAgendaStore`] — the durable agenda (M1)
 //! - [`ChronosError`] / [`ChronosResult`] — crate-local error type
 //!
 //! ## Why `tokio` in core?
@@ -32,11 +33,16 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+mod agenda;
 mod error;
 mod router;
 mod trigger;
 mod wake;
 
+pub use agenda::{
+    AgendaItem, AgendaItemId, AgendaItemState, AgendaStore, InMemoryAgendaStore, NewAgendaItem,
+    Priority, sort_for_dispatch,
+};
 pub use error::{ChronosError, ChronosResult};
 pub use router::WakeRouter;
 pub use trigger::WakeTrigger;

--- a/crates/chronos/chronos-lago/src/lib.rs
+++ b/crates/chronos/chronos-lago/src/lib.rs
@@ -20,12 +20,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aios_protocol::EventKind;
-use chronos_core::WakeEvent;
+use async_trait::async_trait;
+use chronos_core::{
+    AgendaItem, AgendaItemId, AgendaItemState, AgendaStore, ChronosError, ChronosResult,
+    NewAgendaItem, WakeEvent, sort_for_dispatch,
+};
 use lago_core::error::LagoError;
 use lago_core::event::EventEnvelope;
 use lago_core::id::{BranchId, EventId, SeqNo, SessionId};
-use lago_core::journal::Journal;
-use tracing::{debug, instrument};
+use lago_core::journal::{EventQuery, Journal};
+use tracing::{debug, instrument, warn};
 
 /// Lago `event_type` written for chronos wake events. The kernel does not yet have a typed
 /// variant; this string is the stable identifier downstream consumers (replay, projections,
@@ -90,6 +94,209 @@ pub async fn record_wake(
     let seq = journal.append(envelope).await?;
     debug!(seq, "chronos.wake appended");
     Ok(seq)
+}
+
+// ---------------------------------------------------------------------------
+// M1 — Agenda store (pure event-projection fold)
+// ---------------------------------------------------------------------------
+
+/// Lago `event_type` written when an agenda item is created.
+pub const CHRONOS_AGENDA_ADDED_EVENT_TYPE: &str = "chronos.agenda.added";
+/// Lago `event_type` written when an agenda item is completed.
+pub const CHRONOS_AGENDA_COMPLETED_EVENT_TYPE: &str = "chronos.agenda.completed";
+/// Lago `event_type` written when an agenda item is deferred.
+pub const CHRONOS_AGENDA_DEFERRED_EVENT_TYPE: &str = "chronos.agenda.deferred";
+/// Lago `event_type` written when an agenda item is cancelled.
+pub const CHRONOS_AGENDA_CANCELLED_EVENT_TYPE: &str = "chronos.agenda.cancelled";
+
+/// Dedicated lago session holding the chronos agenda ledger.
+///
+/// Every `chronos.agenda.*` event lands here regardless of the item's *target* session (which is
+/// carried as the `session_id` field inside the event payload). Keeping the agenda in a single
+/// stream is what lets [`AgendaStore::complete`] / `defer` / `cancel` address an item by id alone:
+/// the projection folds the whole ledger and filters by the item's `session_id` field on
+/// [`AgendaStore::list`]. Wake events, by contrast, still route to their target session via
+/// [`record_wake`] — the agenda ledger and the wake stream are deliberately separate.
+pub const CHRONOS_AGENDA_SESSION: &str = "chronos.agenda";
+
+/// Lago-backed [`AgendaStore`].
+///
+/// Each mutation appends a `Custom("chronos.agenda.*")` event; reads rebuild state by folding the
+/// ledger from scratch — a *pure event projection* (the M1 option (b) decision), mirroring the
+/// `haima::FinancialState` and `autonomic::HomeostaticState` precedent. No in-memory cache: every
+/// [`AgendaStore::list`] re-derives current state from the journal, so the agenda is automatically
+/// durable across `chronosd` restarts (open a fresh store over the same journal and the items are
+/// still there).
+pub struct LagoAgendaStore {
+    journal: Arc<dyn Journal>,
+    ledger_session: SessionId,
+    branch: BranchId,
+}
+
+impl LagoAgendaStore {
+    /// Construct a store over `journal`, writing the ledger to [`CHRONOS_AGENDA_SESSION`] on
+    /// [`CHRONOS_DEFAULT_BRANCH`].
+    pub fn new(journal: Arc<dyn Journal>) -> Self {
+        Self {
+            journal,
+            ledger_session: SessionId::from_string(CHRONOS_AGENDA_SESSION),
+            branch: BranchId::from_string(CHRONOS_DEFAULT_BRANCH),
+        }
+    }
+
+    /// Append one agenda event to the ledger.
+    async fn append_event(
+        &self,
+        event_type: &str,
+        data: serde_json::Value,
+    ) -> Result<SeqNo, LagoError> {
+        let envelope = EventEnvelope {
+            event_id: EventId::new(),
+            session_id: self.ledger_session.clone(),
+            branch_id: self.branch.clone(),
+            run_id: None,
+            seq: 0, // assigned by the journal
+            timestamp: EventEnvelope::now_micros(),
+            parent_id: None,
+            payload: EventKind::Custom {
+                event_type: event_type.to_string(),
+                data,
+            },
+            metadata: HashMap::new(),
+            schema_version: 1,
+        };
+        self.journal.append(envelope).await
+    }
+
+    /// Fold the agenda ledger into the current item set, keyed by id. `read` returns events in
+    /// seq order (the compound key is `session+branch+seq`), so a single forward pass is correct.
+    async fn project(&self) -> Result<HashMap<AgendaItemId, AgendaItem>, LagoError> {
+        let query = EventQuery::new()
+            .session(self.ledger_session.clone())
+            .branch(self.branch.clone());
+        let events = self.journal.read(query).await?;
+
+        let mut items: HashMap<AgendaItemId, AgendaItem> = HashMap::new();
+        for envelope in &events {
+            let EventKind::Custom { event_type, data } = &envelope.payload else {
+                continue;
+            };
+            match event_type.as_str() {
+                CHRONOS_AGENDA_ADDED_EVENT_TYPE => {
+                    match serde_json::from_value::<AgendaItem>(data.clone()) {
+                        Ok(item) => {
+                            items.insert(item.id.clone(), item);
+                        }
+                        Err(err) => {
+                            warn!(error = %err, "skipping malformed chronos.agenda.added payload");
+                        }
+                    }
+                }
+                CHRONOS_AGENDA_COMPLETED_EVENT_TYPE => {
+                    if let Some(item) = item_for(&mut items, data) {
+                        item.state = AgendaItemState::Completed;
+                    }
+                }
+                CHRONOS_AGENDA_DEFERRED_EVENT_TYPE => {
+                    if let Some(item) = item_for(&mut items, data) {
+                        item.state = AgendaItemState::Deferred;
+                        item.not_before_unix_ms =
+                            data.get("not_before_unix_ms").and_then(|v| v.as_i64());
+                    }
+                }
+                CHRONOS_AGENDA_CANCELLED_EVENT_TYPE => {
+                    if let Some(item) = item_for(&mut items, data) {
+                        item.state = AgendaItemState::Cancelled;
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(items)
+    }
+
+    /// Mirror the `InMemoryAgendaStore` contract: a transition on an unknown id is a
+    /// [`ChronosError::NotFound`], not a silently-appended ghost event.
+    async fn require_exists(&self, id: &AgendaItemId) -> ChronosResult<()> {
+        let items = self.project().await.map_err(agenda_err)?;
+        if items.contains_key(id) {
+            Ok(())
+        } else {
+            Err(ChronosError::NotFound(id.to_string()))
+        }
+    }
+}
+
+/// Resolve the `id` field of a transition event back to a mutable item in the projection.
+fn item_for<'a>(
+    items: &'a mut HashMap<AgendaItemId, AgendaItem>,
+    data: &serde_json::Value,
+) -> Option<&'a mut AgendaItem> {
+    let id = data.get("id").and_then(|v| v.as_str())?;
+    items.get_mut(&AgendaItemId(id.to_string()))
+}
+
+/// Render a lago error as a [`ChronosError::Agenda`], keeping `chronos-core` free of a
+/// `lago-core` dependency.
+fn agenda_err(err: LagoError) -> ChronosError {
+    ChronosError::Agenda(err.to_string())
+}
+
+#[async_trait]
+impl AgendaStore for LagoAgendaStore {
+    async fn add(&self, item: NewAgendaItem) -> ChronosResult<AgendaItemId> {
+        let stored = AgendaItem::pending_from(item);
+        let id = stored.id.clone();
+        let data =
+            serde_json::to_value(&stored).map_err(|e| ChronosError::Agenda(e.to_string()))?;
+        self.append_event(CHRONOS_AGENDA_ADDED_EVENT_TYPE, data)
+            .await
+            .map_err(agenda_err)?;
+        Ok(id)
+    }
+
+    async fn complete(&self, id: &AgendaItemId) -> ChronosResult<()> {
+        self.require_exists(id).await?;
+        self.append_event(
+            CHRONOS_AGENDA_COMPLETED_EVENT_TYPE,
+            serde_json::json!({ "id": id.as_str() }),
+        )
+        .await
+        .map_err(agenda_err)?;
+        Ok(())
+    }
+
+    async fn defer(&self, id: &AgendaItemId, until_unix_ms: i64) -> ChronosResult<()> {
+        self.require_exists(id).await?;
+        self.append_event(
+            CHRONOS_AGENDA_DEFERRED_EVENT_TYPE,
+            serde_json::json!({ "id": id.as_str(), "not_before_unix_ms": until_unix_ms }),
+        )
+        .await
+        .map_err(agenda_err)?;
+        Ok(())
+    }
+
+    async fn cancel(&self, id: &AgendaItemId) -> ChronosResult<()> {
+        self.require_exists(id).await?;
+        self.append_event(
+            CHRONOS_AGENDA_CANCELLED_EVENT_TYPE,
+            serde_json::json!({ "id": id.as_str() }),
+        )
+        .await
+        .map_err(agenda_err)?;
+        Ok(())
+    }
+
+    async fn list(&self, session: &chronos_core::SessionId) -> ChronosResult<Vec<AgendaItem>> {
+        let items = self.project().await.map_err(agenda_err)?;
+        let mut out: Vec<AgendaItem> = items
+            .into_values()
+            .filter(|i| i.session_id.as_str() == session.as_str())
+            .collect();
+        sort_for_dispatch(&mut out);
+        Ok(out)
+    }
 }
 
 #[cfg(test)]
@@ -194,5 +401,186 @@ mod tests {
                 "sequences must be monotonically increasing: {seqs:?}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod agenda_tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use aios_protocol::EventKind;
+    use chronos_core::{
+        AgendaItemState, AgendaStore, NewAgendaItem, Priority, SessionId, WakeSource,
+    };
+    use lago_core::id::{BranchId, SessionId as LagoSessionId};
+    use lago_core::journal::{EventQuery, Journal};
+    use lago_journal::RedbJournal;
+
+    use super::*;
+
+    fn open_journal(dir: &Path) -> Arc<dyn Journal> {
+        Arc::new(RedbJournal::open(dir.join("agenda.redb")).expect("open redb")) as Arc<dyn Journal>
+    }
+
+    fn new_item(session: &str, intent: &str) -> NewAgendaItem {
+        NewAgendaItem::new(SessionId::from_string(session), intent, WakeSource::Http)
+    }
+
+    #[tokio::test]
+    async fn add_then_list_roundtrips_through_lago() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = LagoAgendaStore::new(open_journal(dir.path()));
+
+        let id = store
+            .add(new_item("user-1", "summarize the inbox").with_priority(Priority::Urgent))
+            .await
+            .expect("add");
+
+        let items = store
+            .list(&SessionId::from_string("user-1"))
+            .await
+            .expect("list");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, id);
+        assert_eq!(items[0].state, AgendaItemState::Pending);
+        assert_eq!(items[0].intent, "summarize the inbox");
+        assert_eq!(items[0].priority, Priority::Urgent);
+        assert_eq!(items[0].source, WakeSource::Http);
+    }
+
+    #[tokio::test]
+    async fn complete_defer_cancel_fold_into_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = LagoAgendaStore::new(open_journal(dir.path()));
+
+        let a = store.add(new_item("s", "a")).await.unwrap();
+        let b = store.add(new_item("s", "b")).await.unwrap();
+        let c = store.add(new_item("s", "c")).await.unwrap();
+
+        store.complete(&a).await.unwrap();
+        store.defer(&b, 8_888).await.unwrap();
+        store.cancel(&c).await.unwrap();
+
+        let items = store.list(&SessionId::from_string("s")).await.unwrap();
+        let by_id: std::collections::HashMap<_, _> =
+            items.into_iter().map(|i| (i.id.clone(), i)).collect();
+        assert_eq!(by_id[&a].state, AgendaItemState::Completed);
+        assert_eq!(by_id[&b].state, AgendaItemState::Deferred);
+        assert_eq!(by_id[&b].not_before_unix_ms, Some(8_888));
+        assert_eq!(by_id[&c].state, AgendaItemState::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn mutations_on_unknown_id_error_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = LagoAgendaStore::new(open_journal(dir.path()));
+        let ghost = chronos_core::AgendaItemId("01J0000000000000000000GHOST".to_string());
+        assert!(matches!(
+            store.complete(&ghost).await,
+            Err(chronos_core::ChronosError::NotFound(_))
+        ));
+        assert!(matches!(
+            store.defer(&ghost, 1).await,
+            Err(chronos_core::ChronosError::NotFound(_))
+        ));
+        assert!(matches!(
+            store.cancel(&ghost).await,
+            Err(chronos_core::ChronosError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_target_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = LagoAgendaStore::new(open_journal(dir.path()));
+        store.add(new_item("alpha", "a1")).await.unwrap();
+        store.add(new_item("alpha", "a2")).await.unwrap();
+        store.add(new_item("beta", "b1")).await.unwrap();
+
+        assert_eq!(
+            store
+                .list(&SessionId::from_string("alpha"))
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .list(&SessionId::from_string("beta"))
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    /// The durability guarantee: a fresh store over the SAME journal sees the agenda — i.e. it
+    /// survives a daemon restart. This is the whole point of the lago projection.
+    #[tokio::test]
+    async fn agenda_survives_store_recreation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = open_journal(dir.path());
+
+        let id = {
+            let store = LagoAgendaStore::new(journal.clone());
+            let id = store.add(new_item("persist", "remember me")).await.unwrap();
+            store.complete(&id).await.unwrap();
+            id
+        };
+
+        // Re-open a brand new store over the same journal — simulating a chronosd restart.
+        let reopened = LagoAgendaStore::new(journal.clone());
+        let items = reopened
+            .list(&SessionId::from_string("persist"))
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, id);
+        assert_eq!(items[0].state, AgendaItemState::Completed);
+    }
+
+    /// Agenda events land in the dedicated `chronos.agenda` ledger session (not the item's target
+    /// session), so an id alone is enough to address any item across sessions.
+    #[tokio::test]
+    async fn added_event_is_journaled_under_the_agenda_ledger() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = open_journal(dir.path());
+        let store = LagoAgendaStore::new(journal.clone());
+        store.add(new_item("user-xyz", "do work")).await.unwrap();
+
+        let ledger = journal
+            .read(
+                EventQuery::new()
+                    .session(LagoSessionId::from_string(CHRONOS_AGENDA_SESSION))
+                    .branch(BranchId::from_string(CHRONOS_DEFAULT_BRANCH)),
+            )
+            .await
+            .expect("read ledger");
+        assert_eq!(ledger.len(), 1, "one agenda.added event in the ledger");
+        match &ledger[0].payload {
+            EventKind::Custom { event_type, data } => {
+                assert_eq!(event_type, CHRONOS_AGENDA_ADDED_EVENT_TYPE);
+                assert_eq!(data["session_id"], "user-xyz");
+                assert_eq!(data["intent"], "do work");
+                assert_eq!(data["state"], "pending");
+            }
+            other => panic!("expected EventKind::Custom, got {other:?}"),
+        }
+
+        // The target user session holds no agenda events (only wakes would route there).
+        let user = journal
+            .read(
+                EventQuery::new()
+                    .session(LagoSessionId::from_string("user-xyz"))
+                    .branch(BranchId::from_string(CHRONOS_DEFAULT_BRANCH)),
+            )
+            .await
+            .expect("read user session");
+        assert!(
+            user.is_empty(),
+            "agenda events do not pollute the target session"
+        );
     }
 }

--- a/crates/chronos/chronos-triggers/src/http.rs
+++ b/crates/chronos/chronos-triggers/src/http.rs
@@ -1,0 +1,110 @@
+//! [`HttpTrigger`] — the real HTTP-backed wake trigger (M1).
+//!
+//! Replaces `HttpTriggerStub`. The trigger is deliberately thin: it owns the **receiving** end of
+//! an mpsc channel and yields whatever [`WakeEvent`]s are pushed into it. The **sending** end is
+//! handed to the `chronos-api` HTTP server, which constructs a wake on each `POST /v1/wake` whose
+//! intent is ready to fire now.
+//!
+//! This split keeps the dependency rule clean: `chronos-triggers` depends only on `chronos-core`
+//! (the channel carries `chronos_core::WakeEvent`). `chronos-api` never depends on
+//! `chronos-triggers` — it holds a bare `mpsc::Sender<WakeEvent>` instead — and `chronosd` is the
+//! single place that wires the two ends together via [`wake_channel`].
+
+use async_trait::async_trait;
+use chronos_core::{WakeEvent, WakeTrigger};
+use tokio::sync::mpsc;
+
+/// Sender half of the wake-ingest channel, handed to the HTTP API layer. Pushing a [`WakeEvent`]
+/// here causes the paired [`HttpTrigger`] to yield it on its next `next_wake`.
+pub type WakeSender = mpsc::Sender<WakeEvent>;
+
+/// Real HTTP-backed wake trigger. Yields events pushed into the paired [`WakeSender`].
+///
+/// `next_wake` returns `None` once **every** sender has been dropped (i.e. the API server has shut
+/// down), at which point the [`chronos_core::WakeRouter`] drops the trigger cleanly.
+pub struct HttpTrigger {
+    rx: mpsc::Receiver<WakeEvent>,
+}
+
+impl HttpTrigger {
+    /// Construct a trigger from the receiving end of a wake-ingest channel. Most callers want
+    /// [`wake_channel`] instead, which builds the matched pair.
+    pub fn new(rx: mpsc::Receiver<WakeEvent>) -> Self {
+        Self { rx }
+    }
+}
+
+/// Build a matched ([`WakeSender`], [`HttpTrigger`]) pair with the given channel capacity.
+///
+/// The daemon registers the returned [`HttpTrigger`] with the [`chronos_core::WakeRouter`] and
+/// hands the [`WakeSender`] to `chronos-api`. `buffer` is clamped to at least 1.
+pub fn wake_channel(buffer: usize) -> (WakeSender, HttpTrigger) {
+    let (tx, rx) = mpsc::channel(buffer.max(1));
+    (tx, HttpTrigger::new(rx))
+}
+
+#[async_trait]
+impl WakeTrigger for HttpTrigger {
+    async fn next_wake(&mut self) -> Option<WakeEvent> {
+        self.rx.recv().await
+    }
+
+    fn name(&self) -> &'static str {
+        "http"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chronos_core::{WakeEvent, WakeSource, WakeTrigger};
+
+    use super::wake_channel;
+
+    /// Build an HTTP wake the way `chronos-api` does, without reaching across crates.
+    fn http_intent(intent: impl Into<String>) -> WakeEvent {
+        WakeEvent::new(WakeSource::Http)
+            .with_payload(serde_json::json!({ "intent": intent.into() }))
+    }
+
+    #[tokio::test]
+    async fn pushed_event_is_yielded() {
+        let (tx, mut trigger) = wake_channel(8);
+        let sent = http_intent("rebuild index");
+        tx.send(sent.clone()).await.expect("send");
+
+        let got = trigger.next_wake().await.expect("trigger yields the event");
+        assert_eq!(got.source, WakeSource::Http);
+        assert_eq!(got.event_id, sent.event_id);
+        assert_eq!(got.payload["intent"], "rebuild index");
+    }
+
+    #[tokio::test]
+    async fn events_are_yielded_fifo() {
+        let (tx, mut trigger) = wake_channel(8);
+        for n in 0..3 {
+            tx.send(http_intent(format!("intent-{n}")))
+                .await
+                .expect("send");
+        }
+        for n in 0..3 {
+            let got = trigger.next_wake().await.expect("event");
+            assert_eq!(got.payload["intent"], format!("intent-{n}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_all_senders_exhausts_the_trigger() {
+        let (tx, mut trigger) = wake_channel(4);
+        drop(tx);
+        assert!(
+            trigger.next_wake().await.is_none(),
+            "trigger should return None once every sender is dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn name_is_stable() {
+        let (_tx, trigger) = wake_channel(1);
+        assert_eq!(trigger.name(), "http");
+    }
+}

--- a/crates/chronos/chronos-triggers/src/lib.rs
+++ b/crates/chronos/chronos-triggers/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! ## Per-milestone roadmap
 //!
-//! - **M0** (this crate, today): [`HeartbeatTrigger`], stubs for the rest.
-//! - **M1**: real [`HttpTrigger`] backed by an axum server in `chronos-api`.
+//! - **M0**: [`HeartbeatTrigger`], stubs for the rest.
+//! - **M1** (today): real [`HttpTrigger`] fed by the `chronos-api` axum server via [`wake_channel`].
 //! - **M3**: real [`FsWatchTrigger`] (via the `notify` crate) and `SubAgentReturnTrigger`.
 //! - **Beyond**: cron, webhook, threshold.
 
@@ -16,10 +16,12 @@
 #![warn(missing_docs)]
 
 mod heartbeat;
+mod http;
 mod stubs;
 
 pub use heartbeat::HeartbeatTrigger;
+pub use http::{HttpTrigger, WakeSender, wake_channel};
 pub use stubs::{
-    CronTriggerStub, FsWatchTriggerStub, HttpTriggerStub, SubAgentReturnTriggerStub,
-    ThresholdTriggerStub, WebhookTriggerStub,
+    CronTriggerStub, FsWatchTriggerStub, SubAgentReturnTriggerStub, ThresholdTriggerStub,
+    WebhookTriggerStub,
 };

--- a/crates/chronos/chronos-triggers/src/stubs.rs
+++ b/crates/chronos/chronos-triggers/src/stubs.rs
@@ -8,19 +8,7 @@
 use async_trait::async_trait;
 use chronos_core::{WakeEvent, WakeTrigger};
 
-/// HTTP wake-trigger placeholder. Real impl in M1 backed by `chronos-api`.
-pub struct HttpTriggerStub;
-
-#[async_trait]
-impl WakeTrigger for HttpTriggerStub {
-    async fn next_wake(&mut self) -> Option<WakeEvent> {
-        None
-    }
-
-    fn name(&self) -> &'static str {
-        "http (stub)"
-    }
-}
+// `HttpTriggerStub` was promoted to the real `HttpTrigger` in M1 — see `http.rs`.
 
 /// Cron expression-driven wake-trigger placeholder. Real impl beyond M3 via `tokio-cron-scheduler`.
 pub struct CronTriggerStub;
@@ -102,7 +90,6 @@ mod tests {
     #[tokio::test]
     async fn every_stub_returns_none() {
         let stubs: Vec<Box<dyn WakeTrigger>> = vec![
-            Box::new(HttpTriggerStub),
             Box::new(CronTriggerStub),
             Box::new(FsWatchTriggerStub),
             Box::new(SubAgentReturnTriggerStub),

--- a/crates/chronos/chronosd/Cargo.toml
+++ b/crates/chronos/chronosd/Cargo.toml
@@ -21,6 +21,7 @@ aios-protocol.workspace = true
 chronos-core.workspace = true
 chronos-triggers.workspace = true
 chronos-lago.workspace = true
+chronos-api.workspace = true
 lago-core.workspace = true
 lago-journal.workspace = true
 anyhow.workspace = true
@@ -32,7 +33,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "net", "io-util"] }
 
 [lints]
 workspace = true

--- a/crates/chronos/chronosd/src/lib.rs
+++ b/crates/chronos/chronosd/src/lib.rs
@@ -7,18 +7,21 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chronos_core::{WakeRouter, WakeTrigger};
-use chronos_lago::{CHRONOS_DEFAULT_BRANCH, CHRONOS_SYSTEM_SESSION, record_wake};
-use chronos_triggers::HeartbeatTrigger;
+use chronos_api::ApiState;
+use chronos_core::{AgendaStore, WakeRouter, WakeTrigger};
+use chronos_lago::{CHRONOS_DEFAULT_BRANCH, CHRONOS_SYSTEM_SESSION, LagoAgendaStore, record_wake};
+use chronos_triggers::{HeartbeatTrigger, wake_channel};
 use lago_core::id::{BranchId, SessionId};
 use lago_core::journal::Journal;
 use lago_journal::RedbJournal;
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 /// All configuration the daemon needs to start. Built from CLI / config-file in `main.rs`.
@@ -32,6 +35,9 @@ pub struct DaemonConfig {
     pub journal_filename: String,
     /// Internal mpsc capacity for the [`WakeRouter`].
     pub router_buffer: usize,
+    /// Optional bind address for the M1 HTTP wake-ingest API (`chronos-api`). When `None`,
+    /// chronosd runs heartbeat-only — exactly the M0 behavior.
+    pub http_bind: Option<SocketAddr>,
 }
 
 impl DaemonConfig {
@@ -48,6 +54,7 @@ impl Default for DaemonConfig {
             data_dir: PathBuf::from("/tmp/chronosd"),
             journal_filename: "journal.redb".to_string(),
             router_buffer: 64,
+            http_bind: None,
         }
     }
 }
@@ -78,12 +85,43 @@ pub async fn run(config: DaemonConfig, shutdown: Option<oneshot::Receiver<()>>) 
     let fallback_session = SessionId::from_string(CHRONOS_SYSTEM_SESSION);
     let branch = BranchId::from_string(CHRONOS_DEFAULT_BRANCH);
 
-    // 3. Build the router. M0 only wires the heartbeat trigger; the stubs are deliberately
+    // 3. Build the router. The heartbeat trigger is always wired; the M0 stubs are deliberately
     //    NOT added — they'd just return None immediately and confuse the trace.
     let mut router = WakeRouter::new(config.router_buffer);
     let heartbeat: Box<dyn WakeTrigger> =
         Box::new(HeartbeatTrigger::new(config.heartbeat_interval));
     router.add_trigger(heartbeat);
+
+    // 3b. M1 — HTTP wake ingest. When `--http-bind` is set, register a real HttpTrigger fed by
+    //     the chronos-api server, backed by the lago-projection agenda store. The trigger drains
+    //     into the same router/record_wake path as the heartbeat — wakes from either source are
+    //     journaled identically.
+    let (api_shutdown_tx, api_shutdown_rx) = oneshot::channel::<()>();
+    let mut api_handle: Option<JoinHandle<()>> = None;
+    if let Some(addr) = config.http_bind {
+        let (wake_tx, http_trigger) = wake_channel(config.router_buffer);
+        router.add_trigger(Box::new(http_trigger));
+
+        let agenda: Arc<dyn AgendaStore> = Arc::new(LagoAgendaStore::new(journal.clone()));
+        let api_state = ApiState {
+            agenda,
+            wake_tx,
+            // chronos-api stays free of routing constants; inject the system session here.
+            default_session: chronos_core::SessionId::from_string(CHRONOS_SYSTEM_SESSION),
+        };
+        info!(%addr, "chronos-api enabled — M1 wake ingest (POST /v1/wake, GET /v1/agenda/{{id}})");
+        api_handle = Some(tokio::spawn(async move {
+            let shutdown = async move {
+                let _ = api_shutdown_rx.await;
+            };
+            if let Err(err) = chronos_api::serve(addr, api_state, shutdown).await {
+                warn!(error = %err, "chronos-api server exited with error");
+            }
+        }));
+    } else {
+        // No API: drop the receiver so the unused shutdown sender is harmless.
+        drop(api_shutdown_rx);
+    }
 
     // 4. Shutdown plumbing.
     let mut shutdown_rx = shutdown;
@@ -119,7 +157,14 @@ pub async fn run(config: DaemonConfig, shutdown: Option<oneshot::Receiver<()>>) 
         }
     }
 
-    // 6. Drain the router. Bounded — shutdown should complete in well under 2 seconds.
+    // 6. Stop the HTTP server (if running) and wait for it to drain. Dropping its ApiState drops
+    //    the wake sender, so the HttpTrigger exhausts cleanly when we drain the router next.
+    let _ = api_shutdown_tx.send(());
+    if let Some(handle) = api_handle {
+        let _ = handle.await;
+    }
+
+    // 7. Drain the router. Bounded — shutdown should complete in well under 2 seconds.
     router.shutdown().await;
     info!(wake_total = wake_count, "chronosd shut down cleanly");
     Ok(())
@@ -185,6 +230,7 @@ mod tests {
             data_dir: tmp.path().to_path_buf(),
             journal_filename: "journal.redb".into(),
             router_buffer: 16,
+            http_bind: None,
         };
 
         let (tx, rx) = oneshot::channel();
@@ -227,6 +273,114 @@ mod tests {
                 }
                 other => panic!("expected EventKind::Custom, got {other:?}"),
             }
+        }
+    }
+
+    /// End-to-end M1 acceptance: a real `POST /v1/wake` over the wire makes the daemon journal
+    /// BOTH a `chronos.agenda.added` event (in the agenda ledger) AND a `chronos.wake` event
+    /// (in the target session). Exercises the full API → HttpTrigger → router → record_wake wiring.
+    #[tokio::test]
+    async fn daemon_http_ingest_records_wake_and_agenda_events() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Grab a free port, then drop the probe so chronosd can bind it.
+        let addr: std::net::SocketAddr = {
+            let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+            probe.local_addr().expect("local addr")
+        };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = DaemonConfig {
+            // Long heartbeat so it never fires during the test — isolates the HTTP wake.
+            heartbeat_interval: Duration::from_secs(3_600),
+            data_dir: tmp.path().to_path_buf(),
+            journal_filename: "journal.redb".into(),
+            router_buffer: 16,
+            http_bind: Some(addr),
+        };
+
+        let (tx, rx) = oneshot::channel();
+        let cfg_for_task = cfg.clone();
+        let daemon = tokio::spawn(async move { run(cfg_for_task, Some(rx)).await });
+
+        let body = r#"{"intent":"smoke via http","session_id":"smoke-sess"}"#;
+        let request = format!(
+            "POST /v1/wake HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        // Retry the connect until the API has bound (≤ ~1s).
+        let mut response = String::new();
+        let mut connected = false;
+        for _ in 0..50 {
+            match tokio::net::TcpStream::connect(addr).await {
+                Ok(mut stream) => {
+                    stream.write_all(request.as_bytes()).await.expect("write");
+                    stream.read_to_string(&mut response).await.expect("read");
+                    connected = true;
+                    break;
+                }
+                Err(_) => sleep(Duration::from_millis(20)).await,
+            }
+        }
+        assert!(connected, "could not connect to chronos-api");
+        let status_line = response.lines().next().unwrap_or_default();
+        assert!(
+            status_line.starts_with("HTTP/1.1 202"),
+            "expected 202 Accepted, got: {status_line}"
+        );
+
+        // The agenda.added is journaled synchronously before the 202; the wake flows through the
+        // mpsc, so give the router loop a moment to record it.
+        sleep(Duration::from_millis(200)).await;
+        tx.send(()).expect("signal shutdown");
+        tokio::time::timeout(Duration::from_secs(2), daemon)
+            .await
+            .expect("daemon shutdown within 2s")
+            .expect("daemon task ok")
+            .expect("daemon run ok");
+
+        let journal: Arc<dyn Journal> =
+            Arc::new(RedbJournal::open(cfg.journal_path()).expect("reopen redb"))
+                as Arc<dyn Journal>;
+
+        // chronos.agenda.added landed in the dedicated agenda ledger session.
+        let agenda = journal
+            .read(
+                EventQuery::new()
+                    .session(SessionId::from_string(chronos_lago::CHRONOS_AGENDA_SESSION))
+                    .branch(BranchId::from_string(chronos_lago::CHRONOS_DEFAULT_BRANCH)),
+            )
+            .await
+            .expect("read agenda ledger");
+        assert_eq!(agenda.len(), 1, "exactly one agenda.added event");
+        match &agenda[0].payload {
+            aios_protocol::EventKind::Custom { event_type, data } => {
+                assert_eq!(event_type, chronos_lago::CHRONOS_AGENDA_ADDED_EVENT_TYPE);
+                assert_eq!(data["intent"], "smoke via http");
+                assert_eq!(data["session_id"], "smoke-sess");
+            }
+            other => panic!("expected EventKind::Custom, got {other:?}"),
+        }
+
+        // chronos.wake routed to the target session.
+        let wakes = journal
+            .read(
+                EventQuery::new()
+                    .session(SessionId::from_string("smoke-sess"))
+                    .branch(BranchId::from_string(chronos_lago::CHRONOS_DEFAULT_BRANCH)),
+            )
+            .await
+            .expect("read target session");
+        assert_eq!(wakes.len(), 1, "exactly one chronos.wake event");
+        match &wakes[0].payload {
+            aios_protocol::EventKind::Custom { event_type, data } => {
+                assert_eq!(event_type, chronos_lago::CHRONOS_WAKE_EVENT_TYPE);
+                assert_eq!(data["source"], "http");
+            }
+            other => panic!("expected EventKind::Custom, got {other:?}"),
         }
     }
 }

--- a/crates/chronos/chronosd/src/main.rs
+++ b/crates/chronos/chronosd/src/main.rs
@@ -3,6 +3,7 @@
 //! Thin CLI front-end. All runtime logic lives in [`chronosd`] the library; see
 //! `src/lib.rs`.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -39,6 +40,11 @@ struct Cli {
     /// trigger bursts; smaller values surface backpressure faster.
     #[arg(long, default_value_t = 64, env = "CHRONOSD_ROUTER_BUFFER")]
     router_buffer: usize,
+
+    /// Bind address for the M1 HTTP wake-ingest API, e.g. `127.0.0.1:3007`. When unset, chronosd
+    /// runs heartbeat-only (M0 behavior). Bind to localhost in M1 — auth lands with lifegw.
+    #[arg(long, env = "CHRONOSD_HTTP_BIND")]
+    http_bind: Option<SocketAddr>,
 }
 
 impl From<Cli> for DaemonConfig {
@@ -48,6 +54,7 @@ impl From<Cli> for DaemonConfig {
             data_dir: cli.data_dir,
             journal_filename: cli.journal_filename,
             router_buffer: cli.router_buffer.max(1),
+            http_bind: cli.http_bind,
         }
     }
 }

--- a/docs/testing/harness/runs/2026-06-02-chronos-m1.md
+++ b/docs/testing/harness/runs/2026-06-02-chronos-m1.md
@@ -1,0 +1,92 @@
+---
+tags:
+  - broomva
+  - life
+  - testing
+  - harness
+  - run-report
+  - chronos
+  - temporality
+  - m1
+type: run-report
+status: complete
+created: 2026-06-02
+plan: docs/superpowers/plans/2026-05-13-chronos-temporal-primitive.md
+ticket: BRO-1069
+worktree: .worktrees/bro-1069-chronos-m1
+branch: feature/bro-1069-chronos-m1-agenda-store-http-wake-ingest
+base: 11689e60 (main)
+---
+
+# Run Report — Chronos M1 — 2026-06-02 — BRO-1069
+
+> M1 turns the wake stream from one source (heartbeat) into a **multi-source** surface and
+> introduces the durable per-session **agenda**. External systems push wake intents over HTTP
+> (`POST /v1/wake`); each lands in a lago-projected agenda and fires a `chronos.wake`. Verified
+> end-to-end by a live `chronosd --http-bind` run + `lago log`.
+
+## What shipped
+
+| Crate | Tests | Role |
+|-------|------:|------|
+| `chronos-core` | 15 (+7) | `AgendaStore` trait + `AgendaItem`/`AgendaItemId`/`Priority`/`AgendaItemState`/`NewAgendaItem` + `InMemoryAgendaStore` + `sort_for_dispatch` + `NotFound`/`Agenda` errors |
+| `chronos-triggers` | 7 (+4) | Real `HttpTrigger` (mpsc-fed `WakeTrigger`) + `wake_channel(buffer) -> (WakeSender, HttpTrigger)`; `HttpTriggerStub` retired |
+| `chronos-lago` | 9 (+6) | `LagoAgendaStore` — pure event-projection fold over a dedicated `chronos.agenda` ledger; `chronos.agenda.{added,completed,deferred,cancelled}` constants |
+| `chronos-api` (NEW) | 6 | axum HTTP — `POST /v1/wake`, `GET /v1/agenda/{session_id}`, `GET /v1/health`; `Arc<dyn AgendaStore>` + `mpsc::Sender` injected (depends on `chronos-core` only) |
+| `chronosd` | 2 (+1) | `--http-bind` flag mounts `chronos-api::serve` + registers `HttpTrigger`; end-to-end daemon HTTP test |
+| `verify_dependencies_chronos.sh` | — | Extended: `chronos-api → chronos-core` only; `chronosd → + chronos-api` |
+
+**39 chronos tests total** (was 15 at M0 → +24). Change is **strictly additive** outside the chronos
+crates (only root `Cargo.toml` members/deps + the chronos dep-audit script were touched).
+
+### Key design decision (M1 lock)
+
+AgendaStore projection shape → **option (b): pure event-projection fold** (matches `haima::FinancialState`
+/ `autonomic::HomeostaticState`). All `chronos.agenda.*` events write to one dedicated `chronos.agenda`
+ledger session (the item's *target* session is a payload field), so `complete`/`defer`/`cancel` address an
+item by id alone, and a fresh store over the same journal sees the full agenda — durable across restarts.
+
+## Acceptance criteria — all green
+
+| Criterion (BRO-1069) | Status | Evidence |
+|---|---|---|
+| `AgendaStore` trait + in-memory impl + 4+ unit tests | ✅ | 7 tests (`chronos-core::agenda::tests`) |
+| `LagoAgendaStore` + 4+ tests roundtripping `RedbJournal` | ✅ | 6 tests incl. `agenda_survives_store_recreation` (restart durability) |
+| `HttpTrigger` real impl + 3+ unit tests | ✅ | 4 tests (`chronos-triggers::http::tests`) |
+| `chronos-api` crate + two routes + 3+ integration tests via `oneshot` | ✅ | 6 tests; `tower::ServiceExt::oneshot` |
+| `chronosd --http-bind` flag; `chronos-api::serve` mounted | ✅ | `--http-bind 127.0.0.1:N`; daemon HTTP test |
+| Smoke: curl `POST /v1/wake` → `lago log` shows `chronos.wake` + `chronos.agenda.added` | ✅ | Live run below |
+| `verify_dependencies_chronos.sh` extended for `chronos-api` | ✅ | `chronos dependency audit passed` |
+| No regressions vs baseline | ✅ | Additive; `cargo check --workspace` green; clippy `-D warnings` clean; `cargo fmt --check` clean |
+
+## Live smoke evidence
+
+`chronosd --http-bind 127.0.0.1:39741 --heartbeat-seconds 3600 --data-dir /tmp/chronos-smoke-m1`
+
+```
+GET  /v1/health                        → {"service":"chronos-api","status":"ok"}
+POST /v1/wake {intent,session=demo,urgent}   → 202 {"agenda_item_id":"01KT…3P","fired":true,"session_id":"demo-session"}
+POST /v1/wake {intent} (default session)     → 202 {"…","fired":true,"session_id":"chronos.system"}
+POST /v1/wake {intent,when_unix_ms=+1h}       → 202 {"…","fired":false,"session_id":"demo-session"}   # scheduled, not fired
+POST /v1/wake {intent:"  "}                    → 400
+GET  /v1/agenda/demo-session            → count:2 [urgent pending, nightly pending+not_before]
+daemon log: "chronos-api listening 127.0.0.1:39741" · 2× "wake recorded source=http" · "chronosd shut down cleanly"
+```
+
+Journal dump (`lago log --data-dir /tmp/chronos-smoke-m1 --session …`):
+
+```
+chronos.agenda  → seq 1..3  Custom(chronos.agenda.added)   (summarize / rebuild / nightly)
+demo-session    → seq 1     Custom(chronos.wake)            (payload.agenda_item_id + intent)
+```
+
+Both event types present, correct routing (agenda → ledger, wake → target session) — acceptance met verbatim.
+
+## What M1 does NOT do (deferred, by design)
+
+- **No kernel dispatch** — a fired wake is journaled but does not run an agent yet (that is M2 / BRO-1080;
+  the agenda item stays `pending`).
+- **No future-scheduler** — items with a future `not_before` are stored `pending` but are not auto-fired
+  later in M1 (a timer/sweep is M3+).
+- **No auth** — `--http-bind` is localhost-only; bearer-token gating lands when chronosd moves behind lifegw.
+- **No typed `EventKind::ChronosWake`** — still `Custom("chronos.*")` until the payload stabilizes post-M3.

--- a/scripts/architecture/verify_dependencies_chronos.sh
+++ b/scripts/architecture/verify_dependencies_chronos.sh
@@ -8,6 +8,7 @@
 #   chronos-core      → aios-protocol ONLY  (no other internal Life crates; tokio/serde/etc OK)
 #   chronos-triggers  → chronos-core ONLY  (depends on chronos-core; no other internal Life crates)
 #   chronos-lago      → chronos-core + aios-protocol + lago-core  (lago-journal allowed for dev only)
+#   chronos-api       → chronos-core ONLY  (axum/serde/tokio OK; concrete store + trigger injected)
 #   chronosd          → chronos-* + aios-protocol + lago-*        (no arcan/autonomic/haima/etc)
 #
 # Dev-dependencies are intentionally exempt — the rules constrain the PRODUCTION dep graph.
@@ -59,8 +60,9 @@ ALLOWED = {
     "chronos-core":     {"aios-protocol"},
     "chronos-triggers": {"chronos-core"},
     "chronos-lago":     {"chronos-core", "aios-protocol", "lago-core"},
+    "chronos-api":      {"chronos-core"},
     "chronosd":         {
-        "chronos-core", "chronos-triggers", "chronos-lago",
+        "chronos-core", "chronos-triggers", "chronos-lago", "chronos-api",
         "aios-protocol", "lago-core", "lago-journal",
     },
 }


### PR DESCRIPTION
## Summary

Chronos **M1** ([BRO-1069](https://linear.app/broomva/issue/BRO-1069)) — turns the wake stream from one source (heartbeat, M0) into a **multi-source** surface, and introduces the durable per-session **agenda**. External systems push wake intents over HTTP (`POST /v1/wake`); each lands in a lago-projected agenda and fires a `chronos.wake`.

Builds on Chronos M0 (life#1241, `e5dc46c8`). Unblocks M2 (kernel wake handoff, BRO-1080).

## What shipped

| Crate | Tests | Role |
|---|---:|---|
| `chronos-core` | 15 (+7) | `AgendaStore` trait + `AgendaItem`/`AgendaItemId`/`Priority`/`AgendaItemState`/`NewAgendaItem` + `InMemoryAgendaStore` + `sort_for_dispatch`; `NotFound`/`Agenda` errors |
| `chronos-triggers` | 7 (+4) | real `HttpTrigger` (mpsc-fed `WakeTrigger`) + `wake_channel`; `HttpTriggerStub` retired |
| `chronos-lago` | 9 (+6) | `LagoAgendaStore` — pure event-projection fold; `chronos.agenda.{added,completed,deferred,cancelled}` |
| **`chronos-api`** (new) | 6 | axum: `POST /v1/wake`, `GET /v1/agenda/{session_id}`, `GET /v1/health` |
| `chronosd` | 2 (+1) | `--http-bind` mounts the API + registers `HttpTrigger`; end-to-end HTTP test |

**39 chronos tests** (was 15). Strictly additive outside the chronos crates.

## Locked decision — AgendaStore projection (M1)

**Option (b): pure event-projection fold** (mirrors `haima::FinancialState` / `autonomic::HomeostaticState`). All `chronos.agenda.*` events write to one dedicated **`chronos.agenda`** ledger session — the item's *target* session is a payload field. This is what lets `complete`/`defer`/`cancel` address an item by **id alone**, and what makes the agenda durable across restarts (a fresh `LagoAgendaStore` over the same journal re-derives the full state). `chronos.wake` events route to their target session, separately.

`chronos-api` depends on **`chronos-core` only** — it holds an injected `Arc<dyn AgendaStore>` + `mpsc::Sender<WakeEvent>`; `chronosd` is the single place wiring the concrete `LagoAgendaStore` + real `HttpTrigger` receiver. Keeps the dep graph clean (audited).

## P14 — dependency-chain enumeration

**Upstream (depends on):**
- `crates/aios/aios-protocol` — `EventKind::Custom { event_type, data }`, `SessionId` (re-exported by chronos-core).
- `crates/lago/lago-core/src/journal.rs` — `Journal` (`append`/`read`), `EventQuery`, `EventEnvelope`, `BranchId/EventId/SeqNo/SessionId`, `LagoError`. Fold relies on `read` returning seq-ordered events (compound key `session+branch+seq`).
- `crates/chronos/chronos-core` — `WakeEvent`, `WakeSource::Http`, `WakeTrigger`, `WakeRouter`, `now_unix_ms`.
- `crates/chronos/chronos-lago` — `record_wake`, `CHRONOS_SYSTEM_SESSION`, `CHRONOS_DEFAULT_BRANCH`.
- Workspace deps: `axum` 0.8, `tokio` (sync/net), `serde`/`serde_json`, `tower` (dev — `oneshot`).

**Downstream (affected by / consumes this):**
- `crates/chronos/chronosd/src/{lib,main}.rs` — `--http-bind`; spawns `chronos-api::serve`; wires `HttpTrigger` rx + `LagoAgendaStore` + wake `Sender`. Main loop shape unchanged (still router → `record_wake`).
- `scripts/architecture/verify_dependencies_chronos.sh` — `chronos-api → chronos-core` only; `chronosd → + chronos-api`.
- `Cargo.toml` — `[workspace] members` += `chronos-api`; `[workspace.dependencies]` += `chronos-api`.
- `crates/chronos/CLAUDE.md` — M1 status, event types, `chronos-api`, `--http-bind` (per-crate doc; not the λ₃-budgeted workspace CLAUDE.md).
- **M2 (BRO-1080)** — will consume `AgendaStore` for completion recording + drain the `HttpTrigger`. Not modified here; unblocked.

**Explicitly NOT touched** (constraints honored): `aios-runtime::execute_turn` canonical loop; no new `EventKind` variant (stays `Custom`); workspace `CLAUDE.md`/`AGENTS.md`/`policy.yaml` (λ₃ budget).

## P11 — live smoke (real `chronosd --http-bind`)

```
GET  /v1/health                              → {"service":"chronos-api","status":"ok"}
POST /v1/wake {intent, session=demo, urgent} → 202 {"fired":true,"session_id":"demo-session"}
POST /v1/wake {intent} (default session)     → 202 {"fired":true,"session_id":"chronos.system"}
POST /v1/wake {intent, when_unix_ms=+1h}      → 202 {"fired":false,…}   # scheduled, not fired
POST /v1/wake {intent:"  "}                    → 400
GET  /v1/agenda/demo-session                 → count:2  [urgent pending, nightly pending+not_before]
```

`lago log` (acceptance criterion, verbatim):
```
chronos.agenda  → seq 1..3  Custom(chronos.agenda.added)
demo-session    → seq 1     Custom(chronos.wake)
```

## Gates

- ✅ `cargo fmt --check` clean
- ✅ `cargo clippy -p chronos-* --all-targets -- -D warnings` clean
- ✅ 39 chronos tests (incl. `agenda_survives_store_recreation` restart-durability + end-to-end daemon HTTP)
- ✅ `verify_dependencies_chronos.sh` — `chronos dependency audit passed`
- ✅ `cargo check --workspace` — green, 0 regressions (125 crates)

## Deferred (by design)

No kernel dispatch (wake journaled, item stays `pending` — that's M2); no future-scheduler (future `not_before` stored but not auto-fired — M3+); no auth (localhost-only until behind lifegw); still `Custom("chronos.*")` (typed variant post-M3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP API now available for wake ingest with agenda tracking and health checks
  * Daemon supports optional `--http-bind` flag to enable HTTP server for wake submission
  * Agenda inspection endpoints to list and monitor scheduled items

* **Documentation**
  * Updated architecture and API documentation for M1 milestone (BRO-1069)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->