### PR TITLE
fix(deploy): include apps/ + proto/ in substrate Dockerfile build contexts

### DIFF
--- a/docker/arcan.Dockerfile
+++ b/docker/arcan.Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for arcan agent runtime daemon
 # Build context: repository root (life/)
 
-FROM rust:latest AS builder
+FROM rust:1.93-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
@@ -10,8 +10,12 @@ WORKDIR /build
 # Copy workspace manifest and lockfile first (Docker layer caching)
 COPY Cargo.toml Cargo.lock ./
 
-# Copy all crate Cargo.toml files (for dependency resolution)
+# All workspace members (crates/ + apps/) must be present for cargo to
+# resolve the workspace manifest; proto/ is read by *-substrate-proto,
+# aios-proto, and life-*-proto build scripts relative to the repo root.
 COPY crates/ crates/
+COPY apps/ apps/
+COPY proto/ proto/
 
 # Build release binary
 RUN cargo build --release -p arcan

--- a/docker/autonomicd.Dockerfile
+++ b/docker/autonomicd.Dockerfile
@@ -1,14 +1,19 @@
 # Multi-stage build for autonomicd homeostasis controller
 # Build context: repository root (life/)
 
-FROM rust:1-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
 COPY Cargo.toml Cargo.lock ./
+# All workspace members (crates/ + apps/) must be present for cargo to
+# resolve the workspace manifest; proto/ is read by build scripts
+# relative to the repo root.
 COPY crates/ crates/
+COPY apps/ apps/
+COPY proto/ proto/
 
 RUN cargo build --release -p autonomicd
 

--- a/docker/haimad.Dockerfile
+++ b/docker/haimad.Dockerfile
@@ -1,14 +1,19 @@
 # Multi-stage build for haimad agentic finance engine
 # Build context: repository root (life/)
 
-FROM rust:1-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
 COPY Cargo.toml Cargo.lock ./
+# All workspace members (crates/ + apps/) must be present for cargo to
+# resolve the workspace manifest; proto/ is read by build scripts
+# relative to the repo root.
 COPY crates/ crates/
+COPY apps/ apps/
+COPY proto/ proto/
 
 RUN cargo build --release -p haimad
 

--- a/docker/lagod.Dockerfile
+++ b/docker/lagod.Dockerfile
@@ -1,14 +1,19 @@
 # Multi-stage build for lagod persistence daemon
 # Build context: repository root (life/)
 
-FROM rust:1-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
 COPY Cargo.toml Cargo.lock ./
+# All workspace members (crates/ + apps/) must be present for cargo to
+# resolve the workspace manifest; proto/ is read by build scripts
+# relative to the repo root.
 COPY crates/ crates/
+COPY apps/ apps/
+COPY proto/ proto/
 
 RUN cargo build --release -p lagod
 


### PR DESCRIPTION
## Summary

Railway deploys for **arcan, lagod, haimad, autonomicd** have been failing since 2026-05-20 — every deploy at `main` HEAD currently shows `FAILED`, with 6-week-old images still serving (prod arcand predates the #1686 substrate tool-lifecycle wire).

Root cause: #1415 (BRO-1003) added `apps/bookkeeping-judge` as a workspace member, but `docker/*.Dockerfile` only copies `Cargo.toml Cargo.lock` + `crates/` — cargo fails with:

```
error: failed to load manifest for workspace member `/build/apps/bookkeeping-judge`
```

(verbatim from the failed Railway build logs at `05216fda`).

## Changes

- `COPY apps/ apps/` — workspace members must all be present for manifest resolution
- `COPY proto/ proto/` — `*-substrate-proto`, `aios-proto`, `life-kernel-proto`, `life-runtime-proto` build scripts read repo-root `proto/` paths
- Pin builder to `rust:1.93-bookworm` (= workspace `rust-version`, matches lifegw-stack) replacing floating `rust:latest` / `rust:1-bookworm`

## Test plan

- ✅ Simulated the exact post-fix build context in a temp dir (`Cargo.toml`+`Cargo.lock`+`crates/`+`apps/`+`proto/`): `cargo metadata --no-deps` resolves
- ✅ Negative control: same context **without** `apps/` reproduces the exact Railway error
- ✅ Verified all 7 repo-root proto paths referenced by build scripts exist in context
- ✅ Adversarial cross-review (P20 Strata B): 9/10, no confirmed issues; checked workspace member coverage, compile-time `include_str!` closure, `.dockerignore` non-interference, runtime-stage COPYs, MSRV (1.93 == pin)
- 🔜 Post-merge e2e: Railway auto-rebuilds (watchPatterns include `docker/*.Dockerfile`) — will watch all four services go green and verify `/health`

## Follow-up (noted, not in this PR)

- Railway service watchPatterns don't include `apps/**` or `proto/**` (UI-managed config) — pure proto changes wouldn't auto-trigger rebuilds
- `deploy/railway/Dockerfile.{arcan,lagod,haimad,autonomicd}` are an unused duplicate set (only `Dockerfile.opsisd` is referenced by a service) — candidates for removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)