### PR TITLE
fix(chronos): widen heartbeat-test scheduling window (macOS CI flake)

### DIFF
--- a/crates/chronos/chronosd/src/lib.rs
+++ b/crates/chronos/chronosd/src/lib.rs
@@ -226,7 +226,7 @@ mod tests {
     async fn daemon_starts_writes_a_heartbeat_and_shuts_down_on_signal() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = DaemonConfig {
-            heartbeat_interval: Duration::from_millis(40),
+            heartbeat_interval: Duration::from_millis(20),
             data_dir: tmp.path().to_path_buf(),
             journal_filename: "journal.redb".into(),
             router_buffer: 16,
@@ -237,8 +237,10 @@ mod tests {
         let cfg_for_task = cfg.clone();
         let daemon = tokio::spawn(async move { run(cfg_for_task, Some(rx)).await });
 
-        // Let the daemon emit a handful of heartbeats.
-        sleep(Duration::from_millis(200)).await;
+        // Let the daemon emit a handful of heartbeats. The window is 50x the
+        // interval: loaded CI runners (macOS especially) can stall the spawned
+        // task long enough that a tight window records zero beats.
+        sleep(Duration::from_millis(1000)).await;
         tx.send(()).expect("signal shutdown");
 
         let started_at = std::time::Instant::now();


### PR DESCRIPTION
## Summary

Main CI run 27313751767 (at `f7d18172`, a Dockerfile-only merge) failed in **Test (macOS)** on `chronosd::tests::daemon_starts_writes_a_heartbeat_and_shuts_down_on_signal` — "at least one heartbeat wake should be persisted". The test gave the spawned daemon a 200ms wall-clock window at a 40ms heartbeat interval; a stalled CI runner can miss it entirely. This lane is path-skipped on PRs, so the flake only surfaces on pushes to main.

Interval 40→20ms, window 200ms→1s (50× headroom), comment documents the constraint.

## Test plan

- ✅ `cargo test -p chronosd --lib daemon_starts` ×3 locally, stable (~1.15s each)
- Failed job rerun requested on main to confirm flake independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test reliability by adjusting timing parameters to reduce flakiness on CI runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->