### PR TITLE
feat(arcan): wire AgentAttestationAdapter at serve boot from life-init identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ version = "0.3.0"
 dependencies = [
  "aios-protocol",
  "aios-runtime",
+ "anima-identity",
  "anyhow",
  "arcan-aios-adapters",
  "arcan-commands",
@@ -409,6 +410,7 @@ dependencies = [
  "crossterm",
  "dirs 6.0.0",
  "ergon",
+ "ergon-anima-adapter",
  "ergon-life-hooks",
  "ergon-life-sinks",
  "ergon-nous-adapter",

--- a/crates/arcan/arcan/Cargo.toml
+++ b/crates/arcan/arcan/Cargo.toml
@@ -49,9 +49,13 @@ autonomic-controller.workspace = true
 arcan-aios-adapters = { path = "../arcan-aios-adapters", version = "0.3.0" }
 arcan-ergon = { path = "../arcan-ergon", version = "0.3.0" }
 ergon.workspace = true
+ergon-anima-adapter.workspace = true
 ergon-life-hooks.workspace = true
 ergon-life-sinks.workspace = true
 ergon-nous-adapter.workspace = true
+# Custody identity loading for soul attestation (`--anima-identity-dir`):
+# reconstructs the `life init` InProcessAnima from `.life/identity/`.
+anima-identity = { path = "../../anima/anima-identity", version = "0.3.0" }
 arcan-harness = { path = "../arcan-harness", version = "0.3.0" }
 praxis-core.workspace = true
 praxis-tools.workspace = true

--- a/crates/arcan/arcan/src/config.rs
+++ b/crates/arcan/arcan/src/config.rs
@@ -36,6 +36,11 @@ pub struct DefaultsConfig {
     pub spaces_backend: Option<String>,
     /// Bare mode: minimal prompt and core tools only (for small-context models).
     pub bare: Option<bool>,
+    /// Directory holding the `life init` anima identity (`soul.json` +
+    /// `seed.local.bin`). When set (or when the default `.life/identity`
+    /// exists), `arcan serve` signs workflow session boundaries through
+    /// the custody-backed soul attester instead of the noop fallback.
+    pub anima_identity_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -109,6 +114,9 @@ pub struct ResolvedConfig {
     /// OSS/local dev: set to "pro" for full tool access without auth.
     /// Env: ARCAN_DEFAULT_TIER. Values: anonymous, free, pro, enterprise.
     pub default_tier: Option<String>,
+    /// Anima identity directory for custody-backed soul attestation.
+    /// `None` means unconfigured — workflow ticks keep the noop attester.
+    pub anima_identity_dir: Option<PathBuf>,
 }
 
 impl ArcanConfig {
@@ -135,6 +143,11 @@ impl ArcanConfig {
         }
         if other.defaults.bare.is_some() {
             self.defaults.bare = other.defaults.bare;
+        }
+        if other.defaults.anima_identity_dir.is_some() {
+            self.defaults
+                .anima_identity_dir
+                .clone_from(&other.defaults.anima_identity_dir);
         }
         if other.spaces.host.is_some() {
             self.spaces.host.clone_from(&other.spaces.host);
@@ -214,6 +227,9 @@ impl ArcanConfig {
                     .map_err(|e| format!("invalid bare value: {e}"))?;
                 self.defaults.bare = Some(v);
             }
+            "anima_identity_dir" | "defaults.anima_identity_dir" => {
+                self.defaults.anima_identity_dir = Some(PathBuf::from(value));
+            }
             "spaces.host" => {
                 self.spaces.host = Some(value.to_owned());
             }
@@ -291,6 +307,11 @@ impl ArcanConfig {
             "autonomic_url" | "defaults.autonomic_url" => self.defaults.autonomic_url.clone(),
             "spaces_backend" | "defaults.spaces_backend" => self.defaults.spaces_backend.clone(),
             "bare" | "defaults.bare" => self.defaults.bare.map(|v| v.to_string()),
+            "anima_identity_dir" | "defaults.anima_identity_dir" => self
+                .defaults
+                .anima_identity_dir
+                .as_ref()
+                .map(|p| p.display().to_string()),
             "spaces.host" => self.spaces.host.clone(),
             "spaces.database_id" => self.spaces.database_id.clone(),
             "spaces.token" => self.spaces.token.clone(),
@@ -389,6 +410,7 @@ pub fn resolve(
     cli_spaces_token: Option<&str>,
     cli_bare: bool,
     cli_default_tier: Option<&str>,
+    cli_anima_identity_dir: Option<&Path>,
 ) -> ResolvedConfig {
     // Provider: CLI > env > config > ""
     let provider = cli_provider
@@ -471,6 +493,19 @@ pub fn resolve(
             .unwrap_or(false)
     };
 
+    // Anima identity dir: CLI > env > config > `.life/identity` if present.
+    // (The CLI flag carries `env = "ARCAN_ANIMA_IDENTITY_DIR"` via clap, so
+    // the env arm here only matters for callers bypassing the CLI parser.)
+    let anima_identity_dir = cli_anima_identity_dir
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            std::env::var("ARCAN_ANIMA_IDENTITY_DIR")
+                .ok()
+                .map(PathBuf::from)
+        })
+        .or_else(|| config.defaults.anima_identity_dir.clone())
+        .or_else(default_anima_identity_dir);
+
     ResolvedConfig {
         provider,
         model,
@@ -489,7 +524,17 @@ pub fn resolve(
         hook_registry,
         bare,
         default_tier: cli_default_tier.map(String::from),
+        anima_identity_dir,
     }
+}
+
+/// Default anima identity directory (`.life/identity`, the layout
+/// `life init` bootstraps), returned only when it actually exists on
+/// disk relative to the current working directory — a missing default
+/// is "unconfigured", not an error.
+fn default_anima_identity_dir() -> Option<PathBuf> {
+    let dir = PathBuf::from(".life/identity");
+    dir.is_dir().then_some(dir)
 }
 
 /// Resolve skill discovery directories from config, applying defaults and ~ expansion.
@@ -528,6 +573,7 @@ pub fn default_config_content() -> String {
 # model = "claude-sonnet-4-5-20250929"
 # port = 3000
 # spaces_backend = "mock"  # mock, spacetimedb
+# anima_identity_dir = ".life/identity"  # custody identity for soul attestation
 
 [agent]
 # max_iterations = 10
@@ -589,6 +635,7 @@ mod tests {
                 autonomic_url: None,
                 spaces_backend: None,
                 bare: None,
+                anima_identity_dir: None,
             },
             ..Default::default()
         };
@@ -659,7 +706,7 @@ mod tests {
     fn resolve_defaults() {
         let config = ArcanConfig::default();
         let resolved = resolve(
-            &config, None, None, None, None, None, None, None, None, false, None,
+            &config, None, None, None, None, None, None, None, None, false, None, None,
         );
         assert_eq!(resolved.provider, "anthropic");
         assert!(resolved.model.is_none());
@@ -689,6 +736,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         );
         assert_eq!(resolved.provider, "anthropic");
         assert_eq!(resolved.model.as_deref(), Some("claude-3"));
@@ -706,9 +754,81 @@ mod tests {
         config.providers.insert("ollama".into(), pc);
 
         let resolved = resolve(
-            &config, None, None, None, None, None, None, None, None, false, None,
+            &config, None, None, None, None, None, None, None, None, false, None, None,
         );
         assert_eq!(resolved.model.as_deref(), Some("special-model"));
+    }
+
+    #[test]
+    fn set_and_get_anima_identity_dir() {
+        let mut config = ArcanConfig::default();
+        config
+            .set_key("anima_identity_dir", "/tmp/identity")
+            .unwrap();
+        assert_eq!(
+            config.get_key("defaults.anima_identity_dir").as_deref(),
+            Some("/tmp/identity")
+        );
+        assert_eq!(
+            config.get_key("anima_identity_dir").as_deref(),
+            Some("/tmp/identity")
+        );
+    }
+
+    #[test]
+    fn merge_overrides_anima_identity_dir() {
+        let mut base = ArcanConfig::default();
+        base.defaults.anima_identity_dir = Some(PathBuf::from("/base/identity"));
+
+        let mut overlay = ArcanConfig::default();
+        overlay.defaults.anima_identity_dir = Some(PathBuf::from("/overlay/identity"));
+
+        base.merge(&overlay);
+        assert_eq!(
+            base.defaults.anima_identity_dir.as_deref(),
+            Some(Path::new("/overlay/identity"))
+        );
+
+        // A None overlay preserves the base value.
+        base.merge(&ArcanConfig::default());
+        assert_eq!(
+            base.defaults.anima_identity_dir.as_deref(),
+            Some(Path::new("/overlay/identity"))
+        );
+    }
+
+    #[test]
+    fn resolve_anima_identity_dir_layering() {
+        // Config-file value used when no CLI override.
+        let mut config = ArcanConfig::default();
+        config.defaults.anima_identity_dir = Some(PathBuf::from("/cfg/identity"));
+        let resolved = resolve(
+            &config, None, None, None, None, None, None, None, None, false, None, None,
+        );
+        assert_eq!(
+            resolved.anima_identity_dir.as_deref(),
+            Some(Path::new("/cfg/identity"))
+        );
+
+        // CLI flag wins over the config file.
+        let resolved = resolve(
+            &config,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            Some(Path::new("/cli/identity")),
+        );
+        assert_eq!(
+            resolved.anima_identity_dir.as_deref(),
+            Some(Path::new("/cli/identity"))
+        );
     }
 
     #[test]

--- a/crates/arcan/arcan/src/identity_loader.rs
+++ b/crates/arcan/arcan/src/identity_loader.rs
@@ -231,6 +231,36 @@ mod tests {
         assert_eq!(jws.split('.').count(), 3);
     }
 
+    /// The boot wiring contract end-to-end (sans daemon): a loaded
+    /// custody handle feeds `AgentAttestationAdapter`, which attests a
+    /// workflow session boundary under the on-disk identity's stable
+    /// DID — exactly what `run_serve` wires via `with_soul_attester`.
+    #[tokio::test]
+    async fn loaded_custody_drives_agent_attestation_adapter() {
+        use ergon_life_hooks::SoulAttester as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+
+        let custody = load_custody_from_disk(&identity_dir)
+            .unwrap()
+            .expect("identity loads");
+        let expected_did = custody.user_did().to_owned();
+
+        let attester = ergon_anima_adapter::AgentAttestationAdapter::new(custody);
+        assert_eq!(attester.agent_did(), expected_did, "stable DID from disk");
+
+        let sid = ergon::SessionId::from_string("sid-boot-wiring");
+        attester
+            .sign_session_start(&sid, "greeter")
+            .await
+            .expect("session start attested");
+        attester
+            .sign_session_end(&sid, "greeter", true)
+            .await
+            .expect("session end attested");
+    }
+
     #[test]
     fn corrupt_soul_json_errors() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/arcan/arcan/src/identity_loader.rs
+++ b/crates/arcan/arcan/src/identity_loader.rs
@@ -1,0 +1,320 @@
+//! Loader for the on-disk anima identity produced by `life init`.
+//!
+//! `life init` (crates/cli/life-cli/src/init.rs, #1242) bootstraps
+//! `.life/identity/` with two artifacts:
+//!
+//! - `soul.json` — schema-versioned soul document (flat `did` /
+//!   `wallet` / `soul_hash` / `custody` fields plus the full nested
+//!   `AgentSoul`), kept readable for shell inspection;
+//! - `seed.local.bin` — the raw 32-byte master seed, written `0o600`.
+//!
+//! This module reads those artifacts back and reconstructs the
+//! [`InProcessAnima`] custody handle so `arcan serve` can wire the
+//! `AgentAttestationAdapter` (ergon-anima-adapter) with a STABLE agent
+//! DID — the missing piece that kept workflow soul attestation on the
+//! noop fallback (2026-06-10 harness Phase-2 closure note: a boot-time
+//! `generate_dev()` key would mint a fresh DID every restart, making
+//! the signed session boundaries unverifiable across runs).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anima_identity::custody::AnimaCustody;
+use anima_identity::{InProcessAnima, MasterSeed};
+use anyhow::{Context, bail};
+
+/// Read-side projection of `.life/identity/soul.json`.
+///
+/// Mirrors the writer schema in `life-cli`'s `SoulDocument` but keeps
+/// only the fields the loader needs; unknown fields are ignored so
+/// additive writer changes don't break boot.
+#[derive(serde::Deserialize)]
+struct SoulDocumentView {
+    schema_version: u32,
+    did: String,
+    custody: CustodyView,
+    soul: SoulView,
+}
+
+#[derive(serde::Deserialize)]
+struct CustodyView {
+    kind: String,
+    #[serde(default = "default_seed_file")]
+    seed_file: String,
+}
+
+fn default_seed_file() -> String {
+    "seed.local.bin".to_owned()
+}
+
+#[derive(serde::Deserialize)]
+struct SoulView {
+    /// The agent's compressed auth public key (P-256 SEC1, 33 bytes),
+    /// pinned at init time. The seed must still derive this exact key.
+    root_public_key: Vec<u8>,
+}
+
+/// Load the custody handle from a `life init` identity directory.
+///
+/// Returns:
+/// - `Ok(Some(custody))` — identity present, seed readable, and the
+///   derived auth pubkey + DID match what `soul.json` pins;
+/// - `Ok(None)` — the directory or `soul.json` is missing (identity
+///   simply not initialized — callers fall back to noop attestation);
+/// - `Err(..)` — identity present but unusable (corrupt soul document,
+///   unsupported custody kind, missing/corrupt seed, pubkey/DID
+///   drift). Configured-but-corrupt is a hard error, not a silent
+///   fallback: noop-attesting under a corrupted identity would mask
+///   key tampering.
+pub fn load_custody_from_disk(
+    identity_dir: &Path,
+) -> anyhow::Result<Option<Arc<dyn AnimaCustody>>> {
+    if !identity_dir.is_dir() {
+        return Ok(None);
+    }
+    let soul_path = identity_dir.join("soul.json");
+    if !soul_path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = std::fs::read(&soul_path)
+        .with_context(|| format!("failed to read {}", soul_path.display()))?;
+    let doc: SoulDocumentView = serde_json::from_slice(&bytes)
+        .with_context(|| format!("{} is not a valid soul document", soul_path.display()))?;
+
+    if doc.schema_version != 1 {
+        bail!(
+            "{}: unsupported soul document schema_version {} (this arcan understands version 1)",
+            soul_path.display(),
+            doc.schema_version
+        );
+    }
+    if doc.custody.kind != "in_process" {
+        bail!(
+            "{}: custody kind `{}` cannot be loaded by arcan serve yet — only `in_process` \
+             (vault/tpm/webcrypto/hardware/soma custody wiring is a follow-up)",
+            soul_path.display(),
+            doc.custody.kind
+        );
+    }
+
+    let seed_path = identity_dir.join(&doc.custody.seed_file);
+    let seed_bytes = std::fs::read(&seed_path).with_context(|| {
+        format!(
+            "{} claims in_process custody but the seed at {} is unreadable — restore it from \
+             backup, or remove soul.json and re-run `life init` (this regenerates the DID)",
+            soul_path.display(),
+            seed_path.display()
+        )
+    })?;
+    let seed_arr: [u8; 32] = seed_bytes.try_into().map_err(|v: Vec<u8>| {
+        anyhow::anyhow!(
+            "{} is corrupt: {} bytes (expected 32)",
+            seed_path.display(),
+            v.len()
+        )
+    })?;
+
+    let custody = InProcessAnima::from_seed_arc(MasterSeed::from_bytes(seed_arr))
+        .context("failed to derive identity from master seed")?;
+
+    // Sanity: the soul document pins the auth pubkey + DID at init
+    // time; the seed must still derive the same key. A mismatch means
+    // seed.local.bin and soul.json drifted apart (restored from
+    // different backups, manual edits) — signing under a key the soul
+    // doesn't vouch for would produce unverifiable attestations.
+    if custody.auth_pubkey().as_slice() != doc.soul.root_public_key.as_slice() {
+        bail!(
+            "identity mismatch in {}: the seed derives an auth pubkey that does not match \
+             soul.json's root_public_key — seed.local.bin and soul.json are out of sync",
+            identity_dir.display()
+        );
+    }
+    if custody.user_did() != doc.did {
+        bail!(
+            "identity mismatch in {}: the seed derives DID {} but soul.json pins {}",
+            identity_dir.display(),
+            custody.user_did(),
+            doc.did
+        );
+    }
+
+    Ok(Some(custody))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// Deterministic test seed — mirrors the `deterministic_from_seed`
+    /// pattern in `anima_identity::in_process`.
+    const SEED: [u8; 32] = [7u8; 32];
+
+    /// `unwrap_err` needs `Debug` on the Ok side, which
+    /// `Arc<dyn AnimaCustody>` deliberately doesn't implement — match
+    /// instead.
+    fn load_err(dir: &Path) -> anyhow::Error {
+        match load_custody_from_disk(dir) {
+            Err(e) => e,
+            Ok(_) => panic!("expected load_custody_from_disk to fail"),
+        }
+    }
+
+    /// Write a well-formed identity dir (seed + soul.json) derived from
+    /// `seed`, mirroring what `life init` produces. Returns the
+    /// identity dir path.
+    fn write_identity(root: &Path, seed: [u8; 32]) -> PathBuf {
+        let identity_dir = root.join("identity");
+        std::fs::create_dir_all(&identity_dir).unwrap();
+        std::fs::write(identity_dir.join("seed.local.bin"), seed).unwrap();
+
+        let custody = InProcessAnima::from_seed(MasterSeed::from_bytes(seed)).unwrap();
+        let doc = soul_json(
+            custody.user_did(),
+            &custody.auth_pubkey(),
+            "in_process",
+            "seed.local.bin",
+            1,
+        );
+        std::fs::write(identity_dir.join("soul.json"), doc).unwrap();
+        identity_dir
+    }
+
+    fn soul_json(
+        did: &str,
+        pubkey: &[u8],
+        custody_kind: &str,
+        seed_file: &str,
+        schema_version: u32,
+    ) -> String {
+        serde_json::json!({
+            "schema_version": schema_version,
+            "did": did,
+            "wallet": { "address": "0x0000000000000000000000000000000000000000", "chain": "eip155:8453" },
+            "soul_hash": "blake3:test",
+            "custody": { "kind": custody_kind, "seed_file": seed_file },
+            "soul": { "root_public_key": pubkey.to_vec() },
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn missing_dir_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_custody_from_disk(&tmp.path().join("does-not-exist")).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn dir_without_soul_json_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_custody_from_disk(tmp.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn happy_path_loads_custody_with_pinned_did() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+
+        let expected = InProcessAnima::from_seed(MasterSeed::from_bytes(SEED)).unwrap();
+        let custody = load_custody_from_disk(&identity_dir)
+            .unwrap()
+            .expect("identity loads");
+        assert_eq!(custody.user_did(), expected.user_did());
+        assert_eq!(custody.auth_pubkey(), expected.auth_pubkey());
+
+        // The handle signs — the whole point of loading it.
+        let jws = custody.sign_jws(&serde_json::json!({"k": "v"})).unwrap();
+        assert_eq!(jws.split('.').count(), 3);
+    }
+
+    #[test]
+    fn corrupt_soul_json_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        std::fs::write(identity_dir.join("soul.json"), "{not json").unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(
+            format!("{err:#}").contains("not a valid soul document"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn unsupported_schema_version_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        let custody = InProcessAnima::from_seed(MasterSeed::from_bytes(SEED)).unwrap();
+        let doc = soul_json(
+            custody.user_did(),
+            &custody.auth_pubkey(),
+            "in_process",
+            "seed.local.bin",
+            2,
+        );
+        std::fs::write(identity_dir.join("soul.json"), doc).unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(
+            format!("{err:#}").contains("schema_version 2"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn non_in_process_custody_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        let custody = InProcessAnima::from_seed(MasterSeed::from_bytes(SEED)).unwrap();
+        let doc = soul_json(
+            custody.user_did(),
+            &custody.auth_pubkey(),
+            "vault",
+            "seed.local.bin",
+            1,
+        );
+        std::fs::write(identity_dir.join("soul.json"), doc).unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(format!("{err:#}").contains("`vault`"), "got: {err:#}");
+    }
+
+    #[test]
+    fn missing_seed_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        std::fs::remove_file(identity_dir.join("seed.local.bin")).unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(format!("{err:#}").contains("unreadable"), "got: {err:#}");
+    }
+
+    #[test]
+    fn corrupt_seed_wrong_length_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        std::fs::write(identity_dir.join("seed.local.bin"), [7u8; 16]).unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(
+            format!("{err:#}").contains("16 bytes (expected 32)"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn pubkey_mismatch_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        // Swap the seed for a different one: soul.json still pins the
+        // original pubkey/DID, so derivation no longer matches.
+        std::fs::write(identity_dir.join("seed.local.bin"), [9u8; 32]).unwrap();
+
+        let err = load_err(&identity_dir);
+        assert!(format!("{err:#}").contains("out of sync"), "got: {err:#}");
+    }
+}

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -11,6 +11,7 @@ mod embedding;
 mod ephemeral_journal;
 mod ergon_wiring;
 mod factory;
+mod identity_loader;
 mod markdown;
 mod memory_observer;
 mod memory_tools;
@@ -124,6 +125,20 @@ struct Cli {
     /// See `agents/README.md` for the authoring format.
     #[arg(long, global = true, env = "ARCAN_AGENTS_DIR", value_name = "DIR")]
     agents_dir: Option<PathBuf>,
+
+    /// Directory holding the `life init` anima identity (`soul.json` +
+    /// `seed.local.bin`). When the identity loads, `arcan serve` signs
+    /// ergon workflow session boundaries through the custody-backed
+    /// soul attester (stable agent DID). Defaults to `.life/identity`
+    /// when that directory exists; unset otherwise — workflow ticks
+    /// then keep the noop attester with a boot warning.
+    #[arg(
+        long,
+        global = true,
+        env = "ARCAN_ANIMA_IDENTITY_DIR",
+        value_name = "DIR"
+    )]
+    anima_identity_dir: Option<PathBuf>,
 
     /// Bind arcand's substrate-plane gRPC server (`arcan.v1.AgentSubstrate`)
     /// on this Unix-domain socket alongside the HTTP `:3000` server.
@@ -993,11 +1008,10 @@ fn run_serve(
     //   Hustle clamps max_tokens) — mirroring the Direct path;
     // - responses are scored through the Nous evaluator registry when
     //   it initialized.
-    // Anima soul attestation stays on the Noop fallback until arcan
-    // serve grows a custody identity config (the adapter itself is
-    // implemented + tested in `ergon-anima-adapter`; wiring requires
-    // a stable agent DID, which a boot-time `generate_dev()` key would
-    // not provide).
+    // - session boundaries are attested through the custody-backed
+    //   `AgentAttestationAdapter` when a `life init` identity is
+    //   configured (see below); unconfigured hosts keep the explicit
+    //   Noop fallback with a boot warning.
     let mut workflow_inputs = arcan_ergon::runner::WorkflowRunInputs::empty()
         .with_agent_registry(agent_registry)
         .with_stream_sink_factory(ergon_wiring::lago_stream_sink_factory(journal.clone()))
@@ -1020,9 +1034,39 @@ fn run_serve(
             );
         }
     }
-    tracing::warn!(
-        "ergon workflow ticks: anima custody not configured — soul attestation falls back to noop"
-    );
+    // Anima soul attestation: load the `life init` identity from disk
+    // (default `.life/identity`, override via --anima-identity-dir /
+    // ARCAN_ANIMA_IDENTITY_DIR / `defaults.anima_identity_dir`) and
+    // sign workflow session boundaries under the agent's stable DID.
+    // A configured-but-corrupt identity FAILS the boot (see
+    // `identity_loader`); an absent identity falls back to the noop
+    // attester with a warning.
+    match resolved.anima_identity_dir.as_deref() {
+        Some(identity_dir) => match identity_loader::load_custody_from_disk(identity_dir)? {
+            Some(custody) => {
+                let attester = ergon_anima_adapter::AgentAttestationAdapter::new(custody);
+                tracing::info!(
+                    did = attester.agent_did(),
+                    identity_dir = %identity_dir.display(),
+                    "ergon workflow ticks: soul attestation wired to anima custody"
+                );
+                workflow_inputs = workflow_inputs.with_soul_attester(Arc::new(attester));
+            }
+            None => {
+                tracing::warn!(
+                    identity_dir = %identity_dir.display(),
+                    "ergon workflow ticks: no anima identity at the configured directory — \
+                     soul attestation falls back to noop (run `life init` to create one)"
+                );
+            }
+        },
+        None => {
+            tracing::warn!(
+                "ergon workflow ticks: anima custody not configured — soul attestation falls \
+                 back to noop"
+            );
+        }
+    }
     let workflow_inputs = Arc::new(workflow_inputs);
     let workflow_dispatcher: Arc<dyn aios_runtime::WorkflowTickDispatcher> = Arc::new(
         arcan_ergon::ErgonWorkflowDispatcher::new(workflow_registry, workflow_inputs),
@@ -1649,6 +1693,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             run_serve(
@@ -1685,6 +1730,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1707,6 +1753,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1741,6 +1788,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1764,6 +1812,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
             run_skills(&data_dir, &resolved, &action)
         }
@@ -1827,6 +1876,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             // Build the Tokio runtime FIRST — same as `serve` mode.
@@ -1866,6 +1916,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1886,6 +1937,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1915,6 +1967,7 @@ fn main() -> anyhow::Result<()> {
                 cli.spaces_token.as_deref(),
                 cli.bare,
                 cli.default_tier.as_deref(),
+                cli.anima_identity_dir.as_deref(),
             );
 
             let runtime = tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
## Summary

Closes the handoff pickup item "Anima custody config for arcan serve": `arcan serve` now loads the `life init` (#1242) identity from `.life/identity/` and wires `AgentAttestationAdapter` as the ergon `soul_attester` — custody-signed JWS session boundaries replace the noop fallback when an identity exists.

- `--anima-identity-dir` flag / `ARCAN_ANIMA_IDENTITY_DIR` env / config key, layered CLI > env > file > default-`.life/identity`-if-present (matches existing `resolve()` convention)
- new `identity_loader`: `soul.json` + `seed.local.bin` → `InProcessAnima`, with pubkey/DID sanity check against the soul document
- configured-but-corrupt identity (bad seed length, schema≠1, non-`in_process` custody kind, pubkey drift) **hard-fails boot** rather than silently noop-attesting; missing dir → existing noop warning (now mentions `life init`)
- boot test covers the full contract: disk identity → loader → adapter → signed session start/end under the stable DID

## Validation (workflow stream: implement → adversarial verify, approved with zero must-fix)

- `cargo test -p arcan`: 169 passing (incl. 10 new identity_loader + 14 config tests)
- `cargo clippy -p arcan --all-targets -- -D warnings` clean, fmt clean
- smoke: `arcan serve --help` shows the new flag + env
- P20 adversarial review: approved, checks_pass, 0 must-fix; 3 nice-to-haves noted for follow-up (zeroize transient seed copies; CWD-relative default dir note; hermetic env guard in one test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)