### PR TITLE
fix(ci): harden Test (Linux) against runner-death (disk exhaustion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,46 @@ jobs:
       - run: cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments
 
   # ── Gate 3: Tests (Linux) ─────────────────────────────────────────
+  #
+  # Runner-death hardening (2026-06-11): this lane died on three
+  # consecutive main pushes (and twice on PR #1693) with the
+  # `cargo test --workspace` step ending in a NULL conclusion — the
+  # runner agent itself was killed, not the tests. That is the
+  # disk-exhaustion signature: a 125-crate workspace debug+test build
+  # plus a multi-GB restored cache overruns the ~14 GB usable disk on
+  # ubuntu-latest. Three mitigations, in order of leverage:
+  #   1. CARGO_PROFILE_*_DEBUG=0 — debuginfo dominates target/ size
+  #      (typically 50-70% of it); tests don't need DWARF on CI.
+  #      debug-assertions are a separate knob and stay on.
+  #   2. Shed ~10 GB of preinstalled runner bloat we never use.
+  #   3. Bump the rust-cache lineage (v0 grew past usefulness; a fresh
+  #      lineage caches the slimmer no-debuginfo artifacts).
+  # macOS keeps full debuginfo — its runners have ~100 GB disk.
   test-linux:
     name: Test (Linux)
     needs: [format, lint]
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@v4
+      - name: Free runner disk (unused preinstalled toolchains)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift || true
+          df -h /
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
       - run: cargo test --workspace
+      - name: Disk headroom after tests
+        if: always()
+        run: df -h /
 
   # ── Gate 4: Tests (macOS) — post-merge only ──────────────────────
   #


### PR DESCRIPTION
## Summary

The **Test (Linux)** lane has been dying with a *runner-death* signature — the `cargo test --workspace` step ends with a **NULL conclusion** (the runner agent is killed; no test failure, no logs) — on three consecutive main pushes (`d09257b0`, `cb5e1245`, `bac6d543`'s predecessor runs) and twice on PR #1693. This blocks every merge gate in the repo.

Diagnosis: disk exhaustion. A 125-crate workspace debug+test build plus a multi-GB restored `v0` rust-cache overruns the ~14 GB usable disk on `ubuntu-latest`. OOM kills `rustc` and the step *fails with logs*; disk-full wedges the runner agent itself → NULL step conclusions, which matches the observed pattern exactly (see `docs/handoffs/2026-06-10-prod-restoration-and-tool-wire.md` §Pickup).

## Mitigations (in order of leverage)

1. `CARGO_PROFILE_DEV_DEBUG=0` + `CARGO_PROFILE_TEST_DEBUG=0` — debuginfo dominates `target/` size (typically 50-70%). CI tests don't need DWARF; `debug-assertions` are a separate knob and stay on. macOS lane keeps full debuginfo (~100 GB disk there).
2. Free ~10 GB of preinstalled runner bloat we never use (dotnet, Android SDK, GHC, CodeQL bundle, Swift).
3. Bump rust-cache lineage `v0 → v1` (`prefix-key: v1-rust`) so the fresh lineage caches the slimmer no-debuginfo artifacts instead of restoring the bloated cache that contributes to the exhaustion.
4. `df -h /` probes before and after the test run for future forensics.

## Test plan

- [x] YAML validated locally
- [ ] This PR's own **Test (Linux)** run passes on the first attempt — that lane *is* the empirical receipt (it exercises the freed disk + fresh cache + no-debuginfo build end-to-end)
- [ ] `df -h` output in the job log shows comfortable headroom after tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline stability and efficiency by optimizing runner resource management and cache configuration during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->