### PR TITLE
test(haimad): live base-sepolia x402 round-trip — confirmed on-chain [BRO-1365]

### DIFF
--- a/crates/haima/haimad/src/substrate.rs
+++ b/crates/haima/haimad/src/substrate.rs
@@ -679,4 +679,64 @@ mod x402_tests {
             tonic::Code::InvalidArgument
         );
     }
+
+    /// Live base-sepolia x402 round-trip through the real `X402Pay`
+    /// handler (BRO-1365). `#[ignore]` because it needs a funded wallet
+    /// (`print_live_wallet_address` → CDP faucet) + a running x402 seller
+    /// at `X402_LIVE_RESOURCE_URL` that settles the EIP-3009 authorization
+    /// on-chain. Drives the EXACT handler: resolve custody → wrap in
+    /// CustodyWalletAdapter → X402Client → pay_x402. Asserts the payment
+    /// settled and prints the on-chain settlement tx hash.
+    ///
+    /// Run: `X402_LIVE_RESOURCE_URL=http://127.0.0.1:8402/paid \
+    ///       cargo test -p haimad live_base_sepolia_roundtrip -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "live: needs a funded wallet + a running x402 seller (BRO-1365)"]
+    async fn live_base_sepolia_roundtrip() {
+        let url = std::env::var("X402_LIVE_RESOURCE_URL")
+            .expect("set X402_LIVE_RESOURCE_URL to the running x402 seller");
+        let user = std::env::var("X402_LIVE_USER").unwrap_or_else(|_| "x402-live".into());
+        let project = std::env::var("X402_LIVE_PROJECT").unwrap_or_else(|_| "base-sepolia".into());
+        let resp = service()
+            .x402_pay(Request::new(haima_pb::X402PayReq {
+                user_id: user,
+                project_id: project,
+                resource_url: url,
+                network: "base-sepolia".into(),
+                max_amount_micros: Some(100),
+            }))
+            .await
+            .expect("x402_pay handler errored")
+            .into_inner();
+        println!("LIVE_X402_STATUS={}", resp.status);
+        println!("LIVE_X402_TX={}", resp.tx_hash);
+        println!("LIVE_X402_NETWORK={}", resp.network);
+        println!("LIVE_X402_RECIPIENT={}", resp.recipient);
+        println!("LIVE_X402_MICRO_CREDITS={}", resp.micro_credits);
+        println!("LIVE_X402_DECLINED_REASON={}", resp.declined_reason);
+        assert_eq!(
+            resp.status, "settled",
+            "expected settled; declined_reason={}",
+            resp.declined_reason
+        );
+        assert!(resp.settled, "facilitator did not report settled");
+        assert!(!resp.tx_hash.is_empty(), "no settlement tx hash returned");
+    }
+
+    /// Prints the deterministic x402 signing wallet address the rail
+    /// resolves for `(X402_LIVE_USER, X402_LIVE_PROJECT)`. Used by the
+    /// BRO-1365 live base-sepolia round-trip to know which address to
+    /// fund via the CDP faucet. Not an assertion — run with
+    /// `--ignored --nocapture`.
+    #[test]
+    #[ignore = "utility: prints the live wallet address to fund (BRO-1365)"]
+    fn print_live_wallet_address() {
+        let user = std::env::var("X402_LIVE_USER").unwrap_or_else(|_| "x402-live".into());
+        let project = std::env::var("X402_LIVE_PROJECT").unwrap_or_else(|_| "base-sepolia".into());
+        let custody = InProcessAnima::from_seed_arc(derive_custody_seed(&user, &project)).unwrap();
+        println!(
+            "X402_LIVE_WALLET_ADDRESS={}",
+            custody.wallet_address().unwrap().address
+        );
+    }
 }

--- a/scripts/x402-live/README.md
+++ b/scripts/x402-live/README.md
@@ -27,7 +27,7 @@ API-key-authenticated) — the public web faucets are all login/captcha-gated.
 
 ## Architecture
 
-```
+```text
 haimad X402Pay (rail, unmodified)            seller (this dir)           Base Sepolia
   resolve_custody(user,project)                                          USDC FiatTokenV2
   → InProcessAnima (deterministic)

--- a/scripts/x402-live/README.md
+++ b/scripts/x402-live/README.md
@@ -1,0 +1,79 @@
+# x402 live base-sepolia round-trip (BRO-1365 #2)
+
+Reproducible harness that drives haimad's **real `X402Pay` handler** through a
+full x402 payment that **settles on-chain on Base Sepolia** — confirming the
+slice-2 transport rail (BRO-1354) end-to-end against live infrastructure.
+
+The rail (`haimad::substrate::SubstrateService::x402_pay`) is exercised
+unmodified: resolve custody → `CustodyWalletAdapter` (EIP-3009 signing from the
+user's secp256k1 wallet) → `X402Client` → `pay_x402`. The only non-production
+pieces are the **seller** (a tiny resource server) and the **relayer** (the
+gas-payer that submits the EIP-3009 `transferWithAuthorization`), because
+haima's own facilitator does not yet broadcast on-chain (F4 gap).
+
+## Confirmed run (2026-06-03, Base Sepolia)
+
+| | |
+|---|---|
+| Settlement tx | [`0xc94a975375dcf6678d330eddd5150e044d0b2a45862cb1c590d776f44f23023a`](https://sepolia.basescan.org/tx/0xc94a975375dcf6678d330eddd5150e044d0b2a45862cb1c590d776f44f23023a) |
+| Status / block | `1` (success) / `42379188` |
+| USDC contract | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` (Circle FiatTokenV2) |
+| Transfer | `0x6b9ca44686d5d7ea0e6e019767c40cc03e81a2ba` (rail wallet) → `0x389b6a704d3b34688863def723b3890453b53aee` (recipient), value `100` (0.0001 USDC) |
+| Payer USDC | `1000000` → `999900` (−100) · Recipient USDC: `100` |
+| Rail handler result | `status="settled"`, `settled=true`, `tx_hash=0xc94a…23023a` |
+
+The payer wallet was funded autonomously via the **CDP faucet** (programmatic,
+API-key-authenticated) — the public web faucets are all login/captcha-gated.
+
+## Architecture
+
+```
+haimad X402Pay (rail, unmodified)            seller (this dir)           Base Sepolia
+  resolve_custody(user,project)                                          USDC FiatTokenV2
+  → InProcessAnima (deterministic)
+  → CustodyWalletAdapter.sign_eip712  ──X-PAYMENT (payment-signature)──►  decode auth + sig
+  pay_x402: GET → 402 → policy → sign → retry                            relayer submits
+                                          ◄──payment-response (tx)──────  transferWithAuthorization
+                                                                          → real on-chain transfer
+```
+
+## Reproduce
+
+Prereqs: a CDP API key JSON (`{ "id", "privateKey" }`); Python venv with
+`cdp-sdk` + `web3` + `eth-account`; the workspace built.
+
+```bash
+# 0. venv
+python3 -m venv .venv && . .venv/bin/activate && pip install cdp-sdk web3 eth-account
+
+# 1. compute the rail's deterministic signing wallet for (user, project)
+cargo test -p haimad print_live_wallet_address -- --ignored --nocapture
+#   → X402_LIVE_WALLET_ADDRESS=0x...
+
+# 2. fund it with base-sepolia USDC (+ ETH) via the CDP faucet
+CDP_KEY_FILE="/path/to/CDP API Key.json" FUND_ADDRESS=0x<rail-wallet> \
+  python3 scripts/x402-live/fund.py
+
+# 3. generate + ETH-fund a relayer, then run the seller (settles on-chain)
+#    (the seller reads /tmp/x402-live/relayer.key — a 0600 EOA key; see seller.py header)
+RECIPIENT=0x<recipient> AMOUNT=100 PORT=8402 python3 scripts/x402-live/seller.py &
+
+# 4. drive the rail's real handler against the seller
+X402_LIVE_RESOURCE_URL=http://127.0.0.1:8402/paid X402_LIVE_USER=x402-live \
+  X402_LIVE_PROJECT=base-sepolia \
+  cargo test -p haimad live_base_sepolia_roundtrip -- --ignored --nocapture
+#   → LIVE_X402_STATUS=settled, LIVE_X402_TX=0x...
+```
+
+## Security
+
+- The CDP API key is **never** committed or echoed; `fund.py` reads it by
+  `CDP_KEY_FILE` path.
+- The relayer EOA key is generated locally to a `0600` file outside the repo.
+- AMOUNT defaults to `100` atomic units (0.0001 USDC) — ≤ haima's 100-µc
+  auto-approve cap, so the rail's `PaymentPolicy::default()` auto-approves.
+
+## base-sepolia only
+
+`network="base"` (mainnet) is rejected by the rail with `failed_precondition`
+(BRO-1354). Mainnet is slice 3, behind the financial control gate.

--- a/scripts/x402-live/fund.py
+++ b/scripts/x402-live/fund.py
@@ -5,6 +5,9 @@ The public web faucets are all login/captcha-gated; the CDP faucet API
 (authenticated by a CDP API key) is programmatic. The key is read by file
 PATH from $CDP_KEY_FILE and never printed.
 
+Exits non-zero if any requested token failed to fund, so callers/CI don't
+treat a failed fund as success.
+
 Usage:
   CDP_KEY_FILE="/path/to/CDP API Key.json" FUND_ADDRESS=0x... \
     python3 scripts/x402-live/fund.py [tokens...]   # default: usdc eth
@@ -17,10 +20,11 @@ import sys
 from cdp import CdpClient
 
 
-async def main() -> None:
+async def main() -> int:
     key = json.load(open(os.environ["CDP_KEY_FILE"]))
     addr = os.environ["FUND_ADDRESS"]
     tokens = sys.argv[1:] or ["usdc", "eth"]
+    failures = 0
     async with CdpClient(api_key_id=key["id"], api_key_secret=key["privateKey"]) as cdp:
         for token in tokens:
             try:
@@ -30,8 +34,10 @@ async def main() -> None:
                 txh = getattr(r, "transaction_hash", None) or str(r)
                 print(f"FAUCET_OK token={token} tx={txh}")
             except Exception as e:  # noqa: BLE001
+                failures += 1
                 print(f"FAUCET_ERR token={token} err={type(e).__name__}: {e}")
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(asyncio.run(main()))

--- a/scripts/x402-live/fund.py
+++ b/scripts/x402-live/fund.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Fund a Base Sepolia address with USDC (+ ETH) via the CDP faucet.
+
+The public web faucets are all login/captcha-gated; the CDP faucet API
+(authenticated by a CDP API key) is programmatic. The key is read by file
+PATH from $CDP_KEY_FILE and never printed.
+
+Usage:
+  CDP_KEY_FILE="/path/to/CDP API Key.json" FUND_ADDRESS=0x... \
+    python3 scripts/x402-live/fund.py [tokens...]   # default: usdc eth
+"""
+import asyncio
+import json
+import os
+import sys
+
+from cdp import CdpClient
+
+
+async def main() -> None:
+    key = json.load(open(os.environ["CDP_KEY_FILE"]))
+    addr = os.environ["FUND_ADDRESS"]
+    tokens = sys.argv[1:] or ["usdc", "eth"]
+    async with CdpClient(api_key_id=key["id"], api_key_secret=key["privateKey"]) as cdp:
+        for token in tokens:
+            try:
+                r = await cdp.evm.request_faucet(
+                    address=addr, network="base-sepolia", token=token
+                )
+                txh = getattr(r, "transaction_hash", None) or str(r)
+                print(f"FAUCET_OK token={token} tx={txh}")
+            except Exception as e:  # noqa: BLE001
+                print(f"FAUCET_ERR token={token} err={type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/x402-live/seller.py
+++ b/scripts/x402-live/seller.py
@@ -8,77 +8,132 @@ EOA (the gasless-payer model EIP-3009 enables), then returns the real
 settlement tx hash in haima's `payment-response` header.
 
 The relayer key is read from /tmp/x402-live/relayer.key (a 0600 EOA key you
-generate + ETH-fund via the CDP faucet). No secrets are embedded here.
+generate + ETH-fund via the CDP faucet). The file mode is enforced at start.
+No secrets are embedded here.
 
 env: RECIPIENT, AMOUNT (atomic USDC, default 100 = 0.0001 USDC), PORT (8402).
 """
-import base64, json, os, sys, time
+import base64
+import json
+import os
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from web3 import Web3
+
 from eth_account import Account
+from web3 import Web3
 
 RPC = "https://sepolia.base.org"
-USDC = Web3.to_checksum_address("0x036CbD53842c5426634e7929541eC2318f3dCF7e")  # base-sepolia USDC (FiatTokenV2)
-RECIPIENT = Web3.to_checksum_address(os.environ.get("RECIPIENT", "0x389b6a704d3b34688863def723b3890453b53aee"))
-AMOUNT = os.environ.get("AMOUNT", "100")  # 0.0001 USDC (<= 100 micro-credit auto-approve cap)
+NETWORK = "eip155:84532"
+USDC = Web3.to_checksum_address("0x036CbD53842c5426634e7929541eC2318f3dCF7e")  # base-sepolia FiatTokenV2
+RECIPIENT = Web3.to_checksum_address(
+    os.environ.get("RECIPIENT", "0x389b6a704d3b34688863def723b3890453b53aee")
+)
+AMOUNT = int(os.environ.get("AMOUNT", "100"))  # 0.0001 USDC (<= 100 micro-credit auto-approve cap)
 PORT = int(os.environ.get("PORT", "8402"))
+RELAYER_KEY_FILE = os.environ.get("RELAYER_KEY_FILE", "/tmp/x402-live/relayer.key")
+
+# CodeRabbit (Major): enforce the documented 0600 on the relayer key file.
+_st = os.stat(RELAYER_KEY_FILE)
+if _st.st_mode & 0o077:
+    raise SystemExit(
+        f"refusing to start: {RELAYER_KEY_FILE} is group/other-accessible "
+        f"(mode {oct(_st.st_mode & 0o777)}); chmod 600 it"
+    )
 
 w3 = Web3(Web3.HTTPProvider(RPC))
-relayer = Account.from_key(open("/tmp/x402-live/relayer.key").read())
-ABI = [{"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"},
-        {"name":"validAfter","type":"uint256"},{"name":"validBefore","type":"uint256"},{"name":"nonce","type":"bytes32"},
-        {"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],
-        "name":"transferWithAuthorization","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+relayer = Account.from_key(open(RELAYER_KEY_FILE).read())
+ABI = [{"inputs": [{"name": "from", "type": "address"}, {"name": "to", "type": "address"},
+                   {"name": "value", "type": "uint256"}, {"name": "validAfter", "type": "uint256"},
+                   {"name": "validBefore", "type": "uint256"}, {"name": "nonce", "type": "bytes32"},
+                   {"name": "v", "type": "uint8"}, {"name": "r", "type": "bytes32"},
+                   {"name": "s", "type": "bytes32"}],
+        "name": "transferWithAuthorization", "outputs": [], "stateMutability": "nonpayable",
+        "type": "function"}]
 usdc = w3.eth.contract(address=USDC, abi=ABI)
 
-def log(m): 
-    with open("/tmp/x402-live/seller.log","a") as f: f.write(m+"\n")
+
+def log(m: str) -> None:
+    with open("/tmp/x402-live/seller.log", "a") as f:
+        f.write(m + "\n")
     print(m, flush=True)
 
-def make_402():
-    header = {"schemes":[{"scheme":"exact","network":"eip155:84532","token":USDC,"amount":AMOUNT,
-              "recipient":RECIPIENT,"facilitator":"http://localhost/none","max_timeout_seconds":600}],"version":"v2"}
+
+def make_402() -> str:
+    header = {"schemes": [{"scheme": "exact", "network": NETWORK, "token": USDC,
+                           "amount": str(AMOUNT), "recipient": RECIPIENT,
+                           "facilitator": "http://localhost/none", "max_timeout_seconds": 600}],
+              "version": "v2"}
     return base64.b64encode(json.dumps(header).encode()).decode()
 
+
 class H(BaseHTTPRequestHandler):
-    def log_message(self, *a): pass
+    def log_message(self, *a):  # quiet
+        pass
+
     def do_GET(self):
         sig = self.headers.get("payment-signature")
         if not sig:
-            self.send_response(402); self.send_header("payment-required", make_402()); self.end_headers()
-            self.wfile.write(b"payment required"); return
+            self.send_response(402)
+            self.send_header("payment-required", make_402())
+            self.end_headers()
+            self.wfile.write(b"payment required")
+            return
         try:
-            ps = json.loads(base64.b64decode(sig)); auth = ps["authorization"]
-            pl = ps["payload"]; pl = pl[2:] if pl.startswith("0x") else pl
-            raw = bytes.fromhex(pl); r, s, v = raw[0:32], raw[32:64], raw[64]
-            nonce = auth["nonce"]; nonce = bytes.fromhex(nonce[2:] if nonce.startswith("0x") else nonce)
+            ps = json.loads(base64.b64decode(sig))
+            auth = ps["authorization"]
+            # CodeRabbit (Critical): the signed authorization MUST match the
+            # advertised charge — never settle a recipient/amount/network the
+            # 402 did not ask for.
+            if ps.get("network") != NETWORK:
+                raise ValueError(f"network {ps.get('network')} != advertised {NETWORK}")
+            if Web3.to_checksum_address(auth["to"]) != RECIPIENT:
+                raise ValueError(f"authorization.to {auth['to']} != advertised recipient {RECIPIENT}")
+            if int(auth["value"]) != AMOUNT:
+                raise ValueError(f"authorization.value {auth['value']} != advertised amount {AMOUNT}")
+
+            pl = ps["payload"]
+            pl = pl[2:] if pl.startswith("0x") else pl
+            raw = bytes.fromhex(pl)
+            r, s, v = raw[0:32], raw[32:64], raw[64]
+            nonce = auth["nonce"]
+            nonce = bytes.fromhex(nonce[2:] if nonce.startswith("0x") else nonce)
             log(f"SETTLING from={auth['from']} to={auth['to']} value={auth['value']} v={v}")
             tx = usdc.functions.transferWithAuthorization(
                 Web3.to_checksum_address(auth["from"]), Web3.to_checksum_address(auth["to"]),
                 int(auth["value"]), int(auth["validAfter"]), int(auth["validBefore"]),
-                nonce, v, r, s
-            ).build_transaction({"from": relayer.address,
+                nonce, v, r, s,
+            ).build_transaction({
+                "from": relayer.address,
                 "nonce": w3.eth.get_transaction_count(relayer.address),
-                "gas": 250000, "gasPrice": max(int(w3.eth.gas_price), w3.to_wei("0.1","gwei")),
-                "chainId": 84532})
+                "gas": 250000,
+                "gasPrice": max(int(w3.eth.gas_price), w3.to_wei("0.1", "gwei")),
+                "chainId": 84532,
+            })
             stx = relayer.sign_transaction(tx)
             txh = w3.eth.send_raw_transaction(stx.raw_transaction)
             log(f"BROADCAST tx={txh.hex()}")
             rc = w3.eth.wait_for_transaction_receipt(txh, timeout=120)
             settled = rc.status == 1
             log(f"RECEIPT tx={txh.hex()} status={rc.status} block={rc.blockNumber}")
-            resp = {"tx_hash": txh.hex() if txh.hex().startswith('0x') else '0x'+txh.hex(),
-                    "network":"eip155:84532", "settled": settled}
+            txh_hex = txh.hex()
+            resp = {"tx_hash": txh_hex if txh_hex.startswith("0x") else "0x" + txh_hex,
+                    "network": NETWORK, "settled": settled}
             self.send_response(200 if settled else 402)
             self.send_header("payment-response", base64.b64encode(json.dumps(resp).encode()).decode())
-            self.end_headers(); self.wfile.write(b'{"data":"paid resource ok"}')
-        except Exception as e:
+            self.end_headers()
+            self.wfile.write(b'{"data":"paid resource ok"}')
+        except Exception as e:  # noqa: BLE001
             log(f"SETTLE_ERR {type(e).__name__}: {e}")
-            self.send_response(500); self.end_headers(); self.wfile.write(str(e).encode())
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(str(e).encode())
 
-# wait for relayer ETH
+
+# wait for the relayer to be ETH-funded before serving
 for _ in range(20):
-    if w3.eth.get_balance(relayer.address) > 0: break
+    if w3.eth.get_balance(relayer.address) > 0:
+        break
     time.sleep(6)
-log(f"SELLER_READY relayer={relayer.address} eth={w3.eth.get_balance(relayer.address)} recipient={RECIPIENT} amount={AMOUNT} port={PORT}")
+log(f"SELLER_READY relayer={relayer.address} eth={w3.eth.get_balance(relayer.address)} "
+    f"recipient={RECIPIENT} amount={AMOUNT} port={PORT}")
 HTTPServer(("127.0.0.1", PORT), H).serve_forever()

--- a/scripts/x402-live/seller.py
+++ b/scripts/x402-live/seller.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Minimal x402 seller that speaks haima's wire format and settles on-chain.
+
+Returns a 402 with haima's `payment-required` header; on the signed retry it
+decodes haima's `payment-signature` (EIP-3009 authorization + r||s||v) and
+submits `USDC.transferWithAuthorization(...)` to Base Sepolia via a relayer
+EOA (the gasless-payer model EIP-3009 enables), then returns the real
+settlement tx hash in haima's `payment-response` header.
+
+The relayer key is read from /tmp/x402-live/relayer.key (a 0600 EOA key you
+generate + ETH-fund via the CDP faucet). No secrets are embedded here.
+
+env: RECIPIENT, AMOUNT (atomic USDC, default 100 = 0.0001 USDC), PORT (8402).
+"""
+import base64, json, os, sys, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from web3 import Web3
+from eth_account import Account
+
+RPC = "https://sepolia.base.org"
+USDC = Web3.to_checksum_address("0x036CbD53842c5426634e7929541eC2318f3dCF7e")  # base-sepolia USDC (FiatTokenV2)
+RECIPIENT = Web3.to_checksum_address(os.environ.get("RECIPIENT", "0x389b6a704d3b34688863def723b3890453b53aee"))
+AMOUNT = os.environ.get("AMOUNT", "100")  # 0.0001 USDC (<= 100 micro-credit auto-approve cap)
+PORT = int(os.environ.get("PORT", "8402"))
+
+w3 = Web3(Web3.HTTPProvider(RPC))
+relayer = Account.from_key(open("/tmp/x402-live/relayer.key").read())
+ABI = [{"inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"},
+        {"name":"validAfter","type":"uint256"},{"name":"validBefore","type":"uint256"},{"name":"nonce","type":"bytes32"},
+        {"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],
+        "name":"transferWithAuthorization","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+usdc = w3.eth.contract(address=USDC, abi=ABI)
+
+def log(m): 
+    with open("/tmp/x402-live/seller.log","a") as f: f.write(m+"\n")
+    print(m, flush=True)
+
+def make_402():
+    header = {"schemes":[{"scheme":"exact","network":"eip155:84532","token":USDC,"amount":AMOUNT,
+              "recipient":RECIPIENT,"facilitator":"http://localhost/none","max_timeout_seconds":600}],"version":"v2"}
+    return base64.b64encode(json.dumps(header).encode()).decode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        sig = self.headers.get("payment-signature")
+        if not sig:
+            self.send_response(402); self.send_header("payment-required", make_402()); self.end_headers()
+            self.wfile.write(b"payment required"); return
+        try:
+            ps = json.loads(base64.b64decode(sig)); auth = ps["authorization"]
+            pl = ps["payload"]; pl = pl[2:] if pl.startswith("0x") else pl
+            raw = bytes.fromhex(pl); r, s, v = raw[0:32], raw[32:64], raw[64]
+            nonce = auth["nonce"]; nonce = bytes.fromhex(nonce[2:] if nonce.startswith("0x") else nonce)
+            log(f"SETTLING from={auth['from']} to={auth['to']} value={auth['value']} v={v}")
+            tx = usdc.functions.transferWithAuthorization(
+                Web3.to_checksum_address(auth["from"]), Web3.to_checksum_address(auth["to"]),
+                int(auth["value"]), int(auth["validAfter"]), int(auth["validBefore"]),
+                nonce, v, r, s
+            ).build_transaction({"from": relayer.address,
+                "nonce": w3.eth.get_transaction_count(relayer.address),
+                "gas": 250000, "gasPrice": max(int(w3.eth.gas_price), w3.to_wei("0.1","gwei")),
+                "chainId": 84532})
+            stx = relayer.sign_transaction(tx)
+            txh = w3.eth.send_raw_transaction(stx.raw_transaction)
+            log(f"BROADCAST tx={txh.hex()}")
+            rc = w3.eth.wait_for_transaction_receipt(txh, timeout=120)
+            settled = rc.status == 1
+            log(f"RECEIPT tx={txh.hex()} status={rc.status} block={rc.blockNumber}")
+            resp = {"tx_hash": txh.hex() if txh.hex().startswith('0x') else '0x'+txh.hex(),
+                    "network":"eip155:84532", "settled": settled}
+            self.send_response(200 if settled else 402)
+            self.send_header("payment-response", base64.b64encode(json.dumps(resp).encode()).decode())
+            self.end_headers(); self.wfile.write(b'{"data":"paid resource ok"}')
+        except Exception as e:
+            log(f"SETTLE_ERR {type(e).__name__}: {e}")
+            self.send_response(500); self.end_headers(); self.wfile.write(str(e).encode())
+
+# wait for relayer ETH
+for _ in range(20):
+    if w3.eth.get_balance(relayer.address) > 0: break
+    time.sleep(6)
+log(f"SELLER_READY relayer={relayer.address} eth={w3.eth.get_balance(relayer.address)} recipient={RECIPIENT} amount={AMOUNT} port={PORT}")
+HTTPServer(("127.0.0.1", PORT), H).serve_forever()


### PR DESCRIPTION
## Confirmed: the full x402 flow settles on-chain on Base Sepolia 🎉

haimad's **real `X402Pay` handler** drove a full x402 payment that settled a real USDC transfer on Base Sepolia. The rail is exercised unmodified (resolve custody → `CustodyWalletAdapter` EIP-3009 signing → `X402Client` → `pay_x402`).

| Evidence | Value |
|---|---|
| Settlement tx | [`0xc94a975375dcf6678d330eddd5150e044d0b2a45862cb1c590d776f44f23023a`](https://sepolia.basescan.org/tx/0xc94a975375dcf6678d330eddd5150e044d0b2a45862cb1c590d776f44f23023a) |
| Status / block | `1` (success) / `42379188` |
| USDC | `0x036CbD…F7e` (base-sepolia FiatTokenV2) |
| Transfer | rail wallet `0x6b9ca4…2ba` → recipient `0x389b6a…aee`, value `100` (0.0001 USDC) |
| Payer USDC | `1000000` → `999900` (−100) · Recipient: `100` |
| Handler result | `status="settled"`, `settled=true`, `tx_hash=0xc94a…23023a` |

The payer wallet was funded **autonomously via the CDP faucet API** (the public web faucets are login/captcha-gated — that was the only blocker, solved by the provided CDP key).

## What's in this PR
- `substrate.rs`: `live_base_sepolia_roundtrip` (`#[ignore]`) — drives the unmodified handler against a seller URL, asserts settled + a real tx hash; `print_live_wallet_address` (`#[ignore]`) — prints the rail's deterministic signing wallet to fund.
- `scripts/x402-live/`: `fund.py` (CDP faucet — key read by `$CDP_KEY_FILE` path, never embedded), `seller.py` (speaks haima's wire format; settles the EIP-3009 authorization on-chain via web3 + a relayer EOA), `README.md` (reproducible procedure + the on-chain evidence).

## Notes
- No production logic changed — test + scripts + docs only.
- haima's own facilitator only produces deterministic hashes (F4 gap), so the **seller** does the real on-chain settlement via `USDC.transferWithAuthorization` (the gasless-payer model EIP-3009 enables). This faithfully exercises our rail's signing + a real on-chain transfer.
- base-sepolia only; mainnet (slice 3) stays behind the financial gate.
- **Still open on BRO-1365:** #1 soma-custody resolver (sign from the soma-resident `/account` wallet) and #3 Lago Gate #4 audit event. The funding + settlement infra is now proven, so #1 can re-use this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added live integration test utilities for x402 payment functionality against Base Sepolia network

* **Documentation**
  * Added comprehensive setup and execution guide for x402 live testing harness with architecture overview

* **Chores**
  * Added helper scripts for test funding via faucet and seller server operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->