### PR TITLE
fix(arcan): repair main — resolve-call-site merge skew between #1694 and #1696

### DIFF
--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -1863,6 +1863,7 @@ fn main() -> anyhow::Result<()> {
                         cli.spaces_token.as_deref(),
                         cli.bare,
                         cli.default_tier.as_deref(),
+                        cli.anima_identity_dir.as_deref(),
                     );
                     let provider = build_provider(&resolved)?;
                     let ergon_provider =


### PR DESCRIPTION
## Summary

**Main is compile-broken** since `0caa70bd`: #1694 added a 12th parameter to `config::resolve` (`anima_identity_dir`) and threaded all *then-existing* call sites; #1696 — branched before #1694 landed — introduced a *new* call site with the old 11-arg shape in the `agent test --live` arm. No textual conflict, both PRs green independently, the union fails E0061. Broke: main MSRV Check + Lint lanes (seen on rebased #1693) and the lifegw-stack Railway build at `1249bd87`.

One-line fix: pass `cli.anima_identity_dir.as_deref()` like the other nine call sites.

## Test plan

- ✅ `cargo check -p arcan` + `cargo clippy -p arcan --all-targets -- -D warnings` clean
- ✅ `cargo test -p arcan`: 179 passing (first run with both streams' suites combined)
- 🔜 Post-merge: lifegw-stack Railway rebuild should reach SUCCESS and boot with `substrates: arcan=real …`

## Process note

Two-green-PRs-broken-merge is exactly what a merge queue / `require_branch_up_to_date` would have caught — worth considering for rust-touching PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)