### PR TITLE
fix(deploy): ship blessed authored agents in the arcan image

### DIFF
--- a/docker/arcan.Dockerfile
+++ b/docker/arcan.Dockerfile
@@ -31,6 +31,10 @@ RUN useradd --create-home --shell /bin/bash arcan
 
 COPY --from=builder /build/target/release/arcan /usr/local/bin/arcan
 
+# Blessed authored agents (agents/*.md) — FsAgentRegistry loads ./agents
+# relative to the workdir; without them spawn_agent returns unknown_agent.
+COPY --chown=arcan:arcan agents/ /home/arcan/agents/
+
 USER arcan
 WORKDIR /home/arcan
 


### PR DESCRIPTION
## Summary

Prod arcan (Railway, just restored by #1691) boots with:

```
WARN no agents directory at `agents`; spawn_agent calls will return unknown_agent. Pass --agents-dir or place authored agents in ./agents/.
```

The runtime image never ships `agents/*.md`, so the 9 blessed authored agents (BRO-1006 arc) are absent in prod and `spawn_agent` dispatch is dead there. Adds `COPY --chown=arcan:arcan agents/ /home/arcan/agents/` to the runtime stage — `WORKDIR /home/arcan` means FsAgentRegistry's `./agents` discovery finds it.

## Test plan

- ✅ `agents/` not excluded by `.dockerignore`
- ✅ Path matches the boot warning's expectation (`./agents` relative to `/home/arcan`)
- 🔜 Post-merge: Railway rebuild (watchPatterns include the Dockerfile) → boot log should show the FsAgentRegistry load instead of the warning

Found while dogfooding the restored prod deploys (boot-log tracing). Sibling ops fix applied directly: stale `LAGO_URL` env on the arcan service pointed at lagod `:3001`; lagod binds `:8080` — updated + redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)