### PR TITLE
fix(lifed): surface arcan dispatch failures as ERROR+FINISH instead of silent hang

### DIFF
--- a/crates/life-runtime/lifed/src/services/agent.rs
+++ b/crates/life-runtime/lifed/src/services/agent.rs
@@ -185,7 +185,29 @@ fn spawn_or_attach_fanout_pump(
                 while let Some(evt) = up.next().await {
                     match evt {
                         Ok(e) => fanout.broadcast(e),
-                        Err(_) => break,
+                        Err(status) => {
+                            // The upstream arcan stream errored mid-turn
+                            // (e.g. the provider dropped the connection
+                            // after some tokens). Previously we just
+                            // `break`'d, leaving attached tabs to stall
+                            // until the client-side frame deadline (~30s)
+                            // fired with a generic timeout. Surface a
+                            // structured ERROR + terminal FINISH so the UI
+                            // shows the failure immediately and closes the
+                            // stream cleanly.
+                            tracing::warn!(
+                                sid = %sid,
+                                error = ?status,
+                                "arcan upstream stream errored mid-turn; surfacing error event"
+                            );
+                            fanout.broadcast(make_error_event(
+                                &sid,
+                                "lifed.arcan.stream_error",
+                                &status.to_string(),
+                            ));
+                            fanout.broadcast(make_finish_event(&sid, "error"));
+                            break;
+                        }
                     }
                 }
                 // PoolGuardedStream records the breaker outcome on
@@ -193,11 +215,75 @@ fn spawn_or_attach_fanout_pump(
                 // for the pump to do.
             }
             Err(e) => {
-                tracing::warn!(sid = %sid, error = ?e, "fanout pump failed to dial arcan");
+                // `dispatch_message` failed before yielding any event.
+                // The most common production cause is the arcan provider
+                // rejecting the turn outright (e.g. AI-gateway 403
+                // "model not accessible" or 429 rate-limit). Previously
+                // this path only logged, so attached tabs received ZERO
+                // frames and hung until the client-side 30s frame
+                // deadline fired with an opaque timeout. Surface a
+                // structured ERROR + terminal FINISH so the failure is
+                // visible immediately and the stream closes cleanly.
+                tracing::warn!(
+                    sid = %sid,
+                    error = ?e,
+                    "fanout pump failed to dial arcan; surfacing error event to attached tabs"
+                );
+                fanout.broadcast(make_error_event(
+                    &sid,
+                    "lifed.arcan.dispatch_failed",
+                    &e.to_string(),
+                ));
+                fanout.broadcast(make_finish_event(&sid, "error"));
             }
         }
         // _pump_guard drops here, releasing the per-session slot.
     });
+}
+
+/// Build a terminal `ERROR` agent event for the fan-out broadcast.
+///
+/// The `EventRecord.payload` carries `{code, message}` JSON — the shape
+/// the browser-side `decodeAgentEvent` reads for `AGENT_EVENT_KIND_ERROR`
+/// frames (`payload.code` / `payload.message`). lifegw forwards it
+/// verbatim over the WS as an `agent_kind: "ERROR"` frame.
+fn make_error_event(sid: &str, code: &str, message: &str) -> pb::AgentEvent {
+    pb::AgentEvent {
+        record: Some(pb::EventRecord {
+            session_id: Some(aios_v1::SessionId {
+                value: sid.to_string(),
+            }),
+            sequence: 0,
+            at: Some(prost_types::Timestamp::from(std::time::SystemTime::now())),
+            kind: "ERROR".to_string(),
+            payload: serde_json::to_vec(&serde_json::json!({
+                "code": code,
+                "message": message,
+            }))
+            .unwrap_or_default(),
+        }),
+        kind: pb::AgentEventKind::Error as i32,
+    }
+}
+
+/// Build a terminal `FINISH` agent event so the downstream stream closes
+/// cleanly instead of waiting for the client-side frame deadline. The
+/// `reason` lands in `payload.reason`, mirroring the arcan proxy's own
+/// FINISH events (`{"reason": "stop"}`).
+fn make_finish_event(sid: &str, reason: &str) -> pb::AgentEvent {
+    pb::AgentEvent {
+        record: Some(pb::EventRecord {
+            session_id: Some(aios_v1::SessionId {
+                value: sid.to_string(),
+            }),
+            sequence: 0,
+            at: Some(prost_types::Timestamp::from(std::time::SystemTime::now())),
+            kind: "FINISH".to_string(),
+            payload: serde_json::to_vec(&serde_json::json!({ "reason": reason }))
+                .unwrap_or_default(),
+        }),
+        kind: pb::AgentEventKind::Finish as i32,
+    }
 }
 
 /// `Agent` service implementation. Holds typed substrate proxies, the
@@ -549,5 +635,57 @@ impl pb::agent_server::Agent for AgentService {
             "Agent.SpawnChild ships in Spec C₇ (recursive embedding, post-MVS). \
              Tracking ticket: BRO-926.",
         ))
+    }
+}
+
+#[cfg(test)]
+mod fanout_pump_error_tests {
+    use super::*;
+    use crate::dev_mocks::MockArcan;
+    use futures::StreamExt;
+
+    /// Regression: when `dispatch_message` fails outright (the production
+    /// AI-gateway 403/429 class), the pump must broadcast a structured
+    /// ERROR followed by a terminal FINISH — not just log and leave
+    /// attached tabs to hang until the client-side 30s frame deadline.
+    #[tokio::test]
+    async fn dispatch_failure_broadcasts_error_then_finish() {
+        let arcan = MockArcan::new();
+        arcan.set_force_fail(true); // dispatch_message returns Err
+
+        let fanout = Arc::new(FanoutRegistry::new());
+        let mut stream = fanout.attach(8);
+
+        spawn_or_attach_fanout_pump(
+            &fanout,
+            Arc::new(arcan) as Arc<dyn ArcanCall>,
+            "sid-test".to_string(),
+            "hi".to_string(),
+            None,
+        );
+
+        // First broadcast: a structured ERROR carrying {code, message}.
+        let first = stream
+            .next()
+            .await
+            .expect("error event present")
+            .expect("event ok");
+        assert_eq!(first.kind(), pb::AgentEventKind::Error);
+        let record = first.record.expect("error record present");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&record.payload).expect("error payload is JSON");
+        assert_eq!(payload["code"], "lifed.arcan.dispatch_failed");
+        assert!(
+            payload["message"].as_str().is_some_and(|m| !m.is_empty()),
+            "error message should be populated"
+        );
+
+        // Second broadcast: the terminal FINISH that ends the stream.
+        let second = stream
+            .next()
+            .await
+            .expect("finish event present")
+            .expect("event ok");
+        assert_eq!(second.kind(), pb::AgentEventKind::Finish);
     }
 }


### PR DESCRIPTION
## Problem

When lifed's agent fan-out pump fails to get events from arcan, attached WS clients receive **zero frames** and hang until the browser-side ~30s frame deadline fires with an opaque timeout. Two paths swallowed the failure:

- `dispatch_message().await` → `Err(e)` — only `tracing::warn!`'d (no broadcast). This is the **production failure today**: the Vercel AI-gateway returns `403 "Free tier users do not have access to this model"` for the configured premium model, so every turn failed silently.
- mid-stream `up.next()` → `Err(_)` — bare `break` (no broadcast).

Observed in prod `railway logs`:
\`\`\`
arcan.dispatch_message: gateway returned non-2xx status=403 body="Free tier users do not have access..."
lifed::services::agent: fanout pump failed to dial arcan error=Transport(... HTTP 403 ...)
\`\`\`
…and the broomva.tech client just sat until `lifed.stream.no-first-frame: No first frame within 30000ms`.

## Fix

Broadcast a structured **ERROR** (`{code, message}` JSON — the shape the browser `decodeAgentEvent` reads for `AGENT_EVENT_KIND_ERROR`) followed by a terminal **FINISH** on both failure paths. The UI now shows the real provider error immediately and the stream closes cleanly instead of hanging.

## Test plan

- [x] `cargo check -p lifed` — clean
- [x] `cargo test -p lifed --lib fanout_pump_error` — new regression test (MockArcan force-fail → asserts ERROR then FINISH) passes
- [x] `cargo fmt -p lifed`

## Context

Companion to broomva.tech#243 (consumer-side: accept short-form `agent_kind`). Together they make the chat path fail loudly+fast and stream correctly. The immediate prod outage was also mitigated by setting `OPENAI_MODEL=openai/gpt-5-mini` on the Railway `lifegw` service (the free-tier gateway key can't serve `anthropic/claude-sonnet-4-6`). Durable fix for premium models: top up Vercel AI Gateway credits / add BYOK keys.

> ⚠️ Linear ticket: not created — Linear MCP unauthenticated in this session. Please link the relevant BRO- ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)