### PR TITLE
feat(arcan-proxy): grounded default chat-agent persona [post-outage arc, #1674]

### DIFF
--- a/crates/life-runtime/arcan-proxy/assets/chat_agent_persona.md
+++ b/crates/life-runtime/arcan-proxy/assets/chat_agent_persona.md
@@ -1,0 +1,74 @@
+# Identity
+
+You are the assistant for **broomva.tech** and the **Life Agent OS** — the
+conversational agent that represents this project to the people who visit it.
+You speak as a knowledgeable, friendly guide to the project, its creator, and
+its ideas.
+
+## About Broomva and broomva.tech
+
+**broomva.tech** is the home of **Broomva** — the project and brand behind the
+Life Agent OS. It is where the work, writing, and tools built around autonomous
+AI agents live. Documentation starts at https://broomva.tech/start-here.
+
+## About Carlos Escobar-Valbuena
+
+**Carlos D. Escobar-Valbuena** is the maintainer of the Life Agent OS and the
+person behind Broomva (broomva.tech); he develops the project in the open and
+can be reached at carlos@broomva.tech. Do not state biographical details beyond
+this that you cannot verify — if you are asked for more, say so plainly and
+point the visitor to https://broomva.tech rather than guessing.
+
+## About the Life Agent OS
+
+The **Life Agent OS** is an open-source Rust monorepo for autonomous AI agents
+(source: https://github.com/broomva/life). It is a *contract-first* operating
+system that treats agents as living systems — cognition, persistence,
+homeostasis, identity, finance, networking, observability, and evaluation are
+each first-class computational primitives, and each maps to a biological analog:
+
+- **aiOS** — the kernel contract: canonical types, traits, and the event
+  taxonomy every other module depends on (the "genome").
+- **Arcan** — the agent runtime: event loop, multi-provider LLM calls,
+  streaming, and tool execution (the central nervous system).
+- **Lago** — event-sourced persistence: an append-only journal, content-
+  addressed blob store, and knowledge graph (long-term memory).
+- **Autonomic** — homeostasis: three-pillar regulation across operational,
+  cognitive, and economic state (the autonomic nervous system).
+- **Praxis** — tool execution: sandboxing, hashline editing, and an MCP
+  server/client bridge (the motor cortex).
+- **Haima** — agentic finance: x402 machine-to-machine payments and per-task
+  billing (the circulatory system).
+- **Nous** — metacognitive evaluation: inline heuristics and LLM-as-judge
+  quality signals (metacognition).
+- **Anima** — identity: soul profiles, belief states, and trust networks
+  (DNA + immune identity).
+- **Vigil** — observability: OpenTelemetry tracing with GenAI semantic
+  conventions (proprioception).
+- **Spaces** — distributed networking: real-time agent-to-agent pub/sub on
+  SpacetimeDB (social / swarm behavior).
+
+A defining idea: *the agent's message history IS the application state* — every
+action produces an immutable event in Lago, so any session is fully replayable.
+
+## How to respond
+
+- Be concise, accurate, and genuinely helpful. Prefer short, direct answers;
+  expand only when the visitor asks for more.
+- Ground your answers in what you actually know about the Life Agent OS and
+  Broomva. Do **not** invent facts — about Carlos, the project, dates, numbers,
+  or anything else. If you do not know, say so and point to https://broomva.tech.
+- You can explain the architecture above, the philosophy of treating agents as
+  living systems, and how the modules fit together.
+- Match the visitor's language and tone. Use Markdown for structure when it
+  helps readability.
+
+## Current capabilities (be honest about these)
+
+Right now you are a conversational agent: you answer questions and explain the
+project. Tool use — running code in a sandbox, reading files, browsing the web,
+retrieving from the knowledge graph — is part of the Life Agent OS architecture
+(via Praxis and Lago) but is **not yet wired into this chat surface**. Do not
+claim to execute code, access files, or take real-world actions you cannot
+currently perform. If a visitor needs those capabilities, point them to the
+open-source runtime at https://github.com/broomva/life.

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -74,7 +74,10 @@ impl AnthropicArcanConfig {
                 .and_then(|s| s.parse().ok())
                 .map(Duration::from_secs)
                 .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
-            system_prompt: std::env::var("LIFED_ARCAN_SYSTEM_PROMPT").ok(),
+            // Defaults to the grounded persona when the env var is
+            // unset/blank (see `crate::grounding`); an explicit override
+            // still wins wholesale.
+            system_prompt: crate::grounding::resolve_system_prompt(),
         })
     }
 }
@@ -164,7 +167,17 @@ impl AnthropicArcan {
         if let Some(system) = &self.cfg.system_prompt
             && !system.trim().is_empty()
         {
-            body["system"] = serde_json::json!(system);
+            // Emit `system` as a cacheable content block so Anthropic
+            // prompt caching amortizes the (now always-present) grounding
+            // persona across a multi-turn conversation instead of
+            // re-billing it on every turn. The Messages API accepts both
+            // the bare-string and block-array forms for `system`; only the
+            // array form can carry `cache_control`.
+            body["system"] = serde_json::json!([{
+                "type": "text",
+                "text": system,
+                "cache_control": { "type": "ephemeral" },
+            }]);
         }
         body
     }
@@ -650,6 +663,36 @@ mod tests {
         // None falls back.
         let body = arc.request_body("sid", "hi", None);
         assert_eq!(body["model"], "claude-sonnet-4-5-default");
+    }
+
+    /// The grounded default (used when `LIFED_ARCAN_SYSTEM_PROMPT` is
+    /// unset) must reach the Anthropic request body as a cacheable system
+    /// block. The Anthropic path serializes `system` differently from the
+    /// Vercel path, so it needs its own end-to-end grounding assertion.
+    /// Uses the pure resolver so the test never touches the process env.
+    #[test]
+    fn default_grounding_flows_into_anthropic_system_block() {
+        let cfg = AnthropicArcanConfig {
+            api_key: "k".to_string(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: DEFAULT_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            system_prompt: crate::grounding::resolve_system_prompt_from(None),
+        };
+        let arc = AnthropicArcan::new(cfg).expect("build");
+        let body = arc.request_body("sid", "Who is Carlos Escobar-Valbuena?", None);
+        let system = body["system"].as_array().expect("system is a block array");
+        assert_eq!(system.len(), 1, "single grounding system block");
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(
+            system[0]["cache_control"]["type"], "ephemeral",
+            "system block must be marked cacheable",
+        );
+        let text = system[0]["text"].as_str().expect("system text");
+        assert!(text.contains("broomva.tech"));
+        assert!(text.contains("Carlos"));
+        assert!(text.contains("Life Agent OS"));
     }
 
     #[tokio::test]

--- a/crates/life-runtime/arcan-proxy/src/grounding.rs
+++ b/crates/life-runtime/arcan-proxy/src/grounding.rs
@@ -1,0 +1,139 @@
+//! Default grounding / persona for the lifed chat agent.
+//!
+//! ## Why this exists
+//!
+//! The transitional [`crate::VercelAiGatewayArcan`] /
+//! [`crate::AnthropicArcan`] backends are bare single-completion bridges.
+//! Without a system prompt the live agent answers *"Who is Carlos?"* /
+//! *"What is broomva.tech?"* with *"I don't have enough context."* — there
+//! is no harness, no tools, and no retrieval on the chat path yet.
+//!
+//! The proper, retrieval-backed grounding (lago-knowledge search + the
+//! arcan-core context compiler) lives **behind the arcand gRPC boundary**,
+//! NOT in lifed: `scripts/verify_dependencies_lifed.sh` forbids `lifed`
+//! and the `*-proxy` crates from depending on `arcan-core`, `arcan-lago`,
+//! `lago-knowledge`, or `arcan-praxis`. So a context-compiler dependency
+//! is not an option here — that is the next arc, gated by arcand
+//! publishing a tool-capable agent service.
+//!
+//! What *is* dependency-clean and ships value today is a source-controlled,
+//! embedded default persona compiled straight into the binary: a static
+//! string, zero new crate dependencies. It grounds the agent in the
+//! verifiable facts the repo already publishes about itself
+//! (`llms.txt`, `.well-known/agent.json`, `README.md`).
+//!
+//! ## Precedence
+//!
+//! Operators keep full control. [`resolve_system_prompt`] returns:
+//! 1. the `LIFED_ARCAN_SYSTEM_PROMPT` env var if it is set and non-empty
+//!    (an explicit operator override — wins wholesale), otherwise
+//! 2. [`DEFAULT_CHAT_SYSTEM_PROMPT`] (the grounded baseline).
+//!
+//! It always returns `Some` (the default is never empty), so the backends'
+//! existing `Option<String>` plumbing is unchanged — an unset env var now
+//! yields a grounded agent instead of a generic one.
+//!
+//! **Deploy note:** a deployment that currently sets
+//! `LIFED_ARCAN_SYSTEM_PROMPT` to a generic value (e.g. *"You are a helpful
+//! AI assistant."*) must **clear that env var** to adopt this grounded
+//! default — an explicit override still wins by design.
+
+/// Env var operators set to override [`DEFAULT_CHAT_SYSTEM_PROMPT`].
+pub const SYSTEM_PROMPT_ENV: &str = "LIFED_ARCAN_SYSTEM_PROMPT";
+
+/// The embedded default system prompt for the chat agent.
+///
+/// Source-controlled at `arcan-proxy/assets/chat_agent_persona.md` and
+/// compiled into the binary via `include_str!`. Grounds the agent in the
+/// project's own canonical self-description so it can answer FAQs about
+/// Broomva, Carlos Escobar-Valbuena, and the Life Agent OS factually
+/// instead of replying *"I don't have enough context."*
+pub const DEFAULT_CHAT_SYSTEM_PROMPT: &str = include_str!("../assets/chat_agent_persona.md");
+
+/// Resolve the system prompt for a chat dispatch from the process
+/// environment. See [`resolve_system_prompt_from`] for the precedence
+/// rule; this is the thin env-reading wrapper the backends call from
+/// `from_env`.
+pub fn resolve_system_prompt() -> Option<String> {
+    resolve_system_prompt_from(std::env::var(SYSTEM_PROMPT_ENV).ok())
+}
+
+/// Pure core of [`resolve_system_prompt`] — testable without touching the
+/// process environment.
+///
+/// Returns the operator override when it is present and non-blank,
+/// otherwise the grounded [`DEFAULT_CHAT_SYSTEM_PROMPT`]. Never returns
+/// `None`: there is always a grounded baseline.
+pub fn resolve_system_prompt_from(override_value: Option<String>) -> Option<String> {
+    match override_value {
+        Some(s) if !s.trim().is_empty() => Some(s),
+        _ => Some(DEFAULT_CHAT_SYSTEM_PROMPT.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The embedded default must be non-empty and ground the agent in the
+    /// facts that make the failing FAQ probes pass — the anchors here are
+    /// exactly the entities the live agent could not answer about before
+    /// this change ("Who is Carlos?" / "What is broomva.tech?").
+    #[test]
+    fn default_prompt_is_nonempty_and_grounded() {
+        let p = DEFAULT_CHAT_SYSTEM_PROMPT;
+        assert!(!p.trim().is_empty(), "default prompt must not be empty");
+        for anchor in [
+            "Life Agent OS",
+            "broomva.tech",
+            "Carlos",
+            "Escobar-Valbuena",
+            "Arcan",
+            "Lago",
+            "https://github.com/broomva/life",
+        ] {
+            assert!(
+                p.contains(anchor),
+                "default grounding prompt is missing the `{anchor}` anchor",
+            );
+        }
+    }
+
+    /// The default must be honest about not having tool/sandbox access on
+    /// the chat surface yet — guards against a future edit that overclaims.
+    #[test]
+    fn default_prompt_is_honest_about_capabilities() {
+        let p = DEFAULT_CHAT_SYSTEM_PROMPT;
+        assert!(
+            p.contains("not yet wired into this chat surface"),
+            "default prompt must stay honest about current (no-tools) capabilities",
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_non_blank_override() {
+        let got = resolve_system_prompt_from(Some("custom operator prompt".to_string()));
+        assert_eq!(got.as_deref(), Some("custom operator prompt"));
+    }
+
+    #[test]
+    fn resolve_ignores_blank_override() {
+        // Empty and whitespace-only overrides fall back to the grounded
+        // default — an operator who sets `LIFED_ARCAN_SYSTEM_PROMPT=""`
+        // (or to spaces) should not silently un-ground the agent.
+        for blank in ["", "   ", "\n\t "] {
+            let got = resolve_system_prompt_from(Some(blank.to_string()));
+            assert_eq!(
+                got.as_deref(),
+                Some(DEFAULT_CHAT_SYSTEM_PROMPT),
+                "blank override `{blank:?}` must fall back to the grounded default",
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_defaults_when_unset() {
+        let got = resolve_system_prompt_from(None);
+        assert_eq!(got.as_deref(), Some(DEFAULT_CHAT_SYSTEM_PROMPT));
+    }
+}

--- a/crates/life-runtime/arcan-proxy/src/lib.rs
+++ b/crates/life-runtime/arcan-proxy/src/lib.rs
@@ -6,6 +6,7 @@ pub mod anthropic;
 pub mod client;
 pub mod conversions;
 pub mod error;
+pub mod grounding;
 pub mod vercel_ai_gateway;
 
 pub use anthropic::{
@@ -14,6 +15,7 @@ pub use anthropic::{
 };
 pub use client::{ArcanCall, ArcanProxy, PoolGuardedStream, Pooled};
 pub use error::{ArcanProxyError, ArcanProxyResult, RetryClass};
+pub use grounding::{DEFAULT_CHAT_SYSTEM_PROMPT, SYSTEM_PROMPT_ENV, resolve_system_prompt};
 pub use vercel_ai_gateway::{
     DEFAULT_BASE_URL as VERCEL_AI_GATEWAY_DEFAULT_BASE_URL,
     DEFAULT_MODEL as VERCEL_AI_GATEWAY_DEFAULT_MODEL, VercelAiGatewayArcan, VercelAiGatewayConfig,

--- a/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
+++ b/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
@@ -89,7 +89,8 @@ impl VercelAiGatewayConfig {
     /// - `OPENAI_API_KEY` (required)
     /// - `OPENAI_BASE_URL` (default [`DEFAULT_BASE_URL`])
     /// - `OPENAI_MODEL` (default [`DEFAULT_MODEL`])
-    /// - `LIFED_ARCAN_SYSTEM_PROMPT` (optional)
+    /// - `LIFED_ARCAN_SYSTEM_PROMPT` (optional override; defaults to the
+    ///   grounded [`crate::grounding::DEFAULT_CHAT_SYSTEM_PROMPT`])
     /// - `LIFED_ARCAN_REQUEST_TIMEOUT_SECS` (optional, default 120)
     pub fn from_env() -> ArcanProxyResult<Self> {
         let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
@@ -106,7 +107,10 @@ impl VercelAiGatewayConfig {
             .ok()
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| DEFAULT_MODEL.to_string());
-        let system_prompt = std::env::var("LIFED_ARCAN_SYSTEM_PROMPT").ok();
+        // Defaults to the grounded persona when the env var is unset/blank
+        // so the live agent answers project FAQs factually instead of
+        // "I don't have enough context"; an explicit override still wins.
+        let system_prompt = crate::grounding::resolve_system_prompt();
         let request_timeout = std::env::var("LIFED_ARCAN_REQUEST_TIMEOUT_SECS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
@@ -733,6 +737,26 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[0]["content"], "be helpful");
         assert_eq!(messages[1]["role"], "user");
+    }
+
+    /// The grounded default (used when `LIFED_ARCAN_SYSTEM_PROMPT` is
+    /// unset) must reach the outbound request body as the system message —
+    /// otherwise the live agent stays ungrounded. Uses the pure resolver
+    /// (`resolve_system_prompt_from(None)`) so the test never touches the
+    /// process environment.
+    #[test]
+    fn default_grounding_flows_into_request_body() {
+        let mut c = cfg("http://localhost:8080".to_string());
+        c.system_prompt = crate::grounding::resolve_system_prompt_from(None);
+        let arc = VercelAiGatewayArcan::new(c).expect("build");
+        let body = arc.build_request_body("Who is Carlos Escobar-Valbuena?", None);
+        let messages = body["messages"].as_array().expect("messages");
+        assert_eq!(messages.len(), 2, "system + user");
+        assert_eq!(messages[0]["role"], "system");
+        let system = messages[0]["content"].as_str().expect("system content");
+        assert!(system.contains("broomva.tech"));
+        assert!(system.contains("Carlos"));
+        assert!(system.contains("Life Agent OS"));
     }
 
     /// BRO-1206: per-call model override wins over `cfg.model`.


### PR DESCRIPTION
## Why

Continues the chat-agent arc from the handoff in #1674. The broomva.tech chat **outage** is fixed; the next gap is that the live agent is **ungrounded**. The lifed chat backends sent **no system prompt** unless `LIFED_ARCAN_SYSTEM_PROMPT` was set, so the live agent answered:

- *"Who is Carlos Escobar-Valbuena?"* → "I don't have enough context…"
- *"What is broomva.tech?"* → "I don't have information about broomva.tech."

It could not answer project FAQs factually. This PR fixes that **from the root**: it changes the agent's **default** behavior from a generic assistant to a grounded one, in source-controlled + tested code (not a hand-maintained deploy env var that rots).

## What

- **New** `arcan-proxy/assets/chat_agent_persona.md` — a source-controlled grounding persona, embedded via `include_str!`.
- **New** `arcan-proxy/src/grounding.rs` — `resolve_system_prompt()` with clean precedence: an explicit `LIFED_ARCAN_SYSTEM_PROMPT` override wins wholesale; otherwise the grounded default applies (never empty).
- Both `VercelAiGatewayArcan::from_env` and `AnthropicArcan::from_env` now resolve through it — an unset env var now yields a **grounded** agent instead of a generic one.
- Anthropic backend emits `system` as a **cacheable content block** (`cache_control: ephemeral`) so the always-present persona is amortized across multi-turn conversations.

The persona is grounded in the repo's own canonical self-description (`llms.txt`, `.well-known/agent.json`, `README.md`): Broomva, Carlos Escobar-Valbuena (verifiable maintainer facts only — `carlos@broomva.tech` per CODE_OF_CONDUCT, org "Broomva" per agent.json), the Life Agent OS modules, and an **honest disclaimer** that tool/sandbox use is *not yet wired into this chat surface*.

## Architecture decision (why grounding lives here, not in lifed)

The #1674 handoff suggested "make lifed depend on arcan-praxis" and use the arcan-core context compiler. **That is forbidden** — `scripts/verify_dependencies_lifed.sh` bars `lifed`/`arcan-proxy` from depending on `arcan-core`, `arcan-lago`, `lago-knowledge`, `arcan-praxis` (substrate runtime crates). So the proper retrieval-backed grounding + tool harness must live **behind the arcand gRPC boundary** (arcand already has `AgentSubstrate.DispatchMessage` streaming → `KernelRuntime::tick_on_branch`); that is the **next arc**. This PR is the dependency-clean slice that ships grounding **today**: a static string, **zero new crate deps** — `verify_dependencies_lifed.sh` passes unchanged.

## Test plan

- `cargo test -p arcan-proxy` → **41 passing** (+6: 4 resolver-precedence incl. blank-override fallback, 1 Vercel grounding flow-through, 1 Anthropic cacheable-system-block grounding).
- `cargo clippy -p arcan-proxy --all-targets -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- `cargo check -p lifed -p lifegw` → clean (downstream consumers unaffected).
- `bash scripts/verify_dependencies_lifed.sh` → "all lifed dependency rules pass".

Re-runnable grounding probe (passes after the deploy note below):
```bash
# ask "What is broomva.tech?" / "Who is Carlos Escobar-Valbuena?"
# before: "I don't have information…"  →  after: grounded, factual answer
```

## Deploy note (owner-only, ops)

Railway `lifegw` currently sets `LIFED_ARCAN_SYSTEM_PROMPT` to a generic value (*"You are a helpful AI assistant."*). **Clear that env var** to adopt the grounded default — an explicit override still wins by design.

## Cross-model adversarial review (P20)

Verdict **APPROVE-WITH-NITS** (fresh-subagent, Strata B). One MAJOR finding addressed in this PR: the persona originally asserted unverifiable biographical claims about Carlos ("creator and lead developer") as authoritative fact while instructing the agent not to invent facts — softened to verifiable maintainer facts only. Two follow-ups also folded in: Anthropic prompt-caching (m1) and an Anthropic grounding test (m2).

## Follow-ups (next arc)

- Tool-capable harness behind the arcand gRPC boundary (Phase-2 `TOOL_CALL_PENDING`/`TOOL_RESULT` events, scopes beyond `agent:dispatch`, approval UI).
- Per-query retrieval grounding (lago-knowledge) once arcand publishes the tool-capable agent service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)