### PR TITLE
feat(lifegw-stack): run real lagod — lifed selects lago=real (Stage 6)

### DIFF
--- a/crates/lago/lago-cli/src/commands/serve.rs
+++ b/crates/lago/lago-cli/src/commands/serve.rs
@@ -31,5 +31,8 @@ pub async fn run(opts: ServeOptions) -> Result<(), Box<dyn std::error::Error>> {
         Some(opts.data_dir),
     );
 
-    lagod::run(config).await
+    // `lago serve` is the standalone dev/TCP path — no substrate-plane
+    // UDS. The Topology-B UDS surface is driven by the `lagod` binary's
+    // `--uds-socket` flag (Stage 6).
+    lagod::run(config, None).await
 }

--- a/crates/lago/lagod/Cargo.toml
+++ b/crates/lago/lagod/Cargo.toml
@@ -29,6 +29,12 @@ clap.workspace = true
 prost-types.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+# `tokio-stream` (workspace features include `net`) provides
+# `UnixListenerStream`, used by the optional substrate-plane UDS serve
+# mode (`--uds-socket`). Previously dev-only — promoted to a runtime
+# dep when the UDS listener moved from the BRO-1017 wire test into the
+# daemon itself (Stage 6: lifed dials lagod over `/run/life/lago.sock`).
+tokio-stream.workspace = true
 tonic.workspace = true
 axum.workspace = true
 toml.workspace = true
@@ -48,5 +54,7 @@ aios-protocol.workspace = true
 lago-proxy.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-tokio-stream = { workspace = true, features = ["net"] }
+# `tokio-stream` is now a runtime dependency (see above) with the `net`
+# feature; the wire test reuses it for its in-test UDS listener.
+tokio-stream.workspace = true
 tonic = "0.14"

--- a/crates/lago/lagod/src/lib.rs
+++ b/crates/lago/lagod/src/lib.rs
@@ -38,8 +38,22 @@ pub async fn serve_substrate_uds<S>(
 where
     S: Future<Output = ()> + Send + 'static,
 {
-    use lago_substrate_proto::lago::v1::lago_substrate_server::LagoSubstrateServer;
+    let listener = bind_substrate_uds(&socket_path)?;
+    serve_substrate_uds_on(socket_path, listener, journal, shutdown).await
+}
 
+/// Bind the substrate-plane Unix socket: ensure the parent dir exists,
+/// unlink any stale socket file (a crashed predecessor leaves one
+/// behind and a fresh `bind()` would fail with AddrInUse), then bind.
+///
+/// Split from the serve future so `run()` can bind EAGERLY: a failed
+/// `--uds-socket` is an explicitly requested plane and must fail the
+/// daemon fast — not log-and-continue inside a spawned task while the
+/// TCP/HTTP planes keep serving with the substrate plane silently dead.
+#[doc(hidden)]
+pub fn bind_substrate_uds(
+    socket_path: &std::path::Path,
+) -> Result<tokio::net::UnixListener, Box<dyn std::error::Error>> {
     if let Some(parent) = socket_path.parent()
         && !parent.as_os_str().is_empty()
     {
@@ -47,17 +61,33 @@ where
             .map_err(|e| format!("create parent dir {}: {e}", parent.display()))?;
     }
     if socket_path.exists() {
-        std::fs::remove_file(&socket_path)
+        std::fs::remove_file(socket_path)
             .map_err(|e| format!("unlink stale socket {}: {e}", socket_path.display()))?;
     }
 
-    let listener = tokio::net::UnixListener::bind(&socket_path)
+    let listener = tokio::net::UnixListener::bind(socket_path)
         .map_err(|e| format!("bind {}: {e}", socket_path.display()))?;
 
     info!(
         socket = %socket_path.display(),
         "lago substrate-plane gRPC listening (lago.v1.LagoSubstrate over UDS)"
     );
+    Ok(listener)
+}
+
+/// Serve `lago.v1.LagoSubstrate` on an already-bound listener until
+/// `shutdown` resolves, then best-effort remove the socket file.
+#[doc(hidden)]
+pub async fn serve_substrate_uds_on<S>(
+    socket_path: PathBuf,
+    listener: tokio::net::UnixListener,
+    journal: Arc<dyn lago_core::Journal>,
+    shutdown: S,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
+    use lago_substrate_proto::lago::v1::lago_substrate_server::LagoSubstrateServer;
 
     let service = substrate::SubstrateService::new(journal);
     let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
@@ -160,16 +190,30 @@ pub async fn run(
     // is set, bind that service on the socket using the SAME journal as
     // the TCP gRPC + HTTP planes. Additive — the standalone TCP/HTTP
     // daemon is unchanged when the socket is absent.
-    let uds_handle = uds_socket.map(|socket_path| {
-        let uds_journal = journal.clone() as Arc<dyn lago_core::Journal>;
-        tokio::spawn(async move {
-            if let Err(e) =
-                serve_substrate_uds(socket_path, uds_journal, shutdown::shutdown_signal()).await
-            {
-                tracing::error!(error = %e, "substrate-plane UDS server exited with error");
-            }
-        })
-    });
+    let uds_handle = match uds_socket {
+        Some(socket_path) => {
+            // Bind eagerly (cross-review finding): the UDS is the only
+            // plane Topology B consumes — a bind failure must fail the
+            // daemon NOW with the real error, not surface 30 seconds
+            // later as the stack entrypoint's generic probe timeout
+            // while TCP/HTTP keep serving a substrate-dead lagod.
+            let listener = bind_substrate_uds(&socket_path)?;
+            let uds_journal = journal.clone() as Arc<dyn lago_core::Journal>;
+            Some(tokio::spawn(async move {
+                if let Err(e) = serve_substrate_uds_on(
+                    socket_path,
+                    listener,
+                    uds_journal,
+                    shutdown::shutdown_signal(),
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "substrate-plane UDS server exited with error");
+                }
+            }))
+        }
+        None => None,
+    };
 
     // --- Configure auth layer (optional)
     let jwt_secret = config

--- a/crates/lago/lagod/src/lib.rs
+++ b/crates/lago/lagod/src/lib.rs
@@ -3,12 +3,74 @@ pub mod shutdown;
 pub mod substrate;
 
 use config::DaemonConfig;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 
+/// Bind lagod's substrate-plane gRPC server (`lago.v1.LagoSubstrate`) on
+/// a Unix-domain socket and serve it until the shutdown signal fires.
+///
+/// Stage 6 (June 2026): this is the entry point lifed's `lago-proxy`
+/// reaches in Topology B. lago-proxy dials a UDS (`LagoProxy::connect`
+/// → `UnixStream::connect`), so the TCP `LagoSubstrate` mounted on the
+/// gRPC port (BRO-1017) is unreachable from lifed — lifed needs a
+/// *socket*. This binds the SAME service over a UDS, sharing the one
+/// `Arc<dyn Journal>` the TCP gRPC + HTTP planes already drive. Mirrors
+/// arcand's `serve_substrate_uds` (`crates/arcan/arcan/src/main.rs`):
+/// ensure the parent dir exists, unlink any stale socket, bind, then
+/// serve via `serve_with_incoming_shutdown`.
+async fn serve_substrate_uds(
+    socket_path: PathBuf,
+    journal: Arc<dyn lago_core::Journal>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use lago_substrate_proto::lago::v1::lago_substrate_server::LagoSubstrateServer;
+
+    if let Some(parent) = socket_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create parent dir {}: {e}", parent.display()))?;
+    }
+    if socket_path.exists() {
+        std::fs::remove_file(&socket_path)
+            .map_err(|e| format!("unlink stale socket {}: {e}", socket_path.display()))?;
+    }
+
+    let listener = tokio::net::UnixListener::bind(&socket_path)
+        .map_err(|e| format!("bind {}: {e}", socket_path.display()))?;
+
+    info!(
+        socket = %socket_path.display(),
+        "lago substrate-plane gRPC listening (lago.v1.LagoSubstrate over UDS)"
+    );
+
+    let service = substrate::SubstrateService::new(journal);
+    let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
+
+    tonic::transport::Server::builder()
+        .add_service(LagoSubstrateServer::new(service))
+        .serve_with_incoming_shutdown(incoming, shutdown::shutdown_signal())
+        .await
+        .map_err(|e| format!("substrate UDS serve: {e}"))?;
+
+    // Best-effort cleanup of the socket file on graceful shutdown.
+    let _ = std::fs::remove_file(&socket_path);
+    Ok(())
+}
+
 /// Run the Lago daemon with the given configuration.
-pub async fn run(config: DaemonConfig) -> Result<(), Box<dyn std::error::Error>> {
-    info!(?config, "starting lagod");
+///
+/// When `uds_socket` is `Some(path)`, an additional substrate-plane
+/// gRPC server (`lago.v1.LagoSubstrate`) is bound on that Unix-domain
+/// socket alongside the TCP gRPC + HTTP servers — this is the surface
+/// lifed's `lago-proxy` dials under Topology B (Stage 6). When `None`,
+/// only the TCP gRPC + HTTP planes run (the standalone / `lago serve`
+/// behavior).
+pub async fn run(
+    config: DaemonConfig,
+    uds_socket: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!(?config, ?uds_socket, "starting lagod");
 
     // --- Ensure data directory exists
     std::fs::create_dir_all(&config.data_dir)?;
@@ -76,6 +138,22 @@ pub async fn run(config: DaemonConfig) -> Result<(), Box<dyn std::error::Error>>
             .map_err(|e| format!("gRPC server error: {e}"))
     });
 
+    // --- Optional substrate-plane UDS server (Topology B, Stage 6)
+    //
+    // lifed's `lago-proxy` dials `lago.v1.LagoSubstrate` over a Unix
+    // socket (not TCP). When `--uds-socket <PATH>` / `LAGO_UDS_SOCKET`
+    // is set, bind that service on the socket using the SAME journal as
+    // the TCP gRPC + HTTP planes. Additive — the standalone TCP/HTTP
+    // daemon is unchanged when the socket is absent.
+    let uds_handle = uds_socket.map(|socket_path| {
+        let uds_journal = journal.clone() as Arc<dyn lago_core::Journal>;
+        tokio::spawn(async move {
+            if let Err(e) = serve_substrate_uds(socket_path, uds_journal).await {
+                tracing::error!(error = %e, "substrate-plane UDS server exited with error");
+            }
+        })
+    });
+
     // --- Configure auth layer (optional)
     let jwt_secret = config
         .auth
@@ -141,13 +219,19 @@ pub async fn run(config: DaemonConfig) -> Result<(), Box<dyn std::error::Error>>
     shutdown::shutdown_signal().await;
     info!("shutdown signal received");
 
-    // Abort both servers
+    // Abort the servers. The UDS server (if running) drains itself via
+    // its own `serve_with_incoming_shutdown(shutdown_signal())`, so it
+    // observes the same SIGTERM/SIGINT and exits gracefully; we still
+    // await its handle so the socket-file cleanup runs before we return.
     grpc_handle.abort();
     http_handle.abort();
 
     // Wait for tasks to finish (they may have already been aborted)
     let _ = grpc_handle.await;
     let _ = http_handle.await;
+    if let Some(handle) = uds_handle {
+        let _ = handle.await;
+    }
 
     info!("lagod stopped");
     Ok(())

--- a/crates/lago/lagod/src/lib.rs
+++ b/crates/lago/lagod/src/lib.rs
@@ -3,12 +3,13 @@ pub mod shutdown;
 pub mod substrate;
 
 use config::DaemonConfig;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 
 /// Bind lagod's substrate-plane gRPC server (`lago.v1.LagoSubstrate`) on
-/// a Unix-domain socket and serve it until the shutdown signal fires.
+/// a Unix-domain socket and serve it until `shutdown` resolves.
 ///
 /// Stage 6 (June 2026): this is the entry point lifed's `lago-proxy`
 /// reaches in Topology B. lago-proxy dials a UDS (`LagoProxy::connect`
@@ -19,10 +20,24 @@ use tracing::info;
 /// arcand's `serve_substrate_uds` (`crates/arcan/arcan/src/main.rs`):
 /// ensure the parent dir exists, unlink any stale socket, bind, then
 /// serve via `serve_with_incoming_shutdown`.
-async fn serve_substrate_uds(
+///
+/// The shutdown trigger is injected rather than hard-wired to
+/// `shutdown::shutdown_signal()` so the bind→serve→cleanup path can be
+/// exercised by an integration test with a `oneshot` (the daemon passes
+/// the real signal future at its single call site below).
+///
+/// `#[doc(hidden)] pub` purely so `tests/topology_b_e2e_lago.rs` can
+/// drive lagod's OWN serve path (rather than a hand-rolled copy of it);
+/// not part of the supported API surface.
+#[doc(hidden)]
+pub async fn serve_substrate_uds<S>(
     socket_path: PathBuf,
     journal: Arc<dyn lago_core::Journal>,
-) -> Result<(), Box<dyn std::error::Error>> {
+    shutdown: S,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
     use lago_substrate_proto::lago::v1::lago_substrate_server::LagoSubstrateServer;
 
     if let Some(parent) = socket_path.parent()
@@ -49,7 +64,7 @@ async fn serve_substrate_uds(
 
     tonic::transport::Server::builder()
         .add_service(LagoSubstrateServer::new(service))
-        .serve_with_incoming_shutdown(incoming, shutdown::shutdown_signal())
+        .serve_with_incoming_shutdown(incoming, shutdown)
         .await
         .map_err(|e| format!("substrate UDS serve: {e}"))?;
 
@@ -148,7 +163,9 @@ pub async fn run(
     let uds_handle = uds_socket.map(|socket_path| {
         let uds_journal = journal.clone() as Arc<dyn lago_core::Journal>;
         tokio::spawn(async move {
-            if let Err(e) = serve_substrate_uds(socket_path, uds_journal).await {
+            if let Err(e) =
+                serve_substrate_uds(socket_path, uds_journal, shutdown::shutdown_signal()).await
+            {
                 tracing::error!(error = %e, "substrate-plane UDS server exited with error");
             }
         })

--- a/crates/lago/lagod/src/main.rs
+++ b/crates/lago/lagod/src/main.rs
@@ -28,6 +28,15 @@ struct Args {
     /// Data directory (overrides config file)
     #[arg(long)]
     data_dir: Option<PathBuf>,
+
+    /// Bind lagod's substrate-plane gRPC server (`lago.v1.LagoSubstrate`)
+    /// on this Unix-domain socket alongside the TCP gRPC + HTTP servers.
+    /// When unset, only the TCP/HTTP planes run (standalone behavior).
+    /// Topology-B operators set this so lifed's `lago-proxy` can dial in
+    /// over `/run/life/lago.sock`. Stage 6 — sibling of arcand's
+    /// `--uds-socket` (BRO-1016).
+    #[arg(long, env = "LAGO_UDS_SOCKET", value_name = "PATH")]
+    uds_socket: Option<PathBuf>,
 }
 
 // --- Entry point
@@ -51,6 +60,6 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut config = DaemonConfig::load(&args.config)?;
     config.merge_cli(args.grpc_port, args.http_port, args.data_dir);
 
-    // --- Run the daemon
-    lagod::run(config).await
+    // --- Run the daemon (optionally binding the substrate-plane UDS)
+    lagod::run(config, args.uds_socket).await
 }

--- a/crates/lago/lagod/tests/topology_b_e2e_lago.rs
+++ b/crates/lago/lagod/tests/topology_b_e2e_lago.rs
@@ -326,3 +326,91 @@ async fn proxy_to_server_round_trip() {
 
     env.shutdown().await;
 }
+
+/// Stage 6: drive lagod's OWN `serve_substrate_uds` helper (not a
+/// hand-rolled copy like `SubstrateUnderTest` above) over a tempdir
+/// UDS, dial it with `LagoProxy`, and prove the full bind → serve →
+/// inject-shutdown → socket-cleanup path lifed reaches in production.
+///
+/// The helper is `#[doc(hidden)] pub` solely for this test; the daemon
+/// passes `shutdown::shutdown_signal()` at its single call site, this
+/// test passes a `oneshot` it controls so the drain is deterministic
+/// (no process-global SIGTERM/SIGINT in the harness).
+#[tokio::test]
+async fn serve_substrate_uds_binds_dials_and_cleans_up() {
+    let tempdir = TempDir::new().expect("tempdir");
+    // Nest the socket one dir deep to also exercise the helper's
+    // `create_dir_all(parent)` branch.
+    let socket = tempdir.path().join("run").join("lago.sock");
+    let db_path = tempdir.path().join("journal.redb");
+    let journal = Arc::new(RedbJournal::open(&db_path).expect("open journal"));
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let serve_journal = Arc::clone(&journal) as Arc<dyn Journal>;
+    let serve_socket = socket.clone();
+    // `serve_substrate_uds` returns `Box<dyn Error>` (not `+ Send`), so
+    // collapse it to a `String` (Send) inside the task — same shape as
+    // the daemon's call site, which maps the error to a log line.
+    let server = tokio::spawn(async move {
+        lagod::serve_substrate_uds(serve_socket, serve_journal, async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .map_err(|e| e.to_string())
+    });
+
+    // The helper creates the parent dir + binds the socket; wait for it.
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(socket.exists(), "helper bound the UDS (parent dir created)");
+
+    // Dial lagod's real serve path and round-trip an append into the
+    // SHARED journal — the same handle lifed's lago-proxy reaches.
+    let proxy = LagoProxy::connect(socket.clone())
+        .await
+        .expect("dial lagod serve_substrate_uds over UDS");
+    let namespace = "session/stage6-uds-serve";
+    let payload = serde_json::json!({"stage": 6, "real": true});
+    proxy
+        .append_event(
+            namespace,
+            "stage6.boot",
+            serde_json::to_vec(&payload).unwrap(),
+        )
+        .await
+        .expect("append_event through lagod serve path");
+
+    let events = journal
+        .read(
+            EventQuery::new()
+                .session(SessionId::from_string(namespace))
+                .branch(BranchId::from_string("main")),
+        )
+        .await
+        .expect("read journal");
+    assert_eq!(events.len(), 1, "append journaled via lagod's serve path");
+    match &events[0].payload {
+        EventKind::Custom { event_type, data } => {
+            assert_eq!(event_type, "stage6.boot");
+            assert_eq!(data, &payload);
+        }
+        other => panic!("expected EventKind::Custom, got: {other:?}"),
+    }
+
+    // Trigger the injected shutdown and assert the helper drains AND
+    // best-effort-removes the socket file (the production cleanup).
+    let _ = shutdown_tx.send(());
+    let served = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("serve task drained within 5s")
+        .expect("serve task joined");
+    served.expect("serve_substrate_uds returned Ok after shutdown");
+    assert!(
+        !socket.exists(),
+        "socket file cleaned up on graceful shutdown"
+    );
+}

--- a/crates/lago/lagod/tests/topology_b_e2e_lago.rs
+++ b/crates/lago/lagod/tests/topology_b_e2e_lago.rs
@@ -414,3 +414,56 @@ async fn serve_substrate_uds_binds_dials_and_cleans_up() {
         "socket file cleaned up on graceful shutdown"
     );
 }
+
+#[tokio::test]
+async fn serve_substrate_uds_rebinds_over_stale_socket() {
+    // A crashed predecessor (SIGKILL, OOM) leaves the socket FILE
+    // behind with no listener — the exact state a container restart
+    // inherits. `bind_substrate_uds` must unlink it and bind fresh
+    // instead of failing AddrInUse and (via the eager-bind contract)
+    // taking the daemon down.
+    let tempdir = TempDir::new().expect("tempdir");
+    let socket = tempdir.path().join("lagod.sock");
+    let db_path = tempdir.path().join("journal.redb");
+    let journal = Arc::new(RedbJournal::open(&db_path).expect("open journal"));
+
+    // Fabricate the stale state: bind a real UDS at the path, then
+    // drop the listener WITHOUT removing the file (a kill leaves
+    // exactly this — `exists()` true, `connect()` refused).
+    {
+        let stale = tokio::net::UnixListener::bind(&socket).expect("bind stale socket");
+        drop(stale);
+    }
+    assert!(socket.exists(), "stale socket file is present pre-rebind");
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let serve_journal = Arc::clone(&journal) as Arc<dyn Journal>;
+    // `Box<dyn Error>` is not Send — collapse to String inside the
+    // task, same shape as the bind→dial→cleanup test above.
+    let serve_socket = socket.clone();
+    let server = tokio::spawn(async move {
+        lagod::serve_substrate_uds(serve_socket, serve_journal, async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .map_err(|e| e.to_string())
+    });
+
+    // The rebind must yield a CONNECTABLE listener (not merely a file).
+    let mut connected = false;
+    for _ in 0..100 {
+        if tokio::net::UnixStream::connect(&socket).await.is_ok() {
+            connected = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(connected, "rebound socket accepts connections");
+
+    let _ = shutdown_tx.send(());
+    let served = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("serve task drained within 5s")
+        .expect("serve task joined");
+    served.expect("serve_substrate_uds returned Ok after shutdown");
+}

--- a/deploy/railway/lifegw-stack/Dockerfile
+++ b/deploy/railway/lifegw-stack/Dockerfile
@@ -2,8 +2,10 @@
 #
 # What runs inside:
 #   - arcan          (substrate-plane gRPC UDS at /run/life/arcan.sock —
-#                     Stage 5: lifed picks it up as the REAL arcan substrate;
-#                     lago/haima/anima stay mocked via LIFED_ALLOW_MOCK_FALLBACK)
+#                     Stage 5: lifed picks it up as the REAL arcan substrate)
+#   - lagod          (substrate-plane gRPC UDS at /run/life/lago.sock —
+#                     Stage 6: lifed picks it up as the REAL lago substrate;
+#                     haima/anima stay mocked via LIFED_ALLOW_MOCK_FALLBACK)
 #   - lifed          (UDS at /run/life/life.sock + /run/life/life-admin.sock)
 #   - lifegw         (HTTPS on 127.0.0.1:8443, self-signed cert, dev signer)
 #   - caddy          (binds :$PORT cleartext, reverse-proxies to https://127.0.0.1:8443
@@ -49,12 +51,16 @@ COPY . .
 # Stage 5: `-p arcan` ships the real arcan substrate daemon — its
 # `serve --uds-socket /run/life/arcan.sock` binds the substrate-plane
 # gRPC server that lifed's per-substrate bootstrap dials.
+# Stage 6: `-p lagod` ships the real lago substrate daemon — its
+# `--uds-socket /run/life/lago.sock` binds `lago.v1.LagoSubstrate` over
+# the same socket lifed's lago-proxy dials.
 RUN cargo build --release \
         --manifest-path Cargo.toml \
         -p lifegw \
         -p lifed \
         -p arcan \
- && strip ./.target/release/lifegw ./.target/release/lifed ./.target/release/arcan
+        -p lagod \
+ && strip ./.target/release/lifegw ./.target/release/lifed ./.target/release/arcan ./.target/release/lagod
 
 # ── Stage 2 — runtime image ─────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -80,9 +86,12 @@ RUN apt-get update \
  && apt-get purge -y --auto-remove curl gnupg \
  && rm -rf /var/lib/apt/lists/*
 
-# Runtime layout — every UDS lifegw + lifed + arcan touches lives under
-# /run/life/. /var/lib/arcan holds arcan's journal + blob storage (mount
-# a Railway volume there to persist sessions across redeploys).
+# Runtime layout — every UDS lifegw + lifed + arcan + lagod touches
+# lives under /run/life/. /var/lib/arcan holds arcan's journal + blob
+# storage. lagod's journal + blobs live under the mounted volume at
+# ${LIFE_STATE_DIR}/lago (entrypoint.sh creates it) so events survive
+# redeploys — the dir is NOT pre-created here because LIFE_STATE_DIR is
+# a runtime mount point.
 RUN groupadd --system life-runtime \
  && useradd  --system --gid life-runtime --home-dir /var/lib/life --create-home life \
  && mkdir -p /run/life /etc/lifegw/tls /etc/lifegw /etc/lifed /var/lib/arcan \
@@ -93,6 +102,7 @@ WORKDIR /opt/life
 COPY --from=builder /build/.target/release/lifegw /usr/local/bin/lifegw
 COPY --from=builder /build/.target/release/lifed  /usr/local/bin/lifed
 COPY --from=builder /build/.target/release/arcan  /usr/local/bin/arcan
+COPY --from=builder /build/.target/release/lagod  /usr/local/bin/lagod
 
 # Blessed authored agents for arcan's FsAgentRegistry (spawn_agent
 # fails-closed with unknown_agent when the registry is empty).
@@ -105,14 +115,15 @@ COPY deploy/railway/lifegw-stack/entrypoint.sh  /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Railway sets PORT at runtime; default for local docker run.
-# LIFED_ALLOW_MOCK_FALLBACK stays true: Stage 5's per-substrate
-# selection picks up the REAL arcand (its UDS is bound before lifed
-# starts — see entrypoint.sh) and mocks only lago/haima/anima.
+# LIFED_ALLOW_MOCK_FALLBACK stays true: Stage 6's per-substrate
+# selection picks up the REAL arcand AND lagod (their UDS sockets are
+# bound before lifed starts — see entrypoint.sh) and mocks only
+# haima/anima until their daemons ship.
 ENV PORT=8080 \
     LIFEGW_CONFIG=/etc/lifegw/config.toml \
     LIFED_CONFIG=/etc/lifed/config.toml \
     LIFED_ALLOW_MOCK_FALLBACK=true \
-    RUST_LOG=info,lifegw=info,lifed=info,arcan=info,arcand=info \
+    RUST_LOG=info,lifegw=info,lifed=info,arcan=info,arcand=info,lagod=info,lago=info \
     RUST_BACKTRACE=1
 
 EXPOSE 8080

--- a/deploy/railway/lifegw-stack/Dockerfile
+++ b/deploy/railway/lifegw-stack/Dockerfile
@@ -123,11 +123,12 @@ ENV PORT=8080 \
     LIFEGW_CONFIG=/etc/lifegw/config.toml \
     LIFED_CONFIG=/etc/lifed/config.toml \
     LIFED_ALLOW_MOCK_FALLBACK=true \
-    RUST_LOG=info,lifegw=info,lifed=info,arcan=info,arcand=info,lagod=info,lago=info \
+    RUST_LOG=info,lifegw=info,lifed=info,arcan=info,arcand=info,lagod=info,lago_journal=info,lago_api=info \
     RUST_BACKTRACE=1
 
 EXPOSE 8080
 
-# tini guards against caddy → lifegw → lifed orphan reaping; entrypoint.sh
-# fans out the three processes and execs caddy in fg so SIGTERM propagates.
+# tini guards orphan reaping; entrypoint.sh fans out the five processes
+# (arcan, lagod, lifed, lifegw, caddy) and waits on caddy under a live
+# trap so SIGTERM drains every child (see entrypoint §6).
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/deploy/railway/lifegw-stack/README.md
+++ b/deploy/railway/lifegw-stack/README.md
@@ -92,12 +92,16 @@ the railway service variables for `RAILWAY_DOCKERFILE_PATH`.
 ## Local smoke test
 
 ```bash
+# ANTHROPIC_API_KEY unlocks the REAL arcan substrate (else MockArcan);
+# the life-state volume persists lagod's journal + the Tier-2 key.
+# (Comments cannot ride backslash continuations — `\  #` is an escaped
+# space, which would terminate the command mid-line.)
 docker run --rm -p 8080:8080 \
   -e PORT=8080 \
   -e LIFED_ALLOW_MOCK_FALLBACK=1 \
-  -e ANTHROPIC_API_KEY=...  \  # unlocks the REAL arcan substrate (else MockArcan)
-  -e RUST_LOG=info,lifegw=debug,lifed=debug,arcan=info,lagod=info,lago=info \
-  -v life-state:/var/life-state \  # persists lagod's journal + the Tier-2 key
+  -e ANTHROPIC_API_KEY=... \
+  -e RUST_LOG=info,lifegw=debug,lifed=debug,arcan=info,lagod=info \
+  -v life-state:/var/life-state \
   lifegw-stack
 
 # In another shell:

--- a/deploy/railway/lifegw-stack/README.md
+++ b/deploy/railway/lifegw-stack/README.md
@@ -1,9 +1,12 @@
 # lifegw-stack — Railway deploy
 
-A multi-process container that ships `lifegw` + `lifed` together, fronted by
-Caddy, behind Railway's TLS-terminating edge. This is the **Stage-1** deploy
-profile referenced by the canonical Life runtime spec at
+A multi-process container that ships `lifegw` + `lifed` together with the
+real `arcan` and `lagod` substrate daemons, fronted by Caddy, behind
+Railway's TLS-terminating edge. This is the deploy profile referenced by
+the canonical Life runtime spec at
 `apps/chat/docs/superpowers/specs/2026-05-03-life-runtime-canonical.md` §M.
+It has advanced incrementally (#1695): Stage 5 added real arcan, **Stage 6
+adds real lago** — `arcan=real lago=real haima=mock anima=mock`.
 
 ## Topology
 
@@ -22,7 +25,14 @@ broomva.tech (Vercel)
 │                                    lifegw                          │
 │                                       │                            │
 │                                       ▼ /run/life/life.sock        │
-│                                    lifed (mock-fallback)           │
+│                                    lifed (per-substrate selection) │
+│                                       │                            │
+│                  ┌────────────────────┼────────────────────┐       │
+│                  ▼ arcan.sock         ▼ lago.sock           │       │
+│               arcan (REAL)         lagod (REAL)      haima/anima    │
+│            substrate-plane gRPC   lago.v1.Lago-      (MOCK — no     │
+│            (arcan.v1.Agent-       Substrate over     socket bound)  │
+│             Substrate over UDS)    UDS               │             │
 │                                                                    │
 +────────────────────────────────────────────────────────────────────+
 ```
@@ -34,18 +44,37 @@ broomva.tech (Vercel)
 | `caddy` | reverse-proxy / TLS-terminated bridge | `:$PORT` (cleartext) |
 | `lifegw` | edge gateway — Tier-1/Tier-2 mint, WS bidi pump, `/anima/custody/*` | `127.0.0.1:8443` (self-signed TLS) |
 | `lifed` | facade aggregator — `life.v1.{Agent,Events,Wallet,Identity}` | `/run/life/life.sock` (UDS) |
+| `arcan` | REAL arcan substrate — `arcan.v1.AgentSubstrate` (agent loop) | `/run/life/arcan.sock` (UDS) + `:3000` HTTP (internal) |
+| `lagod` | REAL lago substrate — `lago.v1.LagoSubstrate` (event journal + blobs) | `/run/life/lago.sock` (UDS) + `:50051` gRPC / `:8077` HTTP (internal) |
 
-`lifed` boots with `LIFED_ALLOW_MOCK_FALLBACK=1`, which substitutes mock substrates
-for arcand / lagod / haimad / animad / soma. The wire path through Caddy → lifegw →
-lifed runs against real code; substrate behaviour is mocked.
+`lifed` boots with `LIFED_ALLOW_MOCK_FALLBACK=1` and per-substrate real/mock
+selection: it dials each substrate's UDS once at boot. `arcan.sock` and
+`lago.sock` are bound by `entrypoint.sh` **before** lifed starts, so lifed
+selects the **real** arcan + lago substrates; `haima.sock` / `anima.sock`
+are absent, so haima/anima degrade to in-process mocks (gated by the
+fallback flag). Boot log prints the selection:
+`substrates: arcan=real lago=real haima=mock anima=mock`.
 
-## Stage 1 vs production
+> **Why real arcan + lago but mock haima/anima?** Stage 5/6 ship the two
+> substrates the core chat path exercises — the agent loop (arcan) and its
+> durable event journal (lago). haima (finance) and anima (custody) are not
+> on the chat hot path; their daemons join the container in later stages
+> (drop `LIFED_ALLOW_MOCK_FALLBACK` once all four sockets are bound).
+>
+> Stage 6 also required a lagod-side change: `lagod --uds-socket <PATH>`
+> binds `lago.v1.LagoSubstrate` over a UDS. BRO-1017 had mounted that
+> service on the TCP gRPC port only, so lifed's lago-proxy (which dials a
+> Unix socket) had nothing to connect to — lago could never be selected as
+> real until the substrate-plane UDS server existed.
 
-| | Stage 1 (this image) | Production |
+## This image vs production
+
+| | This image (Stage 6) | Production |
 |---|---|---|
 | Tier-1 verification | dev signer (`Bearer dev-token-for-{user_id}`) | real Vercel JWKS |
 | Tier-2 / Tier-User mint | in-process keystore | Vault / AWS / GCP KMS |
-| Substrates | mock fallback | arcand + lagod + haimad + animad + soma sharing `/run/life/` |
+| Substrates | **arcan + lago real**; haima/anima mock | arcand + lagod + haimad + animad + soma sharing `/run/life/` |
+| Persistence | arcan → `/var/lib/arcan`; lago → `${LIFE_STATE_DIR}/lago` (volume) | volume-backed per substrate |
 | TLS | self-signed (loopback only) | real cert via Vault PKI / Let's Encrypt |
 | Rate limit | defaults (60/min/user, 10 WS/user) | tuned per tenant |
 
@@ -66,13 +95,31 @@ the railway service variables for `RAILWAY_DOCKERFILE_PATH`.
 docker run --rm -p 8080:8080 \
   -e PORT=8080 \
   -e LIFED_ALLOW_MOCK_FALLBACK=1 \
-  -e RUST_LOG=info,lifegw=debug,lifed=debug \
+  -e ANTHROPIC_API_KEY=...  \  # unlocks the REAL arcan substrate (else MockArcan)
+  -e RUST_LOG=info,lifegw=debug,lifed=debug,arcan=info,lagod=info,lago=info \
+  -v life-state:/var/life-state \  # persists lagod's journal + the Tier-2 key
   lifegw-stack
 
 # In another shell:
 curl -sf http://127.0.0.1:8080/healthz
 curl -sf http://127.0.0.1:8080/caddy/healthz   # caddy-side liveness
 ```
+
+Expect these lines in the boot log (entrypoint ordering — arcan + lago
+sockets bound before lifed samples them):
+
+```
+[entrypoint] arcan UDS accepting connections ...
+[entrypoint] lagod UDS accepting connections (after N half-seconds)
+... lifed: substrates: arcan=real lago=real haima=mock anima=mock
+```
+
+`lagod`'s journal + blobs live under `${LIFE_STATE_DIR}/lago` (default
+`/var/life-state/lago`); mount a volume there to keep events across
+redeploys. Its TCP planes (`:50051` gRPC, `:8077` HTTP) are container-
+internal — lifed reaches lagod purely over `/run/life/lago.sock`. They are
+deliberately off `:8080` so they never collide with Caddy's `$PORT`
+(override via `LAGO_GRPC_PORT` / `LAGO_HTTP_PORT`).
 
 ## Vercel handoff
 
@@ -93,8 +140,8 @@ flip via `health.ts`, and the Dock SIM/LIVE/COMING badges follow.
 
 | Path | Role |
 |---|---|
-| `Dockerfile` | multi-stage builder + runtime image |
+| `Dockerfile` | multi-stage builder (`lifegw`+`lifed`+`arcan`+`lagod`) + runtime image |
 | `Caddyfile` | reverse-proxy config (`:$PORT` → `https://127.0.0.1:8443`) |
 | `lifegw.toml` | lifegw config — dev signer, dev KMS, loopback bind |
-| `lifed.toml` | lifed config — dev signer, mock substrate fallback |
-| `entrypoint.sh` | fan-out script (cert gen → lifed → lifegw → caddy fg) |
+| `lifed.toml` | lifed config — per-substrate selection (arcan + lago real, haima/anima mock) |
+| `entrypoint.sh` | fan-out script (cert gen → arcan → lagod → lifed → lifegw → caddy fg) |

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# lifegw-stack entrypoint — fan out arcan + lifed + lifegw + caddy in
-# one container.
+# lifegw-stack entrypoint — fan out arcan + lagod + lifed + lifegw +
+# caddy in one container.
 #
 # Stage-2 ordering (May 2026 — addresses the lifegw/lifed boot-race
 # described in `HANDOFF.md` §6/§7), extended by Stage 5 (June 2026 —
-# real arcan substrate inside the stack):
+# real arcan substrate inside the stack) and Stage 6 (June 2026 — real
+# lago substrate alongside arcan):
 #
 #   1. Self-signed TLS cert for the lifegw → Caddy hop. Regenerated each
 #      boot — Caddy proxies upstream with `tls_insecure_skip_verify` so
@@ -20,8 +21,13 @@
 #   3. Start `arcan serve --uds-socket /run/life/arcan.sock` and probe
 #      until it accepts UDS connections. MUST precede lifed: lifed's
 #      per-substrate bootstrap samples socket presence once at boot —
-#      arcan socket present ⇒ real arcan substrate; lago/haima/anima
-#      absent ⇒ in-process mocks (LIFED_ALLOW_MOCK_FALLBACK=true).
+#      arcan socket present ⇒ real arcan substrate; haima/anima absent
+#      ⇒ in-process mocks (LIFED_ALLOW_MOCK_FALLBACK=true).
+#   3b. Start `lagod --uds-socket /run/life/lago.sock` and probe until
+#      it accepts UDS connections. ALSO MUST precede lifed (same
+#      single-sample-at-boot reason as arcan) ⇒ lago=real. Unlike
+#      arcan, lagod needs no provider credentials, so it ALWAYS starts
+#      (no env gate).
 #   4. Start `lifed`. Its `JwksCache` is lazy + file-backed (Stage 2
 #      change in `lifed::auth::jwks`): the first `validate()` call
 #      reads `/run/life/lifegw-jwks.json`, and subsequent calls watch
@@ -169,12 +175,88 @@ if ! nc -zU "${LIFE_RUNTIME_DIR}/arcan.sock" 2>/dev/null; then
 fi
 fi # ARCAN_ENABLED
 
+# ── 3b. Start lagod (real lago substrate) ───────────────────────────────────
+# Stage 6 (June 2026): lifed's bootstrap samples substrate UDS presence
+# ONCE at boot (per-substrate selection — see lifed::bootstrap). lagod
+# must therefore bind /run/life/lago.sock and be ACCEPTING connections
+# BEFORE lifed starts, or lifed honestly falls back to MockLago for the
+# container's lifetime. Same ordering rationale as the arcan block above.
+#
+# NO env gate — unlike arcan, lagod needs no provider credentials and
+# never preflights an LLM. It is the durable event journal + blob store,
+# so it ALWAYS starts. The flag is `--uds-socket` (env LAGO_UDS_SOCKET):
+# it binds `lago.v1.LagoSubstrate` over the UDS alongside lagod's TCP
+# gRPC + HTTP planes, sharing the one RedbJournal lifed's lago-proxy
+# dials.
+#
+# Persistence: journal + blobs live at ${LAGO_DATA_DIR} under the
+# volume-backed mount (${LIFE_STATE_DIR}/lago) so events survive
+# redeploys. The mount root is 0750 life:life-runtime (set in §0); the
+# data subdir is created here with the same owner so the `life` user can
+# write `journal.redb` + `blobs/`.
+LAGO_DATA_DIR="${LAGO_DATA_DIR:-${LIFE_STATE_DIR}/lago}"
+mkdir -p "${LAGO_DATA_DIR}"
+chown -R life:life-runtime "${LAGO_DATA_DIR}"
+chmod 0750 "${LAGO_DATA_DIR}"
+
+# Port hygiene: lagod ALWAYS binds a TCP gRPC plane AND a `0.0.0.0` HTTP
+# plane (lib.rs — both unconditional), and its HTTP default is **8080**,
+# which is exactly Caddy's default `$PORT`. Unmanaged, lagod would grab
+# 8080 first and Caddy's later bind would crash the public entrypoint.
+# Nothing in this container consumes lagod's TCP planes — lifed reaches
+# it purely over the UDS — so pin them to fixed internal ports clear of
+# the in-use set (Caddy `$PORT`, lifegw 8443, arcan HTTP 3000). Both are
+# env-overridable; guard each against an accidental `$PORT` collision by
+# bumping it once (covers a Railway-assigned `$PORT` that lands on the
+# default).
+LAGO_GRPC_PORT="${LAGO_GRPC_PORT:-50051}"
+LAGO_HTTP_PORT="${LAGO_HTTP_PORT:-8077}"
+if [[ "${LAGO_HTTP_PORT}" == "${PORT}" ]]; then LAGO_HTTP_PORT=$((PORT + 1)); fi
+if [[ "${LAGO_GRPC_PORT}" == "${PORT}" ]]; then LAGO_GRPC_PORT=$((PORT + 2)); fi
+
+echo "[entrypoint] starting lagod substrate (uds=${LIFE_RUNTIME_DIR}/lago.sock data=${LAGO_DATA_DIR} grpc=${LAGO_GRPC_PORT} http=${LAGO_HTTP_PORT})"
+# `env -u`: the Tier-2 token-minting key is lifegw's secret; scrub it
+# from lagod's environment for the same defense-in-depth reason as the
+# arcan block (lagod has no business holding the signing key).
+runuser --preserve-environment -u life -g life-runtime -- \
+  env -u LIFEGW_TIER2_SIGNING_KEY_PEM \
+  /usr/local/bin/lagod \
+    --uds-socket "${LIFE_RUNTIME_DIR}/lago.sock" \
+    --data-dir "${LAGO_DATA_DIR}" \
+    --grpc-port "${LAGO_GRPC_PORT}" \
+    --http-port "${LAGO_HTTP_PORT}" \
+  &
+LAGOD_PID=$!
+
+# Same probe discipline as the arcan + lifed probes (BRO-1193): `nc -zU`
+# proves the listen backlog is up, not merely that bind() created the
+# socket file. A half-bound socket here would make lifed dial a dead
+# lago at boot and fail the whole stack.
+echo "[entrypoint] waiting for lagod UDS at ${LIFE_RUNTIME_DIR}/lago.sock"
+for i in $(seq 1 60); do
+  if [[ -S "${LIFE_RUNTIME_DIR}/lago.sock" ]] \
+     && nc -zU "${LIFE_RUNTIME_DIR}/lago.sock" 2>/dev/null; then
+    echo "[entrypoint] lagod UDS accepting connections (after ${i} half-seconds)"
+    break
+  fi
+  if ! kill -0 "${LAGOD_PID}" 2>/dev/null; then
+    echo "[entrypoint] FATAL: lagod exited before binding UDS" >&2
+    wait "${LAGOD_PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! nc -zU "${LIFE_RUNTIME_DIR}/lago.sock" 2>/dev/null; then
+  echo "[entrypoint] FATAL: lagod did not accept UDS connections within 30s" >&2
+  exit 1
+fi
+
 # ── 4. Start lifed ──────────────────────────────────────────────────────────
-# Stage 5: lifed's per-substrate bootstrap sees /run/life/arcan.sock
-# (bound above) and dials the REAL arcan substrate; lago/haima/anima
-# sockets are absent so they fall back to mocks under
-# LIFED_ALLOW_MOCK_FALLBACK=true. Boot log prints the selection, e.g.
-# "arcan=real lago=mock haima=mock anima=mock".
+# Stage 6: lifed's per-substrate bootstrap sees /run/life/arcan.sock AND
+# /run/life/lago.sock (both bound above) and dials the REAL arcan + lago
+# substrates; haima/anima sockets are absent so they fall back to mocks
+# under LIFED_ALLOW_MOCK_FALLBACK=true. Boot log prints the selection:
+# "arcan=real lago=real haima=mock anima=mock".
 # Stage 3b knob retained: `LIFED_ARCAN_BACKEND=vercel_ai_gateway` only
 # applies when the arcan socket is ABSENT (the real substrate wins).
 echo "[entrypoint] starting lifed (mock-fallback=${LIFED_ALLOW_MOCK_FALLBACK:-false}, arcan-backend=${LIFED_ARCAN_BACKEND:-mock})"
@@ -247,6 +329,7 @@ shutdown() {
   echo "[entrypoint] SIGTERM received — draining"
   if kill -0 "${LIFEGW_PID}" 2>/dev/null; then kill -TERM "${LIFEGW_PID}" || true; fi
   if kill -0 "${LIFED_PID}"  2>/dev/null; then kill -TERM "${LIFED_PID}"  || true; fi
+  if [[ -n "${LAGOD_PID:-}" ]] && kill -0 "${LAGOD_PID}" 2>/dev/null; then kill -TERM "${LAGOD_PID}" || true; fi
   if [[ -n "${ARCAN_PID:-}" ]] && kill -0 "${ARCAN_PID}" 2>/dev/null; then kill -TERM "${ARCAN_PID}" || true; fi
 }
 trap shutdown TERM INT

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -139,8 +139,13 @@ echo "[entrypoint] starting arcan substrate (uds=${LIFE_RUNTIME_DIR}/arcan.sock 
 # OPENAI_BASE_URL **with** /v1; arcan-provider appends /v1 itself
 # (openai.rs: format!("{base}/v1/chat/completions")). Same container,
 # same var — so arcan gets a stripped copy, overridable via
-# ARCAN_OPENAI_BASE_URL.
-ARCAN_BASE_URL_EFFECTIVE="${ARCAN_OPENAI_BASE_URL:-${OPENAI_BASE_URL%/v1}}"
+# ARCAN_OPENAI_BASE_URL. The `:-` default matters under `set -u`: an
+# ANTHROPIC_API_KEY-only config (the README smoke example) leaves
+# OPENAI_BASE_URL unset, and a bare ${OPENAI_BASE_URL%/v1} would abort
+# the whole entrypoint with 'unbound variable' here in §3 — before
+# lagod or lifed ever start.
+OPENAI_BASE_URL_RAW="${OPENAI_BASE_URL:-}"
+ARCAN_BASE_URL_EFFECTIVE="${ARCAN_OPENAI_BASE_URL:-${OPENAI_BASE_URL_RAW%/v1}}"
 runuser --preserve-environment -u life -g life-runtime -- \
   env -u LIFEGW_TIER2_SIGNING_KEY_PEM \
       OPENAI_BASE_URL="${ARCAN_BASE_URL_EFFECTIVE}" \
@@ -324,9 +329,17 @@ for i in $(seq 1 60); do
   sleep 0.5
 done
 
-# ── 6. Caddy as PID 1's foreground process ─────────────────────────────────
+# ── 6. Caddy under a live trap ──────────────────────────────────────────────
+# Caddy must NOT be exec'd: `exec` replaces this shell and erases the
+# trap below, so SIGTERM would only ever reach caddy while lagod /
+# arcan / lifed / lifegw get orphan-SIGKILLed at namespace teardown —
+# no graceful drain, no UDS socket-file cleanup. Backgrounding caddy
+# and `wait`ing keeps the trap live: tini (PID 1) forwards TERM to this
+# shell, the trap TERMs every child (caddy included), and the trailing
+# `wait` reaps them before the script exits.
 shutdown() {
   echo "[entrypoint] SIGTERM received — draining"
+  if [[ -n "${CADDY_PID:-}" ]] && kill -0 "${CADDY_PID}" 2>/dev/null; then kill -TERM "${CADDY_PID}" || true; fi
   if kill -0 "${LIFEGW_PID}" 2>/dev/null; then kill -TERM "${LIFEGW_PID}" || true; fi
   if kill -0 "${LIFED_PID}"  2>/dev/null; then kill -TERM "${LIFED_PID}"  || true; fi
   if [[ -n "${LAGOD_PID:-}" ]] && kill -0 "${LAGOD_PID}" 2>/dev/null; then kill -TERM "${LAGOD_PID}" || true; fi
@@ -335,4 +348,13 @@ shutdown() {
 trap shutdown TERM INT
 
 echo "[entrypoint] starting caddy on :${PORT}"
-exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+CADDY_PID=$!
+
+# `wait` returns early (>128) when the trapped signal arrives; by then
+# the trap has TERMed every child. The second wait reaps stragglers so
+# tini observes a clean, drained exit.
+CADDY_EXIT=0
+wait "${CADDY_PID}" || CADDY_EXIT=$?
+wait || true
+exit "${CADDY_EXIT}"

--- a/deploy/railway/lifegw-stack/lifed.toml
+++ b/deploy/railway/lifegw-stack/lifed.toml
@@ -1,14 +1,14 @@
-# lifed config — Railway lifegw-stack deploy (Stage 5, June 2026).
+# lifed config — Railway lifegw-stack deploy (Stage 6, June 2026).
 #
 # JwksCache is lazy + file-backed (Stage 2 notes preserved): no
 # boot-order race with lifegw.
 #
-# Stage 5: per-substrate real/mock selection. The container ships the
-# real arcan daemon; entrypoint.sh binds /run/life/arcan.sock BEFORE
-# lifed boots, so lifed's bootstrap selects the real arcan substrate
-# and mocks only lago / haima / anima (still gated by
-# `LIFED_ALLOW_MOCK_FALLBACK=true`). Boot log prints the selection:
-# "arcan=real lago=mock haima=mock anima=mock".
+# Stage 6: per-substrate real/mock selection. The container ships the
+# real arcan AND lagod daemons; entrypoint.sh binds /run/life/arcan.sock
+# and /run/life/lago.sock BEFORE lifed boots, so lifed's bootstrap
+# selects the real arcan + lago substrates and mocks only haima / anima
+# (still gated by `LIFED_ALLOW_MOCK_FALLBACK=true`). Boot log prints the
+# selection: "arcan=real lago=real haima=mock anima=mock".
 #
 # Stage 3b knob retained for socket-less deploys: when the arcan
 # socket is ABSENT, `LIFED_ARCAN_BACKEND=vercel_ai_gateway` (plus
@@ -16,10 +16,9 @@
 # LLM tokens through the gateway slot instead of MockArcan. A present
 # arcan socket always wins.
 #
-# Production swap-in (Stage 6+): ship lagod / haimad / animad / soma
-# into the same container (or multi-container), drop
-# `LIFED_ALLOW_MOCK_FALLBACK`, and let lifed fail-fast on missing UDS
-# sockets.
+# Production swap-in (next stages): ship haimad / animad / soma into the
+# same container (or multi-container), drop `LIFED_ALLOW_MOCK_FALLBACK`,
+# and let lifed fail-fast on missing UDS sockets.
 
 [public_plane]
 unix_socket       = "/run/life/life.sock"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1626,6 +1626,19 @@ the runbook §6.1 known-limitations log):**
 the runbook → Phase 1 SHIPPED; then queue Phase 2 (J-Sub-H/I/J)
 gated on Spec E E-Sub-F conformance completion.
 
+**2026-06-11 — lifegw-stack Stage 6: real lago substrate (BRO-1464).**
+lagod gains a substrate-plane UDS server (`--uds-socket` / env
+`LAGO_UDS_SOCKET`, mirroring arcand's serve shape) — BRO-1017 had left
+`lago.v1.LagoSubstrate` TCP-only while lifed's lago-proxy dials a Unix
+socket, so real lago was unselectable. The lifegw-stack container now
+builds + ships `lagod`, starts it before lifed (socket presence is
+sampled once at lifed boot), persists its journal/blobs under the
+volume-backed `${LIFE_STATE_DIR}/lago`, and pins lagod's TCP planes
+clear of Caddy's `$PORT` (HTTP default was 8080 — a boot-order
+collision hazard). Expected prod boot line:
+`substrates: arcan=real lago=real haima=mock anima=mock`. haima/anima
+stay mocked pending their daemons (incremental rollout per #1695).
+
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |


### PR DESCRIPTION
## Summary

Stage 6 of the lifegw-stack substrate rollout: **lago joins arcan as a real substrate inside the container**. Expected prod boot line flips to `substrates: arcan=real lago=real haima=mock anima=mock`.

The blocker this PR removes: BRO-1017 mounted `lago.v1.LagoSubstrate` on lagod's **TCP** gRPC plane only, while lifed's lago-proxy dials a **Unix socket** (`LagoProxy::connect → UnixStream::connect`) — so per-substrate selection (#1695) could never pick real lago. lagod now gains an optional substrate-plane UDS server (`--uds-socket <PATH>` / env `LAGO_UDS_SOCKET`), mirroring arcand's serve shape, sharing the same RedbJournal as its other planes.

## What changed

- `crates/lago/lagod`: `serve_substrate_uds` — binds `lago.v1.LagoSubstrate` on the given UDS alongside the TCP gRPC + HTTP planes; covered by a bind→dial→cleanup e2e test over a real socket (`tests/topology_b_e2e_lago.rs`).
- `deploy/railway/lifegw-stack/Dockerfile`: builds + ships `lagod`; header/topology comments updated; `RUST_LOG` includes lago targets.
- `deploy/railway/lifegw-stack/entrypoint.sh`: §3b starts lagod **before lifed** (socket presence is sampled once at lifed boot), `nc -zU` probe with the same FATAL discipline as the arcan block, `LAGOD_PID` in the shutdown trap, Tier-2 PEM scrubbed from its env. **No env gate** — lagod needs no provider credentials and always starts.
- **Port hygiene**: lagod unconditionally binds TCP gRPC + HTTP planes, and its HTTP default is `8080` — exactly Caddy's `$PORT`. Unmanaged, lagod would grab the public port first and crash the gateway at boot. Pinned to internal defaults (gRPC 50051, HTTP 8077) with `$PORT`-collision guards; nothing in-container consumes them (lifed dials the UDS).
- **Persistence**: journal + blobs at `${LIFE_STATE_DIR}/lago` under the mounted Railway volume — events survive redeploys (unlike arcan's ephemeral `/var/lib/arcan`, unchanged here).
- `lifed.toml` + `README.md`: socket config + process table + boot expectation.
- `docs/STATUS.md`: dated Stage-6 entry.

## Deferred (deliberate)

haima/anima stay mocked: haimad needs wallet/chain env, anima custody is a different shape (soma). Per-substrate selection (#1695) makes this rollout incremental by design. Tracked as the Stage-7 follow-up.

## Test plan

- [x] `bash -n` + entrypoint review against the arcan block's probe discipline
- [x] `cargo fmt --check` clean, `cargo clippy -p lagod -p lago -- -D warnings` clean
- [x] `cargo test -p lagod -p lifed` green (incl. new UDS e2e: bind→dial→cleanup)
- [x] `cargo check --workspace` green
- [ ] CI green (Test (Linux) on the #1700-hardened lane)
- [ ] Post-merge: Railway lifegw-stack boot log shows `substrates: arcan=real lago=real haima=mock anima=mock`

Closes BRO-1464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)