### PR TITLE
feat(x402): transport rail (slice 2) — WalletSubstrate.X402Pay → proxy → lifed → lifegw [BRO-1354]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,7 @@ version = "0.3.0"
 dependencies = [
  "aios-proto",
  "aios-protocol",
+ "anima-identity",
  "anyhow",
  "async-trait",
  "axum 0.8.8",
@@ -4444,8 +4445,10 @@ dependencies = [
  "life-vigil",
  "prost 0.14.3",
  "prost-types 0.14.3",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4456,6 +4459,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/haima/CLAUDE.md
+++ b/crates/haima/CLAUDE.md
@@ -23,7 +23,7 @@ Rust 2024 | axum (HTTP API) | k256 (secp256k1) | x402 protocol | aios-protocol (
 - `haima-x402` (61 tests + 5 e2e smoke) — x402 protocol integration: client middleware with **real EIP-3009 signing** (`sign_payment` produces 65-byte recoverable signatures + structured `Eip3009Authorization`), server middleware scaffold, facilitator client (Coinbase CDP / self-hosted), **agentic.market bazaar discovery** (`bazaar.rs`, TTL cache, graceful degradation).
 - `haima-lago` (8 tests) — Lago bridge: finance event publishing, deterministic projection fold → FinancialState
 - `haima-api` (2 tests) — axum HTTP server: /health, /state endpoints
-- `haimad` (2 tests) — Daemon binary with CLI args, config, optional Lago journal
+- `haimad` (14 lib tests) — Daemon binary with CLI args, config, optional Lago journal. Also serves the substrate-plane `haima.v1.WalletSubstrate` gRPC (`--uds-socket`): bind/unbind/balance/statement/debit/transfer **+ `X402Pay`** (BRO-1354) — resolves the user's custody (P1: deterministic per-`(user,project)` `InProcessAnima`; slice 2b → `SomaCustody`), wraps it in `CustodyWalletAdapter`, and drives `pay_x402`. **base-sepolia only** (`network="base"` → `failed_precondition`).
 
 ## Running
 

--- a/crates/haima/haimad/Cargo.toml
+++ b/crates/haima/haimad/Cargo.toml
@@ -19,7 +19,11 @@ path = "src/main.rs"
 [dependencies]
 haima-core.workspace = true
 haima-wallet.workspace = true
-haima-x402.workspace = true
+# `custody-adapter` pulls `anima-identity` so the x402 substrate RPC can
+# sign EIP-3009 authorizations from the user's Anima-custodied wallet
+# (CustodyWalletAdapter). BRO-1354 (x402 transport, slice 2).
+haima-x402 = { workspace = true, features = ["custody-adapter"] }
+anima-identity = { path = "../../anima/anima-identity", version = "0.3.0" }
 haima-lago.workspace = true
 haima-api.workspace = true
 haima-outcome.workspace = true
@@ -32,8 +36,10 @@ chrono.workspace = true
 futures.workspace = true
 prost = "0.14"
 prost-types = "0.14"
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tonic = "0.14"
 tracing.workspace = true
@@ -54,6 +60,7 @@ futures.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-stream.workspace = true
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/haima/haimad/src/substrate.rs
+++ b/crates/haima/haimad/src/substrate.rs
@@ -25,15 +25,27 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use anima_identity::InProcessAnima;
+use anima_identity::seed::MasterSeed;
 use futures::Stream;
+use haima_core::HaimaError;
+use haima_core::wallet::ChainId;
 use haima_substrate_proto::haima::v1::{
     self as haima_pb, wallet_substrate_server::WalletSubstrate,
 };
+use haima_x402::{
+    CustodyWalletAdapter, Facilitator, FacilitatorConfig, X402Client, X402PayResult, pay_x402,
+};
+use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
 use crate::state::{HaimaState, HaimaStateError};
+
+/// HTTP status the substrate reports for a settled payment — the
+/// paid-resource fetch is always a 200 once settlement succeeds.
+const SETTLED_RESOURCE_STATUS: u32 = 200;
 
 /// Bounded channel capacity for the `Statement` server-streaming
 /// response. Mirrors arcand's BRO-1016 capacity choice — 64 is more
@@ -243,6 +255,160 @@ impl WalletSubstrate for SubstrateService {
             }),
         }))
     }
+
+    /// Initiate an x402 payment from the user's Anima-custodied wallet
+    /// (BRO-1354, slice 2 of the BRO-1341 x402 epic).
+    ///
+    /// Flow: resolve the user's custody backend → wrap it in a
+    /// [`CustodyWalletAdapter`] so EIP-3009 `transferWithAuthorization`
+    /// signing routes through the user's secp256k1 key → build an
+    /// [`X402Client`] → drive [`pay_x402`] (GET → 402 → policy/cap gate
+    /// → sign → retry → settlement + resource).
+    ///
+    /// **P1 custody (documented deviation):** the custody backend is a
+    /// per-`(user_id, project_id)` deterministic [`InProcessAnima`]
+    /// (seeded from the pair), NOT yet the soma-resident Anima wallet
+    /// shown on `/account`. This exercises the full sign + policy +
+    /// settlement path on base-sepolia. Binding to the production
+    /// soma-custodied key is a localized follow-up (slice 2b): swap
+    /// [`resolve_custody`] to `SomaCustody` / `RemoteAnima` behind the
+    /// same handler — no wire change.
+    ///
+    /// **base-sepolia only.** `network = "base"` (mainnet) is rejected
+    /// with `failed_precondition`; mainnet is the slice-3 financial
+    /// control gate's concern.
+    async fn x402_pay(
+        &self,
+        req: Request<haima_pb::X402PayReq>,
+    ) -> Result<Response<haima_pb::X402PayResp>, Status> {
+        let body = req.into_inner();
+        if body.user_id.is_empty() {
+            return Err(Status::invalid_argument("empty user_id"));
+        }
+        if body.project_id.is_empty() {
+            return Err(Status::invalid_argument("empty project_id"));
+        }
+        if body.resource_url.is_empty() {
+            return Err(Status::invalid_argument("empty resource_url"));
+        }
+
+        // Resolve the signing network. P1 = base-sepolia only.
+        let network = resolve_network(&body.network)?;
+
+        // Resolve the user's custody backend and wrap it so x402 signs
+        // EIP-3009 authorizations from the user's wallet half.
+        let custody = resolve_custody(&body.user_id, &body.project_id)?;
+        let adapter = CustodyWalletAdapter::from_custody_on_network(custody, network)
+            .map_err(map_haima_error)?;
+
+        // P1 uses the default facilitator + policy. The facilitator is
+        // not contacted on the client happy-path (the resource server
+        // returns the settlement in its `payment-response` header); a
+        // configurable per-deployment facilitator is a follow-up.
+        let client = X402Client::new(
+            Arc::new(adapter),
+            Facilitator::new(FacilitatorConfig::default()),
+            haima_core::policy::PaymentPolicy::default(),
+        );
+        let http = reqwest::Client::new();
+
+        let result = pay_x402(&client, &http, &body.resource_url, body.max_amount_micros)
+            .await
+            .map_err(map_haima_error)?;
+
+        Ok(Response::new(map_pay_result(result)))
+    }
+}
+
+/// Resolve the per-`(user_id, project_id)` custody backend used to sign
+/// the x402 payment. P1: a deterministic [`InProcessAnima`] seeded from
+/// the pair (stable wallet address across calls). See
+/// [`SubstrateService::x402_pay`] for the production-binding follow-up.
+fn resolve_custody(
+    user_id: &str,
+    project_id: &str,
+) -> Result<Arc<dyn anima_identity::custody::AnimaCustody>, Status> {
+    let seed = derive_custody_seed(user_id, project_id);
+    InProcessAnima::from_seed_arc(seed)
+        .map_err(|e| Status::internal(format!("resolve custody: {e}")))
+}
+
+/// Deterministically derive a 32-byte [`MasterSeed`] from
+/// `(user_id, project_id)` so the same pair always resolves the same
+/// wallet. Domain-separated with an `x402:` prefix so this seed never
+/// collides with other per-user key derivations.
+fn derive_custody_seed(user_id: &str, project_id: &str) -> MasterSeed {
+    let mut hasher = Sha256::new();
+    hasher.update(b"x402:v1:");
+    hasher.update(user_id.as_bytes());
+    hasher.update(b":");
+    hasher.update(project_id.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&digest);
+    MasterSeed::from_bytes(bytes)
+}
+
+/// Resolve the payment network label to a [`ChainId`]. P1 accepts only
+/// base-sepolia (the empty string defaults to it); `base` (mainnet) is
+/// rejected behind the slice-3 financial control gate.
+fn resolve_network(network: &str) -> Result<ChainId, Status> {
+    match network {
+        "" | "base-sepolia" => Ok(ChainId::base_sepolia()),
+        "base" => Err(Status::failed_precondition(
+            "network 'base' (mainnet) is gated behind the slice-3 financial control gate; \
+             P1 supports base-sepolia only",
+        )),
+        other => Err(Status::invalid_argument(format!(
+            "unknown network '{other}'; expected 'base-sepolia'"
+        ))),
+    }
+}
+
+/// Map a [`X402PayResult`] onto the flat wire `X402PayResp`. The
+/// `status` discriminant tells the caller which fields are populated.
+fn map_pay_result(result: X402PayResult) -> haima_pb::X402PayResp {
+    match result {
+        X402PayResult::NotRequired {
+            status,
+            resource_body,
+        } => haima_pb::X402PayResp {
+            status: "not_required".to_string(),
+            resource_body,
+            resource_status: u32::from(status),
+            ..Default::default()
+        },
+        X402PayResult::Paid(outcome) => haima_pb::X402PayResp {
+            status: "settled".to_string(),
+            tx_hash: outcome.tx_hash.unwrap_or_default(),
+            network: outcome.network,
+            recipient: outcome.recipient,
+            micro_credits: outcome.micro_credits,
+            settled: outcome.settled,
+            resource_body: outcome.resource_body,
+            resource_status: SETTLED_RESOURCE_STATUS,
+            ..Default::default()
+        },
+        X402PayResult::Declined {
+            reason,
+            micro_credits,
+        } => haima_pb::X402PayResp {
+            status: "declined".to_string(),
+            declined_reason: reason,
+            micro_credits,
+            ..Default::default()
+        },
+    }
+}
+
+/// Map a [`HaimaError`] from the x402 engine to a `tonic::Status`.
+/// Transport faults (`Http`) become `unavailable` (retryable upstream);
+/// everything else is `internal`.
+fn map_haima_error(err: HaimaError) -> Status {
+    match &err {
+        HaimaError::Http(_) => Status::unavailable(format!("x402 upstream: {err}")),
+        _ => Status::internal(format!("x402 pay: {err}")),
+    }
 }
 
 /// Map `HaimaStateError` to a `tonic::Status`. Permanent failures
@@ -255,5 +421,210 @@ fn map_state_error(err: HaimaStateError) -> Status {
             format!("insufficient balance: have {have} micros, want {want}"),
         ),
         HaimaStateError::Crypto(e) => Status::internal(format!("crypto: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod x402_tests {
+    use super::*;
+    use crate::state::HaimaState;
+    use haima_x402::{
+        PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER, PAYMENT_SIGNATURE_HEADER,
+        PaymentRequiredHeader, PaymentResponseHeader, SchemeRequirement, encode_payment_required,
+        encode_payment_response,
+    };
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // A base-sepolia x402 recipient + USDC token (the canonical
+    // base-sepolia USDC test address used across haima-x402's suite).
+    const TEST_RECIPIENT: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+    const USDC_BASE_SEPOLIA_ADDR: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+    // base-sepolia CAIP-2 chain reference.
+    const BASE_SEPOLIA_CAIP2: &str = "eip155:84532";
+
+    fn service() -> SubstrateService {
+        SubstrateService::new(Arc::new(HaimaState::new()))
+    }
+
+    fn payment_required_header(amount: &str) -> String {
+        let header = PaymentRequiredHeader {
+            schemes: vec![SchemeRequirement {
+                scheme: "exact".into(),
+                network: BASE_SEPOLIA_CAIP2.into(),
+                token: USDC_BASE_SEPOLIA_ADDR.into(),
+                amount: amount.into(),
+                recipient: TEST_RECIPIENT.into(),
+                facilitator: "https://x402.org/facilitator".into(),
+                max_timeout_seconds: Some(300),
+            }],
+            version: "v2".into(),
+        };
+        encode_payment_required(&header).expect("encode header")
+    }
+
+    /// Mount the 402 (first GET) leg.
+    async fn mount_402(server: &MockServer, amount: &str) {
+        Mock::given(method("GET"))
+            .and(path("/api/data"))
+            .respond_with(
+                ResponseTemplate::new(402)
+                    .insert_header(PAYMENT_REQUIRED_HEADER, payment_required_header(amount)),
+            )
+            .up_to_n_times(1)
+            .mount(server)
+            .await;
+    }
+
+    /// Mount the 200 + payment-response (retry-with-signature) leg.
+    async fn mount_paid(server: &MockServer) {
+        let resp = PaymentResponseHeader {
+            tx_hash: "0xfeedface".into(),
+            network: BASE_SEPOLIA_CAIP2.into(),
+            settled: true,
+        };
+        let encoded = encode_payment_response(&resp).expect("encode response");
+        Mock::given(method("GET"))
+            .and(path("/api/data"))
+            .and(header_exists(PAYMENT_SIGNATURE_HEADER))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header(PAYMENT_RESPONSE_HEADER, encoded)
+                    .set_body_string("{\"ok\":true}"),
+            )
+            .mount(server)
+            .await;
+    }
+
+    fn req(server_uri: &str, network: &str, max: Option<i64>) -> haima_pb::X402PayReq {
+        haima_pb::X402PayReq {
+            user_id: "alice".into(),
+            project_id: "proj".into(),
+            resource_url: format!("{server_uri}/api/data"),
+            network: network.into(),
+            max_amount_micros: max,
+        }
+    }
+
+    #[tokio::test]
+    async fn x402_pay_settles_on_base_sepolia() {
+        let server = MockServer::start().await;
+        mount_402(&server, "50").await; // 50 μc < 100 auto-approve cap
+        mount_paid(&server).await;
+
+        let resp = service()
+            .x402_pay(Request::new(req(&server.uri(), "base-sepolia", None)))
+            .await
+            .expect("x402_pay")
+            .into_inner();
+
+        assert_eq!(resp.status, "settled");
+        assert_eq!(resp.tx_hash, "0xfeedface");
+        assert!(resp.settled);
+        assert_eq!(resp.network, BASE_SEPOLIA_CAIP2);
+        assert_eq!(resp.recipient.to_lowercase(), TEST_RECIPIENT.to_lowercase());
+        assert_eq!(resp.micro_credits, 50);
+        assert_eq!(resp.resource_body, b"{\"ok\":true}");
+        assert_eq!(resp.resource_status, 200);
+    }
+
+    #[tokio::test]
+    async fn x402_pay_declines_over_cap_before_signing() {
+        let server = MockServer::start().await;
+        // Only the 402 leg — if it signed + retried, the request would
+        // 404 (no matching signed mock). Getting Declined proves the
+        // cap short-circuited before signing.
+        mount_402(&server, "50").await;
+
+        let resp = service()
+            .x402_pay(Request::new(req(&server.uri(), "base-sepolia", Some(10))))
+            .await
+            .expect("x402_pay")
+            .into_inner();
+
+        assert_eq!(resp.status, "declined");
+        assert_eq!(resp.micro_credits, 50);
+        assert!(resp.declined_reason.contains("max_amount"));
+    }
+
+    #[tokio::test]
+    async fn x402_pay_not_required_when_unpaywalled() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/data"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("free"))
+            .mount(&server)
+            .await;
+
+        // Empty network defaults to base-sepolia.
+        let resp = service()
+            .x402_pay(Request::new(req(&server.uri(), "", None)))
+            .await
+            .expect("x402_pay")
+            .into_inner();
+
+        assert_eq!(resp.status, "not_required");
+        assert_eq!(resp.resource_status, 200);
+        assert_eq!(resp.resource_body, b"free");
+    }
+
+    #[tokio::test]
+    async fn x402_pay_rejects_mainnet_behind_gate() {
+        let err = service()
+            .x402_pay(Request::new(req("https://example.com", "base", None)))
+            .await
+            .expect_err("mainnet must be gated");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn x402_pay_rejects_unknown_network() {
+        let err = service()
+            .x402_pay(Request::new(req("https://example.com", "solana", None)))
+            .await
+            .expect_err("unknown network must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn x402_pay_rejects_empty_resource_url() {
+        let mut r = req("https://example.com", "base-sepolia", None);
+        r.resource_url = String::new();
+        let err = service()
+            .x402_pay(Request::new(r))
+            .await
+            .expect_err("empty resource_url must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn derive_custody_seed_is_deterministic_and_scoped() {
+        // Same (user, project) → same wallet address; different user →
+        // different address. The x402 signing key is stable per pair.
+        let wa1 = InProcessAnima::from_seed_arc(derive_custody_seed("alice", "proj")).unwrap();
+        let wa2 = InProcessAnima::from_seed_arc(derive_custody_seed("alice", "proj")).unwrap();
+        let wb = InProcessAnima::from_seed_arc(derive_custody_seed("bob", "proj")).unwrap();
+        let addr1 = wa1.wallet_address().unwrap().address.clone();
+        let addr2 = wa2.wallet_address().unwrap().address.clone();
+        let addrb = wb.wallet_address().unwrap().address.clone();
+        assert_eq!(addr1, addr2, "same pair must resolve the same wallet");
+        assert_ne!(
+            addr1, addrb,
+            "different user must resolve a different wallet"
+        );
+    }
+
+    #[test]
+    fn resolve_network_maps_base_sepolia_and_gates_mainnet() {
+        assert!(resolve_network("").is_ok());
+        assert!(resolve_network("base-sepolia").is_ok());
+        assert_eq!(
+            resolve_network("base").unwrap_err().code(),
+            tonic::Code::FailedPrecondition
+        );
+        assert_eq!(
+            resolve_network("ethereum").unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
     }
 }

--- a/crates/life-runtime/haima-proxy/src/client.rs
+++ b/crates/life-runtime/haima-proxy/src/client.rs
@@ -56,6 +56,23 @@ pub struct LedgerEntry {
     pub sid: String,
 }
 
+/// Outcome of an [`HaimaCall::x402_pay`] round-trip. Flattens
+/// haima-x402's `X402PayResult` onto a single struct; `status` is the
+/// discriminant (`"settled"` / `"not_required"` / `"declined"`) and the
+/// remaining fields are populated per-variant. BRO-1354.
+#[derive(Clone, Debug)]
+pub struct X402PayOutcome {
+    pub status: String,
+    pub tx_hash: String,
+    pub network: String,
+    pub recipient: String,
+    pub micro_credits: i64,
+    pub declined_reason: String,
+    pub settled: bool,
+    pub resource_body: Vec<u8>,
+    pub resource_status: u32,
+}
+
 impl HaimaProxy {
     pub async fn connect(socket: PathBuf) -> HaimaProxyResult<Self> {
         let endpoint = Endpoint::try_from("http://[::]:0")
@@ -329,6 +346,51 @@ impl HaimaProxy {
             }
         }
     }
+
+    /// Initiate an x402 payment via `haima.v1.WalletSubstrate.X402Pay`.
+    /// BRO-1354. The substrate signs from the user's Anima-custodied
+    /// wallet and drives the full client round-trip; this proxy just
+    /// marshals the request + maps the flat response.
+    pub async fn x402_pay(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        resource_url: &str,
+        network: &str,
+        max_amount_micros: Option<i64>,
+    ) -> HaimaProxyResult<X402PayOutcome> {
+        let guard = self.acquire_guard().await?;
+        let mut client = WalletSubstrateClient::new(self.channel.clone());
+        let mut req = tonic::Request::new(haima_pb::X402PayReq {
+            user_id: user_id.to_owned(),
+            project_id: project_id.to_owned(),
+            resource_url: resource_url.to_owned(),
+            network: network.to_owned(),
+            max_amount_micros,
+        });
+        self.attach_token(&mut req);
+        match client.x402_pay(req).await.map_err(HaimaProxyError::from) {
+            Ok(resp) => {
+                let body = resp.into_inner();
+                record_outcome(guard, true);
+                Ok(X402PayOutcome {
+                    status: body.status,
+                    tx_hash: body.tx_hash,
+                    network: body.network,
+                    recipient: body.recipient,
+                    micro_credits: body.micro_credits,
+                    declined_reason: body.declined_reason,
+                    settled: body.settled,
+                    resource_body: body.resource_body,
+                    resource_status: body.resource_status,
+                })
+            }
+            Err(e) => {
+                record_outcome(guard, !e.is_retryable());
+                Err(e)
+            }
+        }
+    }
 }
 
 /// Record a `PoolGuard` outcome based on whether the call succeeded
@@ -377,6 +439,14 @@ pub trait HaimaCall: Send + Sync {
         amount_micros: u64,
         memo: &str,
     ) -> HaimaProxyResult<(String, WalletBalance, WalletBalance)>;
+    async fn x402_pay(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        resource_url: &str,
+        network: &str,
+        max_amount_micros: Option<i64>,
+    ) -> HaimaProxyResult<X402PayOutcome>;
 }
 
 #[async_trait]
@@ -432,6 +502,24 @@ impl HaimaCall for HaimaProxy {
             to_project,
             amount_micros,
             memo,
+        )
+        .await
+    }
+    async fn x402_pay(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        resource_url: &str,
+        network: &str,
+        max_amount_micros: Option<i64>,
+    ) -> HaimaProxyResult<X402PayOutcome> {
+        HaimaProxy::x402_pay(
+            self,
+            user_id,
+            project_id,
+            resource_url,
+            network,
+            max_amount_micros,
         )
         .await
     }
@@ -548,6 +636,23 @@ impl<C: HaimaCall> HaimaCall for Pooled<C> {
             to_project,
             amount_micros,
             memo,
+        ))
+        .await
+    }
+    async fn x402_pay(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        resource_url: &str,
+        network: &str,
+        max_amount_micros: Option<i64>,
+    ) -> HaimaProxyResult<X402PayOutcome> {
+        self.bracket(self.inner.x402_pay(
+            user_id,
+            project_id,
+            resource_url,
+            network,
+            max_amount_micros,
         ))
         .await
     }

--- a/crates/life-runtime/haima-proxy/src/lib.rs
+++ b/crates/life-runtime/haima-proxy/src/lib.rs
@@ -5,5 +5,7 @@
 pub mod client;
 pub mod error;
 
-pub use client::{HaimaCall, HaimaProxy, LedgerEntry, LedgerGuardedStream, Pooled, WalletBalance};
+pub use client::{
+    HaimaCall, HaimaProxy, LedgerEntry, LedgerGuardedStream, Pooled, WalletBalance, X402PayOutcome,
+};
 pub use error::{HaimaProxyError, HaimaProxyResult, RetryClass};

--- a/crates/life-runtime/lifed/src/dev_mocks.rs
+++ b/crates/life-runtime/lifed/src/dev_mocks.rs
@@ -21,7 +21,9 @@ use anima_proxy::{
     Account, AnimaCall, AnimaProxyError, AnimaProxyResult, Profile, SessionDescriptor,
 };
 use arcan_proxy::{ArcanCall, ArcanProxyError, ArcanProxyResult};
-use haima_proxy::{HaimaCall, HaimaProxyError, HaimaProxyResult, LedgerEntry, WalletBalance};
+use haima_proxy::{
+    HaimaCall, HaimaProxyError, HaimaProxyResult, LedgerEntry, WalletBalance, X402PayOutcome,
+};
 use lago_proxy::{LagoCall, LagoProxyError, LagoProxyResult};
 use life_runtime_proto::life::v1 as pb;
 
@@ -316,6 +318,7 @@ pub struct MockHaima {
     pub unbind_wallet_calls: Arc<Mutex<Vec<String>>>,
     pub debit_calls: Arc<Mutex<Vec<(String, String, u64)>>>,
     pub transfer_calls: Arc<Mutex<Vec<(String, String, String, String, u64)>>>,
+    pub x402_pay_calls: Arc<Mutex<Vec<(String, String, String)>>>,
     pub balances: Arc<Mutex<HashMap<String, u64>>>,
     pub fail_next: Arc<AtomicBool>,
     pub force_fail: Arc<AtomicBool>,
@@ -444,6 +447,35 @@ impl HaimaCall for MockHaima {
                 currency: "USDC".to_string(),
             },
         ))
+    }
+    async fn x402_pay(
+        &self,
+        user_id: &str,
+        project_id: &str,
+        resource_url: &str,
+        _network: &str,
+        _max_amount_micros: Option<i64>,
+    ) -> HaimaProxyResult<X402PayOutcome> {
+        self.x402_pay_calls.lock().push((
+            user_id.to_string(),
+            project_id.to_string(),
+            resource_url.to_string(),
+        ));
+        if let Some(s) = self.force_fail_status() {
+            return Err(HaimaProxyError::Substrate(s));
+        }
+        // Canned "settled" outcome on base-sepolia for handler tests.
+        Ok(X402PayOutcome {
+            status: "settled".to_string(),
+            tx_hash: "0xmocktx".to_string(),
+            network: "eip155:84532".to_string(),
+            recipient: "0x036CbD53842c5426634e7929541eC2318f3dCF7e".to_string(),
+            micro_credits: 50,
+            declined_reason: String::new(),
+            settled: true,
+            resource_body: b"{\"ok\":true}".to_vec(),
+            resource_status: 200,
+        })
     }
 }
 

--- a/crates/life-runtime/lifed/src/services/wallet.rs
+++ b/crates/life-runtime/lifed/src/services/wallet.rs
@@ -231,8 +231,22 @@ impl pb::wallet_server::Wallet for WalletService {
         &self,
         req: Request<pb::X402PayReq>,
     ) -> Result<Response<pb::X402PayResp>, Status> {
-        let _claims = Self::claims(&req)?;
+        // BRO-1354 hardening (P20 cross-review MEDIUM): X402Pay initiates
+        // an EXTERNAL payment (scope `x402:pay`, strictly more powerful
+        // than an internal ledger debit), so bind the payer to the
+        // authenticated identity — a capability for user A must not pay
+        // from user B's wallet, even on the direct gRPC path. (The
+        // bespoke lifegw HTTP route already sources the user from the
+        // verified Tier-1 token.) `project_id` is intentionally NOT
+        // pinned: it selects which of the caller's OWN project wallets
+        // to draw from, not a cross-tenant boundary.
+        let claims_user = Self::claims(&req)?.user_id.clone();
         let r = req.into_inner();
+        if r.user_id != claims_user {
+            return Err(Status::permission_denied(
+                "x402_pay: request user_id must match the capability subject",
+            ));
+        }
         let outcome = self
             .haima
             .x402_pay(

--- a/crates/life-runtime/lifed/src/services/wallet.rs
+++ b/crates/life-runtime/lifed/src/services/wallet.rs
@@ -217,4 +217,43 @@ impl pb::wallet_server::Wallet for WalletService {
         self.idem.persist(key, buf).await?;
         Ok(Response::new(receipt))
     }
+
+    /// Initiate an x402 payment from the user's Anima-custodied wallet
+    /// (BRO-1354). Forwards to haima-proxy's `x402_pay`, which dials
+    /// haimad's `WalletSubstrate.X402Pay`. The substrate owns the full
+    /// client round-trip + signing; this handler is a thin marshaller.
+    ///
+    /// Not idempotent-cached: a payment that settled on-chain cannot be
+    /// safely replayed from a cache, and the substrate's per-call nonce
+    /// (EIP-3009) already makes a re-submit a distinct authorization.
+    /// base-sepolia only in P1 — mainnet is rejected substrate-side.
+    async fn x402_pay(
+        &self,
+        req: Request<pb::X402PayReq>,
+    ) -> Result<Response<pb::X402PayResp>, Status> {
+        let _claims = Self::claims(&req)?;
+        let r = req.into_inner();
+        let outcome = self
+            .haima
+            .x402_pay(
+                &r.user_id,
+                &r.project_id,
+                &r.resource_url,
+                &r.network,
+                r.max_amount_micros,
+            )
+            .await
+            .map_err(Status::from)?;
+        Ok(Response::new(pb::X402PayResp {
+            status: outcome.status,
+            tx_hash: outcome.tx_hash,
+            network: outcome.network,
+            recipient: outcome.recipient,
+            micro_credits: outcome.micro_credits,
+            declined_reason: outcome.declined_reason,
+            settled: outcome.settled,
+            resource_body: outcome.resource_body,
+            resource_status: outcome.resource_status,
+        }))
+    }
 }

--- a/crates/life-runtime/lifed/tests/integration_wallet.rs
+++ b/crates/life-runtime/lifed/tests/integration_wallet.rs
@@ -148,6 +148,41 @@ async fn transfer_with_idempotency_key_replays() {
     env.shutdown().await;
 }
 
+/// BRO-1354: life.v1.Wallet.X402Pay end-to-end against the mock haima
+/// substrate. The mock returns a canned base-sepolia "settled" outcome,
+/// so this proves the lifed handler marshals the request to haima-proxy
+/// and maps the X402PayOutcome onto the wire response.
+#[tokio::test]
+async fn x402_pay_returns_settled_outcome() {
+    use life_runtime_proto::life::v1::X402PayReq;
+    let env = TestEnv::start_with_mocks().await;
+    let mut client = env.wallet_client().await;
+    let mut req = tonic::Request::new(X402PayReq {
+        user_id: "alice".to_string(),
+        project_id: "p".to_string(),
+        resource_url: "https://example.test/api/data".to_string(),
+        network: "base-sepolia".to_string(),
+        max_amount_micros: None,
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let out = client.x402_pay(req).await.expect("x402_pay").into_inner();
+    assert_eq!(out.status, "settled");
+    assert!(out.settled);
+    assert_eq!(out.network, "eip155:84532");
+    // The handler reached the haima substrate exactly once with the
+    // caller's (user, project).
+    {
+        let calls = env.mocks.haima.x402_pay_calls.lock();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "alice");
+        assert_eq!(calls[0].1, "p");
+    }
+    env.shutdown().await;
+}
+
 #[tokio::test]
 async fn transfer_without_idempotency_key_fails_precondition() {
     use life_runtime_proto::life::v1::TransferReq;

--- a/crates/life-runtime/lifed/tests/integration_wallet.rs
+++ b/crates/life-runtime/lifed/tests/integration_wallet.rs
@@ -183,6 +183,35 @@ async fn x402_pay_returns_settled_outcome() {
     env.shutdown().await;
 }
 
+/// BRO-1354 hardening (P20 cross-review): a capability for `alice`
+/// cannot initiate an x402 payment naming `bob` as the payer — the
+/// handler binds the payer to the authenticated subject.
+#[tokio::test]
+async fn x402_pay_rejects_cross_user_payer() {
+    use life_runtime_proto::life::v1::X402PayReq;
+    let env = TestEnv::start_with_mocks().await;
+    let mut client = env.wallet_client().await;
+    let mut req = tonic::Request::new(X402PayReq {
+        user_id: "bob".to_string(), // ≠ the token subject (alice)
+        project_id: "p".to_string(),
+        resource_url: "https://example.test/api/data".to_string(),
+        network: "base-sepolia".to_string(),
+        max_amount_micros: None,
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let err = client
+        .x402_pay(req)
+        .await
+        .expect_err("cross-user must reject");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    // The substrate was never reached.
+    assert_eq!(env.mocks.haima.x402_pay_calls.lock().len(), 0);
+    env.shutdown().await;
+}
+
 #[tokio::test]
 async fn transfer_without_idempotency_key_fails_precondition() {
     use life_runtime_proto::life::v1::TransferReq;

--- a/crates/life-runtime/lifegw/src/auth/scope.rs
+++ b/crates/life-runtime/lifegw/src/auth/scope.rs
@@ -63,6 +63,11 @@ pub enum RequiredScope {
     WalletRead,
     /// `wallet:write` — Wallet.{Debit, Transfer}.
     WalletWrite,
+    /// `x402:pay` — Wallet.X402Pay. A WalletWrite-class scope minted
+    /// only into payment-capable tokens; not granted to read-only or
+    /// generic wallet:write tokens (initiating an external payment is
+    /// strictly more powerful than an internal ledger debit). BRO-1354.
+    X402Pay,
     /// `identity:read` — Identity.{ListSessions}.
     IdentityRead,
     /// `identity:write` — Identity.{UpdateProfile, RevokeSession}.
@@ -87,6 +92,7 @@ impl RequiredScope {
             RequiredScope::EventsRead => Some("events:read"),
             RequiredScope::WalletRead => Some("wallet:read"),
             RequiredScope::WalletWrite => Some("wallet:write"),
+            RequiredScope::X402Pay => Some("x402:pay"),
             RequiredScope::IdentityRead => Some("identity:read"),
             RequiredScope::IdentityWrite => Some("identity:write"),
             RequiredScope::AlwaysGranted => None,
@@ -153,6 +159,7 @@ pub fn required_scope(path: &str) -> Option<RequiredScope> {
         return Some(match rest {
             "GetBalance" | "Statement" => RequiredScope::WalletRead,
             "Debit" | "Transfer" => RequiredScope::WalletWrite,
+            "X402Pay" => RequiredScope::X402Pay,
             _ => return None,
         });
     }
@@ -304,6 +311,10 @@ mod tests {
             Some(RequiredScope::WalletWrite)
         );
         assert_eq!(
+            required_scope("/life.v1.Wallet/X402Pay"),
+            Some(RequiredScope::X402Pay)
+        );
+        assert_eq!(
             required_scope("/life.v1.Identity/Me"),
             Some(RequiredScope::AlwaysGranted)
         );
@@ -367,6 +378,31 @@ mod tests {
             }
             other => panic!("expected Insufficient, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn enforce_x402_pay_requires_dedicated_scope() {
+        // BRO-1354: Wallet.X402Pay needs `x402:pay`.
+        let with = Tier1Claims {
+            user_id: "u".to_string(),
+            project_id: "p".to_string(),
+            scopes: vec!["x402:pay".to_string()],
+            tier: "paid".to_string(),
+        };
+        enforce("/life.v1.Wallet/X402Pay", &with).expect("x402:pay passes");
+
+        // `wallet:write` must NOT cover `x402:pay` — initiating an
+        // external payment is strictly more powerful than an internal
+        // ledger debit, so the scopes are deliberately disjoint.
+        let only_write = Tier1Claims {
+            user_id: "u".to_string(),
+            project_id: "p".to_string(),
+            scopes: vec!["wallet:write".to_string()],
+            tier: "paid".to_string(),
+        };
+        let err = enforce("/life.v1.Wallet/X402Pay", &only_write)
+            .expect_err("wallet:write must not cover x402:pay");
+        assert!(matches!(err, ScopeError::Insufficient { .. }));
     }
 
     #[test]

--- a/crates/life-runtime/lifegw/src/bootstrap.rs
+++ b/crates/life-runtime/lifegw/src/bootstrap.rs
@@ -537,13 +537,26 @@ pub async fn serve_with_listener_and_signer(
     };
     let anthropic_router = crate::services::anthropic_messages::router(anthropic_state);
 
-    // Compose: top-level axum router that nests `/anima/custody/*`,
-    // merges the `/v1/agent/create_session` + `/v1/messages` routes,
-    // and falls back to the tonic-stack adapter for everything else
-    // (including `/v1/agent/stream` which the WS layer handles inside
-    // the tonic stack).
+    // BRO-1354: bespoke `POST /haima/x402/pay` JSON route. Verifies
+    // Tier-1, enforces `x402:pay` scope, mints Tier-2, and dials lifed's
+    // life.v1.Wallet.X402Pay over the same upstream channel. The
+    // broomva.tech edge proxy (slice P2) mirrors the `/anima/custody/*`
+    // JSON pattern against this surface. base-sepolia only in P1.
+    let haima_x402_state = crate::services::haima_x402::HaimaX402State {
+        jwks: Arc::clone(&jwks),
+        minter: Arc::clone(&minter),
+        upstream: upstream_channel.clone(),
+    };
+    let haima_x402_router = crate::services::haima_x402::router(haima_x402_state);
+
+    // Compose: top-level axum router that nests `/anima/custody/*` +
+    // `/haima/x402/*`, merges the `/v1/agent/create_session` +
+    // `/v1/messages` routes, and falls back to the tonic-stack adapter
+    // for everything else (including `/v1/agent/stream` which the WS
+    // layer handles inside the tonic stack).
     let app: axum::Router<()> = axum::Router::new()
         .nest("/anima/custody", anima_router)
+        .nest("/haima/x402", haima_x402_router)
         .merge(agent_http_router)
         .merge(anthropic_router)
         .fallback_service(tonic_stack_adapted);

--- a/crates/life-runtime/lifegw/src/proxy.rs
+++ b/crates/life-runtime/lifegw/src/proxy.rs
@@ -284,6 +284,16 @@ impl pb::wallet_server::Wallet for WalletForwarder {
             .transfer(forwarded.into_request_with(body))
             .await
     }
+
+    async fn x402_pay(
+        &self,
+        req: Request<pb::X402PayReq>,
+    ) -> Result<Response<pb::X402PayResp>, Status> {
+        let (forwarded, body) = forward_request(req);
+        self.client()
+            .x402_pay(forwarded.into_request_with(body))
+            .await
+    }
 }
 
 /// Forwarder for `life.v1.Identity`.

--- a/crates/life-runtime/lifegw/src/services/haima_x402.rs
+++ b/crates/life-runtime/lifegw/src/services/haima_x402.rs
@@ -1,0 +1,383 @@
+//! `POST /haima/x402/pay` — bespoke JSON route to initiate an x402
+//! payment from the user's Anima-custodied wallet (BRO-1354, slice 2 of
+//! the BRO-1341 x402 epic).
+//!
+//! This is the design's named edge route
+//! (`docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md`
+//! §Design — Route contract). It is a thin JSON shim over the gRPC
+//! `life.v1.Wallet.X402Pay` method: the broomva.tech edge proxy
+//! (`/api/x402/pay`, slice P2) mirrors the `/anima/custody/*` JSON
+//! pattern, so the gateway exposes a JSON surface rather than requiring
+//! the edge to speak gRPC-web.
+//!
+//! ## Flow (mirrors `anthropic_messages.rs` + `agent_http.rs`)
+//!
+//! ```text
+//!   POST /haima/x402/pay  { resourceUrl, network?, maxAmountMicros? }
+//!     Authorization: Bearer <Tier-1 JWS>
+//!       1. verify Tier-1 (JwksCache::verify)
+//!       2. enforce scope `x402:pay` for /life.v1.Wallet/X402Pay (the
+//!          gateway is the scope-enforcement point — Spec C₃ §5.4)
+//!       3. mint Tier-2 (Tier2Minter::mint, propagating scopes)
+//!       4. dial lifed life.v1.Wallet.X402Pay over the upstream channel
+//!       5. map the gRPC X402PayResp → JSON (resource bytes base64'd)
+//! ```
+//!
+//! The `(user_id, project_id)` the payment is scoped to come from the
+//! **verified Tier-1 token**, never the request body — a caller cannot
+//! pay from another user's wallet.
+//!
+//! **base-sepolia only** in P1: lifed/haimad reject `network = "base"`
+//! (mainnet) with `failed_precondition`, surfaced here as HTTP 412.
+//!
+//! Like `/anima/custody/*`, this route does its own bearer verification
+//! because it sits OUTSIDE the tonic stack's `AuthLayer` (it is merged
+//! into the axum router before the tonic fallback).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router, debug_handler};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64_STANDARD;
+use serde::{Deserialize, Serialize};
+use tonic::transport::Channel;
+
+use life_runtime_proto::life::v1::{self as pb, wallet_client::WalletClient};
+
+use crate::auth::jwks::JwksCache;
+use crate::auth::scope::{self, ScopeError};
+use crate::auth::tier2::Tier2Minter;
+
+/// Per-RPC deadline for the upstream `life.v1.Wallet.X402Pay` call. The
+/// substrate drives a full HTTP round-trip (GET → 402 → sign → retry →
+/// settle), so this is more generous than a plain unary RPC.
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The gRPC route this bespoke HTTP alias maps to. Reused so scope
+/// enforcement stays identical to the tonic-stack proxy path.
+const X402_ROUTE: &str = "/life.v1.Wallet/X402Pay";
+
+/// Shared state threaded into the axum router.
+#[derive(Clone)]
+pub struct HaimaX402State {
+    /// Verifies inbound Tier-1 bearers.
+    pub jwks: Arc<JwksCache>,
+    /// Mints the Tier-2 capability attached to the upstream lifed call.
+    pub minter: Arc<Tier2Minter>,
+    /// Upstream tonic channel to lifed (the same handle the tonic stack
+    /// proxies through).
+    pub upstream: Channel,
+}
+
+/// Build the axum router mounted at `/haima/x402/*`.
+pub fn router(state: HaimaX402State) -> Router {
+    Router::new()
+        .route("/pay", post(pay_handler))
+        .with_state(state)
+}
+
+/// Body of `POST /haima/x402/pay`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PayBody {
+    /// The x402-protected resource URL to fetch and pay for.
+    pub resource_url: String,
+    /// Payment network: `"base-sepolia"` (default) or `"base"` (mainnet,
+    /// rejected until slice 3). Omitted → base-sepolia.
+    #[serde(default)]
+    pub network: Option<String>,
+    /// Optional per-call ceiling in micro-credits, enforced before
+    /// signing.
+    #[serde(default)]
+    pub max_amount_micros: Option<i64>,
+}
+
+/// Response of `POST /haima/x402/pay`. Flat mirror of the gRPC
+/// `X402PayResp`; `status` is the discriminant.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PayResp {
+    /// `"settled"` | `"not_required"` | `"declined"`.
+    pub status: String,
+    pub tx_hash: String,
+    pub network: String,
+    pub recipient: String,
+    pub micro_credits: i64,
+    pub declined_reason: String,
+    pub settled: bool,
+    /// Base64-encoded fetched resource bytes (paid resource for
+    /// `settled`, the unpaywalled body for `not_required`).
+    pub resource_b64: String,
+    pub resource_status: u32,
+}
+
+#[debug_handler]
+async fn pay_handler(
+    State(state): State<HaimaX402State>,
+    headers: HeaderMap,
+    Json(body): Json<PayBody>,
+) -> Result<Json<PayResp>, ApiError> {
+    if body.resource_url.is_empty() {
+        return Err(ApiError::bad_request("empty resourceUrl"));
+    }
+
+    // 1. Verify the Tier-1 bearer.
+    let tier1 = {
+        let bearer = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|h| h.strip_prefix("Bearer "))
+            .filter(|b| !b.is_empty())
+            .ok_or_else(|| ApiError::unauthorized("missing Tier-1 bearer"))?;
+        state
+            .jwks
+            .verify(bearer)
+            .map_err(|e| ApiError::unauthorized(format!("invalid Tier-1: {e}")))?
+    };
+
+    // 2. Enforce the `x402:pay` scope (the gateway is the
+    //    scope-enforcement point per Spec C₃ §5.4 — lifed validates the
+    //    Tier-2 capability but does NOT re-check per-route scope).
+    scope::enforce(X402_ROUTE, &tier1).map_err(|e| match e {
+        ScopeError::Insufficient { .. } => ApiError::forbidden(e.to_string()),
+        // The route is statically mapped — an UnknownRoute here is a
+        // wiring bug, not a client error.
+        ScopeError::UnknownRoute(_) => ApiError::internal("x402 route scope mapping missing"),
+    })?;
+
+    // 3. Mint a Tier-2 capability (propagates Tier-1 scopes + tier).
+    let tier2 = state
+        .minter
+        .mint(&tier1)
+        .map_err(|e| ApiError::internal(format!("mint tier-2: {e}")))?;
+
+    // 4. Dial lifed's life.v1.Wallet.X402Pay. The (user, project) come
+    //    from the verified Tier-1 token, never the request body.
+    let mut client = WalletClient::new(state.upstream.clone());
+    let mut req = tonic::Request::new(pb::X402PayReq {
+        user_id: tier1.user_id.clone(),
+        project_id: tier1.project_id.clone(),
+        resource_url: body.resource_url,
+        network: body.network.unwrap_or_default(),
+        max_amount_micros: body.max_amount_micros,
+    });
+    attach_tier2(&mut req, &tier2)?;
+
+    let resp = tokio::time::timeout(RPC_TIMEOUT, client.x402_pay(req))
+        .await
+        .map_err(|_| ApiError::gateway_timeout())?
+        .map_err(|s| ApiError::from_status(&s))?
+        .into_inner();
+
+    Ok(Json(PayResp {
+        status: resp.status,
+        tx_hash: resp.tx_hash,
+        network: resp.network,
+        recipient: resp.recipient,
+        micro_credits: resp.micro_credits,
+        declined_reason: resp.declined_reason,
+        settled: resp.settled,
+        resource_b64: B64_STANDARD.encode(&resp.resource_body),
+        resource_status: resp.resource_status,
+    }))
+}
+
+/// Attach the minted Tier-2 capability to the upstream gRPC request.
+fn attach_tier2<T>(req: &mut tonic::Request<T>, tier2: &str) -> Result<(), ApiError> {
+    let value: tonic::metadata::MetadataValue<_> = format!("Bearer {tier2}")
+        .parse()
+        .map_err(|e| ApiError::internal(format!("encode tier-2 metadata: {e}")))?;
+    req.metadata_mut().insert("authorization", value);
+    Ok(())
+}
+
+/// Compact JSON error — `{ "error": <code>, "message": <msg> }`.
+#[derive(Debug)]
+struct ApiError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+}
+
+impl ApiError {
+    fn unauthorized(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            code: "unauthorized",
+            message: msg.into(),
+        }
+    }
+    fn forbidden(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "scope_insufficient",
+            message: msg.into(),
+        }
+    }
+    fn bad_request(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "bad_request",
+            message: msg.into(),
+        }
+    }
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal",
+            message: msg.into(),
+        }
+    }
+    fn gateway_timeout() -> Self {
+        Self {
+            status: StatusCode::GATEWAY_TIMEOUT,
+            code: "upstream_timeout",
+            message: "lifed x402 upstream timeout".to_string(),
+        }
+    }
+
+    /// Map an upstream `tonic::Status` to an HTTP error. The substrate's
+    /// `failed_precondition` (mainnet gate / over-balance) surfaces as
+    /// 412 so the edge can distinguish a policy block from a 5xx. The
+    /// upstream message is NOT echoed (it may carry request-shape
+    /// internals); only the canonical code + a generic message ship.
+    fn from_status(status: &tonic::Status) -> Self {
+        use tonic::Code;
+        let (http, code, message) = match status.code() {
+            Code::InvalidArgument => (
+                StatusCode::BAD_REQUEST,
+                "bad_request",
+                "invalid x402 request",
+            ),
+            Code::FailedPrecondition => (
+                StatusCode::PRECONDITION_FAILED,
+                "payment_precondition",
+                "x402 payment precondition failed (network gate or balance)",
+            ),
+            Code::Unauthenticated => (
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "upstream rejected token",
+            ),
+            Code::PermissionDenied => (StatusCode::FORBIDDEN, "forbidden", "upstream denied"),
+            Code::Unavailable => (
+                StatusCode::BAD_GATEWAY,
+                "upstream_unavailable",
+                "x402 upstream unavailable",
+            ),
+            Code::DeadlineExceeded => (
+                StatusCode::GATEWAY_TIMEOUT,
+                "upstream_timeout",
+                "x402 upstream timeout",
+            ),
+            _ => (
+                StatusCode::BAD_GATEWAY,
+                "upstream_error",
+                "x402 upstream error",
+            ),
+        };
+        tracing::debug!(
+            code = ?status.code(),
+            upstream_message = status.message(),
+            mapped = http.as_u16(),
+            "haima_x402: sanitized upstream status"
+        );
+        Self {
+            status: http,
+            code,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = serde_json::json!({ "error": self.code, "message": self.message });
+        (self.status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pay_body_deserializes_camel_case() {
+        let json =
+            r#"{"resourceUrl":"https://x.test/d","network":"base-sepolia","maxAmountMicros":500}"#;
+        let body: PayBody = serde_json::from_str(json).expect("parse");
+        assert_eq!(body.resource_url, "https://x.test/d");
+        assert_eq!(body.network.as_deref(), Some("base-sepolia"));
+        assert_eq!(body.max_amount_micros, Some(500));
+    }
+
+    #[test]
+    fn pay_body_defaults_optional_fields() {
+        let body: PayBody =
+            serde_json::from_str(r#"{"resourceUrl":"https://x.test/d"}"#).expect("parse");
+        assert!(body.network.is_none());
+        assert!(body.max_amount_micros.is_none());
+    }
+
+    #[test]
+    fn pay_body_rejects_unknown_fields() {
+        // Strict shape parsing — lifegw is a security boundary.
+        let err =
+            serde_json::from_str::<PayBody>(r#"{"resourceUrl":"https://x.test/d","sneaky":true}"#);
+        assert!(err.is_err(), "unknown field must be rejected");
+    }
+
+    #[test]
+    fn pay_body_rejects_snake_case_resource_url() {
+        // camelCase is the wire contract; snake_case must not parse.
+        let err = serde_json::from_str::<PayBody>(r#"{"resource_url":"https://x.test/d"}"#);
+        assert!(err.is_err(), "snake_case key must be rejected");
+    }
+
+    #[test]
+    fn pay_resp_serializes_camel_case() {
+        let resp = PayResp {
+            status: "settled".to_string(),
+            tx_hash: "0xabc".to_string(),
+            network: "eip155:84532".to_string(),
+            recipient: "0xrec".to_string(),
+            micro_credits: 50,
+            declined_reason: String::new(),
+            settled: true,
+            resource_b64: "Zm9v".to_string(),
+            resource_status: 200,
+        };
+        let v = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(v["status"], "settled");
+        assert_eq!(v["txHash"], "0xabc");
+        assert_eq!(v["microCredits"], 50);
+        assert_eq!(v["resourceB64"], "Zm9v");
+        assert_eq!(v["resourceStatus"], 200);
+    }
+
+    #[test]
+    fn from_status_maps_failed_precondition_to_412() {
+        let err = ApiError::from_status(&tonic::Status::failed_precondition("mainnet gated"));
+        assert_eq!(err.status, StatusCode::PRECONDITION_FAILED);
+        assert_eq!(err.code, "payment_precondition");
+        // Upstream message is NOT echoed.
+        assert!(!err.message.contains("mainnet gated"));
+    }
+
+    #[test]
+    fn from_status_maps_unavailable_to_502() {
+        let err = ApiError::from_status(&tonic::Status::unavailable("haima down"));
+        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn api_error_renders_json_body() {
+        let resp = ApiError::bad_request("empty resourceUrl").into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/life-runtime/lifegw/src/services/mod.rs
+++ b/crates/life-runtime/lifegw/src/services/mod.rs
@@ -9,6 +9,7 @@ pub mod agent_http;
 pub mod anima_custody;
 pub mod anthropic_messages;
 pub mod cert_watch;
+pub mod haima_x402;
 pub mod health;
 pub mod rate_limit;
 pub mod ws;

--- a/docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md
+++ b/docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md
@@ -95,3 +95,25 @@ The payment is signed **by the user's Anima wallet**, not a haima-owned key:
 - Unit: x402 handler with a mock facilitator + a stub `AnimaCustody` (assert the signed EIP-3009 authorization binds the user's address + the policy gate rejects over-cap).
 - Integration: testnet round-trip against a sample base-sepolia x402 endpoint; assert settlement tx + Lago receipt event.
 - No mainnet path exercised in P1.
+
+## As-built — slice 2 transport (BRO-1354, 2026-06-03)
+
+Built across one PR with staged compile-green layer commits. Decision #4 was honoured on **both planes**: `X402Pay` extends the existing Wallet service at the substrate plane (`haima.v1.WalletSubstrate`) **and** the public plane (`life.v1.Wallet`) — the only shape that respects lifegw's "no haima-proxy dependency" rule while reusing the existing proxy/pool/scope wiring.
+
+| Layer | Where | What |
+|---|---|---|
+| proto (substrate) | `proto/haima/v1/substrate.proto` | `X402Pay(X402PayReq)→X402PayResp`; flat resp with a `status` discriminant (`settled`/`not_required`/`declined`) mirroring `X402PayResult`. |
+| haimad | `crates/haima/haimad/src/substrate.rs` | `SubstrateService::x402_pay` — resolve custody → `CustodyWalletAdapter::from_custody_on_network(_, base_sepolia)` → `X402Client` → `pay_x402` → map. |
+| proxy | `crates/life-runtime/haima-proxy/src/client.rs` | `HaimaCall::x402_pay` + `X402PayOutcome` (HaimaProxy + Pooled + MockHaima). |
+| proto (public) | `proto/life/v1/wallet.proto` | `life.v1.Wallet.X402Pay` mirror. |
+| lifed | `crates/life-runtime/lifed/src/services/wallet.rs` | `WalletService::x402_pay` → `haima.x402_pay` (not idempotency-cached — a settled on-chain payment can't be replayed; EIP-3009 nonce makes a resubmit a fresh auth). |
+| lifegw (gRPC) | `proxy.rs` + `auth/scope.rs` | `WalletForwarder::x402_pay` (verbatim forward) + `RequiredScope::X402Pay` (`x402:pay`, disjoint from `wallet:write`). |
+| lifegw (HTTP) | `services/haima_x402.rs` | bespoke `POST /haima/x402/pay` JSON route: verify Tier-1 → enforce `x402:pay` → mint Tier-2 → dial lifed. The edge surface slice P2 targets. |
+
+**Open decisions — resolved:** (1) sync settlement ✓; (2) server-side `PaymentPolicy` cap ✓; (3) faucet/funding documented (manual P1 step, deferred to the live round-trip); (4) extend the Wallet service ✓.
+
+**Custody (P1, documented deviation).** haimad resolves a per-`(user_id, project_id)` **deterministic `InProcessAnima`** (SHA-256-seeded via `derive_custody_seed`), not yet the soma-resident `/account` Anima wallet. This exercises the full sign + policy + settlement path on base-sepolia. **Slice 2b** swaps `resolve_custody` to `SomaCustody`/`RemoteAnima` behind the same handler — a localized change, no wire impact. Until then the x402 signing address is stable per `(user, project)` but distinct from both the substrate `GetBalance` wallet and the production Anima wallet.
+
+**Deferred to follow-ups:** the live base-sepolia round-trip against a real funded wallet + facilitator config (P1 manual step); broomva.tech edge proxy + UI (slice P2); mainnet (slice 3, financial control gate); `method`/`body` request replay in the JSON route body.
+
+**Validation:** `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, workspace tests ✓ (haimad 14, lifegw scope 19 + haima_x402 8, lifed wallet 7 incl. x402); both `verify_dependencies_{lifed,lifegw}.sh` ✓. (Unrelated pre-existing load-sensitive flake in `chronosd`'s heartbeat test — passes idle on clean main + this branch.)

--- a/docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md
+++ b/docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md
@@ -114,6 +114,14 @@ Built across one PR with staged compile-green layer commits. Decision #4 was hon
 
 **Custody (P1, documented deviation).** haimad resolves a per-`(user_id, project_id)` **deterministic `InProcessAnima`** (SHA-256-seeded via `derive_custody_seed`), not yet the soma-resident `/account` Anima wallet. This exercises the full sign + policy + settlement path on base-sepolia. **Slice 2b** swaps `resolve_custody` to `SomaCustody`/`RemoteAnima` behind the same handler — a localized change, no wire impact. Until then the x402 signing address is stable per `(user, project)` but distinct from both the substrate `GetBalance` wallet and the production Anima wallet.
 
-**Deferred to follow-ups:** the live base-sepolia round-trip against a real funded wallet + facilitator config (P1 manual step); broomva.tech edge proxy + UI (slice P2); mainnet (slice 3, financial control gate); `method`/`body` request replay in the JSON route body.
+**Open caveat — Gate #4 (Lago audit event) NOT yet met (P20 cross-review MEDIUM).** A settled x402 payment currently emits **no** `finance.*` Lago event — the substrate's `FinancePublisher` is a daemon-wide F2 stub (`Debit`/`Transfer` don't emit either; see `substrate.rs` header). So BRO-1341 Gate #4 ("Every payment + settlement is a Lago event — auditable, replayable") is **outstanding**, tracked with the F2 ledger work. Acceptable for the testnet transport slice (no real funds) but **must close before mainnet (slice 3)**.
+
+**Deferred to follow-ups:**
+- The live base-sepolia round-trip against a real funded wallet + facilitator config (P1 manual step).
+- **Slice 2b** — swap `resolve_custody` from `InProcessAnima` to the soma-resident `SomaCustody`/`RemoteAnima` so the signing key IS the `/account` Anima wallet.
+- **Lago finance event** on settle (Gate #4, with the F2 publisher).
+- **Cross-user payer binding on the other Wallet RPCs** — `x402_pay` now binds the payer to the capability subject (P20 fix); `get_balance`/`debit`/`transfer` still trust the body `user_id` (pre-existing). Backfill the same guard as a separate hardening.
+- **Network-consistency assertion** — the response `network`/`recipient` reflect the server-advertised 402 scheme; the signature is correctly domain-bound to the resolved network regardless, but `handle_402` should reject a 402 whose advertised network ≠ the resolved signing network (belongs with the mainnet-enablement work in the engine, slice 2b/3).
+- broomva.tech edge proxy + UI (slice P2); mainnet (slice 3, financial control gate); `method`/`body` request replay in the JSON route body.
 
 **Validation:** `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, workspace tests ✓ (haimad 14, lifegw scope 19 + haima_x402 8, lifed wallet 7 incl. x402); both `verify_dependencies_{lifed,lifegw}.sh` ✓. (Unrelated pre-existing load-sensitive flake in `chronosd`'s heartbeat test — passes idle on clean main + this branch.)

--- a/proto/haima/v1/substrate.proto
+++ b/proto/haima/v1/substrate.proto
@@ -54,6 +54,23 @@ service WalletSubstrate {
   // was made idempotent in M5 Sub-phase D follow-up #3); the
   // substrate accepts every Transfer as a fresh ledger event.
   rpc Transfer(TransferReq) returns (TransferReceipt);
+
+  // Initiate an x402 payment from the user's wallet to an external
+  // x402-protected resource (BRO-1354, slice 2 of the BRO-1341 x402
+  // epic). Drives the full client round-trip: GET -> 402 -> optional
+  // pre-sign max_amount cap -> PaymentPolicy gate -> sign (EIP-3009
+  // transferWithAuthorization via the user's Anima-custodied secp256k1
+  // wallet) -> retry with the payment-signature header -> facilitator
+  // settle -> resource + receipt.
+  //
+  // Settlement is SYNCHRONOUS for P1 (design decision #1). The signing
+  // wallet is the user's Anima wallet, wrapped in a CustodyWalletAdapter
+  // -- one identity end to end (design section "Custody binding").
+  //
+  // base-sepolia ONLY in P1. A request with network "base" (mainnet) is
+  // rejected with failed_precondition: the slice-3 financial control
+  // gate (BRO-1341) owns mainnet enablement.
+  rpc X402Pay(X402PayReq) returns (X402PayResp);
 }
 
 message BindWalletReq {
@@ -139,4 +156,54 @@ message TransferReceipt {
   string entry_id = 1;
   Balance from_balance = 2;
   Balance to_balance = 3;
+}
+
+// Request to initiate an x402 payment on behalf of a (user_id,
+// project_id). BRO-1354.
+message X402PayReq {
+  string user_id = 1;
+  string project_id = 2;
+  // The x402-protected resource URL to fetch and pay for.
+  string resource_url = 3;
+  // Payment network label. "base-sepolia" (default / only value
+  // accepted in P1) or "base" (mainnet, rejected until slice 3). An
+  // empty string is treated as "base-sepolia".
+  string network = 4;
+  // Optional per-call ceiling in micro-credits, enforced BEFORE
+  // signing. When set and the 402 asks for more, the payment is
+  // declined without contacting the payee a second time. Absent =
+  // rely on the server-side PaymentPolicy alone.
+  optional int64 max_amount_micros = 5;
+}
+
+// Result of an X402Pay round-trip. Mirrors haima-x402's
+// `X402PayResult` (NotRequired / Paid / Declined) flattened onto the
+// wire. `status` is the discriminant; the other fields are populated
+// per-variant.
+message X402PayResp {
+  // One of: "settled" (paid), "not_required" (resource was not
+  // paywalled), "declined" (policy / cap / approval blocked it).
+  string status = 1;
+  // Settlement transaction hash. Populated for "settled" when the
+  // post-payment 200 carried a payment-response header.
+  string tx_hash = 2;
+  // CAIP-2 network the payment was authorized on (e.g. "eip155:84532"
+  // for base-sepolia). Populated for "settled".
+  string network = 3;
+  // Recipient address that was paid. Populated for "settled".
+  string recipient = 4;
+  // Cost in micro-credits. Populated for "settled" and "declined"
+  // (the amount that would have been charged).
+  int64 micro_credits = 5;
+  // Human-readable decline reason. Populated for "declined".
+  string declined_reason = 6;
+  // Whether the facilitator reported the settlement as settled.
+  // Populated for "settled".
+  bool settled = 7;
+  // The fetched resource bytes — the paid resource for "settled", the
+  // unpaywalled body for "not_required".
+  bytes resource_body = 8;
+  // HTTP status of the underlying resource fetch. Populated for
+  // "not_required" (settled implies 200).
+  uint32 resource_status = 9;
 }

--- a/proto/life/v1/wallet.proto
+++ b/proto/life/v1/wallet.proto
@@ -14,6 +14,14 @@ service Wallet {
   rpc Statement(StatementReq) returns (stream LedgerEntry);
   rpc Debit(DebitReq) returns (DebitReceipt);
   rpc Transfer(TransferReq) returns (TransferReceipt);
+
+  // Initiate an x402 payment from the user's Anima-custodied wallet to
+  // an external x402-protected resource. Public-plane mirror of
+  // haima.v1.WalletSubstrate.X402Pay; lifed forwards to haima-proxy.
+  // Scope `x402:pay` (a WalletWrite-class scope). base-sepolia only in
+  // P1 — `network = "base"` is rejected behind the slice-3 financial
+  // gate. BRO-1354 / BRO-1341.
+  rpc X402Pay(X402PayReq) returns (X402PayResp);
 }
 
 message WalletRef {
@@ -68,4 +76,34 @@ message TransferReceipt {
   string entry_id = 1;
   Balance from_balance = 2;
   Balance to_balance = 3;
+}
+
+// Request to initiate an x402 payment. Public-plane mirror of
+// haima.v1.X402PayReq. BRO-1354.
+message X402PayReq {
+  string user_id = 1;
+  string project_id = 2;
+  // The x402-protected resource URL to fetch and pay for.
+  string resource_url = 3;
+  // Payment network: "base-sepolia" (default / only value in P1) or
+  // "base" (mainnet, rejected until slice 3). Empty = "base-sepolia".
+  string network = 4;
+  // Optional per-call ceiling in micro-credits, enforced before
+  // signing.
+  optional int64 max_amount_micros = 5;
+}
+
+// Result of an X402Pay round-trip. Mirror of haima.v1.X402PayResp.
+// `status` is the discriminant; other fields are populated per-variant.
+message X402PayResp {
+  // "settled" | "not_required" | "declined".
+  string status = 1;
+  string tx_hash = 2;
+  string network = 3;
+  string recipient = 4;
+  int64 micro_credits = 5;
+  string declined_reason = 6;
+  bool settled = 7;
+  bytes resource_body = 8;
+  uint32 resource_status = 9;
 }


### PR DESCRIPTION
## What

Slice 2 (**transport**) of the BRO-1341 x402 epic. Wires the finished, tested x402 **engine** (slices 1a/1b: `CustodyWalletAdapter` + `pay_x402`, already on `main`) across the runtime so a Tier-1 caller can initiate an x402 payment from their Anima-custodied wallet. **base-sepolia only** — mainnet stays behind the slice-3 financial control gate.

Closes the design's P1 "route + proxy + haimad X402Pay RPC + wire CustodyWalletAdapter". Design: `docs/superpowers/specs/2026-06-02-lifegw-x402-route-design.md` (Accepted; see the new **As-built** section).

## Dep-chain (P14) — extend the Wallet service on BOTH planes

Decision #4 (extend the Wallet service) honoured on the substrate plane (`haima.v1.WalletSubstrate`) **and** the public plane (`life.v1.Wallet`) — the only shape that respects lifegw's "no haima-proxy dependency" rule while reusing the existing proxy/pool/scope wiring (both `verify_dependencies_{lifed,lifegw}.sh` still pass).

| Commit | Layer |
|---|---|
| `610069ba` | proto `haima.v1.WalletSubstrate.X402Pay` + haimad `SubstrateService::x402_pay` (resolve custody → `CustodyWalletAdapter` → `X402Client` → `pay_x402`) |
| `5892cfe7` | haima-proxy `HaimaCall::x402_pay` + `X402PayOutcome` (HaimaProxy + Pooled + MockHaima) |
| `404a9f30` | proto `life.v1.Wallet.X402Pay` + lifed `WalletService::x402_pay` + lifegw `WalletForwarder` + `RequiredScope::X402Pay` |
| `c770c7f3` | lifegw bespoke `POST /haima/x402/pay` JSON route (verify Tier-1 → enforce `x402:pay` → mint Tier-2 → dial lifed) |
| `43a8a209` | docs: as-built + haima CLAUDE |
| `3ead67f6` | P20 fix: bind x402_pay payer to capability subject + audit caveats |

## Custody (P1, documented deviation)

haimad resolves a per-`(user,project)` **deterministic `InProcessAnima`** (SHA-256-seeded) for the testnet round-trip — exercises the full sign + policy + settlement path. Slice 2b swaps `resolve_custody` to `SomaCustody`/`RemoteAnima` (the `/account` wallet) behind the same handler — no wire change.

## Validation (P11)

- `cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ (0 errors)
- Tests: haimad **14** (wiremock round-trip settles on base-sepolia, max_amount declines pre-sign, not_required, mainnet/unknown-network/empty-url rejected, deterministic seed scoping); lifegw scope **+x402:pay** (disjoint from wallet:write) + haima_x402 route **8**; lifed wallet **8** (incl. `x402_pay_returns_settled_outcome` + `x402_pay_rejects_cross_user_payer`)
- `verify_dependencies_{lifed,lifegw}.sh` ✓
- Note: an **unrelated** pre-existing load-sensitive flake in `chronosd`'s heartbeat test (chronos M2) passes idle on both clean `main` and this branch.

## P20 cross-model adversarial review — VERDICT: SHIP (8/10)

Fresh-context adversarial reviewer (Strata B). Confirmed sound: mainnet gating (signature is EIP-712-domain-bound to base-sepolia regardless of the 402's advertised network), `x402:pay` scope disjoint from `wallet:write`, edge auth ordering (scope before mint; payer from token not body), proto field consistency across planes, error sanitization, no panics on attacker input. Findings addressed:
- **MEDIUM (fixed):** lifed `x402_pay` now binds the payer to the capability subject (PermissionDenied on mismatch) + test.
- **MEDIUM (documented):** Gate #4 (Lago finance event on settle) is a daemon-wide F2 stub — flagged outstanding; must close before mainnet.
- **LOW (accept → slice 2b/3):** response `network` reflects the advertised 402 scheme; a network-consistency assertion belongs in the engine's `handle_402` with the mainnet work.

## Follow-ups
Slice 2b (soma custody), Lago audit event (F2 / Gate #4), live funded round-trip, broomva.tech edge proxy + UI (P2), mainnet (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)