### PR TITLE
feat(arcan): agent test --live — live-LLM mode for authored agents [BRO-1008]

### DIFF
--- a/crates/arcan/arcan/src/agent_cmd.rs
+++ b/crates/arcan/arcan/src/agent_cmd.rs
@@ -13,10 +13,25 @@
 //! | `show <name>` | Pretty-printed full `AgentSpec` for one agent. |
 //! | `new <name>` | Scaffold a new `agents/<name>.md` from a template. |
 //! | `test <name> --input <…> --dry-run` | Validate input JSON against the agent's `input_schema`. |
+//! | `test <name> --input <…> --live` | Execute the agent against the configured provider (costs money). |
 //!
-//! Live-LLM execution (`arcan agent test` without `--dry-run`) is
-//! deliberately out of scope for this PR — it requires wiring an
-//! arcan provider stack and is a fast-follow.
+//! ## Live-LLM execution (`--live`, BRO-1008 follow-up)
+//!
+//! [`test_live`] drives the same `ergon::Agent::run` interpreter the
+//! runtime uses, over the same provider adapter chain `arcan serve`
+//! builds at boot (`arcan_core::Provider` → [`ArcanProviderAdapter`] →
+//! [`ModelProviderAdapter`]). The chain is assembled by
+//! [`build_ergon_provider`], which the binary calls in **sync**
+//! context (the Anthropic provider's `reqwest::blocking` client owns
+//! an inner tokio runtime — constructing or dropping it inside an
+//! async context panics; see
+//! `crates/arcan/arcan-ergon/tests/anthropic_agents_smoke.rs`).
+//!
+//! Spend is bounded by [`AGENT_TEST_MAX_TOKENS`] via a
+//! [`TokenBudgetHook`] registered on the run — a runaway agent is
+//! denied its next inference call once the cumulative token count
+//! crosses the cap. Bare `arcan agent test` (neither `--dry-run` nor
+//! `--live`) still errors so no invocation spends money by accident.
 //!
 //! ## Why this module exists
 //!
@@ -37,9 +52,22 @@
 //! cases — that's the contract the surrounding shell relies on.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use aios_protocol::mode::OperatingMode;
+use aios_protocol::{BranchId, ModelProviderPort, RunId};
 use anyhow::{Context, Result, anyhow, bail};
-use ergon::{AgentRegistry, AgentSpec, FsAgentRegistry, parse_agent_md};
+use arcan_aios_adapters::ArcanProviderAdapter;
+use arcan_core::runtime::Provider as ArcanProvider;
+use arcan_ergon::{ModeRuntimeHandle, ModelProviderAdapter};
+use async_trait::async_trait;
+use ergon::{
+    AgentRegistry, AgentSpec, BufferSink, ErgonError, FsAgentRegistry, Hook, HookCtx, HookOutcome,
+    HookRegistry, InferenceHookOutcome, ModelRequest, ModelResponse, Provider as ErgonProvider,
+    SessionId, StepCtx, StreamSink, ToolCall, ToolDefinition, ToolRegistry, ToolResult,
+    parse_agent_md,
+};
 use serde_json::Value;
 
 /// Default model for `arcan agent new` scaffolds. Mirrors the model
@@ -332,8 +360,9 @@ pub async fn test_dry_run(dir: &Path, name: &str, raw_input: &str) -> Result<()>
         spec.name,
     );
     println!(
-        "note: live execution (without --dry-run) is not yet supported in this build; \
-         see BRO-1008 follow-ups for the live-LLM path."
+        "note: to execute this agent against the configured LLM provider, re-run \
+         with --live instead of --dry-run (this costs money; capped at \
+         {AGENT_TEST_MAX_TOKENS} tokens)."
     );
     Ok(())
 }
@@ -346,10 +375,29 @@ pub async fn test_dry_run(dir: &Path, name: &str, raw_input: &str) -> Result<()>
 /// Public so the integration tests can drive validation directly
 /// without going through the registry load.
 pub fn validate_input(spec: &AgentSpec, input: &Value) -> Result<()> {
+    validate_against_schema(&spec.input_schema, input, "input", &spec.name)
+}
+
+/// Validate `value` against an arbitrary JSON schema, reporting every
+/// violation in one joined error message. `what` names the payload in
+/// the error text (`"input"` / `"output"`); `agent_name` identifies
+/// which agent's schema rejected it.
+///
+/// This is the shared engine behind [`validate_input`] (dry-run path)
+/// and the output check in [`test_live`] — both use the same
+/// `jsonschema` crate the ergon runtime uses for `record_answer`
+/// validation, so the CLI's accept/reject judgement matches the
+/// runtime's.
+pub fn validate_against_schema(
+    schema: &Value,
+    value: &Value,
+    what: &str,
+    agent_name: &str,
+) -> Result<()> {
     let compiled = jsonschema::JSONSchema::options()
-        .compile(&spec.input_schema)
-        .map_err(|e| anyhow!("agent `{}` input_schema is malformed: {e}", spec.name))?;
-    if let Err(errors) = compiled.validate(input) {
+        .compile(schema)
+        .map_err(|e| anyhow!("agent `{agent_name}` {what}_schema is malformed: {e}"))?;
+    if let Err(errors) = compiled.validate(value) {
         let messages: Vec<String> = errors
             .map(|e| {
                 let path = e.instance_path.to_string();
@@ -361,8 +409,7 @@ pub fn validate_input(spec: &AgentSpec, input: &Value) -> Result<()> {
             })
             .collect();
         bail!(
-            "input is INVALID for agent `{}`:\n  - {}",
-            spec.name,
+            "{what} is INVALID for agent `{agent_name}`:\n  - {}",
             messages.join("\n  - "),
         );
     }
@@ -387,6 +434,244 @@ fn parse_input_arg(raw: &str) -> Result<Value> {
     };
     serde_json::from_str(&json)
         .with_context(|| format!("failed to parse --input as JSON ({} bytes)", json.len()))
+}
+
+// ─── test --live ────────────────────────────────────────────────────────
+
+/// Hard cap on cumulative tokens (input + output) a single
+/// `arcan agent test --live` run may consume. Once the cap is crossed
+/// the [`TokenBudgetHook`] denies the next inference call, aborting
+/// the run with a budget error instead of letting a runaway agent
+/// spend unboundedly. At Sonnet pricing 50K tokens is well under a
+/// dollar even in the worst (all-output) case.
+pub const AGENT_TEST_MAX_TOKENS: u64 = 50_000;
+
+/// Empty tool registry for CLI test runs.
+///
+/// Mirrors `EmptyTools` in
+/// `crates/arcan/arcan-ergon/tests/anthropic_agents_smoke.rs`: the
+/// CLI test surface deliberately advertises **no** workflow tools —
+/// the framework's own `record_answer` tool is synthesized by
+/// `ergon::run_spec` regardless, which is all an authored agent needs
+/// to produce its typed answer.
+struct CliTestTools;
+
+#[async_trait]
+impl ToolRegistry for CliTestTools {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        Vec::new()
+    }
+    async fn invoke(&self, call: ToolCall) -> std::result::Result<ToolResult, ErgonError> {
+        Err(ErgonError::Tool(format!(
+            "CliTestTools cannot invoke `{}` — `arcan agent test --live` runs with no \
+             workflow tools",
+            call.name
+        )))
+    }
+}
+
+/// Cost guard for live CLI test runs.
+///
+/// Tracks cumulative token usage across every inference turn
+/// (`on_post_inference`) and denies the next provider call
+/// (`on_pre_inference`) once the total crosses `max_tokens`. Denial
+/// surfaces as `ErgonError::Hook` from the autonomous loop, aborting
+/// the run — the answer captured so far (if any) still wins, because
+/// `ergon::run_spec` checks the answer slot before inspecting the
+/// loop result.
+///
+/// Also serves as the usage ledger for the post-run summary line:
+/// [`Self::input_tokens`] / [`Self::output_tokens`] expose what the
+/// run actually consumed.
+pub struct TokenBudgetHook {
+    max_tokens: u64,
+    input_used: AtomicU64,
+    output_used: AtomicU64,
+}
+
+impl TokenBudgetHook {
+    /// Construct a guard with the given cumulative token cap.
+    pub fn new(max_tokens: u64) -> Self {
+        Self {
+            max_tokens,
+            input_used: AtomicU64::new(0),
+            output_used: AtomicU64::new(0),
+        }
+    }
+
+    /// Input tokens consumed so far.
+    pub fn input_tokens(&self) -> u64 {
+        self.input_used.load(Ordering::Relaxed)
+    }
+
+    /// Output tokens consumed so far.
+    pub fn output_tokens(&self) -> u64 {
+        self.output_used.load(Ordering::Relaxed)
+    }
+
+    /// Total tokens consumed so far (input + output).
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens() + self.output_tokens()
+    }
+}
+
+#[async_trait]
+impl Hook for TokenBudgetHook {
+    fn name(&self) -> &str {
+        "agent-test-token-budget"
+    }
+
+    async fn on_pre_inference(
+        &self,
+        _ctx: &HookCtx<'_>,
+        _req: &mut ModelRequest,
+    ) -> std::result::Result<InferenceHookOutcome, ErgonError> {
+        let used = self.total_tokens();
+        if used >= self.max_tokens {
+            return Ok(InferenceHookOutcome::Deny(format!(
+                "agent test token budget exhausted: used {used} tokens >= cap {} \
+                 (AGENT_TEST_MAX_TOKENS)",
+                self.max_tokens
+            )));
+        }
+        Ok(InferenceHookOutcome::Continue)
+    }
+
+    async fn on_post_inference(
+        &self,
+        _ctx: &HookCtx<'_>,
+        resp: &ModelResponse,
+    ) -> std::result::Result<HookOutcome, ErgonError> {
+        self.input_used
+            .fetch_add(u64::from(resp.usage.input_tokens), Ordering::Relaxed);
+        self.output_used
+            .fetch_add(u64::from(resp.usage.output_tokens), Ordering::Relaxed);
+        Ok(HookOutcome::Continue)
+    }
+}
+
+/// Adapt an `arcan_core::Provider` into the `ergon::Provider` the
+/// agent interpreter consumes.
+///
+/// This is the **same chain the runtime uses** (see
+/// `crates/arcan/arcan-ergon/tests/anthropic_agents_smoke.rs` and the
+/// `arcan serve` boot path):
+///
+/// ```text
+/// arcan_core::Provider
+///   → ArcanProviderAdapter   (aios_protocol::ModelProviderPort)
+///   → ModelProviderAdapter   (ergon::Provider)
+/// ```
+///
+/// `provider_name` is what `ergon::Provider::name` reports (embedded
+/// in `StreamEvent::SessionStart`); pass the resolved provider label
+/// (`"anthropic"`, `"ollama"`, …).
+///
+/// ## Sync-context requirement
+///
+/// MUST be called from a **sync** context (outside any tokio
+/// runtime), and the returned `Arc` must outlive the `block_on` that
+/// drives [`test_live`] so the final drop also happens in sync
+/// context. The Anthropic provider holds a `reqwest::blocking::Client`
+/// whose inner tokio runtime panics if constructed or dropped from
+/// async context.
+pub fn build_ergon_provider(
+    provider: Arc<dyn ArcanProvider>,
+    provider_name: &str,
+) -> Arc<dyn ErgonProvider> {
+    // ArcanProviderAdapter wants a tools list (empty — authored agents
+    // get their `record_answer` tool from the chained registry inside
+    // `ergon::run_spec`) and a streaming-sender handle (empty mutex —
+    // the CLI does not subscribe to the runtime broadcast).
+    let streaming_sender = Arc::new(std::sync::Mutex::new(None));
+    let port: Arc<dyn ModelProviderPort> = Arc::new(ArcanProviderAdapter::new(
+        provider,
+        Vec::new(),
+        streaming_sender,
+    ));
+
+    Arc::new(ModelProviderAdapter::new(
+        port,
+        aios_protocol::SessionId::from_string("agent-test-live".to_owned()),
+        BranchId::main(),
+        RunId::new_uuid(),
+        provider_name,
+    ))
+}
+
+/// Implementation of `arcan agent test <name> --input <…> --live`.
+///
+/// Loads the agent from `dir`, validates the parsed input against the
+/// agent's `input_schema` (same gate as `--dry-run`), then drives the
+/// production `ergon::Agent::run` interpreter against `provider`:
+/// empty tools ([`CliTestTools`]), a [`TokenBudgetHook`] capped at
+/// [`AGENT_TEST_MAX_TOKENS`], a [`BufferSink`], and an Execute-mode
+/// [`ModeRuntimeHandle`]. On success the typed answer is re-validated
+/// against the agent's `output_schema` (defense in depth — the
+/// interpreter already validated it), pretty-printed to stdout, and
+/// followed by a one-line usage/cost summary.
+///
+/// `provider` must come from [`build_ergon_provider`] called in sync
+/// context — see its docs for the `reqwest::blocking` drop-order
+/// constraint.
+#[allow(clippy::print_stdout)]
+pub async fn test_live(
+    dir: &Path,
+    name: &str,
+    raw_input: &str,
+    provider: Arc<dyn ErgonProvider>,
+) -> Result<()> {
+    let registry = load_registry(dir)?;
+    let agent = registry
+        .get(name)
+        .await
+        .ok_or_else(|| anyhow!("agent `{name}` not found in {}", dir.display()))?;
+    let spec = agent.spec();
+
+    // Same input gate as --dry-run: never spend tokens on a payload
+    // the agent's own schema would reject.
+    let input = parse_input_arg(raw_input)?;
+    validate_input(&spec, &input)?;
+
+    let budget = Arc::new(TokenBudgetHook::new(AGENT_TEST_MAX_TOKENS));
+    let hooks = HookRegistry::new().with_arc(Arc::clone(&budget) as Arc<dyn Hook>);
+
+    let mut ctx = StepCtx::new(
+        SessionId::from_string("agent-test-live".to_owned()),
+        "agent-test",
+        provider,
+        Arc::new(CliTestTools) as Arc<dyn ToolRegistry>,
+        Arc::new(hooks),
+        Arc::new(BufferSink::new()) as Arc<dyn StreamSink>,
+        Arc::new(ModeRuntimeHandle::new(OperatingMode::Execute)) as Arc<dyn ergon::RuntimeHandle>,
+        tracing::Span::current(),
+    );
+
+    println!(
+        "running agent `{}` live (model {}, max_turns {}, token cap {AGENT_TEST_MAX_TOKENS})…",
+        spec.name, spec.model, spec.max_turns,
+    );
+
+    let answer = agent
+        .run(&mut ctx, input)
+        .await
+        .map_err(|e| anyhow!("agent `{}` live run failed: {e}", spec.name))?;
+
+    // Defense in depth: `ergon::run_spec` already validated the
+    // captured answer, but re-checking here surfaces a clear CLI error
+    // if that invariant is ever bypassed.
+    validate_against_schema(&spec.output_schema, &answer, "output", &spec.name)?;
+
+    println!("{}", pretty_json(&answer));
+    let input_tokens = budget.input_tokens();
+    let output_tokens = budget.output_tokens();
+    let cost = crate::cost::estimate_cost(input_tokens, output_tokens, &spec.model);
+    println!(
+        "agent `{}` OK — model {} | tokens: {input_tokens} in / {output_tokens} out \
+         (cap {AGENT_TEST_MAX_TOKENS}) | est. cost ${cost:.4}",
+        spec.name, spec.model,
+    );
+    Ok(())
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────
@@ -484,5 +769,238 @@ mod tests {
         assert_eq!(spec.name, "test-agent");
         assert_eq!(spec.model, DEFAULT_NEW_AGENT_MODEL);
         assert!(spec.instructions.contains("body"));
+    }
+
+    // ─── test --live plumbing (offline — no network, no real provider) ──
+
+    use ergon::{ContentBlock, Message, MessageRole, StopReason, Usage};
+
+    fn hook_ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
+        HookCtx::new(
+            SessionId::from_string("agent-test-unit".to_owned()),
+            "agent-test",
+            span,
+        )
+    }
+
+    fn response_with_usage(input: u32, output: u32) -> ModelResponse {
+        let mut usage = Usage::default();
+        usage.input_tokens = input;
+        usage.output_tokens = output;
+        ModelResponse::new(vec![ContentBlock::text("ok")], StopReason::EndTurn).with_usage(usage)
+    }
+
+    #[tokio::test]
+    async fn token_budget_hook_continues_under_cap() {
+        let span = tracing::Span::current();
+        let ctx = hook_ctx(&span);
+        let hook = TokenBudgetHook::new(1_000);
+
+        let mut req = ModelRequest::new("m", vec![]);
+        assert!(matches!(
+            hook.on_pre_inference(&ctx, &mut req).await.unwrap(),
+            InferenceHookOutcome::Continue
+        ));
+    }
+
+    #[tokio::test]
+    async fn token_budget_hook_accumulates_usage_and_denies_over_cap() {
+        let span = tracing::Span::current();
+        let ctx = hook_ctx(&span);
+        let hook = TokenBudgetHook::new(100);
+
+        // Record 60 in + 50 out = 110 total — over the 100 cap.
+        hook.on_post_inference(&ctx, &response_with_usage(60, 50))
+            .await
+            .unwrap();
+        assert_eq!(hook.input_tokens(), 60);
+        assert_eq!(hook.output_tokens(), 50);
+        assert_eq!(hook.total_tokens(), 110);
+
+        let mut req = ModelRequest::new("m", vec![]);
+        match hook.on_pre_inference(&ctx, &mut req).await.unwrap() {
+            InferenceHookOutcome::Deny(reason) => {
+                assert!(
+                    reason.contains("token budget exhausted"),
+                    "deny reason must explain the cap: {reason}"
+                );
+                assert!(
+                    reason.contains("110"),
+                    "deny reason carries usage: {reason}"
+                );
+            }
+            other => panic!("expected Deny over cap, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn token_budget_hook_denies_exactly_at_cap() {
+        let span = tracing::Span::current();
+        let ctx = hook_ctx(&span);
+        let hook = TokenBudgetHook::new(50);
+        hook.on_post_inference(&ctx, &response_with_usage(25, 25))
+            .await
+            .unwrap();
+        let mut req = ModelRequest::new("m", vec![]);
+        assert!(matches!(
+            hook.on_pre_inference(&ctx, &mut req).await.unwrap(),
+            InferenceHookOutcome::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn validate_against_schema_accepts_and_rejects_output() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "response": { "type": "string" } },
+            "required": ["response"],
+            "additionalProperties": false,
+        });
+        validate_against_schema(
+            &schema,
+            &serde_json::json!({"response": "hi"}),
+            "output",
+            "a",
+        )
+        .expect("conformant output must pass");
+
+        let err = validate_against_schema(&schema, &serde_json::json!({"bogus": 1}), "output", "a")
+            .expect_err("non-conformant output must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("output is INVALID for agent `a`"),
+            "error names the payload and agent: {msg}"
+        );
+    }
+
+    /// Scripted `ergon::Provider` for offline `test_live` runs.
+    ///
+    /// Turn 1: emit a `record_answer` tool call carrying `answer`.
+    /// Turn 2+: plain EndTurn text (the loop's natural exit).
+    /// Every turn reports `usage_per_turn` tokens so the budget hook
+    /// ledger is exercised.
+    struct ScriptedProvider {
+        answer: Value,
+        usage_per_turn: u32,
+        calls: AtomicU64,
+    }
+
+    #[async_trait]
+    impl ErgonProvider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn stream(
+            &self,
+            _req: ModelRequest,
+            _sink: Arc<dyn StreamSink>,
+        ) -> std::result::Result<ModelResponse, ErgonError> {
+            let call_n = self.calls.fetch_add(1, Ordering::Relaxed);
+            let mut usage = Usage::default();
+            usage.input_tokens = self.usage_per_turn;
+            usage.output_tokens = self.usage_per_turn;
+            let response = if call_n == 0 {
+                // `record_answer` wraps the typed answer as
+                // `{"answer": <payload>}` — mirror what a real model
+                // following the Output Contract emits.
+                ModelResponse::new(
+                    vec![ContentBlock::ToolUse {
+                        id: "call-1".to_owned(),
+                        name: ergon::RECORD_ANSWER_TOOL.to_owned(),
+                        input: serde_json::json!({ "answer": self.answer.clone() }),
+                    }],
+                    StopReason::ToolUse,
+                )
+            } else {
+                ModelResponse::new(vec![ContentBlock::text("done")], StopReason::EndTurn)
+            };
+            Ok(response.with_usage(usage))
+        }
+    }
+
+    /// Write a minimal agent file usable by `test_live` into a fresh
+    /// temp dir; returns the dir.
+    fn scripted_agents_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "arcan-agent-test-live-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp agents dir");
+        std::fs::write(
+            dir.join("echo.md"),
+            render_new_agent_template("echo", DEFAULT_NEW_AGENT_MODEL, "Echo the request."),
+        )
+        .expect("write echo agent");
+        dir
+    }
+
+    #[tokio::test]
+    async fn test_live_round_trips_with_scripted_provider() {
+        let dir = scripted_agents_dir();
+        let provider: Arc<dyn ErgonProvider> = Arc::new(ScriptedProvider {
+            answer: serde_json::json!({"response": "echoed"}),
+            usage_per_turn: 10,
+            calls: AtomicU64::new(0),
+        });
+
+        test_live(&dir, "echo", r#"{"request": "hello"}"#, provider)
+            .await
+            .expect("scripted live run must succeed");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_live_rejects_input_before_calling_provider() {
+        let dir = scripted_agents_dir();
+        let scripted = Arc::new(ScriptedProvider {
+            answer: serde_json::json!({"response": "never"}),
+            usage_per_turn: 10,
+            calls: AtomicU64::new(0),
+        });
+        let provider: Arc<dyn ErgonProvider> = Arc::clone(&scripted) as Arc<dyn ErgonProvider>;
+
+        let err = test_live(&dir, "echo", r#"{"wrong": 1}"#, provider)
+            .await
+            .expect_err("schema-invalid input must fail before any spend");
+        assert!(format!("{err:#}").contains("INVALID"));
+
+        // The provider must never have been called — input gating
+        // happens before the loop starts.
+        assert_eq!(
+            scripted.calls.load(Ordering::Relaxed),
+            0,
+            "provider must not be invoked on invalid input"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_live_surfaces_schema_violation_from_agent_answer() {
+        let dir = scripted_agents_dir();
+        // The scripted answer violates `echo`'s output_schema (which
+        // requires `response: string`); run_spec retries then fails.
+        let provider: Arc<dyn ErgonProvider> = Arc::new(ScriptedProvider {
+            answer: serde_json::json!({"not_response": 42}),
+            usage_per_turn: 10,
+            calls: AtomicU64::new(0),
+        });
+
+        let err = test_live(&dir, "echo", r#"{"request": "hello"}"#, provider)
+            .await
+            .expect_err("schema-violating answer must surface as an error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("live run failed"),
+            "error wraps the interpreter failure: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/arcan/arcan/src/agent_cmd.rs
+++ b/crates/arcan/arcan/src/agent_cmd.rs
@@ -773,7 +773,7 @@ mod tests {
 
     // ─── test --live plumbing (offline — no network, no real provider) ──
 
-    use ergon::{ContentBlock, Message, MessageRole, StopReason, Usage};
+    use ergon::{ContentBlock, StopReason, Usage};
 
     fn hook_ctx<'a>(span: &'a tracing::Span) -> HookCtx<'a> {
         HookCtx::new(

--- a/crates/arcan/arcan/src/cost.rs
+++ b/crates/arcan/arcan/src/cost.rs
@@ -1,0 +1,76 @@
+//! Cost estimation helpers shared across the arcan CLI surfaces.
+//!
+//! Originally a private helper in the shell REPL (`src/shell.rs`,
+//! BRO-364), promoted to the library so the `arcan agent test`
+//! live-LLM path (BRO-1008) can report an estimated spend per run
+//! without duplicating the pricing table. Both surfaces deliberately
+//! share one table so an operator sees consistent numbers between
+//! `arcan shell` and `arcan agent test --live`.
+
+/// Estimate cost in USD for a model call based on token usage and model name.
+///
+/// Uses published Claude pricing (per million tokens):
+/// - Opus: $15 input, $75 output
+/// - Sonnet: $3 input, $15 output
+/// - Haiku: $0.25 input, $1.25 output
+///
+/// Unknown models default to Sonnet pricing — the mid-tier estimate is
+/// the least-surprising fallback for budget displays.
+pub fn estimate_cost(input_tokens: u64, output_tokens: u64, model: &str) -> f64 {
+    let (input_rate, output_rate) = match model {
+        m if m.contains("opus") => (15.0, 75.0),
+        m if m.contains("sonnet") => (3.0, 15.0),
+        m if m.contains("haiku") => (0.25, 1.25),
+        _ => (3.0, 15.0), // default to sonnet pricing
+    };
+    (input_tokens as f64 * input_rate + output_tokens as f64 * output_rate) / 1_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- BRO-364: estimate_cost tests (moved from src/shell.rs) ---
+
+    #[test]
+    fn test_estimate_cost_opus() {
+        let cost = estimate_cost(1_000_000, 1_000_000, "claude-opus-4-20250514");
+        // $15 input + $75 output = $90
+        assert!((cost - 90.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_sonnet() {
+        let cost = estimate_cost(1_000_000, 1_000_000, "claude-sonnet-4-20250514");
+        // $3 input + $15 output = $18
+        assert!((cost - 18.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_haiku() {
+        let cost = estimate_cost(1_000_000, 1_000_000, "claude-haiku-4-20250514");
+        // $0.25 input + $1.25 output = $1.50
+        assert!((cost - 1.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_unknown_defaults_to_sonnet() {
+        let cost = estimate_cost(1_000_000, 1_000_000, "some-unknown-model");
+        // Should use sonnet pricing: $3 + $15 = $18
+        assert!((cost - 18.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_zero_tokens() {
+        let cost = estimate_cost(0, 0, "claude-sonnet-4-20250514");
+        assert!((cost).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_estimate_cost_typical_turn() {
+        // A typical turn: 5000 input, 1000 output, sonnet
+        let cost = estimate_cost(5000, 1000, "claude-sonnet-4-20250514");
+        // (5000 * 3 + 1000 * 15) / 1_000_000 = (15000 + 15000) / 1_000_000 = 0.03
+        assert!((cost - 0.03).abs() < 0.001);
+    }
+}

--- a/crates/arcan/arcan/src/lib.rs
+++ b/crates/arcan/arcan/src/lib.rs
@@ -9,14 +9,18 @@
 //! Currently re-exported:
 //!
 //! - [`agent_cmd`] — handlers for the `arcan agent
-//!   list/show/new/test --dry-run` subcommands. Shipped under
-//!   BRO-1008 to give operators an offline tooling surface for the
-//!   authored-agent substrate (see
+//!   list/show/new/test` subcommands (offline `--dry-run` validation
+//!   plus the `--live` LLM execution path). Shipped under BRO-1008 to
+//!   give operators a tooling surface for the authored-agent
+//!   substrate (see
 //!   `core/life/docs/superpowers/specs/2026-05-09-bro-1006-authored-agents-architecture.md`
 //!   §M5).
+//! - [`cost`] — USD cost estimation shared by the shell REPL and the
+//!   `agent test --live` summary line (single pricing table, BRO-364).
 //!
 //! Adding a module to this re-export list is a deliberate boundary
 //! expansion. The default for binary-internal helpers is to stay
 //! private to `main.rs`.
 
 pub mod agent_cmd;
+pub mod cost;

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -292,8 +292,10 @@ enum AgentAction {
         instructions: Option<String>,
     },
     /// Validate an input JSON document against an agent's
-    /// `input_schema` without invoking the LLM. Live execution
-    /// (without `--dry-run`) is deferred to a follow-up PR.
+    /// `input_schema` (`--dry-run`), or execute the agent against
+    /// the configured LLM provider (`--live`). Exactly one mode must
+    /// be selected — bare `arcan agent test` errors so no invocation
+    /// spends money by accident.
     Test {
         /// The agent name (matches the filename stem under
         /// `<--agents-dir>`).
@@ -303,11 +305,15 @@ enum AgentAction {
         #[arg(long)]
         input: String,
         /// Validate against `input_schema` only — do not execute.
-        /// Currently the only supported mode; bare `arcan agent
-        /// test` (without `--dry-run`) is rejected with an
-        /// explanatory error.
         #[arg(long)]
         dry_run: bool,
+        /// Execute the agent against the configured provider
+        /// (resolved exactly like `arcan serve`: --provider/--model
+        /// flags, config file, API-key env vars). Costs money;
+        /// cumulative spend is capped at
+        /// `agent_cmd::AGENT_TEST_MAX_TOKENS` tokens.
+        #[arg(long, conflicts_with = "dry_run")]
+        live: bool,
     },
 }
 
@@ -1768,45 +1774,95 @@ fn main() -> anyhow::Result<()> {
             run_skills(&data_dir, &resolved, &action)
         }
         Some(Command::Agent { action }) => {
-            // Agent CLI handlers are filesystem-only — no daemon, no
-            // provider stack, no telemetry initialization needed. We
-            // build a current-thread tokio runtime so the async
+            // Agent CLI handlers are mostly filesystem-only — no
+            // daemon, no telemetry initialization needed. We build a
+            // current-thread tokio runtime so the async
             // `AgentRegistry::get` / `names` paths still work without
             // pulling in the multi-thread executor.
+            //
+            // The one exception is `test --live` (BRO-1008): it needs
+            // a real provider stack, resolved exactly like the serve
+            // path (config file + CLI flags + env vars). The provider
+            // adapter chain MUST be constructed in sync context and
+            // its final Arc must drop in sync context too — the
+            // Anthropic provider holds a `reqwest::blocking::Client`
+            // whose inner tokio runtime panics if built or dropped
+            // inside an async context (see
+            // `arcan-ergon/tests/anthropic_agents_smoke.rs`). So the
+            // live arm builds the chain HERE, before `block_on`, and
+            // keeps an Arc alive in this scope until after it returns.
             let agents_dir = agent_cmd::resolve_agents_dir(cli.agents_dir);
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            runtime.block_on(async move {
-                match action {
-                    AgentAction::List => agent_cmd::list(&agents_dir).await,
-                    AgentAction::Show { name } => agent_cmd::show(&agents_dir, &name).await,
-                    AgentAction::New {
-                        name,
-                        model,
-                        instructions,
-                    } => agent_cmd::new_agent(
+            match action {
+                AgentAction::Test {
+                    name,
+                    input,
+                    dry_run: false,
+                    live: true,
+                } => {
+                    let resolved = config::resolve(
+                        &file_config,
+                        cli.provider.as_deref(),
+                        cli.model.as_deref(),
+                        cli.port,
+                        None,
+                        None,
+                        cli.autonomic_url.as_deref(),
+                        cli.spaces_backend.as_deref(),
+                        cli.spaces_token.as_deref(),
+                        cli.bare,
+                        cli.default_tier.as_deref(),
+                    );
+                    let provider = build_provider(&resolved)?;
+                    let ergon_provider =
+                        agent_cmd::build_ergon_provider(provider, &resolved.provider);
+                    // `ergon_provider` (and the provider chain under
+                    // it) drops at the end of this arm, in sync
+                    // context, AFTER block_on returned — preserving
+                    // the reqwest::blocking drop-order invariant.
+                    runtime.block_on(agent_cmd::test_live(
                         &agents_dir,
                         &name,
-                        model.as_deref(),
-                        instructions.as_deref(),
-                    ),
-                    AgentAction::Test {
-                        name,
-                        input,
-                        dry_run,
-                    } => {
-                        if !dry_run {
-                            return Err(anyhow::anyhow!(
-                                "live `arcan agent test` execution is not yet supported in this \
-                                 build — pass --dry-run to validate the input against the agent's \
-                                 input_schema. See BRO-1008 follow-ups for the live-LLM path."
-                            ));
-                        }
-                        agent_cmd::test_dry_run(&agents_dir, &name, &input).await
-                    }
+                        &input,
+                        Arc::clone(&ergon_provider),
+                    ))
                 }
-            })
+                action => runtime.block_on(async move {
+                    match action {
+                        AgentAction::List => agent_cmd::list(&agents_dir).await,
+                        AgentAction::Show { name } => agent_cmd::show(&agents_dir, &name).await,
+                        AgentAction::New {
+                            name,
+                            model,
+                            instructions,
+                        } => agent_cmd::new_agent(
+                            &agents_dir,
+                            &name,
+                            model.as_deref(),
+                            instructions.as_deref(),
+                        ),
+                        AgentAction::Test {
+                            name,
+                            input,
+                            dry_run,
+                            live: _,
+                        } => {
+                            if !dry_run {
+                                return Err(anyhow::anyhow!(
+                                    "`arcan agent test` needs an explicit mode: pass --dry-run \
+                                     to validate the input against the agent's input_schema \
+                                     offline (free), or --live to execute the agent against the \
+                                     configured LLM provider (costs money; capped at {} tokens).",
+                                    agent_cmd::AGENT_TEST_MAX_TOKENS,
+                                ));
+                            }
+                            agent_cmd::test_dry_run(&agents_dir, &name, &input).await
+                        }
+                    }
+                }),
+            }
         }
         Some(Command::Shell {
             session,

--- a/crates/arcan/arcan/src/shell.rs
+++ b/crates/arcan/arcan/src/shell.rs
@@ -143,21 +143,10 @@ const EXTRACT_MAX_CHARS: usize = 2000;
 /// Fallback context window (tokens) when the provider doesn't report one.
 const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
 
-/// Estimate cost in USD for a model call based on token usage and model name.
-///
-/// Uses published Claude pricing (per million tokens):
-/// - Opus: $15 input, $75 output
-/// - Sonnet: $3 input, $15 output
-/// - Haiku: $0.25 input, $1.25 output
-fn estimate_cost(input_tokens: u64, output_tokens: u64, model: &str) -> f64 {
-    let (input_rate, output_rate) = match model {
-        m if m.contains("opus") => (15.0, 75.0),
-        m if m.contains("sonnet") => (3.0, 15.0),
-        m if m.contains("haiku") => (0.25, 1.25),
-        _ => (3.0, 15.0), // default to sonnet pricing
-    };
-    (input_tokens as f64 * input_rate + output_tokens as f64 * output_rate) / 1_000_000.0
-}
+// Cost estimation lives in the library half of this crate
+// (`arcan::cost`) so the `arcan agent test --live` path shares the
+// same pricing table (BRO-364 / BRO-1008).
+use arcan::cost::estimate_cost;
 
 /// Query the Autonomic daemon for the current economic mode.
 ///
@@ -2816,49 +2805,7 @@ mod tests {
         assert!(!dir.join("session_summary.md").exists());
     }
 
-    // --- BRO-364: estimate_cost tests ---
-
-    #[test]
-    fn test_estimate_cost_opus() {
-        let cost = estimate_cost(1_000_000, 1_000_000, "claude-opus-4-20250514");
-        // $15 input + $75 output = $90
-        assert!((cost - 90.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_estimate_cost_sonnet() {
-        let cost = estimate_cost(1_000_000, 1_000_000, "claude-sonnet-4-20250514");
-        // $3 input + $15 output = $18
-        assert!((cost - 18.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_estimate_cost_haiku() {
-        let cost = estimate_cost(1_000_000, 1_000_000, "claude-haiku-4-20250514");
-        // $0.25 input + $1.25 output = $1.50
-        assert!((cost - 1.50).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_estimate_cost_unknown_defaults_to_sonnet() {
-        let cost = estimate_cost(1_000_000, 1_000_000, "some-unknown-model");
-        // Should use sonnet pricing: $3 + $15 = $18
-        assert!((cost - 18.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_estimate_cost_zero_tokens() {
-        let cost = estimate_cost(0, 0, "claude-sonnet-4-20250514");
-        assert!((cost).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_estimate_cost_typical_turn() {
-        // A typical turn: 5000 input, 1000 output, sonnet
-        let cost = estimate_cost(5000, 1000, "claude-sonnet-4-20250514");
-        // (5000 * 3 + 1000 * 15) / 1_000_000 = (15000 + 15000) / 1_000_000 = 0.03
-        assert!((cost - 0.03).abs() < 0.001);
-    }
+    // --- BRO-364: estimate_cost tests moved to `arcan::cost` ---
 
     // --- Phase 7: Identity tests (BRO-370) ---
 

--- a/crates/arcan/arcan/tests/agent_cmd.rs
+++ b/crates/arcan/arcan/tests/agent_cmd.rs
@@ -13,6 +13,11 @@
 //! - `new` scaffolds a parseable agent file and refuses to overwrite.
 //! - `test --dry-run` accepts valid input and rejects schema violations
 //!   with structured error messages.
+//! - `test --live` plumbing: the provider adapter chain
+//!   (`build_ergon_provider`), the spend cap pin, and the shared
+//!   schema validator — all offline. The one networked test
+//!   (`test_live_smoke_against_live_anthropic`) is `#[ignore]`d AND
+//!   gated behind `ARCAN_AGENT_TEST_LIVE=1`.
 //!
 //! Per spec
 //! `core/life/docs/superpowers/specs/2026-05-09-bro-1006-authored-agents-architecture.md`
@@ -343,4 +348,108 @@ fn resolve_agents_dir_defaults_to_relative_agents() {
 fn resolve_agents_dir_honors_explicit_path() {
     let custom = PathBuf::from("/tmp/custom-agents");
     assert_eq!(agent_cmd::resolve_agents_dir(Some(custom.clone())), custom);
+}
+
+// ─── test --live plumbing (offline) ────────────────────────────────────
+
+/// The provider adapter chain built by `build_ergon_provider` must
+/// report the supplied provider label through `ergon::Provider::name`
+/// — that's what `StreamEvent::SessionStart` embeds, and the only
+/// chain property observable without a model call.
+#[test]
+fn build_ergon_provider_reports_provider_name() {
+    use std::sync::Arc;
+
+    let provider: Arc<dyn arcan_core::runtime::Provider> = Arc::new(arcand::mock::MockProvider);
+    let chain = agent_cmd::build_ergon_provider(provider, "mock");
+    assert_eq!(chain.name(), "mock");
+}
+
+/// Pin the live-run spend cap. Bumping this constant changes how much
+/// money a single `arcan agent test --live` invocation may burn —
+/// that's a deliberate decision, not a drive-by edit.
+#[test]
+fn agent_test_token_cap_is_pinned() {
+    assert_eq!(agent_cmd::AGENT_TEST_MAX_TOKENS, 50_000);
+}
+
+/// `validate_against_schema` is the shared engine behind the dry-run
+/// input gate AND the live-run output check; its error text must name
+/// both the payload kind and the agent so operators can tell which
+/// side rejected.
+#[test]
+fn validate_against_schema_names_payload_and_agent() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": { "response": { "type": "string" } },
+        "required": ["response"],
+    });
+    let err =
+        agent_cmd::validate_against_schema(&schema, &serde_json::json!({}), "output", "goal-judge")
+            .expect_err("missing required field must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("output is INVALID for agent `goal-judge`"));
+}
+
+// ─── test --live (gated live-LLM smoke) ────────────────────────────────
+
+/// Live-LLM smoke for `arcan agent test --live` (BRO-1008).
+///
+/// Follows the gating pattern of
+/// `crates/arcan/arcan-ergon/tests/anthropic_agents_smoke.rs`:
+///
+/// - `#[ignore]` — real network call, costs money (~$0.01 at Sonnet
+///   pricing), requires `ANTHROPIC_API_KEY`.
+/// - Additionally requires `ARCAN_AGENT_TEST_LIVE=1` so a blanket
+///   `--ignored` sweep doesn't accidentally spend.
+///
+/// Run manually:
+/// ```bash
+/// ARCAN_AGENT_TEST_LIVE=1 ANTHROPIC_API_KEY=sk-ant-... \
+///   cargo test -p arcan --test agent_cmd -- --ignored --nocapture \
+///     test_live_smoke_against_live_anthropic
+/// ```
+///
+/// ## Why `#[test]` not `#[tokio::test]`
+///
+/// `arcan_provider::AnthropicProvider` uses `reqwest::blocking`
+/// internally, which owns an inner tokio runtime. The provider chain
+/// must be constructed in sync context and its final `Arc` must drop
+/// in sync context, or the inner runtime panics with "Cannot drop a
+/// runtime in a context where blocking is not allowed". Mirrors the
+/// smoke test and the `arcan agent test --live` arm in `main.rs`.
+#[test]
+#[ignore = "requires ARCAN_AGENT_TEST_LIVE=1, ANTHROPIC_API_KEY, and live network"]
+fn test_live_smoke_against_live_anthropic() {
+    use std::sync::Arc;
+
+    if std::env::var("ARCAN_AGENT_TEST_LIVE").as_deref() != Ok("1") {
+        eprintln!("[agent-test-live] skipped: set ARCAN_AGENT_TEST_LIVE=1 to run this smoke");
+        return;
+    }
+
+    // Provider chain in sync context (see doc comment above).
+    let config = arcan_provider::anthropic::AnthropicConfig::from_env().expect(
+        "ANTHROPIC_API_KEY must be set for the live smoke; \
+         run with --ignored and provide the env var",
+    );
+    let provider: Arc<dyn arcan_core::runtime::Provider> =
+        Arc::new(arcan_provider::anthropic::AnthropicProvider::new(config));
+    let chain = agent_cmd::build_ergon_provider(provider, "anthropic");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    runtime
+        .block_on(agent_cmd::test_live(
+            &workspace_agents_dir(),
+            "general",
+            r#"{"request": "What is 2 + 2? Reply with just the number, no preamble."}"#,
+            Arc::clone(&chain),
+        ))
+        .expect("live `arcan agent test --live` run must succeed");
+
+    // `chain` drops here, in sync context, after block_on returned.
 }


### PR DESCRIPTION
## Summary

Closes the last architecture-audit gap (BRO-1008): `arcan agent test <name> --live` executes an authored agent against the real configured provider through the same `run_spec` interpreter as production, with a hard cost cap.

- explicit dual-mode CLI: `--dry-run` (schema-only, unchanged) XOR `--live` (`conflicts_with`); bare `arcan agent test` still errors with a hint to both — no accidental spend
- provider resolved exactly like `arcan serve` (config + flags + env), adapted through the canonical chain `arcan_core::Provider → ArcanProviderAdapter → ModelProviderAdapter → ergon::Provider` (the trait-mismatch correction from adversarial review of the original plan)
- `reqwest::blocking` constraint honored: the chain is built and dropped in sync context (documented in code, mirrors `anthropic_agents_smoke.rs`)
- cost guard: `TokenBudgetHook` denies `on_pre_inference` at 50K cumulative tokens and doubles as the usage ledger for the post-run summary (tokens + est. USD); `estimate_cost` promoted from `shell.rs` to a shared `arcan::cost` module (BRO-364 tests moved with it)
- live Anthropic smoke double-gated (`#[ignore]` + `ARCAN_AGENT_TEST_LIVE=1`), not executed in CI

## Validation

- Stream agent: full `cargo test -p arcan` + clippy `-D warnings` + fmt green; manual CLI checks incl. driving the full adapter chain offline via `--provider mock` (16 turns, typed `AnswerNotEmitted` failure, no blocking-client panic)
- Independent re-verification (this session): clippy clean; 16 lib + 120 bin + 20 agent_cmd (+1 gated) + 10 praxis tests pass
- The stream's adversarial-review slot was lost to a session limit; reviewed inline instead (diff read + independent test/clippy run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)