### PR TITLE
feat(ergon): wire durable workflow sinks + real auto-hook adapters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,24 +343,33 @@ Topology B is now production-deployable for real agent traffic; see
 `research/entities/concept/topology-b-substrate-stub-gap.md` for the
 audit record + closure note.
 
-⚠️ **Three small wiring gaps remain — all localized to Workflow tick path:**
+✅ **Workflow tick path gaps CLOSED (2026-06-10, harness Phase-2 arc):**
 
-1. **`ergon-life-sinks` has zero consumers** —
-   `crates/arcan/arcan-ergon/src/runner.rs:157` uses `BufferSink::new()`.
-   Workflow stream events never reach lago; `lago replay --tree`
-   cannot see them. ~30 LOC fix.
-2. **3 of 4 ergon auto-hook adapters are Noop** —
-   `crates/arcan/arcan-ergon/src/runner.rs:146-150` wires
-   `NoopBudgetGate` / `NoopResponseScorer` / `NoopSoulAttester`
-   (only `PraxisCapabilityHook` is real). Workflow ticks bypass
-   budget/score/attest. ~50 LOC each + real impls.
-3. **`arcan agent test` is `--dry-run` only** (CLI) — no live-LLM mode
-   for Python consumers. BRO-1008 follow-up.
+1. ~~`ergon-life-sinks` has zero consumers~~ — **CLOSED**: the runner
+   composes `FanoutSink([BufferSink, factory(session, branch)])` per
+   invocation; `arcan serve` wires `ergon_life_sinks::LagoSink` over
+   the kernel's own lago journal via
+   `WorkflowRunInputs::with_stream_sink_factory`
+   (`crates/arcan/arcan/src/ergon_wiring.rs`). Workflow stream events
+   now reach lago.
+2. ~~3 of 4 ergon auto-hook adapters are Noop~~ — **CLOSED**: real
+   adapters shipped + wired — `EconomicBudgetGate` (Autonomic:
+   Hibernate denies, Hustle clamps tokens), `NousAdapter` (evaluator
+   fan-out, fail-open per evaluator), `AgentAttestationAdapter`
+   (custody-signed JWS session boundaries; implemented + tested,
+   arcan serve wiring awaits a custody identity config — noop
+   fallback warns at boot). Noops remain only as explicit fallbacks
+   for unwired hosts.
 
-**Direct tick path (Topology A) is unaffected by gaps 1 & 2** —
-autonomic + nous + lago all wired through `PolicyGatePort` +
-`ToolHarnessPort` + turn middleware. Gap 3 is small / utility. Total
-remaining: ~1 weekend of cleanup.
+Also closed 2026-06-10: **substrate tool lifecycle (harness Phase 2)**
+— `arcand DispatchMessage` emits `TOOL_CALL_PENDING` / `TOOL_RESULT`
+with structured payloads (64KB wire cap, kernel sequence carried);
+`arcan-proxy` translates them into `life.v1.AgentEvent` records and no
+longer drops TOKEN text on the real-arcand path (PR #1686, merge
+`14e39f3c`).
+
+⚠️ **One small gap remains:** `arcan agent test` is `--dry-run` only
+(CLI) — no live-LLM mode for Python consumers. BRO-1008 follow-up.
 
 ### Spec progress
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,9 @@ dependencies = [
  "crossterm",
  "dirs 6.0.0",
  "ergon",
+ "ergon-life-hooks",
+ "ergon-life-sinks",
+ "ergon-nous-adapter",
  "fastrand",
  "filetime",
  "futures-util",
@@ -3587,9 +3590,11 @@ version = "0.3.0"
 dependencies = [
  "anima-identity",
  "async-trait",
+ "base64 0.22.1",
  "ergon",
  "ergon-life-hooks",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 
@@ -3629,6 +3634,7 @@ dependencies = [
  "ergon-life-hooks",
  "nous-core",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/arcan/arcan-ergon/CLAUDE.md
+++ b/crates/arcan/arcan-ergon/CLAUDE.md
@@ -41,7 +41,7 @@ L0 — Kernel contract (aios-protocol)
 | `runtime_handle`  | `ModeRuntimeHandle` — `ergon::RuntimeHandle` over a captured `OperatingMode` |
 | `provider`        | `ModelProviderAdapter` — `ergon::Provider` over `ModelProviderPort` |
 | `tools`           | `ToolHarnessAdapter` — `ergon::ToolRegistry` over `ToolHarnessPort` |
-| `hooks`           | The four `ergon-life-hooks` adapter-trait implementations (capability + 3 noops) |
+| `hooks`           | `KernelCapabilityResolver` (always real) + the three noop fallbacks used when the host wires no real adapter via `WorkflowRunInputs` |
 | `runner`          | `run_workflow_as_tick` — the workflow body executor |
 | `dispatcher`      | `ErgonWorkflowDispatcher` — `WorkflowTickDispatcher` impl wired into the kernel |
 
@@ -82,20 +82,33 @@ L0 — Kernel contract (aios-protocol)
    the registered praxis tools at startup). Tools missing from the
    map are denied fail-closed.
 
-2. **`NoopBudgetGate` / `NoopResponseScorer` / `NoopSoulAttester`.**
-   The spec's intent is that all four auto-hooks have real
-   substrate-backed implementations. The BRO-1001 minimum ships only
-   capability-gating as functional; the other three are permissive
-   stand-ins. Real autonomic / nous / anima implementations land in
-   follow-up tickets without changing the public surface.
+2. **Real auto-hook adapters wire in via `WorkflowRunInputs`**
+   *(closed 2026-06-10, harness Phase-2 gap closure)*. The runner
+   uses host-supplied `budget_gate` / `response_scorer` /
+   `soul_attester` when present and falls back to the permissive
+   noops otherwise (tests, minimal embedders). The real adapters:
+   `arcan::ergon_wiring::EconomicBudgetGate` (Autonomic economic
+   advisory — Hibernate denies, Hustle clamps `max_tokens`),
+   `ergon_nous_adapter::NousAdapter` (evaluator-registry fan-out,
+   fail-open per evaluator), `ergon_anima_adapter::
+   AgentAttestationAdapter` (custody-signed JWS session boundaries —
+   implemented + tested; arcan serve wires it once a custody
+   identity config exists, until then the noop fallback warns at
+   boot).
 
-3. **`BufferSink` instead of `FanoutSink(LagoSink, VigilSink, LifegwSink)`.**
-   Substrate-coupled stream sinks (BRO-999b follow-up) aren't in
-   this crate's dep graph yet. We capture stream events in memory
-   and account their count in `WorkflowTickOutcome.events_emitted`
-   for the kernel's bookkeeping. When the substrate sinks land, the
-   `runner.rs::run_workflow_as_tick` body grows a `FanoutSink`
-   composing them in.
+3. **Durable stream sink fans in via `WorkflowRunInputs::
+   stream_sink_factory`** *(closed 2026-06-10)*. The runner composes
+   `FanoutSink([BufferSink, factory(session, branch)])` per
+   invocation — the buffer still feeds `events_emitted` accounting;
+   the factory-built sink (arcan serve wires
+   `ergon_life_sinks::LagoSink` over the same lago journal the
+   kernel's `EventStorePort` uses) makes workflow stream events
+   visible to `lago replay`. Direct `EventStorePort::append` from
+   the dispatcher is deliberately NOT used: the kernel owns a
+   per-branch sequence counter and the store enforces strict
+   sequence continuity — dispatcher-side appends would desync it.
+   lago assigns its own sequences, so the `lago_core::Journal` path
+   is collision-free.
 
 ## Useful commands
 

--- a/crates/arcan/arcan-ergon/src/runner.rs
+++ b/crates/arcan/arcan-ergon/src/runner.rs
@@ -8,11 +8,14 @@
 //! 2. Construct port-backed [`crate::ModelProviderAdapter`] +
 //!    [`crate::ToolHarnessAdapter`] for this tick.
 //! 3. Build a [`ergon::HookRegistry`] holding the four
-//!    `ergon-life-hooks` auto-hooks (each wrapped over the BRO-1001
-//!    minimum-viable adapter from [`crate::hooks`]).
-//! 4. Create a [`ergon::StepCtx`] with a [`ergon::BufferSink`] (the
-//!    tick's stream events accumulate there; the kernel surfaces them
-//!    afterwards via the standard journal mechanisms).
+//!    `ergon-life-hooks` auto-hooks — capability gating always real
+//!    ([`KernelCapabilityResolver`]); budget / scorer / attester use
+//!    the host-wired adapters from [`WorkflowRunInputs`] when present
+//!    and permissive noops otherwise.
+//! 4. Create a [`ergon::StepCtx`] whose sink is a [`ergon::BufferSink`]
+//!    (feeds `events_emitted` accounting) fanned out with the host's
+//!    durable per-session sink (e.g. `ergon_life_sinks::LagoSink`)
+//!    when a [`StreamSinkFactory`] is wired.
 //! 5. Drive the workflow through [`ergon::WorkflowExecutor::run`] via
 //!    the type-erased registry entry's `run_json`.
 //! 6. Return a [`aios_runtime::WorkflowTickOutcome`] with the JSON
@@ -28,10 +31,27 @@ use crate::provider::ModelProviderAdapter;
 use crate::registry::{BoxedWorkflowExecutor, WorkflowRegistry};
 use crate::runtime_handle::ModeRuntimeHandle;
 use crate::tools::ToolHarnessAdapter;
+use aios_protocol::{BranchId, SessionId};
 use aios_runtime::{WorkflowTickInvocation, WorkflowTickOutcome};
-use ergon::{AgentRegistry, BufferSink, HookRegistry, RecursionContext, StepCtx, ToolDefinition};
-use ergon_life_hooks::{AnimaAttestHook, AutonomicBudgetHook, NousScoreHook, PraxisCapabilityHook};
+use ergon::{
+    AgentRegistry, BufferSink, FanoutSink, HookRegistry, RecursionContext, StepCtx, StreamSink,
+    ToolDefinition,
+};
+use ergon_life_hooks::{
+    AnimaAttestHook, AutonomicBudgetHook, BudgetGate, NousScoreHook, PraxisCapabilityHook,
+    ResponseScorer, SoulAttester,
+};
 use std::sync::Arc;
+
+/// Per-invocation stream-sink constructor. arcand wires this at boot
+/// with a closure that builds a substrate-coupled sink (e.g.
+/// `ergon_life_sinks::LagoSink`) for the tick's session + branch —
+/// this is how workflow stream events reach the durable lago journal
+/// without `arcan-ergon` taking a `lago-*` dependency (see the crate
+/// CLAUDE.md "Don't" list: substrate sinks plumb in via
+/// [`WorkflowRunInputs`], not direct deps).
+pub type StreamSinkFactory =
+    Arc<dyn Fn(&SessionId, &BranchId) -> Arc<dyn StreamSink> + Send + Sync>;
 
 /// Optional construction inputs for [`run_workflow_as_tick`] that
 /// arcand wires per-deployment.
@@ -59,6 +79,23 @@ pub struct WorkflowRunInputs {
     /// (top-level + descendants). Default
     /// [`ergon::DEFAULT_MAX_INVOCATIONS`].
     pub max_invocations: u32,
+    /// Optional per-invocation durable stream sink constructor. When
+    /// set, the tick's stream events fan out to the constructed sink
+    /// in addition to the in-memory buffer (closing the audited
+    /// "workflow stream events never reach lago" gap). When `None`
+    /// (tests, minimal embedders), events stay buffer-only.
+    pub stream_sink_factory: Option<StreamSinkFactory>,
+    /// Optional real budget gate consulted `on_pre_inference`. When
+    /// `None`, the permissive [`NoopBudgetGate`] stands in.
+    pub budget_gate: Option<Arc<dyn BudgetGate>>,
+    /// Optional real response scorer fired `on_post_inference` (e.g.
+    /// `ergon_nous_adapter::NousAdapter`). When `None`, the
+    /// [`NoopResponseScorer`] stands in.
+    pub response_scorer: Option<Arc<dyn ResponseScorer>>,
+    /// Optional real soul attester fired at workflow start/end (e.g.
+    /// `ergon_anima_adapter::AgentAttestationAdapter`). When `None`,
+    /// the [`NoopSoulAttester`] stands in.
+    pub soul_attester: Option<Arc<dyn SoulAttester>>,
 }
 
 impl WorkflowRunInputs {
@@ -72,6 +109,10 @@ impl WorkflowRunInputs {
             agent_registry: None,
             max_recursion_depth: ergon::DEFAULT_MAX_RECURSION_DEPTH,
             max_invocations: ergon::DEFAULT_MAX_INVOCATIONS,
+            stream_sink_factory: None,
+            budget_gate: None,
+            response_scorer: None,
+            soul_attester: None,
         }
     }
 
@@ -80,6 +121,38 @@ impl WorkflowRunInputs {
     #[must_use]
     pub fn with_agent_registry(mut self, registry: Arc<dyn AgentRegistry>) -> Self {
         self.agent_registry = Some(registry);
+        self
+    }
+
+    /// Builder: attach a per-invocation durable stream-sink factory
+    /// (e.g. one constructing `ergon_life_sinks::LagoSink` over the
+    /// host's lago journal).
+    #[must_use]
+    pub fn with_stream_sink_factory(mut self, factory: StreamSinkFactory) -> Self {
+        self.stream_sink_factory = Some(factory);
+        self
+    }
+
+    /// Builder: attach a real budget gate (replaces [`NoopBudgetGate`]).
+    #[must_use]
+    pub fn with_budget_gate(mut self, gate: Arc<dyn BudgetGate>) -> Self {
+        self.budget_gate = Some(gate);
+        self
+    }
+
+    /// Builder: attach a real response scorer (replaces
+    /// [`NoopResponseScorer`]).
+    #[must_use]
+    pub fn with_response_scorer(mut self, scorer: Arc<dyn ResponseScorer>) -> Self {
+        self.response_scorer = Some(scorer);
+        self
+    }
+
+    /// Builder: attach a real soul attester (replaces
+    /// [`NoopSoulAttester`]).
+    #[must_use]
+    pub fn with_soul_attester(mut self, attester: Arc<dyn SoulAttester>) -> Self {
+        self.soul_attester = Some(attester);
         self
     }
 
@@ -137,24 +210,49 @@ pub async fn run_workflow_as_tick(
     // 3. Assemble the auto-hook registry. Order is significant: the
     //    spec mandates auto-hooks fire BEFORE user hooks. User-supplied
     //    hooks aren't in scope for BRO-1001; once they are, append
-    //    them here after the four auto-hooks.
+    //    them here after the four auto-hooks. The budget / scorer /
+    //    attester slots use the host-wired real adapters when present
+    //    (see [`WorkflowRunInputs`]) and fall back to the permissive
+    //    noops otherwise (tests, minimal embedders).
     let cap_resolver = Arc::new(KernelCapabilityResolver::new(
         invocation.policy_gate.clone(),
         invocation.session_id.clone(),
         inputs.tool_capabilities.clone(),
     ));
+    let budget_gate: Arc<dyn BudgetGate> = inputs
+        .budget_gate
+        .clone()
+        .unwrap_or_else(|| Arc::new(NoopBudgetGate));
+    let response_scorer: Arc<dyn ResponseScorer> = inputs
+        .response_scorer
+        .clone()
+        .unwrap_or_else(|| Arc::new(NoopResponseScorer));
+    let soul_attester: Arc<dyn SoulAttester> = inputs
+        .soul_attester
+        .clone()
+        .unwrap_or_else(|| Arc::new(NoopSoulAttester));
     let hook_registry = HookRegistry::default()
         .with(PraxisCapabilityHook::new(cap_resolver))
-        .with(AutonomicBudgetHook::new(Arc::new(NoopBudgetGate)))
-        .with(NousScoreHook::new(Arc::new(NoopResponseScorer)))
-        .with(AnimaAttestHook::new(Arc::new(NoopSoulAttester)));
+        .with(AutonomicBudgetHook::new(budget_gate))
+        .with(NousScoreHook::new(response_scorer))
+        .with(AnimaAttestHook::new(soul_attester));
 
-    // 4. Build the StepCtx. We use a BufferSink — durable / OTel /
-    //    upstream sinks (LagoSink, VigilSink, LifegwSink) will be
-    //    fanned in via a FanoutSink in the follow-up that lands those
-    //    impls (BRO-999b). For BRO-1001 we capture events in memory
-    //    and account their count in WorkflowTickOutcome.
-    let sink: Arc<BufferSink> = Arc::new(BufferSink::new());
+    // 4. Build the StepCtx sink. The in-memory buffer always runs (it
+    //    feeds `WorkflowTickOutcome.events_emitted`); when the host
+    //    wired a durable sink factory, fan events out to the
+    //    constructed per-session sink as well — this is how workflow
+    //    stream events reach the lago journal (`lago replay --tree`
+    //    visibility). Durable-sink failures short-circuit the fanout
+    //    by design (backpressure + durability-first, see
+    //    `ergon::FanoutSink`).
+    let buffer: Arc<BufferSink> = Arc::new(BufferSink::new());
+    let sink: Arc<dyn StreamSink> = match inputs.stream_sink_factory.as_ref() {
+        Some(factory) => Arc::new(FanoutSink::new(vec![
+            buffer.clone() as Arc<dyn StreamSink>,
+            factory(invocation.session_id, invocation.branch_id),
+        ])),
+        None => buffer.clone() as Arc<dyn StreamSink>,
+    };
     let trace = tracing::Span::current();
     let mut ctx = StepCtx::new(
         invocation.session_id.clone(),
@@ -162,7 +260,7 @@ pub async fn run_workflow_as_tick(
         provider,
         tools,
         Arc::new(hook_registry),
-        sink.clone() as Arc<dyn ergon::StreamSink>,
+        sink,
         runtime,
         trace,
     );
@@ -192,7 +290,7 @@ pub async fn run_workflow_as_tick(
         .await?;
 
     // 6. Tally stream events for the kernel's accounting.
-    let events_emitted = sink.len().await as u64;
+    let events_emitted = buffer.len().await as u64;
 
     Ok(WorkflowTickOutcome {
         events_emitted,

--- a/crates/arcan/arcan-ergon/tests/workflow_tick_e2e.rs
+++ b/crates/arcan/arcan-ergon/tests/workflow_tick_e2e.rs
@@ -356,3 +356,226 @@ fn event_kind_name(kind: &aios_protocol::EventKind) -> String {
         other => format!("{other:?}").chars().take(40).collect(),
     }
 }
+
+/// Harness Phase-2 gap closure: a fully-wired `WorkflowRunInputs`
+/// (stream-sink factory + real budget gate / scorer / attester) drives
+/// every adapter during a workflow tick that runs one inference turn.
+mod fully_wired {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use ergon::{InferenceRequest, Message, ModelRequest, ModelResponse, StreamEvent, StreamSink};
+    use ergon_life_hooks::{BudgetGate, ResponseScorer, SoulAttester};
+    use tokio::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Mutex<Vec<StreamEvent>>,
+    }
+
+    #[async_trait]
+    impl StreamSink for RecordingSink {
+        async fn emit(&self, event: StreamEvent) -> std::result::Result<(), ErgonError> {
+            self.events.lock().await.push(event);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingGate {
+        calls: AtomicU32,
+    }
+
+    #[async_trait]
+    impl BudgetGate for RecordingGate {
+        async fn allow_inference(
+            &self,
+            _req: &mut ModelRequest,
+        ) -> std::result::Result<(), String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingScorer {
+        calls: AtomicU32,
+    }
+
+    #[async_trait]
+    impl ResponseScorer for RecordingScorer {
+        async fn score(
+            &self,
+            _response: &ModelResponse,
+        ) -> std::result::Result<serde_json::Value, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(serde_json::json!({"recorded": true}))
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingAttester {
+        starts: AtomicU32,
+        ends: AtomicU32,
+    }
+
+    #[async_trait]
+    impl SoulAttester for RecordingAttester {
+        async fn sign_session_start(
+            &self,
+            _session_id: &ergon::SessionId,
+            _workflow_name: &str,
+        ) -> std::result::Result<(), String> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn sign_session_end(
+            &self,
+            _session_id: &ergon::SessionId,
+            _workflow_name: &str,
+            _ok: bool,
+        ) -> std::result::Result<(), String> {
+            self.ends.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Workflow that runs exactly one inference turn so the
+    /// pre/post-inference hooks (budget gate + scorer) fire.
+    struct InferringWorkflow;
+
+    #[async_trait]
+    impl Workflow for InferringWorkflow {
+        type Input = Greeting;
+        type Output = Reply;
+
+        fn name(&self) -> &str {
+            "test.inferring"
+        }
+
+        fn role(&self) -> Role {
+            Role::default()
+        }
+
+        async fn execute(
+            &self,
+            ctx: &mut StepCtx<'_>,
+            input: Greeting,
+        ) -> std::result::Result<Reply, ErgonError> {
+            ctx.push_message(Message::user_text(format!("greet {}", input.name)));
+            let request = InferenceRequest::new("echo-1".to_owned()).with_max_turns(1);
+            let response = ctx.run_inference_streaming(&request).await?;
+            Ok(Reply {
+                message: format!("{} blocks", response.content.len()),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn fully_wired_inputs_drive_sink_and_real_hooks() {
+        let root = unique_root("fully-wired");
+        let event_store_backend = Arc::new(FileEventStore::new(root.join("kernel")));
+        let journal = Arc::new(EventJournal::new(
+            event_store_backend,
+            EventStreamHub::new(1024),
+        ));
+        let event_store: Arc<dyn EventStorePort> = journal;
+        let policy_engine = Arc::new(SessionPolicyEngine::new(PolicySet::default()));
+        let policy_gate: Arc<dyn PolicyGatePort> = policy_engine.clone();
+        let approvals: Arc<dyn ApprovalPort> = Arc::new(ApprovalQueue::default());
+        let tool_registry = Arc::new(ToolRegistry::with_core_tools());
+        let sandbox = Arc::new(LocalSandboxRunner::new(vec!["echo".to_owned()]));
+        let dispatcher = Arc::new(ToolDispatcher::new(tool_registry, policy_engine, sandbox));
+        let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
+        let kernel = KernelRuntime::new(
+            RuntimeConfig::new(root),
+            event_store,
+            Arc::new(EchoProvider),
+            tool_harness,
+            approvals,
+            policy_gate,
+        );
+
+        let sink = Arc::new(RecordingSink::default());
+        let factory_seen: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let gate = Arc::new(RecordingGate::default());
+        let scorer = Arc::new(RecordingScorer::default());
+        let attester = Arc::new(RecordingAttester::default());
+
+        let sink_for_factory = Arc::clone(&sink);
+        let seen_for_factory = Arc::clone(&factory_seen);
+        let inputs = WorkflowRunInputs::empty()
+            .with_stream_sink_factory(Arc::new(move |session_id, _branch_id| {
+                *seen_for_factory.lock().expect("factory lock") =
+                    Some(session_id.as_str().to_owned());
+                Arc::clone(&sink_for_factory) as Arc<dyn StreamSink>
+            }))
+            .with_budget_gate(gate.clone())
+            .with_response_scorer(scorer.clone())
+            .with_soul_attester(attester.clone());
+
+        let registry = Arc::new(WorkflowRegistry::new().register(Arc::new(InferringWorkflow)));
+        let workflow_dispatcher: Arc<dyn WorkflowTickDispatcher> =
+            Arc::new(ErgonWorkflowDispatcher::new(registry, Arc::new(inputs)));
+        let runtime = Arc::new(kernel.with_workflow_dispatcher(workflow_dispatcher));
+
+        let session_id = SessionId::from_string("fully-wired".to_owned());
+        runtime
+            .create_session_with_id(
+                session_id.clone(),
+                "tester",
+                PolicySet::default(),
+                ModelRouting::default(),
+            )
+            .await
+            .expect("create session");
+
+        runtime
+            .tick_on_branch(
+                &session_id,
+                &BranchId::main(),
+                TickInput {
+                    objective: "greet".to_owned(),
+                    proposed_tool: None,
+                    system_prompt: None,
+                    allowed_tools: None,
+                    kind: TickKind::Workflow {
+                        name: "test.inferring".to_owned(),
+                        input: serde_json::json!({"name": "wired"}),
+                    },
+                },
+            )
+            .await
+            .expect("workflow tick succeeds");
+
+        assert_eq!(
+            factory_seen.lock().expect("factory lock").as_deref(),
+            Some("fully-wired"),
+            "sink factory receives the invocation's session id"
+        );
+        assert!(
+            !sink.events.lock().await.is_empty(),
+            "stream events reach the host-wired durable sink"
+        );
+        assert!(
+            gate.calls.load(Ordering::SeqCst) >= 1,
+            "budget gate consulted on_pre_inference"
+        );
+        assert!(
+            scorer.calls.load(Ordering::SeqCst) >= 1,
+            "scorer fired on_post_inference"
+        );
+        assert_eq!(
+            attester.starts.load(Ordering::SeqCst),
+            1,
+            "session start attested"
+        );
+        assert_eq!(
+            attester.ends.load(Ordering::SeqCst),
+            1,
+            "session end attested"
+        );
+    }
+}

--- a/crates/arcan/arcan/Cargo.toml
+++ b/crates/arcan/arcan/Cargo.toml
@@ -49,6 +49,9 @@ autonomic-controller.workspace = true
 arcan-aios-adapters = { path = "../arcan-aios-adapters", version = "0.3.0" }
 arcan-ergon = { path = "../arcan-ergon", version = "0.3.0" }
 ergon.workspace = true
+ergon-life-hooks.workspace = true
+ergon-life-sinks.workspace = true
+ergon-nous-adapter.workspace = true
 arcan-harness = { path = "../arcan-harness", version = "0.3.0" }
 praxis-core.workspace = true
 praxis-tools.workspace = true

--- a/crates/arcan/arcan/src/ergon_wiring.rs
+++ b/crates/arcan/arcan/src/ergon_wiring.rs
@@ -1,0 +1,160 @@
+//! Boot-time wiring of the real ergon auto-hook adapters + durable
+//! stream sink into [`arcan_ergon::runner::WorkflowRunInputs`].
+//!
+//! This module is the host side of the arcan-ergon contract: the
+//! library crate stays substrate-free (aios-protocol ports + ergon
+//! traits only — see its CLAUDE.md "Don't" list), and the binary —
+//! which already holds the lago journal, the Autonomic economic
+//! handle, and the Nous registry — constructs the concrete adapters
+//! and passes them in via `WorkflowRunInputs` builders. Closes the
+//! 2026-05-11 architecture-audit gaps "ergon-life-sinks has zero
+//! consumers" and "3 of 4 ergon auto-hook adapters are Noop".
+
+use std::sync::Arc;
+
+use arcan_aios_adapters::EconomicGateHandle;
+use arcan_ergon::runner::StreamSinkFactory;
+use async_trait::async_trait;
+use ergon_life_hooks::BudgetGate;
+
+/// Per-session durable sink factory over the host's lago journal —
+/// the same journal the kernel's `EventStorePort`
+/// (`LagoAiosEventStoreAdapter`) writes to, so workflow stream events
+/// land beside the tick events and are visible to `lago replay`.
+/// lago assigns its own sequence numbers on append, so dispatcher-side
+/// writes cannot collide with the kernel's per-branch sequence counter
+/// (which is why the sink goes through `lago_core::Journal` and NOT
+/// through `EventStorePort::append`).
+pub fn lago_stream_sink_factory(journal: Arc<dyn lago_core::Journal>) -> StreamSinkFactory {
+    Arc::new(move |session_id, branch_id| {
+        Arc::new(
+            ergon_life_sinks::LagoSink::new(journal.clone(), session_id.clone())
+                .with_branch(branch_id.clone()),
+        )
+    })
+}
+
+/// Real [`BudgetGate`] over the Autonomic economic advisory.
+///
+/// Mirrors the gating semantics the Direct path applies inside
+/// `ArcanProviderAdapter` (provider.rs): **Hibernate** denies the
+/// inference outright; **Hustle** clamps `max_tokens` to the advisory
+/// cap; Sovereign/Conserving (and an absent/unfilled handle) pass
+/// through.
+///
+/// Honest scope (P20 review finding): in arcan serve the
+/// `invocation.provider` IS the economically-gated
+/// `ArcanProviderAdapter`, which independently re-applies the
+/// Hibernate deny and Hustle cap at the port. What this hook adds is
+/// (a) the denial becoming hook-visible (`on_pre_inference` outcome +
+/// trace) instead of surfacing only as a provider error, and (b)
+/// enforcement for hosts whose providers are NOT economically gated.
+/// The `max_tokens` clamp mutates the ergon-level `ModelRequest`;
+/// today's `ModelProviderAdapter` → `ModelCompletionRequest` bridge
+/// does not carry a max-tokens field, so the clamp is advisory at the
+/// ergon layer until the port grows one (the port-level cap is what
+/// bites in production).
+pub struct EconomicBudgetGate {
+    handle: EconomicGateHandle,
+}
+
+impl EconomicBudgetGate {
+    pub fn new(handle: EconomicGateHandle) -> Self {
+        Self { handle }
+    }
+}
+
+#[async_trait]
+impl BudgetGate for EconomicBudgetGate {
+    async fn allow_inference(
+        &self,
+        req: &mut ergon::ModelRequest,
+    ) -> std::result::Result<(), String> {
+        let gates = self.handle.read().await;
+        let Some(gates) = gates.as_ref() else {
+            // Advisory not yet published — autonomic is advisory by
+            // design; absence is never fatal.
+            return Ok(());
+        };
+        use arcan_aios_adapters::autonomic::EconomicMode;
+        match gates.economic_mode {
+            EconomicMode::Hibernate => {
+                tracing::warn!("ergon budget gate: Hibernate mode — denying inference");
+                Err("inference blocked: Autonomic Hibernate mode active".to_owned())
+            }
+            EconomicMode::Hustle => {
+                if let Some(cap) = gates.max_tokens_next_turn {
+                    let clamped = req.max_tokens.map_or(cap, |m| m.min(cap));
+                    tracing::info!(
+                        max_tokens = clamped,
+                        "ergon budget gate: Hustle mode — capping tokens"
+                    );
+                    req.max_tokens = Some(clamped);
+                }
+                Ok(())
+            }
+            EconomicMode::Sovereign | EconomicMode::Conserving => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arcan_aios_adapters::autonomic::{EconomicGates, EconomicMode};
+
+    use super::*;
+
+    fn request() -> ergon::ModelRequest {
+        let mut req = ergon::ModelRequest::new("test".to_owned(), Vec::new());
+        req.max_tokens = Some(4096);
+        req
+    }
+
+    fn gate_with(mode: EconomicMode, cap: Option<u32>) -> EconomicBudgetGate {
+        let handle: EconomicGateHandle = Arc::new(tokio::sync::RwLock::new(Some(EconomicGates {
+            economic_mode: mode,
+            max_tokens_next_turn: cap,
+            preferred_model: None,
+            allow_expensive_tools: true,
+            allow_replication: false,
+        })));
+        EconomicBudgetGate::new(handle)
+    }
+
+    #[tokio::test]
+    async fn empty_handle_allows() {
+        let gate = EconomicBudgetGate::new(Arc::new(tokio::sync::RwLock::new(None)));
+        let mut req = request();
+        assert!(gate.allow_inference(&mut req).await.is_ok());
+        assert_eq!(req.max_tokens, Some(4096), "request untouched");
+    }
+
+    #[tokio::test]
+    async fn hibernate_denies() {
+        let gate = gate_with(EconomicMode::Hibernate, None);
+        let mut req = request();
+        let err = gate.allow_inference(&mut req).await.expect_err("denied");
+        assert!(err.contains("Hibernate"));
+    }
+
+    #[tokio::test]
+    async fn hustle_clamps_max_tokens() {
+        let gate = gate_with(EconomicMode::Hustle, Some(512));
+        let mut req = request();
+        assert!(gate.allow_inference(&mut req).await.is_ok());
+        assert_eq!(req.max_tokens, Some(512));
+        // A request already below the cap stays put.
+        let mut small = request();
+        small.max_tokens = Some(128);
+        assert!(gate.allow_inference(&mut small).await.is_ok());
+        assert_eq!(small.max_tokens, Some(128));
+    }
+
+    #[tokio::test]
+    async fn sovereign_passes_through() {
+        let gate = gate_with(EconomicMode::Sovereign, Some(512));
+        let mut req = request();
+        assert!(gate.allow_inference(&mut req).await.is_ok());
+        assert_eq!(req.max_tokens, Some(4096));
+    }
+}

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -9,6 +9,7 @@ mod consolidator;
 mod daemon;
 mod embedding;
 mod ephemeral_journal;
+mod ergon_wiring;
 mod factory;
 mod markdown;
 mod memory_observer;
@@ -861,7 +862,7 @@ fn run_serve(
         tool_definitions,
         streaming_sender.clone(),
     )
-    .with_economic_handle(economic_handle);
+    .with_economic_handle(economic_handle.clone());
 
     // The skill catalog is now injected per-session in arcand/src/canonical.rs,
     // filtered by the session's tier policy (BRO-214).
@@ -983,9 +984,46 @@ fn run_serve(
         );
         Arc::new(ergon::InMemoryAgentRegistry::new())
     };
-    let workflow_inputs = Arc::new(
-        arcan_ergon::runner::WorkflowRunInputs::empty().with_agent_registry(agent_registry),
+    // Harness Phase-2 gap closure (2026-06-10): workflow ticks get the
+    // real substrate wiring instead of buffer-only sinks + noop hooks.
+    // - stream events fan out to a per-session LagoSink over the SAME
+    //   journal the kernel's EventStorePort writes to → `lago replay`
+    //   sees workflow ticks;
+    // - inference passes the Autonomic economic gate (Hibernate denies,
+    //   Hustle clamps max_tokens) — mirroring the Direct path;
+    // - responses are scored through the Nous evaluator registry when
+    //   it initialized.
+    // Anima soul attestation stays on the Noop fallback until arcan
+    // serve grows a custody identity config (the adapter itself is
+    // implemented + tested in `ergon-anima-adapter`; wiring requires
+    // a stable agent DID, which a boot-time `generate_dev()` key would
+    // not provide).
+    let mut workflow_inputs = arcan_ergon::runner::WorkflowRunInputs::empty()
+        .with_agent_registry(agent_registry)
+        .with_stream_sink_factory(ergon_wiring::lago_stream_sink_factory(journal.clone()))
+        .with_budget_gate(Arc::new(ergon_wiring::EconomicBudgetGate::new(
+            economic_handle,
+        )));
+    // The Direct-path observer owns its registry instance, so build a
+    // second one for the workflow scorer — the heuristic evaluators
+    // are stateless, two instances are equivalent.
+    match nous_heuristics::default_registry() {
+        Ok(registry) => {
+            workflow_inputs = workflow_inputs.with_response_scorer(Arc::new(
+                ergon_nous_adapter::NousAdapter::new(Arc::new(registry)),
+            ));
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "ergon workflow ticks: Nous registry unavailable — response scoring falls back to noop"
+            );
+        }
+    }
+    tracing::warn!(
+        "ergon workflow ticks: anima custody not configured — soul attestation falls back to noop"
     );
+    let workflow_inputs = Arc::new(workflow_inputs);
     let workflow_dispatcher: Arc<dyn aios_runtime::WorkflowTickDispatcher> = Arc::new(
         arcan_ergon::ErgonWorkflowDispatcher::new(workflow_registry, workflow_inputs),
     );

--- a/crates/ergon/ergon-anima-adapter/Cargo.toml
+++ b/crates/ergon/ergon-anima-adapter/Cargo.toml
@@ -21,3 +21,7 @@ anima-identity = { path = "../../anima/anima-identity", version = "0.3.0" }
 async-trait.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+base64.workspace = true

--- a/crates/ergon/ergon-anima-adapter/src/lib.rs
+++ b/crates/ergon/ergon-anima-adapter/src/lib.rs
@@ -1,15 +1,21 @@
 //! Anima-backed implementation of ergon attestation traits.
 //!
 //! See `docs/architecture/adr/2026-05-22-anima-signing-surface-for-ergon-attestation.md`
-//! (BRO-1226) for the design rationale + open questions.
+//! (BRO-1226) for the design rationale.
 //!
-//! This crate ships the **skeleton only** — both `sign_step_receipt`
-//! and the two `SoulAttester` methods are unimplemented and return
-//! `Err(...)` pointing back at the ADR. The implementation lands in a
-//! follow-up ticket once Open Questions §1-3 (HookCtx access, journal
-//! abstraction, canonical-JSON serializer) are resolved on review.
+//! Implemented 2026-06-10 (harness Phase-2 gap closure): both
+//! `sign_step_receipt` and the two `SoulAttester` boundaries produce
+//! real compact JWSs through the agent's [`AnimaCustody`] key. ADR
+//! resolutions: Open §2 (journal abstraction) — the adapter signs and
+//! emits the JWS on the trace span; durable journal emission stays at
+//! the hook/host layer, which owns journal handles. Open §3
+//! (canonical JSON) — receipt claims are built as `serde_json` maps
+//! (BTreeMap-backed → key-sorted serialization) with flat ASCII keys,
+//! which is canonical for this shape; full RFC 8785 lands if receipts
+//! ever grow nested/non-ASCII content.
 
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anima_identity::custody::AnimaCustody;
 use async_trait::async_trait;
@@ -55,25 +61,53 @@ impl AgentAttestationAdapter {
     pub fn agent_did(&self) -> &str {
         self.custody.user_did()
     }
+
+    /// Build + sign a session-boundary receipt. The claims map is
+    /// flat, ASCII-keyed and `serde_json`-map-backed (BTreeMap →
+    /// key-sorted serialization), which is canonical for this shape
+    /// (ADR Open §3).
+    fn sign_session_boundary(
+        &self,
+        kind: &str,
+        session_id: &SessionId,
+        workflow_name: &str,
+        ok: Option<bool>,
+    ) -> std::result::Result<String, String> {
+        let mut claims = serde_json::json!({
+            "kind": kind,
+            "session_id": session_id.as_str(),
+            "workflow": workflow_name,
+            "agent_did": self.custody.user_did(),
+            "iat": unix_now_secs(),
+        });
+        if let Some(ok) = ok {
+            claims["ok"] = Value::Bool(ok);
+        }
+        self.custody
+            .sign_jws(&claims)
+            .map_err(|e| format!("anima sign_jws failed for {kind}: {e}"))
+    }
+}
+
+/// Seconds since the Unix epoch — the `iat` claim on every receipt.
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
 }
 
 #[async_trait]
 impl AgentAttestationSigner for AgentAttestationAdapter {
-    async fn sign_step_receipt(&self, _receipt: &Value) -> std::result::Result<String, String> {
-        // Implementation follow-up tracked in BRO-1226 implementation
-        // ticket (filed after the ADR review pass).
-        //
-        // The implementation will:
-        //   1. Serialize the receipt with canonical JSON (RFC 8785 — see
-        //      ADR Open §3).
-        //   2. Call self.custody.sign_jws(canonical_json) → compact JWS.
-        //   3. Return the JWS string.
-        //   4. On AnimaCustody::sign_jws error: log + return Err(msg).
-        Err(format!(
-            "AgentAttestationAdapter::sign_step_receipt not yet implemented \
-             (did={}); see ADR §3-§4",
-            self.custody.user_did()
-        ))
+    async fn sign_step_receipt(&self, receipt: &Value) -> std::result::Result<String, String> {
+        self.custody.sign_jws(receipt).map_err(|e| {
+            tracing::warn!(
+                did = self.custody.user_did(),
+                error = %e,
+                "anima step-receipt signing failed"
+            );
+            format!("anima sign_jws failed for step receipt: {e}")
+        })
     }
 }
 
@@ -81,39 +115,52 @@ impl AgentAttestationSigner for AgentAttestationAdapter {
 impl SoulAttester for AgentAttestationAdapter {
     async fn sign_session_start(
         &self,
-        _session_id: &SessionId,
-        _workflow_name: &str,
+        session_id: &SessionId,
+        workflow_name: &str,
     ) -> std::result::Result<(), String> {
-        // Implementation follow-up. Will build a session-boundary
-        // receipt {kind: "session_start", session, workflow, iat,
-        // agent_did} and call self.custody.sign_jws + emit on journal.
-        Err("SoulAttester::sign_session_start not yet implemented; see ADR §4".into())
+        let jws =
+            self.sign_session_boundary("ergon.session_start", session_id, workflow_name, None)?;
+        tracing::info!(
+            session = %session_id.as_str(),
+            workflow = workflow_name,
+            did = self.custody.user_did(),
+            jws = %jws,
+            "session start attested"
+        );
+        Ok(())
     }
 
     async fn sign_session_end(
         &self,
-        _session_id: &SessionId,
-        _workflow_name: &str,
-        _ok: bool,
+        session_id: &SessionId,
+        workflow_name: &str,
+        ok: bool,
     ) -> std::result::Result<(), String> {
-        // Implementation follow-up. Symmetric with sign_session_start;
-        // adds {kind: "session_end", ok} to the receipt body.
-        Err("SoulAttester::sign_session_end not yet implemented; see ADR §4".into())
+        let jws =
+            self.sign_session_boundary("ergon.session_end", session_id, workflow_name, Some(ok))?;
+        tracing::info!(
+            session = %session_id.as_str(),
+            workflow = workflow_name,
+            did = self.custody.user_did(),
+            ok,
+            jws = %jws,
+            "session end attested"
+        );
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // Adapter unit tests deferred to the implementation ticket — until
-    // the methods do real work, there's no useful behavior to assert.
-    // The skeleton compiles and exposes the public surface; that is
-    // what acceptance §3 of the ADR requires.
+    use anima_identity::InProcessAnima;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
     use super::*;
 
     /// Compile-only sanity: the trait surface is shaped the way the ADR
-    /// promises. If this stops compiling, the public API of the
-    /// skeleton has drifted from the ADR.
+    /// promises. If this stops compiling, the public API has drifted
+    /// from the ADR.
     fn _api_shape_check(
         adapter: AgentAttestationAdapter,
     ) -> (Arc<dyn AgentAttestationSigner>, Arc<dyn SoulAttester>) {
@@ -124,5 +171,79 @@ mod tests {
             custody: adapter.custody,
         });
         (a, b)
+    }
+
+    fn adapter() -> AgentAttestationAdapter {
+        AgentAttestationAdapter::new(InProcessAnima::generate_dev().expect("dev custody"))
+    }
+
+    fn decode_claims(jws: &str) -> Value {
+        let parts: Vec<&str> = jws.split('.').collect();
+        assert_eq!(parts.len(), 3, "compact JWS has three segments");
+        let body = URL_SAFE_NO_PAD.decode(parts[1]).expect("base64url body");
+        serde_json::from_slice(&body).expect("claims JSON")
+    }
+
+    #[tokio::test]
+    async fn session_start_signs_real_jws_with_expected_claims() {
+        let adapter = adapter();
+        let did = adapter.agent_did().to_owned();
+        let sid = SessionId::from_string("sid-attest");
+        adapter
+            .sign_session_start(&sid, "greeter")
+            .await
+            .expect("attest ok");
+        // Sign again via the internal helper to inspect the claims the
+        // boundary produces (the trait surface logs the JWS).
+        let jws = adapter
+            .sign_session_boundary("ergon.session_start", &sid, "greeter", None)
+            .expect("sign");
+        let claims = decode_claims(&jws);
+        assert_eq!(claims["kind"], "ergon.session_start");
+        assert_eq!(claims["session_id"], "sid-attest");
+        assert_eq!(claims["workflow"], "greeter");
+        assert_eq!(claims["agent_did"], did);
+        assert!(claims["iat"].as_u64().unwrap_or(0) > 1_700_000_000);
+    }
+
+    #[tokio::test]
+    async fn session_end_carries_ok_flag() {
+        let adapter = adapter();
+        let sid = SessionId::from_string("sid-attest-end");
+        adapter
+            .sign_session_end(&sid, "greeter", false)
+            .await
+            .expect("attest ok");
+        let jws = adapter
+            .sign_session_boundary("ergon.session_end", &sid, "greeter", Some(false))
+            .expect("sign");
+        let claims = decode_claims(&jws);
+        assert_eq!(claims["kind"], "ergon.session_end");
+        assert_eq!(claims["ok"], false);
+    }
+
+    /// Guard for the module-doc canonicalization claim: the receipt
+    /// claims serialize key-sorted, which holds only while the
+    /// workspace builds `serde_json` WITHOUT `preserve_order`. If a
+    /// future dependency unifies that feature on, this fails loudly
+    /// and the adapter needs a real canonical-JSON serializer
+    /// (RFC 8785).
+    #[test]
+    fn serde_json_maps_serialize_key_sorted() {
+        let v = serde_json::json!({"zeta": 1, "alpha": 2, "mid": 3});
+        assert_eq!(v.to_string(), r#"{"alpha":2,"mid":3,"zeta":1}"#);
+    }
+
+    #[tokio::test]
+    async fn step_receipt_signs_arbitrary_claims() {
+        let adapter = adapter();
+        let receipt = serde_json::json!({"step": 3, "tool": "fs.read"});
+        let jws = adapter
+            .sign_step_receipt(&receipt)
+            .await
+            .expect("receipt signed");
+        let claims = decode_claims(&jws);
+        assert_eq!(claims["step"], 3);
+        assert_eq!(claims["tool"], "fs.read");
     }
 }

--- a/crates/ergon/ergon-nous-adapter/Cargo.toml
+++ b/crates/ergon/ergon-nous-adapter/Cargo.toml
@@ -21,3 +21,6 @@ nous-core.workspace = true
 async-trait.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/ergon/ergon-nous-adapter/src/lib.rs
+++ b/crates/ergon/ergon-nous-adapter/src/lib.rs
@@ -1,20 +1,22 @@
-//! Nous-backed implementation of [`ergon::ResponseScorer`].
+//! Nous-backed implementation of [`ergon_life_hooks::ResponseScorer`].
 //!
 //! See `docs/architecture/adr/2026-05-22-nous-adapter-for-ergon-scoring.md` (BRO-1225)
-//! for the design rationale + open questions.
+//! for the design rationale.
 //!
-//! This crate ships the **skeleton only** — the `score` method body is
-//! deliberately unimplemented and returns an `Err(...)` pointing back at
-//! the ADR. The implementation lands in a follow-up ticket once the open
-//! questions §1-3 (HookCtx access, async/sync boundary, metadata keys)
-//! are resolved on review.
+//! Implemented 2026-06-10 (harness Phase-2 gap closure): `score` fans
+//! the response out over the evaluators registered for the adapter's
+//! hook, fail-open per evaluator (ADR §4 — a broken evaluator is
+//! recorded in the score object's `failures` array, never aborts the
+//! workflow). The ADR's Open §1 (HookCtx/session access) resolved as:
+//! the ergon `ResponseScorer` boundary stays narrow; session-series
+//! evaluators run via `NousToolObserver` on the Direct path instead.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ergon::ModelResponse;
 use ergon_life_hooks::ResponseScorer;
-use nous_core::{EvalHook, EvaluatorRegistry};
+use nous_core::{EvalContext, EvalHook, EvaluatorRegistry};
 use serde_json::Value;
 
 /// Nous-backed `ResponseScorer` — translates per-call ergon hook events
@@ -57,29 +59,116 @@ impl NousAdapter {
 
 #[async_trait]
 impl ResponseScorer for NousAdapter {
-    async fn score(&self, _response: &ModelResponse) -> Result<Value, String> {
-        // Implementation follow-up tracked in BRO-1225 implementation
-        // ticket (filed after the ADR review pass).
-        //
-        // The implementation will:
-        //   1. Build an EvalContext from (&HookCtx, &ModelResponse) — see
-        //      ADR §2 + Open Question §1 on HookCtx access.
-        //   2. Iterate self.registry.evaluators_for(self.hook), calling
-        //      evaluator.evaluate(&ctx) on each.
-        //   3. Flatten Vec<Vec<EvalScore>> → serde_json::Value array.
-        //   4. Handle the four failure-mode branches from ADR §4.
-        Err(format!(
-            "NousAdapter::score not yet implemented \
-             (hook={:?}, evaluators={}); see ADR §1",
-            self.hook,
-            self.evaluator_count()
-        ))
+    /// Fan the response out over the evaluators registered for
+    /// `self.hook` (ADR §2).
+    ///
+    /// The `EvalContext` is built from what the `ResponseScorer`
+    /// boundary actually exposes — the response's token accounting and
+    /// shape. Session identity is not available at this boundary (ADR
+    /// Open §1 resolved as: don't widen the ergon trait; evaluators
+    /// that need session-level series run via `NousToolObserver` on
+    /// the Direct path instead). Failure handling per ADR §4:
+    /// individual evaluator errors are collected and reported in the
+    /// score object (fail-open) — the call itself only errs on
+    /// serialization failure, and the hook layer treats even that as
+    /// non-fatal.
+    async fn score(&self, response: &ModelResponse) -> Result<Value, String> {
+        let evaluators = self.registry.evaluators_for(self.hook);
+        let mut ctx = EvalContext::new("ergon-workflow");
+        ctx.input_tokens = Some(u64::from(response.usage.input_tokens));
+        ctx.output_tokens = Some(u64::from(response.usage.output_tokens));
+        ctx.metadata.insert(
+            "stop_reason".to_owned(),
+            format!("{:?}", response.stop_reason),
+        );
+        ctx.metadata.insert(
+            "content_blocks".to_owned(),
+            response.content.len().to_string(),
+        );
+
+        let mut scores = Vec::new();
+        let mut failures = Vec::new();
+        for evaluator in evaluators {
+            match evaluator.evaluate(&ctx) {
+                Ok(mut produced) => scores.append(&mut produced),
+                Err(e) => {
+                    tracing::warn!(
+                        evaluator = evaluator.name(),
+                        error = %e,
+                        "nous evaluator failed (fail-open, recorded in score object)"
+                    );
+                    failures.push(serde_json::json!({
+                        "evaluator": evaluator.name(),
+                        "error": e.to_string(),
+                    }));
+                }
+            }
+        }
+
+        let scores =
+            serde_json::to_value(&scores).map_err(|e| format!("serialize EvalScores: {e}"))?;
+        Ok(serde_json::json!({
+            "hook": format!("{:?}", self.hook),
+            "scores": scores,
+            "failures": failures,
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use ergon::{ContentBlock, ModelResponse, StopReason, Usage};
+    use nous_core::{EvalLayer, EvalScore, EvalTiming, NousEvaluator, NousResult};
+
     use super::*;
+
+    struct FixedEvaluator;
+
+    impl NousEvaluator for FixedEvaluator {
+        fn name(&self) -> &str {
+            "fixed"
+        }
+        fn layer(&self) -> EvalLayer {
+            EvalLayer::Execution
+        }
+        fn timing(&self) -> EvalTiming {
+            EvalTiming::Inline
+        }
+        fn evaluate(&self, ctx: &EvalContext) -> NousResult<Vec<EvalScore>> {
+            assert_eq!(ctx.output_tokens, Some(7), "usage flows into the context");
+            Ok(vec![EvalScore::new(
+                "fixed",
+                0.9,
+                EvalLayer::Execution,
+                EvalTiming::Inline,
+                ctx.session_id.clone(),
+            )?])
+        }
+    }
+
+    struct BrokenEvaluator;
+
+    impl NousEvaluator for BrokenEvaluator {
+        fn name(&self) -> &str {
+            "broken"
+        }
+        fn layer(&self) -> EvalLayer {
+            EvalLayer::Execution
+        }
+        fn timing(&self) -> EvalTiming {
+            EvalTiming::Inline
+        }
+        fn evaluate(&self, _ctx: &EvalContext) -> NousResult<Vec<EvalScore>> {
+            Err(nous_core::NousError::Registry("boom".to_owned()))
+        }
+    }
+
+    fn response() -> ModelResponse {
+        let mut usage = Usage::default();
+        usage.input_tokens = 3;
+        usage.output_tokens = 7;
+        ModelResponse::new(vec![ContentBlock::text("hi")], StopReason::EndTurn).with_usage(usage)
+    }
 
     #[test]
     fn adapter_constructs_with_empty_registry() {
@@ -93,5 +182,47 @@ mod tests {
         let registry = Arc::new(EvaluatorRegistry::new());
         let adapter = NousAdapter::new(registry).with_hook(EvalHook::BeforeModelCall);
         assert_eq!(adapter.evaluator_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn score_fans_out_to_registered_evaluators() {
+        let mut registry = EvaluatorRegistry::new();
+        registry
+            .register(EvalHook::AfterModelCall, Arc::new(FixedEvaluator))
+            .expect("register");
+        let adapter = NousAdapter::new(Arc::new(registry));
+        let value = adapter.score(&response()).await.expect("score ok");
+        let scores = value["scores"].as_array().expect("scores array");
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0]["evaluator"], "fixed");
+        assert_eq!(scores[0]["value"], 0.9);
+        assert_eq!(value["failures"].as_array().map(Vec::len), Some(0));
+    }
+
+    #[tokio::test]
+    async fn broken_evaluator_fails_open() {
+        let mut registry = EvaluatorRegistry::new();
+        registry
+            .register(EvalHook::AfterModelCall, Arc::new(FixedEvaluator))
+            .expect("register fixed");
+        registry
+            .register(EvalHook::AfterModelCall, Arc::new(BrokenEvaluator))
+            .expect("register broken");
+        let adapter = NousAdapter::new(Arc::new(registry));
+        let value = adapter
+            .score(&response())
+            .await
+            .expect("fail-open: call still succeeds");
+        assert_eq!(value["scores"].as_array().map(Vec::len), Some(1));
+        let failures = value["failures"].as_array().expect("failures array");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0]["evaluator"], "broken");
+    }
+
+    #[tokio::test]
+    async fn empty_registry_scores_empty() {
+        let adapter = NousAdapter::new(Arc::new(EvaluatorRegistry::new()));
+        let value = adapter.score(&response()).await.expect("score ok");
+        assert_eq!(value["scores"].as_array().map(Vec::len), Some(0));
     }
 }


### PR DESCRIPTION
## Summary

Closes the two remaining Workflow-tick-path gaps from the 2026-05-11 architecture audit (root CLAUDE.md "Wired vs stubbed"), completing the gap-closure arc started in #1686.

## Gap 1 — workflow stream events never reached lago

`WorkflowRunInputs` gains a `stream_sink_factory` (per-invocation `Fn(&SessionId, &BranchId) -> Arc<dyn StreamSink>`); the runner composes `FanoutSink([BufferSink, factory(session, branch)])` — the buffer keeps feeding `events_emitted` accounting, the factory-built sink receives every stream event. `arcan serve` wires `ergon_life_sinks::LagoSink` (its **first consumer**) over the **same lago journal** the kernel's `EventStorePort` uses (`crates/arcan/arcan/src/ergon_wiring.rs`), so workflow ticks are now `lago replay`-visible.

**Why not `EventStorePort::append` from the dispatcher**: the kernel owns a per-branch sequence counter and the store enforces strict sequence continuity (`aios-events` bails on gaps) — dispatcher-side appends would desync it. lago assigns its own sequences, so the `lago_core::Journal` path is collision-free. This honors arcan-ergon's dep rule (sinks plumb via `WorkflowRunInputs`, no `lago-*` deps in the adapter crate).

## Gap 2 — 3 of 4 auto-hooks were permissive noops

`WorkflowRunInputs` gains `budget_gate` / `response_scorer` / `soul_attester` slots; the runner uses host-wired real adapters, noops remain only as explicit fallbacks for unwired hosts.

| Adapter | What shipped |
|---|---|
| `arcan::ergon_wiring::EconomicBudgetGate` (new) | Autonomic economic advisory over `EconomicGateHandle`: Hibernate denies, Hustle clamps `max_tokens`, Sovereign/Conserving pass. Honest scope per P20 review: in arcan serve the port-level `ArcanProviderAdapter` independently re-applies these — the hook adds hook-visible early denial + enforcement for ungated hosts; the ergon-level clamp is advisory until the port bridge carries max-tokens. +4 tests |
| `ergon-nous-adapter::NousAdapter::score` (implements BRO-1225 skeleton) | Fans the response over the registry's `AfterModelCall` evaluators, **fail-open per evaluator** (failures recorded in the score object, never abort the workflow). ADR Open §1 resolved: scorer boundary stays narrow. +3 tests (5 total) |
| `ergon-anima-adapter::AgentAttestationAdapter` (implements BRO-1226 skeleton) | Session start/end + step receipts signed as compact JWS via `AnimaCustody::sign_jws`, sorted-key claims `{kind, session_id, workflow, agent_did, iat, ok?}` + a canonicalization guard test. +4 tests vs `InProcessAnima`. arcan serve keeps the warned noop fallback until a custody identity config exists (a boot-time `generate_dev()` DID would be meaningless) |

`arcan serve` wires: LagoSink factory + EconomicBudgetGate (always), NousAdapter (when `nous_heuristics::default_registry()` initializes).

## Cross-review (P20, Strata B adversarial)

Verdict **APPROVE-WITH-NITS, anti-slop 8/10**. Findings addressed: inert Hustle clamp → documented honestly in rustdoc + this description; serde_json `preserve_order` fragility → guard test added; sink-order/durability semantics verified (lago outage folds into RunErrored+Recover exactly like kernel-side append failures — no new failure mode); main.rs journal-layer audit confirmed the sink and `LagoAiosEventStoreAdapter` share the same raw journal handle.

## Test plan

- [x] `cargo test` ergon family: 188 passing (ergon, ergon-life-sinks, ergon-life-hooks, ergon-nous-adapter 5, ergon-anima-adapter 4, arcan-ergon incl. new `fully_wired` e2e proving sink + all three hook slots fire during a real workflow tick)
- [x] `cargo test -p arcan ergon_wiring` (4)
- [x] `cargo clippy` on all 7 touched crates `--all-targets -- -D warnings`
- [x] `cargo check --workspace`
- [ ] CI: full workspace lanes

Docs: arcan-ergon/CLAUDE.md spec-deviations 2+3 marked closed; root CLAUDE.md gap list updated (only `arcan agent test --dry-run` remains). Linear: BRO-1225/BRO-1226 implementation follow-ups delivered (Linear MCP unauthenticated this session — link on re-auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)