### PR TITLE
feat(substrate): Phase-2 tool lifecycle on the arcand dispatch wire

### DIFF
--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -13,8 +13,14 @@
 //! - `DispatchMessage`: drives a Direct tick loop and streams text +
 //!   terminal events back to the caller.
 //!
-//! Phase 2 (separate ticket) will lift the full `life.v1.AgentEvent`
-//! shape, ToolCall events, ApproveDispatch / CancelDispatch, etc.
+//! Phase 2 (harness arc, 2026-06-10): `DispatchMessage` additionally
+//! emits the tool lifecycle — `TOOL_CALL_PENDING` when the model
+//! requests a tool and `TOOL_RESULT` when execution completes or
+//! fails, each carrying a structured JSON payload (`payload_json`).
+//! The kernel already journals + broadcasts these as durable
+//! `EventKind::ToolCall*` records during the Direct tick; this module
+//! translates them onto the substrate wire. Still future:
+//! ApproveDispatch / CancelDispatch and APPROVAL_REQUIRED surfacing.
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -241,6 +247,8 @@ impl AgentSubstrate for SubstrateService {
                                     kind: AgentEventKind::Error as i32,
                                     text: String::new(),
                                     error: format!("tick failed: {e}"),
+                                    payload_json: String::new(),
+                                    sequence: 0,
                                 }))
                                 .await;
                         }
@@ -250,7 +258,23 @@ impl AgentSubstrate for SubstrateService {
                 }
             }
 
-            // If the broadcast pump hasn't already emitted a terminal
+            // Give the broadcast pump a bounded window to drain queued
+            // frames and forward the kernel's own terminal before we
+            // synthesize one. Without this, a starved pump could see
+            // our synthesized FINISH win the CAS while real TOKEN /
+            // TOOL_RESULT frames are still queued behind it (frames
+            // after FINISH). Normal flows break out on the first
+            // check; the full window is only paid when the kernel
+            // never emitted RunFinished/RunErrored at all.
+            if !errored {
+                for _ in 0..25 {
+                    if terminal_sent.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+            // If the broadcast pump still hasn't emitted a terminal
             // (e.g. the test harness's MockProvider returns
             // immediately without a RunFinished event), synthesize a
             // FINISH so the client stream closes cleanly. CAS guards
@@ -261,6 +285,8 @@ impl AgentSubstrate for SubstrateService {
                         kind: AgentEventKind::Finish as i32,
                         text: String::new(),
                         error: String::new(),
+                        payload_json: String::new(),
+                        sequence: 0,
                     }))
                     .await;
             }
@@ -280,29 +306,311 @@ impl AgentSubstrate for SubstrateService {
     }
 }
 
+/// Cap on the serialized `result` value embedded in a TOOL_RESULT
+/// wire frame. Tool outcomes (file reads, shell output) can exceed
+/// tonic's default 4 MB receive limit on the proxy side and would
+/// kill the stream mid-turn; oversized results are truncated on the
+/// wire while the full value stays in the durable kernel journal.
+const MAX_TOOL_RESULT_WIRE_BYTES: usize = 64 * 1024;
+
+/// Clamp a tool result for wire transport. Returns the (possibly
+/// truncated) value and whether truncation happened.
+fn wire_result(result: &serde_json::Value) -> (serde_json::Value, bool) {
+    let serialized = result.to_string();
+    if serialized.len() <= MAX_TOOL_RESULT_WIRE_BYTES {
+        return (result.clone(), false);
+    }
+    let mut cut = MAX_TOOL_RESULT_WIRE_BYTES;
+    while !serialized.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let truncated = format!(
+        "{head}…[truncated {dropped} of {total} bytes; full result in the session journal]",
+        head = &serialized[..cut],
+        dropped = serialized.len() - cut,
+        total = serialized.len(),
+    );
+    (serde_json::Value::String(truncated), true)
+}
+
 /// Translate a kernel `EventRecord` into a substrate-plane
-/// `AgentEvent`. Returns `None` for event kinds outside the Phase 1
-/// scope (which the pump skips silently). Phase 2 will expand to
-/// ToolCall + structured event records.
+/// `AgentEvent`. Returns `None` for event kinds outside the wire
+/// scope (which the pump skips silently).
+///
+/// Phase 2 (harness arc): the tool lifecycle maps as
+/// `ToolCallRequested` → `TOOL_CALL_PENDING` and
+/// `ToolCallCompleted` / `ToolCallFailed` → `TOOL_RESULT`, each with
+/// a structured JSON payload (see the proto for the shape).
+/// `ToolCallStarted` is deliberately skipped — `TOOL_CALL_PENDING`
+/// already announced the call and Started carries no additional
+/// client-visible information. Every translated frame carries the
+/// kernel's durable `record.sequence` so downstream consumers keep
+/// real per-session monotonic cursors.
 fn translate_event(record: &EventRecord) -> Option<AgentEvent> {
+    let event =
+        |kind: AgentEventKind, text: String, error: String, payload_json: String| AgentEvent {
+            kind: kind as i32,
+            text,
+            error,
+            payload_json,
+            sequence: record.sequence,
+        };
     match &record.kind {
         EventKind::AssistantTextDelta { delta, .. } | EventKind::TextDelta { delta, .. } => {
-            Some(AgentEvent {
-                kind: AgentEventKind::Token as i32,
-                text: delta.clone(),
-                error: String::new(),
-            })
+            Some(event(
+                AgentEventKind::Token,
+                delta.clone(),
+                String::new(),
+                String::new(),
+            ))
         }
-        EventKind::RunFinished { .. } => Some(AgentEvent {
-            kind: AgentEventKind::Finish as i32,
-            text: String::new(),
-            error: String::new(),
-        }),
-        EventKind::RunErrored { error } => Some(AgentEvent {
-            kind: AgentEventKind::Error as i32,
-            text: String::new(),
-            error: error.clone(),
-        }),
+        EventKind::ToolCallRequested {
+            call_id,
+            tool_name,
+            arguments,
+            category,
+        } => {
+            let mut payload = serde_json::json!({
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "arguments": arguments,
+            });
+            if let Some(cat) = category {
+                payload["category"] = serde_json::Value::String(cat.clone());
+            }
+            Some(event(
+                AgentEventKind::ToolCallPending,
+                String::new(),
+                String::new(),
+                payload.to_string(),
+            ))
+        }
+        EventKind::ToolCallCompleted {
+            call_id,
+            tool_name,
+            result,
+            duration_ms,
+            status,
+            ..
+        } => {
+            let (result, truncated) = wire_result(result);
+            let mut payload = serde_json::json!({
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "result": result,
+                "duration_ms": duration_ms,
+                "status": status,
+            });
+            if truncated {
+                payload["result_truncated"] = serde_json::Value::Bool(true);
+            }
+            Some(event(
+                AgentEventKind::ToolResult,
+                String::new(),
+                String::new(),
+                payload.to_string(),
+            ))
+        }
+        EventKind::ToolCallFailed {
+            call_id,
+            tool_name,
+            error,
+        } => Some(event(
+            AgentEventKind::ToolResult,
+            String::new(),
+            String::new(),
+            serde_json::json!({
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "error": error,
+                "status": "error",
+            })
+            .to_string(),
+        )),
+        EventKind::RunFinished { .. } => Some(event(
+            AgentEventKind::Finish,
+            String::new(),
+            String::new(),
+            String::new(),
+        )),
+        EventKind::RunErrored { error } => Some(event(
+            AgentEventKind::Error,
+            String::new(),
+            error.clone(),
+            String::new(),
+        )),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aios_protocol::{SpanStatus, ToolRunId};
+
+    use super::*;
+
+    fn record(kind: EventKind) -> EventRecord {
+        EventRecord::new(
+            SessionId::from_string("sid-substrate-test"),
+            BranchId::main(),
+            1,
+            kind,
+        )
+    }
+
+    fn payload(evt: &AgentEvent) -> serde_json::Value {
+        serde_json::from_str(&evt.payload_json).expect("payload_json parses")
+    }
+
+    #[test]
+    fn translates_text_delta_to_token() {
+        let evt = translate_event(&record(EventKind::TextDelta {
+            delta: "hello".into(),
+            index: None,
+        }))
+        .expect("token event");
+        assert_eq!(evt.kind(), AgentEventKind::Token);
+        assert_eq!(evt.text, "hello");
+        assert!(evt.payload_json.is_empty());
+    }
+
+    #[test]
+    fn translates_tool_call_requested_to_pending_with_payload() {
+        let evt = translate_event(&record(EventKind::ToolCallRequested {
+            call_id: "call-1".into(),
+            tool_name: "fs.read".into(),
+            arguments: serde_json::json!({"path": "/tmp/x"}),
+            category: Some("fs".into()),
+        }))
+        .expect("pending event");
+        assert_eq!(evt.kind(), AgentEventKind::ToolCallPending);
+        assert!(evt.text.is_empty());
+        let p = payload(&evt);
+        assert_eq!(p["call_id"], "call-1");
+        assert_eq!(p["tool_name"], "fs.read");
+        assert_eq!(p["arguments"]["path"], "/tmp/x");
+        assert_eq!(p["category"], "fs");
+    }
+
+    #[test]
+    fn translates_tool_call_completed_to_result_with_payload() {
+        let evt = translate_event(&record(EventKind::ToolCallCompleted {
+            tool_run_id: ToolRunId::default(),
+            call_id: Some("call-1".into()),
+            tool_name: "fs.read".into(),
+            result: serde_json::json!({"content": "data"}),
+            duration_ms: 42,
+            status: SpanStatus::Ok,
+        }))
+        .expect("result event");
+        assert_eq!(evt.kind(), AgentEventKind::ToolResult);
+        let p = payload(&evt);
+        assert_eq!(p["call_id"], "call-1");
+        assert_eq!(p["tool_name"], "fs.read");
+        assert_eq!(p["result"]["content"], "data");
+        assert_eq!(p["duration_ms"], 42);
+        assert_eq!(p["status"], "ok");
+    }
+
+    #[test]
+    fn translates_tool_call_failed_to_result_with_error_payload() {
+        let evt = translate_event(&record(EventKind::ToolCallFailed {
+            call_id: "call-2".into(),
+            tool_name: "shell.run".into(),
+            error: "denied by policy".into(),
+        }))
+        .expect("result event");
+        assert_eq!(evt.kind(), AgentEventKind::ToolResult);
+        let p = payload(&evt);
+        assert_eq!(p["call_id"], "call-2");
+        assert_eq!(p["error"], "denied by policy");
+        assert_eq!(p["status"], "error");
+    }
+
+    #[test]
+    fn category_is_omitted_when_absent() {
+        let evt = translate_event(&record(EventKind::ToolCallRequested {
+            call_id: "call-3".into(),
+            tool_name: "fs.read".into(),
+            arguments: serde_json::json!({}),
+            category: None,
+        }))
+        .expect("pending event");
+        let p = payload(&evt);
+        assert!(
+            p.get("category").is_none(),
+            "category key should be omitted, not null"
+        );
+    }
+
+    #[test]
+    fn kernel_sequence_passes_through_to_the_wire() {
+        let rec = EventRecord::new(
+            SessionId::from_string("sid-substrate-test"),
+            BranchId::main(),
+            7,
+            EventKind::TextDelta {
+                delta: "x".into(),
+                index: None,
+            },
+        );
+        let evt = translate_event(&rec).expect("token event");
+        assert_eq!(evt.sequence, 7);
+    }
+
+    #[test]
+    fn oversized_tool_result_is_truncated_on_the_wire() {
+        let big = "x".repeat(MAX_TOOL_RESULT_WIRE_BYTES * 2);
+        let evt = translate_event(&record(EventKind::ToolCallCompleted {
+            tool_run_id: ToolRunId::default(),
+            call_id: Some("call-big".into()),
+            tool_name: "fs.read".into(),
+            result: serde_json::json!({ "content": big }),
+            duration_ms: 1,
+            status: SpanStatus::Ok,
+        }))
+        .expect("result event");
+        assert!(
+            evt.payload_json.len() < MAX_TOOL_RESULT_WIRE_BYTES + 4096,
+            "wire payload stays near the cap (got {})",
+            evt.payload_json.len()
+        );
+        let p = payload(&evt);
+        assert_eq!(p["result_truncated"], true);
+        assert!(
+            p["result"]
+                .as_str()
+                .expect("truncated result is a string")
+                .contains("truncated"),
+        );
+    }
+
+    #[test]
+    fn tool_call_started_is_skipped() {
+        let translated = translate_event(&record(EventKind::ToolCallStarted {
+            tool_run_id: ToolRunId::default(),
+            tool_name: "fs.read".into(),
+        }));
+        assert!(translated.is_none());
+    }
+
+    #[test]
+    fn terminal_kinds_still_translate() {
+        let finish = translate_event(&record(EventKind::RunFinished {
+            reason: "done".into(),
+            total_iterations: 1,
+            final_answer: None,
+            usage: None,
+        }));
+        assert!(matches!(
+            finish.map(|e| e.kind()),
+            Some(AgentEventKind::Finish)
+        ));
+        let errored = translate_event(&record(EventKind::RunErrored {
+            error: "boom".into(),
+        }))
+        .expect("error event");
+        assert_eq!(errored.kind(), AgentEventKind::Error);
+        assert_eq!(errored.error, "boom");
     }
 }

--- a/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
+++ b/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
@@ -25,14 +25,15 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use aios_events::{EventJournal, EventStreamHub, FileEventStore};
 use aios_policy::{ApprovalQueue, SessionPolicyEngine};
 use aios_protocol::{
-    ApprovalPort, EventStorePort, KernelResult, ModelCompletion, ModelCompletionRequest,
-    ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort, PolicySet, SessionId,
-    ToolHarnessPort,
+    ApprovalPort, Capability, EventStorePort, KernelResult, ModelCompletion,
+    ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort,
+    PolicySet, SessionId, ToolCall, ToolHarnessPort,
 };
 use aios_runtime::{KernelRuntime, RuntimeConfig};
 use aios_sandbox::LocalSandboxRunner;
@@ -230,6 +231,157 @@ async fn dispatch_message_streams_real_substrate_events() {
         "dispatch stream should terminate with FINISH or ERROR"
     );
     env.shutdown().await;
+}
+
+/// Provider that requests one `fs.write` tool call on its first
+/// completion, then answers normally — drives the Phase-2 tool
+/// lifecycle through a real Direct tick.
+#[derive(Debug, Default)]
+struct ToolCallingProvider {
+    calls: AtomicU32,
+}
+
+#[async_trait]
+impl ModelProviderPort for ToolCallingProvider {
+    async fn complete(&self, _request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Ok(ModelCompletion {
+                provider: "test".to_owned(),
+                model: "test-model".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::ToolCall {
+                    call: ToolCall {
+                        call_id: "call-e2e-1".to_owned(),
+                        tool_name: "fs.write".to_owned(),
+                        input: serde_json::json!({
+                            "path": "artifacts/e2e.txt",
+                            "content": "phase-2 tool lifecycle"
+                        }),
+                        requested_capabilities: vec![Capability::fs_write("/session/artifacts/**")],
+                    },
+                }],
+                stop_reason: ModelStopReason::ToolCall,
+                usage: None,
+                final_answer: None,
+            })
+        } else {
+            Ok(ModelCompletion {
+                provider: "test".to_owned(),
+                model: "test-model".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::Message {
+                    role: "assistant".to_owned(),
+                    content: "wrote the file".to_owned(),
+                }],
+                stop_reason: ModelStopReason::Completed,
+                usage: None,
+                final_answer: Some("done".to_owned()),
+            })
+        }
+    }
+}
+
+#[tokio::test]
+async fn dispatch_message_streams_tool_lifecycle_events() {
+    // Same harness as `dispatch_message_streams_real_substrate_events`
+    // but with a provider that requests a tool call — asserts the
+    // Phase-2 wire: TOOL_CALL_PENDING and TOOL_RESULT frames arrive at
+    // the proxy as structured `life.v1.AgentEvent`s with payloads.
+    let tempdir = TempDir::new().expect("tempdir");
+    let socket = tempdir.path().join("arcand.sock");
+    let root = tempdir.path().join("kernel-root");
+
+    let event_store_backend = Arc::new(FileEventStore::new(root.join("kernel")));
+    let journal = Arc::new(EventJournal::new(
+        event_store_backend,
+        EventStreamHub::new(1024),
+    ));
+    let event_store: Arc<dyn EventStorePort> = journal;
+    let policy_engine = Arc::new(SessionPolicyEngine::new(PolicySet::default()));
+    let policy_gate: Arc<dyn PolicyGatePort> = policy_engine.clone();
+    let approvals: Arc<dyn ApprovalPort> = Arc::new(ApprovalQueue::default());
+    let registry = Arc::new(ToolRegistry::with_core_tools());
+    let sandbox = Arc::new(LocalSandboxRunner::new(vec!["echo".to_owned()]));
+    let dispatcher = Arc::new(ToolDispatcher::new(registry, policy_engine, sandbox));
+    let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
+    let runtime = Arc::new(KernelRuntime::new(
+        RuntimeConfig::new(root),
+        event_store,
+        Arc::new(ToolCallingProvider::default()),
+        tool_harness,
+        approvals,
+        policy_gate,
+    ));
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let service = SubstrateService::new(Arc::clone(&runtime));
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind UDS");
+    let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
+    let server_handle = tokio::spawn(async move {
+        let _ = tonic::transport::Server::builder()
+            .add_service(AgentSubstrateServer::new(service))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let proxy = ArcanProxy::connect(socket.clone())
+        .await
+        .expect("dial substrate UDS");
+    let sid = "phase2-tool-lifecycle";
+    let _ = proxy.create_agent(sid).await.expect("create_agent");
+    let mut stream = proxy
+        .dispatch_message(sid, "write the e2e artifact", None)
+        .await
+        .expect("dispatch_message");
+
+    let mut pending: Option<serde_json::Value> = None;
+    let mut result: Option<serde_json::Value> = None;
+    let mut terminal_seen = false;
+    let mut count = 0;
+    while let Some(evt) = stream.next().await {
+        let evt = evt.expect("substrate event ok");
+        count += 1;
+        let payload = evt.record.as_ref().map(|r| {
+            serde_json::from_slice::<serde_json::Value>(&r.payload).expect("record payload JSON")
+        });
+        if evt.kind == AgentEventKind::ToolCallPending as i32 {
+            pending = payload.clone();
+        }
+        if evt.kind == AgentEventKind::ToolResult as i32 {
+            result = payload.clone();
+        }
+        if evt.kind == AgentEventKind::Finish as i32 || evt.kind == AgentEventKind::Error as i32 {
+            terminal_seen = true;
+            break;
+        }
+        if count > 64 {
+            break;
+        }
+    }
+    drop(stream);
+
+    assert!(terminal_seen, "stream should reach a terminal frame");
+    let pending = pending.expect("TOOL_CALL_PENDING frame should arrive at the proxy");
+    assert_eq!(pending["call_id"], "call-e2e-1");
+    assert_eq!(pending["tool_name"], "fs.write");
+    assert_eq!(pending["arguments"]["path"], "artifacts/e2e.txt");
+    let result = result.expect("TOOL_RESULT frame should arrive at the proxy");
+    assert_eq!(result["tool_name"], "fs.write");
+    assert_eq!(
+        result["status"], "ok",
+        "fs.write should actually execute (policy allows /session/artifacts/**): {result}"
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_handle).await;
 }
 
 #[tokio::test]

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -11,6 +11,7 @@ use life_runtime_proto::life::v1::{AgentEvent, AgentEventKind, EventRecord};
 use serde::{Deserialize, Serialize};
 
 use crate::client::ArcanCall;
+use crate::conversions::now_timestamp;
 use crate::error::{ArcanProxyError, ArcanProxyResult};
 
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -584,16 +585,6 @@ fn double_newline(buf: &[u8]) -> Option<usize> {
         .enumerate()
         .find(|(_, w)| *w == b"\n\n")
         .map(|(i, _)| i)
-}
-
-fn now_timestamp() -> Option<prost_types::Timestamp> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(prost_types::Timestamp {
-        seconds: now.as_secs() as i64,
-        nanos: now.subsec_nanos() as i32,
-    })
 }
 
 fn truncate(s: &str, limit: usize) -> String {

--- a/crates/life-runtime/arcan-proxy/src/client.rs
+++ b/crates/life-runtime/arcan-proxy/src/client.rs
@@ -173,8 +173,11 @@ impl ArcanProxy {
     /// Dispatch a message and stream the substrate's events back as
     /// `life.v1.AgentEvent`s. BRO-1016 wires this to
     /// `arcan.v1.AgentSubstrate.DispatchMessage` and translates the
-    /// substrate-plane events into the public-plane shape (Phase 1
-    /// maps TOKEN/FINISH/ERROR; tool kinds remain Phase 2 work).
+    /// substrate-plane events into the public-plane shape. Phase 2
+    /// (harness arc): TOKEN/FINISH/ERROR plus the tool lifecycle —
+    /// TOOL_CALL_PENDING / TOOL_RESULT pass through with their
+    /// structured payloads as `EventRecord`s (see
+    /// [`crate::conversions::SubstrateEventTranslator`]).
     ///
     /// BRO-1206: `model` is accepted at the trait boundary so callers
     /// (lifed) can plumb a per-session override end-to-end without a
@@ -218,34 +221,15 @@ impl ArcanProxy {
         };
 
         // Map arcan.v1.AgentEvent → life.v1.AgentEvent at the wire
-        // boundary. Phase 1 emits the kind mapping; structured
-        // EventRecords stay None until the Phase 2 wire is shipped.
+        // boundary. Phase 2 (harness arc): the translator builds a
+        // structured `EventRecord` per event (session id, sequence,
+        // kind tag, JSON payload) so token text and tool payloads
+        // survive the hop — see `conversions::SubstrateEventTranslator`.
         use futures::StreamExt;
-        let mapped = upstream.map(|res| res.map(translate_event));
+        let mut translator = crate::conversions::SubstrateEventTranslator::new(sid);
+        let mapped = upstream.map(move |res| res.map(|evt| translator.translate(evt)));
         let inner = Box::pin(mapped);
         Ok(Box::pin(PoolGuardedStream::new(inner, guard)))
-    }
-}
-
-/// Translate a substrate-plane `arcan.v1.AgentEvent` into the
-/// public-plane `life.v1.AgentEvent` shape that lifed's fan-out
-/// expects. Phase 1 maps three kinds; everything else falls back to
-/// `Token` with the inner text (preserves payload, avoids data loss).
-fn translate_event(evt: arcan_pb::AgentEvent) -> life_runtime_proto::life::v1::AgentEvent {
-    use arcan_pb::AgentEventKind as Sub;
-    use life_runtime_proto::life::v1::AgentEventKind as Pub;
-    // Phase 1 only emits TOKEN/FINISH/ERROR substrate-side; any other
-    // kind we receive in the future maps to TOKEN so downstream
-    // streams don't drop the payload silently.
-    let kind = match Sub::try_from(evt.kind).unwrap_or(Sub::Unspecified) {
-        Sub::Token => Pub::Token,
-        Sub::Finish => Pub::Finish,
-        Sub::Error => Pub::Error,
-        Sub::Unspecified => Pub::Unspecified,
-    };
-    life_runtime_proto::life::v1::AgentEvent {
-        record: None,
-        kind: kind as i32,
     }
 }
 

--- a/crates/life-runtime/arcan-proxy/src/conversions.rs
+++ b/crates/life-runtime/arcan-proxy/src/conversions.rs
@@ -1,4 +1,260 @@
 //! From/Into conversions between aios-protocol Rust types and the wire
 //! types the proxy round-trips. Hand-written until arcan-proto ships.
 
-// Sub-phase B: empty placeholder; populated as the proxy gains real RPCs.
+use aios_proto::aios::v1 as aios_v1;
+use arcan_substrate_proto::arcan::v1 as arcan_pb;
+use life_runtime_proto::life::v1 as life_pb;
+
+/// Stateful translator mapping substrate-plane `arcan.v1.AgentEvent`s
+/// onto public-plane `life.v1.AgentEvent`s for one dispatch stream.
+///
+/// Mirrors the record idiom of the HTTP-backed backends
+/// (`vercel_ai_gateway.rs` / `anthropic.rs`): every emitted event
+/// carries an `EventRecord` with the session id, a stream-local
+/// monotonic `sequence`, a wall-clock timestamp, an UPPERCASE kind
+/// tag, and a structured JSON payload — the shape lifegw's
+/// `event_to_outbound_frame` forwards to the browser, which reads
+/// `payload.text` / `payload.call_id` / etc.
+///
+/// Phase 2 (harness arc): the tool lifecycle passes through —
+/// `TOOL_CALL_PENDING` / `TOOL_RESULT` payloads are decoded from the
+/// substrate's `payload_json` and inlined as the record payload. This
+/// also closes the Phase-1 gap where TOKEN text was dropped at this
+/// boundary (`record` was always `None`).
+pub struct SubstrateEventTranslator {
+    session_id: aios_v1::SessionId,
+    sequence: u64,
+}
+
+impl SubstrateEventTranslator {
+    pub fn new(sid: impl Into<String>) -> Self {
+        Self {
+            session_id: aios_v1::SessionId { value: sid.into() },
+            sequence: 0,
+        }
+    }
+
+    /// Translate one substrate event. Frames carrying the kernel's
+    /// durable per-session sequence (`evt.sequence > 0`) use it
+    /// verbatim — keeping real monotonic cursors intact for the WS
+    /// resume contract; synthesized frames (sequence 0, e.g. the
+    /// fallback FINISH) continue monotonically from the last seen
+    /// value.
+    pub fn translate(&mut self, evt: arcan_pb::AgentEvent) -> life_pb::AgentEvent {
+        use arcan_pb::AgentEventKind as Sub;
+        use life_pb::AgentEventKind as Pub;
+        self.sequence = if evt.sequence > 0 {
+            evt.sequence
+        } else {
+            self.sequence + 1
+        };
+        let (kind, kind_tag, payload) = match Sub::try_from(evt.kind).unwrap_or(Sub::Unspecified) {
+            Sub::Token => (Pub::Token, "TOKEN", serde_json::json!({ "text": evt.text })),
+            Sub::ToolCallPending => (
+                Pub::ToolCallPending,
+                "TOOL_CALL_PENDING",
+                decode_payload(&evt.payload_json),
+            ),
+            Sub::ToolResult => (
+                Pub::ToolResult,
+                "TOOL_RESULT",
+                decode_payload(&evt.payload_json),
+            ),
+            Sub::Finish => (Pub::Finish, "FINISH", serde_json::json!({})),
+            Sub::Error => (
+                Pub::Error,
+                "ERROR",
+                serde_json::json!({ "error": evt.error }),
+            ),
+            // Unknown / future substrate kinds: preserve BOTH the text
+            // and any structured payload under the UNSPECIFIED tag
+            // rather than guessing a semantic for them.
+            Sub::Unspecified => (
+                Pub::Unspecified,
+                "UNSPECIFIED",
+                serde_json::json!({
+                    "text": evt.text,
+                    "payload": decode_payload(&evt.payload_json),
+                }),
+            ),
+        };
+        life_pb::AgentEvent {
+            record: Some(life_pb::EventRecord {
+                session_id: Some(self.session_id.clone()),
+                sequence: self.sequence,
+                at: now_timestamp(),
+                kind: kind_tag.to_string(),
+                payload: serde_json::to_vec(&payload).unwrap_or_default(),
+            }),
+            kind: kind as i32,
+        }
+    }
+}
+
+/// Decode a substrate `payload_json` into a JSON object. Malformed or
+/// non-object payloads are wrapped so the record payload is always an
+/// object — the browser contract per lifegw's
+/// `event_to_outbound_frame` (it inlines objects and wraps everything
+/// else).
+fn decode_payload(payload_json: &str) -> serde_json::Value {
+    if payload_json.is_empty() {
+        return serde_json::json!({});
+    }
+    match serde_json::from_str::<serde_json::Value>(payload_json) {
+        Ok(v) if v.is_object() => v,
+        Ok(other) => serde_json::json!({ "value": other }),
+        Err(_) => serde_json::json!({ "raw": payload_json }),
+    }
+}
+
+/// Wall-clock timestamp for proxy-built `EventRecord`s. Shared by the
+/// substrate translator and the HTTP-backed backends.
+pub(crate) fn now_timestamp() -> Option<prost_types::Timestamp> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(prost_types::Timestamp {
+        seconds: now.as_secs() as i64,
+        nanos: now.subsec_nanos() as i32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sub_event(
+        kind: arcan_pb::AgentEventKind,
+        text: &str,
+        error: &str,
+        payload: &str,
+    ) -> arcan_pb::AgentEvent {
+        arcan_pb::AgentEvent {
+            kind: kind as i32,
+            text: text.to_string(),
+            error: error.to_string(),
+            payload_json: payload.to_string(),
+            sequence: 0,
+        }
+    }
+
+    fn record_payload(evt: &life_pb::AgentEvent) -> serde_json::Value {
+        let record = evt.record.as_ref().expect("record present");
+        serde_json::from_slice(&record.payload).expect("payload is JSON")
+    }
+
+    #[test]
+    fn token_text_flows_into_record_payload() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let out = tr.translate(sub_event(arcan_pb::AgentEventKind::Token, "hello", "", ""));
+        assert_eq!(out.kind(), life_pb::AgentEventKind::Token);
+        let record = out.record.as_ref().expect("record present");
+        assert_eq!(record.kind, "TOKEN");
+        assert_eq!(
+            record.session_id.as_ref().map(|s| s.value.as_str()),
+            Some("sid-1")
+        );
+        assert_eq!(record_payload(&out)["text"], "hello");
+    }
+
+    #[test]
+    fn tool_call_pending_payload_passes_through() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let payload = r#"{"call_id":"c1","tool_name":"fs.read","arguments":{"path":"/x"}}"#;
+        let out = tr.translate(sub_event(
+            arcan_pb::AgentEventKind::ToolCallPending,
+            "",
+            "",
+            payload,
+        ));
+        assert_eq!(out.kind(), life_pb::AgentEventKind::ToolCallPending);
+        let record = out.record.as_ref().expect("record present");
+        assert_eq!(record.kind, "TOOL_CALL_PENDING");
+        let p = record_payload(&out);
+        assert_eq!(p["call_id"], "c1");
+        assert_eq!(p["tool_name"], "fs.read");
+        assert_eq!(p["arguments"]["path"], "/x");
+    }
+
+    #[test]
+    fn tool_result_payload_passes_through() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let payload =
+            r#"{"call_id":"c1","tool_name":"fs.read","result":{"ok":true},"status":"ok"}"#;
+        let out = tr.translate(sub_event(
+            arcan_pb::AgentEventKind::ToolResult,
+            "",
+            "",
+            payload,
+        ));
+        assert_eq!(out.kind(), life_pb::AgentEventKind::ToolResult);
+        let p = record_payload(&out);
+        assert_eq!(p["status"], "ok");
+        assert_eq!(p["result"]["ok"], true);
+    }
+
+    #[test]
+    fn malformed_tool_payload_is_wrapped_not_dropped() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let out = tr.translate(sub_event(
+            arcan_pb::AgentEventKind::ToolResult,
+            "",
+            "",
+            "not json",
+        ));
+        assert_eq!(record_payload(&out)["raw"], "not json");
+    }
+
+    #[test]
+    fn finish_and_error_map_to_terminal_kinds() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let finish = tr.translate(sub_event(arcan_pb::AgentEventKind::Finish, "", "", ""));
+        assert_eq!(finish.kind(), life_pb::AgentEventKind::Finish);
+        assert_eq!(finish.record.as_ref().unwrap().kind, "FINISH");
+        let error = tr.translate(sub_event(
+            arcan_pb::AgentEventKind::Error,
+            "",
+            "tick failed",
+            "",
+        ));
+        assert_eq!(error.kind(), life_pb::AgentEventKind::Error);
+        assert_eq!(record_payload(&error)["error"], "tick failed");
+    }
+
+    #[test]
+    fn sequence_is_monotonic_per_stream() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let a = tr.translate(sub_event(arcan_pb::AgentEventKind::Token, "a", "", ""));
+        let b = tr.translate(sub_event(arcan_pb::AgentEventKind::Token, "b", "", ""));
+        assert_eq!(a.record.unwrap().sequence, 1);
+        assert_eq!(b.record.unwrap().sequence, 2);
+    }
+
+    #[test]
+    fn kernel_sequence_wins_and_synthesized_frames_continue_from_it() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let mut with_seq = sub_event(arcan_pb::AgentEventKind::Token, "a", "", "");
+        with_seq.sequence = 41;
+        let a = tr.translate(with_seq);
+        assert_eq!(
+            a.record.unwrap().sequence,
+            41,
+            "kernel-assigned sequence passes through verbatim"
+        );
+        // A synthesized frame (sequence 0) continues monotonically.
+        let b = tr.translate(sub_event(arcan_pb::AgentEventKind::Finish, "", "", ""));
+        assert_eq!(b.record.unwrap().sequence, 42);
+    }
+
+    #[test]
+    fn unknown_kind_retains_text_and_payload() {
+        let mut tr = SubstrateEventTranslator::new("sid-1");
+        let mut evt = sub_event(arcan_pb::AgentEventKind::Unspecified, "t", "", r#"{"k":1}"#);
+        evt.kind = 99; // future kind unknown to this build
+        let out = tr.translate(evt);
+        assert_eq!(out.kind(), life_pb::AgentEventKind::Unspecified);
+        let p = record_payload(&out);
+        assert_eq!(p["text"], "t");
+        assert_eq!(p["payload"]["k"], 1);
+    }
+}

--- a/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
+++ b/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
@@ -49,6 +49,7 @@ use life_runtime_proto::life::v1::{AgentEvent, AgentEventKind, EventRecord};
 use serde::{Deserialize, Serialize};
 
 use crate::client::ArcanCall;
+use crate::conversions::now_timestamp;
 use crate::error::{ArcanProxyError, ArcanProxyResult};
 
 /// Default base URL for Vercel AI Gateway. Operators override via
@@ -642,16 +643,6 @@ fn find_double_newline(buf: &[u8]) -> Option<usize> {
         .enumerate()
         .find(|(_, w)| *w == b"\n\n")
         .map(|(i, _)| i)
-}
-
-fn now_timestamp() -> Option<prost_types::Timestamp> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?;
-    Some(prost_types::Timestamp {
-        seconds: now.as_secs() as i64,
-        nanos: now.subsec_nanos() as i32,
-    })
 }
 
 fn truncate_body(s: &str, limit: usize) -> String {

--- a/deny.toml
+++ b/deny.toml
@@ -14,8 +14,11 @@ ignore = [
     "RUSTSEC-2024-0436",  # paste unmaintained — widely used, no security issue
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — transitive, migration to rustls-pki-types planned
     "RUSTSEC-2017-0008",  # serial unmaintained — transitive dep, no impact on agent runtime
-    "RUSTSEC-2026-0002",  # lru unsoundness (IterMut stacked-borrows) — transitive, agents don't use IterMut
     "RUSTSEC-2026-0104",  # rustls-webpki reachable panic on empty BIT STRING in CRL onlySomeReasons — we don't parse untrusted CRLs; patched in >=0.103.13 (follow-up dep bump)
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — transitive via tabled_derive→tabled (CLI table rendering only); migrating off tabled tracked as a follow-up dep change
+    # RUSTSEC-2026-0002 (lru IterMut unsoundness) removed 2026-06-10: the
+    # advisory no longer matches any crate in the graph (cargo-deny
+    # "no crate matched advisory criteria").
 ]
 
 [licenses]

--- a/proto/arcan/v1/substrate.proto
+++ b/proto/arcan/v1/substrate.proto
@@ -53,15 +53,36 @@ message DispatchMessageReq {
 }
 
 // Mirrors life.v1.AgentEvent shape but lives in the substrate-plane
-// package. EventRecord is omitted from Phase 1 (will be lifted in
-// Phase 2 when we wire structured events). Phase 1 emits text +
-// terminal events.
+// package. Phase 1 emitted text + terminal events only; Phase 2
+// (harness arc) adds the tool lifecycle kinds with a JSON payload.
+// A full structured EventRecord remains future work — the payload
+// field carries the structured data until a cross-substrate event
+// vocabulary is published (Spec C₂ §10.3).
 message AgentEvent {
   AgentEventKind kind = 1;
   // Text content for TOKEN events. Empty for FINISH/ERROR.
   string text = 2;
   // Error message for ERROR events. Empty otherwise.
   string error = 3;
+  // Structured JSON payload for tool lifecycle events.
+  //
+  // TOOL_CALL_PENDING: {"call_id", "tool_name", "arguments", "category"?}
+  // TOOL_RESULT:       {"call_id"?, "tool_name", "result", "duration_ms",
+  //                     "status", "result_truncated"?} on success, or
+  //                     {"call_id", "tool_name", "error", "status":"error"}
+  //                     on failure. Results larger than the wire cap are
+  //                     truncated ("result_truncated": true); the full
+  //                     value stays in the durable kernel journal.
+  //
+  // Empty for TOKEN/FINISH/ERROR. arcan-proxy forwards these bytes as
+  // the life.v1.EventRecord payload, which the browser decodes as a
+  // structured object (lifegw ws.rs `event_to_outbound_frame`).
+  string payload_json = 4;
+  // Kernel-assigned durable per-session sequence number of the source
+  // EventRecord. 0 for frames synthesized on the wire (e.g. the
+  // fallback FINISH) — consumers needing monotonicity fall back to a
+  // stream-local counter for those.
+  uint64 sequence = 5;
 }
 
 enum AgentEventKind {
@@ -69,4 +90,10 @@ enum AgentEventKind {
   AGENT_EVENT_KIND_TOKEN = 1;
   AGENT_EVENT_KIND_FINISH = 2;
   AGENT_EVENT_KIND_ERROR = 3;
+  // Phase 2 (harness arc): a tool call was requested by the model and
+  // is about to execute (or awaits approval).
+  AGENT_EVENT_KIND_TOOL_CALL_PENDING = 4;
+  // Phase 2 (harness arc): a tool call completed (ok or error) — the
+  // payload carries the result or failure.
+  AGENT_EVENT_KIND_TOOL_RESULT = 5;
 }


### PR DESCRIPTION
## Summary

Harness Phase-2 arc (continues #1676 / the 2026-06-10 handoff): the substrate plane now carries the **tool lifecycle end-to-end** — `arcand`'s gRPC `DispatchMessage` emits `TOOL_CALL_PENDING` / `TOOL_RESULT` frames from the kernel's durable `EventKind::ToolCall*` records, and `arcan-proxy` translates them into structured `life.v1.AgentEvent`s. lifed fanout and lifegw WS already pass all kinds through (lifegw has named these kinds since Stage 3b), so the browser receives tool frames with no further changes.

## Changes

| Layer | Change |
|---|---|
| `proto/arcan/v1/substrate.proto` | +`TOOL_CALL_PENDING`/`TOOL_RESULT` kinds, +`payload_json`, +kernel `sequence` (additive, wire-compatible) |
| `arcand/src/substrate.rs` | `translate_event` tool arms with structured payloads; 64KB wire cap on tool results (full value stays in the journal — tonic 4MB recv guard); kernel `record.sequence` on every frame; bounded drain window before synthesizing FINISH (frames-after-terminal race); +9 unit tests |
| `arcan-proxy/src/conversions.rs` (new content) | `SubstrateEventTranslator` — builds real `life.v1.EventRecord`s (session id, kernel sequence w/ stream-local fallback, kind tag, JSON payload); **fixes Phase-1 bug where TOKEN text was dropped** (`record` was always `None`); `now_timestamp` deduped from both HTTP backends; +8 unit tests |
| `arcand/tests/topology_b_e2e_arcan.rs` | New e2e: real Direct tick + tool-calling provider → `fs.write` executes → `TOOL_CALL_PENDING` + `TOOL_RESULT` (status `ok`) stream over the UDS wire to the proxy |

## Cross-review (P20, Strata B adversarial)

Round-1 verdict REQUEST-CHANGES, all findings resolved in this commit: **MAJOR** unbounded tool-result payload vs tonic 4MB recv cap → 64KB wire truncation with `result_truncated` marker; **MINOR** fabricated per-stream sequence discarding the kernel's durable one (latent WS-resume corruption) → kernel sequence carried over the wire; **MINOR** terminal-ordering race → bounded drain-before-synthesize; 3 nits (category `null` vs omitted, Unspecified payload drop, vacuous e2e assert) fixed. Anti-slop 8/10.

## Test plan

- [x] `cargo test -p arcand` (66 lib + 4 e2e incl. new tool-lifecycle e2e)
- [x] `cargo test -p arcan-proxy` (49)
- [x] `cargo clippy -p arcand -p arcan-proxy -p arcan-substrate-proto --all-targets -- -D warnings`
- [x] `cargo check --workspace`
- [x] `bash scripts/verify_dependencies_lifed.sh`
- [ ] CI: full `cargo test --workspace` (Linux + macOS lanes)

Linear: BRO ticket pending (Linear MCP unauthenticated this session); follow-up arc per `docs/handoffs/2026-06-10-chat-agent-grounding-shipped.md` pickup item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool call lifecycle events now streamed with structured JSON payloads, including tool name, arguments, and results
  * Event sequence tracking for improved ordering guarantees

* **Bug Fixes**
  * Enhanced event ordering and race condition handling in event streams
  * Tool results automatically size-limited to prevent stream truncation issues

* **Tests**
  * Added end-to-end test validating tool lifecycle event streaming and payload contents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->