### PR TITLE
feat(x402): cross-review hardening — network-consistency + payer-binding [BRO-1368]

### DIFF
--- a/crates/haima/haima-x402/src/pay.rs
+++ b/crates/haima/haima-x402/src/pay.rs
@@ -118,6 +118,13 @@ pub async fn pay_x402(
     //    network consistency, then the per-call max_amount cap. Parse the
     //    payment-required header once (handle_402 re-parses internally for
     //    the signing path).
+    //
+    // We inspect the FIRST `exact`/`eip155:` scheme — identical selection
+    // to `client::select_scheme`, so the scheme checked here is exactly the
+    // one that will be signed (no divergence). A 402 advertising multiple
+    // EVM schemes on different networks where only a *later* one matches
+    // `expected_network` would false-decline; that fails closed (toward
+    // not-paying) and cannot occur in P1 (single-network base-sepolia).
     if expected_network.is_some() || max_amount_micro_credits.is_some() {
         let header = parse_payment_required(&required)?;
         if let Some(scheme) = header

--- a/crates/haima/haima-x402/src/pay.rs
+++ b/crates/haima/haima-x402/src/pay.rs
@@ -61,6 +61,15 @@ pub enum X402PayResult {
 
 /// Drive a full x402 client payment round-trip against `resource_url`.
 ///
+/// `expected_network`, when set (a CAIP-2 string like `eip155:84532`), is a
+/// per-call assertion enforced **before signing**: if the 402's advertised
+/// `exact`/EVM scheme names a different network, the payment is
+/// [`X402PayResult::Declined`] without signing. The EIP-712 authorization is
+/// already domain-bound to the wallet's signing network, so a cross-network
+/// signature would never settle anyway — this turns that silent dead-end into
+/// an explicit decline and stops a base-sepolia caller from being steered
+/// toward a mainnet-advertised payment by a hostile/misconfigured endpoint.
+///
 /// `max_amount_micro_credits`, when set, is a per-call ceiling enforced
 /// **before signing**, on top of the [`X402Client`]'s `PaymentPolicy`. An
 /// amount over the cap returns [`X402PayResult::Declined`] without signing or
@@ -73,6 +82,7 @@ pub async fn pay_x402(
     client: &X402Client,
     http: &reqwest::Client,
     resource_url: &str,
+    expected_network: Option<&str>,
     max_amount_micro_credits: Option<i64>,
 ) -> HaimaResult<X402PayResult> {
     // 1. Initial request.
@@ -104,25 +114,46 @@ pub async fn pay_x402(
         .map_err(|e| HaimaError::Protocol(format!("payment-required header not UTF-8: {e}")))?
         .to_string();
 
-    // 3. Enforce the per-call max_amount cap BEFORE signing.
-    if let Some(cap) = max_amount_micro_credits {
+    // 3. Pre-sign checks against the advertised `exact`/EVM scheme:
+    //    network consistency, then the per-call max_amount cap. Parse the
+    //    payment-required header once (handle_402 re-parses internally for
+    //    the signing path).
+    if expected_network.is_some() || max_amount_micro_credits.is_some() {
         let header = parse_payment_required(&required)?;
         if let Some(scheme) = header
             .schemes
             .iter()
             .find(|s| s.scheme == "exact" && s.network.starts_with("eip155:"))
         {
-            let raw: u64 = scheme.amount.parse().map_err(|e| {
-                HaimaError::Protocol(format!("invalid amount '{}': {e}", scheme.amount))
-            })?;
-            let micro_credits = usdc_raw_to_micro_credits(raw);
-            if micro_credits > cap {
+            // 3a. Network consistency. The wallet will sign for its own
+            //     signing network; reject a 402 advertising a different one
+            //     rather than producing a signature that can never settle.
+            if let Some(expected) = expected_network
+                && scheme.network != expected
+            {
                 return Ok(X402PayResult::Declined {
                     reason: format!(
-                        "amount {micro_credits} micro-credits exceeds max_amount {cap}"
+                        "network mismatch: 402 advertised '{}', expected '{expected}'",
+                        scheme.network
                     ),
-                    micro_credits,
+                    micro_credits: 0,
                 });
+            }
+
+            // 3b. max_amount cap.
+            if let Some(cap) = max_amount_micro_credits {
+                let raw: u64 = scheme.amount.parse().map_err(|e| {
+                    HaimaError::Protocol(format!("invalid amount '{}': {e}", scheme.amount))
+                })?;
+                let micro_credits = usdc_raw_to_micro_credits(raw);
+                if micro_credits > cap {
+                    return Ok(X402PayResult::Declined {
+                        reason: format!(
+                            "amount {micro_credits} micro-credits exceeds max_amount {cap}"
+                        ),
+                        micro_credits,
+                    });
+                }
             }
         }
     }
@@ -271,7 +302,9 @@ mod tests {
         let http = reqwest::Client::new();
         let url = format!("{}/api/data", server.uri());
 
-        let result = pay_x402(&client, &http, &url, None).await.expect("pay");
+        let result = pay_x402(&client, &http, &url, None, None)
+            .await
+            .expect("pay");
         match result {
             X402PayResult::Paid(o) => {
                 assert!(o.settled);
@@ -297,7 +330,9 @@ mod tests {
         let http = reqwest::Client::new();
         let url = format!("{}/api/data", server.uri());
 
-        let result = pay_x402(&client, &http, &url, Some(10)).await.expect("pay");
+        let result = pay_x402(&client, &http, &url, None, Some(10))
+            .await
+            .expect("pay");
         match result {
             X402PayResult::Declined {
                 micro_credits,
@@ -320,7 +355,9 @@ mod tests {
         let http = reqwest::Client::new();
         let url = format!("{}/api/data", server.uri());
 
-        let result = pay_x402(&client, &http, &url, None).await.expect("pay");
+        let result = pay_x402(&client, &http, &url, None, None)
+            .await
+            .expect("pay");
         assert!(
             matches!(result, X402PayResult::Declined { .. }),
             "over-hard-cap amount must decline, got {result:?}"
@@ -340,7 +377,9 @@ mod tests {
         let http = reqwest::Client::new();
         let url = format!("{}/api/data", server.uri());
 
-        let result = pay_x402(&client, &http, &url, None).await.expect("pay");
+        let result = pay_x402(&client, &http, &url, None, None)
+            .await
+            .expect("pay");
         match result {
             X402PayResult::NotRequired {
                 status,
@@ -351,5 +390,56 @@ mod tests {
             }
             other => panic!("expected NotRequired, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn network_mismatch_declines_before_signing() {
+        let server = MockServer::start().await;
+        // The 402 advertises eip155:8453 (mainnet). Only the 402 leg is
+        // mounted — if pay_x402 signed + retried, the request would 404.
+        // Getting Declined proves the network check short-circuited before
+        // signing.
+        mount_402(&server, "50").await;
+
+        let client = make_client();
+        let http = reqwest::Client::new();
+        let url = format!("{}/api/data", server.uri());
+
+        // Caller expects base-sepolia (eip155:84532) — mismatch.
+        let result = pay_x402(&client, &http, &url, Some("eip155:84532"), None)
+            .await
+            .expect("pay");
+        match result {
+            X402PayResult::Declined {
+                reason,
+                micro_credits,
+            } => {
+                assert!(reason.contains("network mismatch"), "reason: {reason}");
+                assert!(reason.contains("eip155:8453"));
+                assert!(reason.contains("eip155:84532"));
+                assert_eq!(micro_credits, 0);
+            }
+            other => panic!("expected Declined, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn matching_network_still_settles() {
+        let server = MockServer::start().await;
+        mount_402(&server, "50").await; // eip155:8453
+        mount_paid(&server).await;
+
+        let client = make_client();
+        let http = reqwest::Client::new();
+        let url = format!("{}/api/data", server.uri());
+
+        // Expected network matches the advertised one → no decline.
+        let result = pay_x402(&client, &http, &url, Some("eip155:8453"), None)
+            .await
+            .expect("pay");
+        assert!(
+            matches!(result, X402PayResult::Paid(_)),
+            "matching network must settle, got {result:?}"
+        );
     }
 }

--- a/crates/haima/haimad/src/substrate.rs
+++ b/crates/haima/haimad/src/substrate.rs
@@ -294,6 +294,10 @@ impl WalletSubstrate for SubstrateService {
 
         // Resolve the signing network. P1 = base-sepolia only.
         let network = resolve_network(&body.network)?;
+        // Capture the CAIP-2 string before `network` is moved into the
+        // adapter — pay_x402 declines a 402 that advertises a different
+        // network than the one we will sign for (BRO-1368).
+        let network_caip2 = network.0.clone();
 
         // Resolve the user's custody backend and wrap it so x402 signs
         // EIP-3009 authorizations from the user's wallet half.
@@ -312,9 +316,15 @@ impl WalletSubstrate for SubstrateService {
         );
         let http = reqwest::Client::new();
 
-        let result = pay_x402(&client, &http, &body.resource_url, body.max_amount_micros)
-            .await
-            .map_err(map_haima_error)?;
+        let result = pay_x402(
+            &client,
+            &http,
+            &body.resource_url,
+            Some(network_caip2.as_str()),
+            body.max_amount_micros,
+        )
+        .await
+        .map_err(map_haima_error)?;
 
         Ok(Response::new(map_pay_result(result)))
     }
@@ -526,6 +536,48 @@ mod x402_tests {
         assert_eq!(resp.micro_credits, 50);
         assert_eq!(resp.resource_body, b"{\"ok\":true}");
         assert_eq!(resp.resource_status, 200);
+    }
+
+    #[tokio::test]
+    async fn x402_pay_declines_on_network_mismatch() {
+        // The 402 advertises mainnet (eip155:8453) but the handler resolves
+        // base-sepolia → pay_x402 declines before signing (BRO-1368). Only
+        // the 402 leg is mounted; a decline proves no signed retry happened.
+        let server = MockServer::start().await;
+        let header = PaymentRequiredHeader {
+            schemes: vec![SchemeRequirement {
+                scheme: "exact".into(),
+                network: "eip155:8453".into(), // mainnet — mismatch vs base-sepolia
+                token: USDC_BASE_SEPOLIA_ADDR.into(),
+                amount: "50".into(),
+                recipient: TEST_RECIPIENT.into(),
+                facilitator: "https://x402.org/facilitator".into(),
+                max_timeout_seconds: Some(300),
+            }],
+            version: "v2".into(),
+        };
+        Mock::given(method("GET"))
+            .and(path("/api/data"))
+            .respond_with(ResponseTemplate::new(402).insert_header(
+                PAYMENT_REQUIRED_HEADER,
+                encode_payment_required(&header).expect("encode"),
+            ))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let resp = service()
+            .x402_pay(Request::new(req(&server.uri(), "base-sepolia", None)))
+            .await
+            .expect("x402_pay")
+            .into_inner();
+
+        assert_eq!(resp.status, "declined");
+        assert!(
+            resp.declined_reason.contains("network mismatch"),
+            "reason: {}",
+            resp.declined_reason
+        );
     }
 
     #[tokio::test]

--- a/crates/life-runtime/lifed/src/services/wallet.rs
+++ b/crates/life-runtime/lifed/src/services/wallet.rs
@@ -63,8 +63,16 @@ impl pb::wallet_server::Wallet for WalletService {
         &self,
         req: Request<pb::WalletRef>,
     ) -> Result<Response<pb::Balance>, Status> {
-        let _claims = Self::claims(&req)?;
+        let claims_user = Self::claims(&req)?.user_id.clone();
         let r = req.get_ref();
+        // BRO-1368: bind the queried wallet to the authenticated subject —
+        // a capability for user A cannot read user B's balance. project_id
+        // is not pinned (it selects the caller's own project wallet).
+        if r.user_id != claims_user {
+            return Err(Status::permission_denied(
+                "get_balance: request user_id must match the capability subject",
+            ));
+        }
         let bal = self
             .haima
             .get_balance(&r.user_id, &r.project_id)
@@ -81,12 +89,18 @@ impl pb::wallet_server::Wallet for WalletService {
         &self,
         req: Request<pb::StatementReq>,
     ) -> Result<Response<Self::StatementStream>, Status> {
-        let _claims = Self::claims(&req)?;
+        let claims_user = Self::claims(&req)?.user_id.clone();
         let r = req.get_ref();
         let wref = r
             .wallet
             .as_ref()
             .ok_or_else(|| Status::invalid_argument("wallet"))?;
+        // BRO-1368: bind the statement's wallet to the authenticated subject.
+        if wref.user_id != claims_user {
+            return Err(Status::permission_denied(
+                "statement: request user_id must match the capability subject",
+            ));
+        }
         let since_ms = r.since.as_ref().map(|t| t.seconds * 1000).unwrap_or(0);
         let until_ms = r
             .until
@@ -139,6 +153,13 @@ impl pb::wallet_server::Wallet for WalletService {
         let wref = body
             .wallet
             .ok_or_else(|| Status::invalid_argument("wallet"))?;
+        // BRO-1368: bind the debited wallet to the authenticated subject —
+        // a capability for user A cannot debit user B's wallet.
+        if wref.user_id != claims.user_id {
+            return Err(Status::permission_denied(
+                "debit: request user_id must match the capability subject",
+            ));
+        }
         let (entry_id, bal) = self
             .haima
             .debit(
@@ -185,6 +206,14 @@ impl pb::wallet_server::Wallet for WalletService {
         let body = req.into_inner();
         let from = body.from.ok_or_else(|| Status::invalid_argument("from"))?;
         let to = body.to.ok_or_else(|| Status::invalid_argument("to"))?;
+        // BRO-1368: bind the `from` (payer) wallet to the authenticated
+        // subject — a capability for user A cannot transfer FROM user B's
+        // wallet. `to` (the recipient) is intentionally unconstrained.
+        if from.user_id != claims.user_id {
+            return Err(Status::permission_denied(
+                "transfer: `from` user_id must match the capability subject",
+            ));
+        }
         let (entry_id, fbal, tbal) = self
             .haima
             .transfer(

--- a/crates/life-runtime/lifed/tests/integration_wallet.rs
+++ b/crates/life-runtime/lifed/tests/integration_wallet.rs
@@ -237,3 +237,84 @@ async fn transfer_without_idempotency_key_fails_precondition() {
     assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     env.shutdown().await;
 }
+
+// ── BRO-1368: payer-binding backfill — a capability for `alice` cannot
+// read/debit/transfer-from another user's wallet. ──────────────────────
+
+#[tokio::test]
+async fn get_balance_rejects_cross_user() {
+    let env = TestEnv::start_with_mocks().await;
+    let mut client = env.wallet_client().await;
+    let mut req = tonic::Request::new(WalletRef {
+        user_id: "bob".to_string(), // ≠ token subject (alice)
+        project_id: "p".to_string(),
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    let err = client
+        .get_balance(req)
+        .await
+        .expect_err("cross-user must reject");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn debit_rejects_cross_user() {
+    let env = TestEnv::start_with_mocks().await;
+    let mut client = env.wallet_client().await;
+    let mut req = tonic::Request::new(DebitReq {
+        wallet: Some(WalletRef {
+            user_id: "bob".to_string(), // ≠ token subject (alice)
+            project_id: "p".to_string(),
+        }),
+        amount_micros: 1000,
+        sid: "sid-1".to_string(),
+        reason: "test".to_string(),
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    req.metadata_mut()
+        .insert("idempotency-key", "cross-user-debit".parse().unwrap());
+    let err = client.debit(req).await.expect_err("cross-user must reject");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    // The substrate was never debited.
+    assert_eq!(env.mocks.haima.debit_calls.lock().len(), 0);
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn transfer_rejects_cross_user_from() {
+    use life_runtime_proto::life::v1::TransferReq;
+    let env = TestEnv::start_with_mocks().await;
+    let mut client = env.wallet_client().await;
+    let mut req = tonic::Request::new(TransferReq {
+        from: Some(WalletRef {
+            user_id: "bob".to_string(), // payer ≠ token subject (alice)
+            project_id: "p".to_string(),
+        }),
+        to: Some(WalletRef {
+            user_id: "carol".to_string(),
+            project_id: "p".to_string(),
+        }),
+        amount_micros: 1000,
+        memo: "test".to_string(),
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        "Bearer test-token-for-alice".parse().unwrap(),
+    );
+    req.metadata_mut()
+        .insert("idempotency-key", "cross-user-transfer".parse().unwrap());
+    let err = client
+        .transfer(req)
+        .await
+        .expect_err("cross-user from must reject");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    assert_eq!(env.mocks.haima.transfer_calls.lock().len(), 0);
+    env.shutdown().await;
+}


### PR DESCRIPTION
## What

The fully-codeable, autonomously-validatable subset of the BRO-1354 P20 cross-review findings (BRO-1365's soma-custody / live-round-trip / Lago-Gate-4 items are infra-gated and stay on BRO-1365). base-sepolia only; no behavior change for matched-network / same-subject callers.

## Changes

**#4 — Network-consistency (cross-review LOW)** · `2856eae8` `+doc`
`haima-x402::pay_x402` gains `expected_network: Option<&str>` (CAIP-2). The pre-sign step parses the payment-required header once, then **declines** if the advertised `exact`/`eip155:*` scheme names a different network than the wallet will sign for — turning a silent dead-end (the EIP-712 authorization is domain-bound to the resolved network, so a cross-network signature never settles) into an explicit decline. haimad's `x402_pay` passes the resolved network's CAIP-2 (`network.0`). The pre-check uses identical first-match scheme selection to `select_scheme` (no divergence).

**#5 — Payer-binding backfill (cross-review MEDIUM)** · `a6c9df8b`
lifed `WalletService::{get_balance, statement, debit, transfer}` now reject (`PermissionDenied`) when the request's wallet `user_id` ≠ the authenticated capability subject — matching the guard `x402_pay` already had (BRO-1354). For `transfer`, only the `from` (payer) is bound; `to` is unconstrained. `project_id` is intentionally not pinned (intra-user wallet selector, not a tenant boundary).

**Deferred (with reason):** resource_body size cap → slice-3 mainnet hardening (the paid-but-too-big case needs a streaming-read design).

## Validation (P11)
- `cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (exit 0; 378 ok-results, 0 failures)
- New tests: pay.rs `network_mismatch_declines_before_signing` + `matching_network_still_settles`; haimad `x402_pay_declines_on_network_mismatch`; lifed `{get_balance,debit,transfer}_rejects_cross_user` (+ existing same-subject + idempotency-replay tests unaffected)

## P20 cross-model adversarial review — VERDICT: SHIP (9/10)
Fresh-context Strata-B reviewer refuted all six scrutiny axes: no cap regression when `expected_network` is None; no use-after-move; **pre-check scheme ≡ signed scheme** (identical selection — the network check is load-bearing, not cosmetic, because the signing domain is pinned to the resolved network independently of the 402); idempotency cache is keyed by the authenticated subject (not body), so no cross-user cache poisoning; all 5 `life.v1.Wallet` RPCs carrying a payer user_id are now bound; no legitimate caller broken (`project_id` safely unpinned). One benign LOW (multi-network 402 false-decline — fails closed, impossible in single-network P1) documented inline. Pre-existing "project_id narrowed at handler boundary" comment is unbacked → noted as a follow-up, out of scope.

Follow-ups remain on BRO-1365 (soma custody, live round-trip, Lago Gate #4) + BRO-1341 (mainnet, slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network validation now prevents payments on mismatched networks before signing.
  * Wallet operations now enforce proper authorization to ensure users can only access their own accounts.

* **Tests**
  * Added tests for network mismatch detection and authorization enforcement in wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->