### PR TITLE
feat(arcand): surface client tool definitions on the kernel dispatch path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "chrono",
+ "futures-util",
  "hex",
  "life-vigil",
  "opentelemetry",

--- a/crates/aios/aios-kernel/src/lib.rs
+++ b/crates/aios/aios-kernel/src/lib.rs
@@ -172,6 +172,7 @@ impl AiosKernel {
                     proposed_tool,
                     system_prompt: None,
                     allowed_tools: None,
+                    client_tools: Vec::new(),
                     kind: TickKind::Direct,
                 },
             )

--- a/crates/aios/aios-protocol/src/lib.rs
+++ b/crates/aios/aios-protocol/src/lib.rs
@@ -117,6 +117,6 @@ pub use state::{
     PatchOp, ProvenanceRef, StatePatch, VersionedCanonicalState,
 };
 pub use tool::{
-    Tool, ToolAnnotations, ToolCall, ToolContent, ToolContext, ToolDefinition, ToolError,
-    ToolOutcome, ToolRegistry, ToolResult,
+    ClientToolDefinition, ClientToolDefinitionError, Tool, ToolAnnotations, ToolCall, ToolContent,
+    ToolContext, ToolDefinition, ToolError, ToolOutcome, ToolRegistry, ToolResult,
 };

--- a/crates/aios/aios-protocol/src/ports.rs
+++ b/crates/aios/aios-protocol/src/ports.rs
@@ -12,7 +12,7 @@ use crate::error::KernelResult;
 use crate::event::{EventRecord, TokenUsage};
 use crate::ids::{ApprovalId, BranchId, RunId, SessionId, ToolRunId};
 use crate::policy::Capability;
-use crate::tool::{ToolCall, ToolOutcome};
+use crate::tool::{ClientToolDefinition, ToolCall, ToolOutcome};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures_util::stream::BoxStream;
@@ -40,6 +40,13 @@ pub struct ModelCompletionRequest {
     /// Built by the runtime from the event journal before each provider call.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conversation_history: Vec<ConversationTurn>,
+    /// Client-declared tools (a different trust domain from the kernel
+    /// registry). The provider adapter appends these to the
+    /// model-visible tools array; the kernel never executes them.
+    /// Registry tools shadow client tools of the same name (resolved
+    /// upstream, before this request is built).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub client_tools: Vec<ClientToolDefinition>,
 }
 
 /// A single turn in the conversation history (user message + assistant response).

--- a/crates/aios/aios-protocol/src/tool.rs
+++ b/crates/aios/aios-protocol/src/tool.rs
@@ -110,6 +110,95 @@ pub struct ToolDefinition {
     pub timeout_secs: Option<u32>,
 }
 
+// ── Client-supplied tool definitions ──────────────────────────────────
+
+/// A tool declared by the chat *client* rather than the kernel's own
+/// governed registry.
+///
+/// These arrive over the substrate wire (`DispatchMessageReq.tool_definitions`,
+/// one JSON object per entry in the AI-SDK / OpenAI function shape
+/// `{"name", "description", "parameters"}`). They live in a different
+/// trust domain from registry tools: the kernel never executes them —
+/// it surfaces them to the model and, when the model proposes one,
+/// hands the call back to the client as a `TOOL_CALL_PENDING` frame
+/// (category `"client"`). The client executes the tool and replays the
+/// result as conversation context on the next dispatch.
+///
+/// Because they are never policy-gated or harness-executed, they carry
+/// no [`Capability`] set — only the model-visible surface (name,
+/// description, JSON-Schema parameters passed through verbatim).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClientToolDefinition {
+    /// Unique tool name as the model will reference it.
+    pub name: String,
+    /// Human-readable description of what the tool does.
+    #[serde(default)]
+    pub description: String,
+    /// JSON Schema describing the tool's input parameters. Passed
+    /// through to the provider verbatim (OpenAI `function.parameters`).
+    #[serde(default)]
+    pub parameters: serde_json::Value,
+}
+
+impl ClientToolDefinition {
+    /// Parse one wire entry (a single JSON object in the AI-SDK /
+    /// OpenAI function shape `{"name", "description", "parameters"}`).
+    ///
+    /// Returns an error when the bytes are not valid JSON, are not a
+    /// JSON object, or carry an empty/missing `name`. Callers at the
+    /// trust boundary (the substrate dispatch handler) treat these
+    /// errors as "skip this entry" rather than failing the whole
+    /// dispatch.
+    pub fn from_wire_bytes(bytes: &[u8]) -> Result<Self, ClientToolDefinitionError> {
+        let value: serde_json::Value =
+            serde_json::from_slice(bytes).map_err(ClientToolDefinitionError::Json)?;
+        Self::from_value(value)
+    }
+
+    /// Parse one already-deserialized JSON value. Shares the validation
+    /// rules with [`Self::from_wire_bytes`].
+    pub fn from_value(value: serde_json::Value) -> Result<Self, ClientToolDefinitionError> {
+        let obj = value
+            .as_object()
+            .ok_or(ClientToolDefinitionError::NotAnObject)?;
+        let name = obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+            .filter(|n| !n.is_empty())
+            .ok_or(ClientToolDefinitionError::MissingName)?;
+        let description = obj
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_owned();
+        let parameters = obj
+            .get("parameters")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        Ok(Self {
+            name,
+            description,
+            parameters,
+        })
+    }
+}
+
+/// Reasons a client tool-definition wire entry was rejected.
+///
+/// `thiserror` per the library convention; callers downgrade these to
+/// `warn!`-and-skip at the dispatch boundary so a malformed entry never
+/// aborts an otherwise-valid turn.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientToolDefinitionError {
+    #[error("client tool definition is not valid JSON: {0}")]
+    Json(serde_json::Error),
+    #[error("client tool definition is not a JSON object")]
+    NotAnObject,
+    #[error("client tool definition is missing a non-empty `name`")]
+    MissingName,
+}
+
 // ── Typed content blocks ──────────────────────────────────────────────
 
 /// Typed content block in a tool result (MCP-compatible).
@@ -461,6 +550,69 @@ mod tests {
         let back: ToolDefinition = serde_json::from_str(&json_str).unwrap();
         assert_eq!(def, back);
         assert!(json_str.contains("\"category\":\"filesystem\""));
+    }
+
+    // ── ClientToolDefinition tests ──
+
+    #[test]
+    fn client_tool_def_from_wire_bytes_full_shape() {
+        let bytes = br#"{
+            "name": "get_weather",
+            "description": "Look up the weather",
+            "parameters": {
+                "type": "object",
+                "properties": { "city": { "type": "string" } },
+                "required": ["city"]
+            }
+        }"#;
+        let def = ClientToolDefinition::from_wire_bytes(bytes).expect("valid client tool");
+        assert_eq!(def.name, "get_weather");
+        assert_eq!(def.description, "Look up the weather");
+        // parameters passed through verbatim.
+        assert_eq!(def.parameters["properties"]["city"]["type"], "string");
+        assert_eq!(def.parameters["required"][0], "city");
+    }
+
+    #[test]
+    fn client_tool_def_missing_description_and_parameters_defaults() {
+        let bytes = br#"{ "name": "ping" }"#;
+        let def = ClientToolDefinition::from_wire_bytes(bytes).expect("name-only is valid");
+        assert_eq!(def.name, "ping");
+        assert_eq!(def.description, "");
+        assert_eq!(def.parameters, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn client_tool_def_rejects_invalid_json() {
+        let err = ClientToolDefinition::from_wire_bytes(b"{not json").unwrap_err();
+        assert!(matches!(err, ClientToolDefinitionError::Json(_)));
+    }
+
+    #[test]
+    fn client_tool_def_rejects_non_object() {
+        let err = ClientToolDefinition::from_wire_bytes(b"[1, 2, 3]").unwrap_err();
+        assert!(matches!(err, ClientToolDefinitionError::NotAnObject));
+    }
+
+    #[test]
+    fn client_tool_def_rejects_missing_or_empty_name() {
+        let missing =
+            ClientToolDefinition::from_wire_bytes(br#"{"description": "x"}"#).unwrap_err();
+        assert!(matches!(missing, ClientToolDefinitionError::MissingName));
+        let empty = ClientToolDefinition::from_wire_bytes(br#"{"name": ""}"#).unwrap_err();
+        assert!(matches!(empty, ClientToolDefinitionError::MissingName));
+    }
+
+    #[test]
+    fn client_tool_def_serde_roundtrip() {
+        let def = ClientToolDefinition {
+            name: "search".into(),
+            description: "Search the web".into(),
+            parameters: json!({"type": "object"}),
+        };
+        let json_str = serde_json::to_string(&def).unwrap();
+        let back: ClientToolDefinition = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(def, back);
     }
 
     // ── ToolContent tests ──

--- a/crates/aios/aios-protocol/src/tool.rs
+++ b/crates/aios/aios-protocol/src/tool.rs
@@ -145,8 +145,11 @@ impl ClientToolDefinition {
     /// OpenAI function shape `{"name", "description", "parameters"}`).
     ///
     /// Returns an error when the bytes are not valid JSON, are not a
-    /// JSON object, or carry an empty/missing `name`. Callers at the
-    /// trust boundary (the substrate dispatch handler) treat these
+    /// JSON object, carry an empty/missing `name`, carry a non-string
+    /// `description`, or carry a non-object `parameters`. Absent
+    /// `description`/`parameters` stay permissive (empty string / Null)
+    /// — absence is well-formed, a wrong TYPE is malformed. Callers at
+    /// the trust boundary (the substrate dispatch handler) treat these
     /// errors as "skip this entry" rather than failing the whole
     /// dispatch.
     pub fn from_wire_bytes(bytes: &[u8]) -> Result<Self, ClientToolDefinitionError> {
@@ -167,15 +170,18 @@ impl ClientToolDefinition {
             .map(str::to_owned)
             .filter(|n| !n.is_empty())
             .ok_or(ClientToolDefinitionError::MissingName)?;
-        let description = obj
-            .get("description")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_owned();
-        let parameters = obj
-            .get("parameters")
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
+        let description = match obj.get("description") {
+            Some(v) => v
+                .as_str()
+                .map(str::to_owned)
+                .ok_or(ClientToolDefinitionError::InvalidDescriptionType)?,
+            None => String::new(),
+        };
+        let parameters = match obj.get("parameters") {
+            Some(v) if v.is_object() => v.clone(),
+            Some(_) => return Err(ClientToolDefinitionError::InvalidParametersType),
+            None => serde_json::Value::Null,
+        };
         Ok(Self {
             name,
             description,
@@ -197,6 +203,10 @@ pub enum ClientToolDefinitionError {
     NotAnObject,
     #[error("client tool definition is missing a non-empty `name`")]
     MissingName,
+    #[error("client tool definition has a non-string `description`")]
+    InvalidDescriptionType,
+    #[error("client tool definition has a non-object `parameters`")]
+    InvalidParametersType,
 }
 
 // ── Typed content blocks ──────────────────────────────────────────────
@@ -592,6 +602,26 @@ mod tests {
     fn client_tool_def_rejects_non_object() {
         let err = ClientToolDefinition::from_wire_bytes(b"[1, 2, 3]").unwrap_err();
         assert!(matches!(err, ClientToolDefinitionError::NotAnObject));
+    }
+
+    #[test]
+    fn client_tool_def_rejects_wrong_field_types() {
+        // Present-but-mistyped fields are malformed (warn+skip at the
+        // boundary); absence stays permissive — covered by
+        // client_tool_def_missing_description_and_parameters_defaults.
+        let desc = ClientToolDefinition::from_wire_bytes(br#"{"name": "t", "description": 7}"#)
+            .unwrap_err();
+        assert!(matches!(
+            desc,
+            ClientToolDefinitionError::InvalidDescriptionType
+        ));
+        let params =
+            ClientToolDefinition::from_wire_bytes(br#"{"name": "t", "parameters": "str"}"#)
+                .unwrap_err();
+        assert!(matches!(
+            params,
+            ClientToolDefinitionError::InvalidParametersType
+        ));
     }
 
     #[test]

--- a/crates/aios/aios-runtime/Cargo.toml
+++ b/crates/aios/aios-runtime/Cargo.toml
@@ -25,5 +25,8 @@ opentelemetry = "0.29"
 uuid.workspace = true
 life-vigil.workspace = true
 
+[dev-dependencies]
+futures-util.workspace = true
+
 [lints]
 workspace = true

--- a/crates/aios/aios-runtime/src/lib.rs
+++ b/crates/aios/aios-runtime/src/lib.rs
@@ -933,14 +933,29 @@ impl KernelRuntime {
                 // registry-wins collision rule applied: a name that is
                 // also a kernel registry tool is NOT a client handoff
                 // (the registry tool executes through the harness as
-                // usual). When `registry_tool_names` is empty (the
-                // default), collision pruning is assumed to have already
-                // happened upstream, so every declared name is eligible.
+                // usual). A collision is warned — the kernel keeps the
+                // governed registry tool and drops the client shadow, so
+                // operators can see a client tried to redeclare a name
+                // the kernel owns. When `registry_tool_names` is empty
+                // (the default), collision pruning is assumed to have
+                // already happened upstream, so every declared name is
+                // eligible.
                 let client_tool_names: std::collections::HashSet<&str> = input
                     .client_tools
                     .iter()
                     .map(|t| t.name.as_str())
-                    .filter(|name| !self.registry_tool_names.contains(*name))
+                    .filter(|name| {
+                        if self.registry_tool_names.contains(*name) {
+                            warn!(
+                                tool_name = %name,
+                                "client tool name collides with a kernel registry tool; \
+                                 registry wins — dropping the client shadow"
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    })
                     .collect();
                 // Set when the model proposed at least one client tool in
                 // this completion. Drives the end-of-turn handoff: the

--- a/crates/aios/aios-runtime/src/lib.rs
+++ b/crates/aios/aios-runtime/src/lib.rs
@@ -454,17 +454,23 @@ impl KernelRuntime {
     /// Declare the names of the kernel's own governed tools so the
     /// runtime can enforce registry-wins for client-tool collisions.
     ///
-    /// Builder style (additive). When a `TickInput.client_tools` entry
-    /// names a tool that is also in this set, the kernel executes the
-    /// registry tool through the harness instead of handing the call
-    /// back to the client. Hosts that already prune collisions upstream
-    /// can skip this; it is a belt-and-suspenders second line of defence.
+    /// Builder style (additive across calls). When a
+    /// `TickInput.client_tools` entry names a tool that is also in this
+    /// set, the kernel executes the registry tool through the harness
+    /// instead of handing the call back to the client. Hosts that
+    /// surface `client_tools` MUST wire this (see `arcan serve`) — with
+    /// an empty set, every client-declared name becomes a handoff and a
+    /// malicious client could silently divert registry-tool calls to
+    /// itself (no kernel execution, but also no error). Upstream
+    /// collision pruning (the substrate dispatch handler) is the first
+    /// line of defence; this is the second.
     pub fn with_registry_tool_names<I, S>(mut self, names: I) -> Self
     where
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        self.registry_tool_names = names.into_iter().map(Into::into).collect();
+        self.registry_tool_names
+            .extend(names.into_iter().map(Into::into));
         self
     }
 
@@ -1255,10 +1261,16 @@ impl KernelRuntime {
                 // dispatch loop breaks (mode ≠ Execute) and it is not
                 // treated as an error (mode ≠ Recover). The run still
                 // finishes through the normal `RunFinished` path below, so
-                // the wire emits TOOL_CALL_PENDING then FINISH. A Recover
-                // set earlier in this turn (e.g. a registry tool failed)
-                // takes precedence and is left untouched.
-                if client_tool_proposed && !matches!(mode, OperatingMode::Recover) {
+                // the wire emits TOOL_CALL_PENDING then FINISH. Two modes
+                // set earlier in this turn take precedence and are left
+                // untouched: `Recover` (e.g. a registry tool failed) and
+                // `AskHuman` (a registry tool enqueued an approval — the
+                // host must see the pending-approval signal or the next
+                // dispatch would early-return AskHuman with no model call
+                // and the approval would stall silently).
+                if client_tool_proposed
+                    && !matches!(mode, OperatingMode::Recover | OperatingMode::AskHuman)
+                {
                     mode = OperatingMode::Sleep;
                 }
 

--- a/crates/aios/aios-runtime/src/lib.rs
+++ b/crates/aios/aios-runtime/src/lib.rs
@@ -47,6 +47,13 @@ pub struct TickInput {
     pub system_prompt: Option<String>,
     /// Tool whitelist from active skill. When set, only these tools are sent to the LLM.
     pub allowed_tools: Option<Vec<String>>,
+    /// Client-declared tools (a different trust domain from the kernel
+    /// registry). Surfaced to the model alongside registry tools; when
+    /// the model proposes one, the kernel emits a `ToolCallRequested`
+    /// with category `"client"` and hands the call back to the caller
+    /// instead of policy-gating or executing it. Empty for the common
+    /// case. See `aios_protocol::ClientToolDefinition`.
+    pub client_tools: Vec<aios_protocol::ClientToolDefinition>,
     /// What kind of body runs in this tick — direct (one model call, the
     /// existing default) or workflow (an `ergon::Workflow` runs as the
     /// tick body via an externally-registered handler).
@@ -387,6 +394,16 @@ pub struct KernelRuntime {
     workflow_dispatcher: Option<Arc<dyn WorkflowTickDispatcher>>,
     stream: broadcast::Sender<EventRecord>,
     sessions: Arc<Mutex<HashMap<String, SessionRuntimeState>>>,
+    /// Names of the kernel's own governed (harness/registry) tools.
+    ///
+    /// Used only to enforce the registry-wins collision rule when a
+    /// `TickInput.client_tools` entry shares a name with a registry
+    /// tool: such a name is NOT treated as a client handoff. Empty by
+    /// default — when empty, every `client_tools` name is a potential
+    /// client handoff and collision pruning is expected to have already
+    /// happened upstream (the substrate dispatch handler does this).
+    /// Production wires the real set via [`Self::with_registry_tool_names`].
+    registry_tool_names: std::collections::HashSet<String>,
 }
 
 impl KernelRuntime {
@@ -430,7 +447,25 @@ impl KernelRuntime {
             workflow_dispatcher: None,
             stream,
             sessions: Arc::new(Mutex::new(HashMap::new())),
+            registry_tool_names: std::collections::HashSet::new(),
         }
+    }
+
+    /// Declare the names of the kernel's own governed tools so the
+    /// runtime can enforce registry-wins for client-tool collisions.
+    ///
+    /// Builder style (additive). When a `TickInput.client_tools` entry
+    /// names a tool that is also in this set, the kernel executes the
+    /// registry tool through the harness instead of handing the call
+    /// back to the client. Hosts that already prune collisions upstream
+    /// can skip this; it is a belt-and-suspenders second line of defence.
+    pub fn with_registry_tool_names<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.registry_tool_names = names.into_iter().map(Into::into).collect();
+        self
     }
 
     /// Register a dispatcher for [`TickKind::Workflow`] ticks. Builder
@@ -873,6 +908,7 @@ impl KernelRuntime {
                     system_prompt: input.system_prompt.clone(),
                     allowed_tools: input.allowed_tools.clone(),
                     conversation_history,
+                    client_tools: input.client_tools.clone(),
                 })
                 .await
                 .map_err(|error| anyhow::anyhow!(error.to_string()))
@@ -892,6 +928,27 @@ impl KernelRuntime {
                     .await?;
                     emitted += 1;
                 }
+
+                // Client-declared tool names for this tick, with the
+                // registry-wins collision rule applied: a name that is
+                // also a kernel registry tool is NOT a client handoff
+                // (the registry tool executes through the harness as
+                // usual). When `registry_tool_names` is empty (the
+                // default), collision pruning is assumed to have already
+                // happened upstream, so every declared name is eligible.
+                let client_tool_names: std::collections::HashSet<&str> = input
+                    .client_tools
+                    .iter()
+                    .map(|t| t.name.as_str())
+                    .filter(|name| !self.registry_tool_names.contains(*name))
+                    .collect();
+                // Set when the model proposed at least one client tool in
+                // this completion. Drives the end-of-turn handoff: the
+                // tick must finish cleanly (mode ≠ Execute so the
+                // dispatch loop breaks, ≠ Recover since it is not an
+                // error). The continuation arrives as a new dispatch with
+                // the client's tool result replayed into the history.
+                let mut client_tool_proposed = false;
 
                 let mut directive_count = 0_usize;
                 for directive in completion.directives {
@@ -921,6 +978,39 @@ impl KernelRuntime {
                             emitted += 1;
                         }
                         ModelDirective::ToolCall { call } => {
+                            // Client-tool handoff: a call whose name is a
+                            // client-declared tool (and not a registry
+                            // tool — collisions were pruned above) is not
+                            // ours to gate or execute. Emit a
+                            // `ToolCallRequested` tagged `category:
+                            // "client"` (the wire maps it to
+                            // TOOL_CALL_PENDING) and hand the call back to
+                            // the caller. No guard, no policy gate, no
+                            // harness — the chat client owns this trust
+                            // domain and executes the tool, then replays
+                            // the result as conversation history on the
+                            // next dispatch.
+                            if client_tool_names.contains(call.tool_name.as_str()) {
+                                self.append_event(
+                                    session_id,
+                                    branch_id,
+                                    EventKind::ToolCallRequested {
+                                        call_id: call.call_id.clone(),
+                                        tool_name: call.tool_name.clone(),
+                                        arguments: call.input.clone(),
+                                        category: Some("client".to_owned()),
+                                    },
+                                )
+                                .await?;
+                                emitted += 1;
+                                client_tool_proposed = true;
+                                info!(
+                                    tool_name = %call.tool_name,
+                                    "client-tool call proposed; handed back to caller (no kernel execution)"
+                                );
+                                continue;
+                            }
+
                             let guard_ctx = TurnContext {
                                 session_id: guard_context_template.session_id.clone(),
                                 branch_id: guard_context_template.branch_id.clone(),
@@ -1142,6 +1232,19 @@ impl KernelRuntime {
                             }
                         }
                     }
+                }
+
+                // Client-tool handoff: turn complete; the continuation
+                // arrives as a new dispatch with the client's tool result
+                // replayed into the history. Force `Sleep` so the
+                // dispatch loop breaks (mode ≠ Execute) and it is not
+                // treated as an error (mode ≠ Recover). The run still
+                // finishes through the normal `RunFinished` path below, so
+                // the wire emits TOOL_CALL_PENDING then FINISH. A Recover
+                // set earlier in this turn (e.g. a registry tool failed)
+                // takes precedence and is left untouched.
+                if client_tool_proposed && !matches!(mode, OperatingMode::Recover) {
+                    mode = OperatingMode::Sleep;
                 }
 
                 emitted += self

--- a/crates/aios/aios-runtime/tests/client_tools.rs
+++ b/crates/aios/aios-runtime/tests/client_tools.rs
@@ -1,0 +1,500 @@
+//! Client-tool handoff tests for the Direct tick path (BRO-1463).
+//!
+//! These exercise the kernel's handling of `TickInput.client_tools` —
+//! tools declared by the chat client rather than the kernel's own
+//! governed registry. The contract under test:
+//!
+//! 1. Client tools are threaded into the `ModelCompletionRequest` so
+//!    the provider adapter can surface them to the model.
+//! 2. When the model proposes a client tool, the kernel emits a
+//!    `ToolCallRequested { category: "client" }` and hands the call
+//!    back to the caller — it does NOT evaluate policy or run the
+//!    harness for that call — then ends the turn in a non-`Execute`,
+//!    non-`Recover` mode so the dispatch loop breaks and `RunFinished`
+//!    still emits (wire: TOOL_CALL_PENDING then FINISH).
+//! 3. A name collision between a client tool and a kernel registry tool
+//!    resolves registry-first: the call is treated as a governed
+//!    registry tool (policy + harness), never as a client handoff.
+//!
+//! The kernel only depends on `aios-protocol`, so the ports here are
+//! self-contained in-memory mocks rather than the real `aios-events` /
+//! `aios-policy` implementations (which live one layer up). The mocks
+//! record whether the harness / policy gate were consulted so the
+//! "client tools are never executed or gated" invariant is asserted
+//! directly.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use aios_protocol::{
+    ApprovalId, ApprovalPort, ApprovalRequest, ApprovalResolution, ApprovalTicket, BranchId,
+    Capability, ClientToolDefinition, EventKind, EventRecord, EventRecordStream, EventStorePort,
+    KernelResult, ModelCompletion, ModelCompletionRequest, ModelDirective, ModelProviderPort,
+    ModelRouting, ModelStopReason, OperatingMode, PolicyGateDecision, PolicyGatePort, PolicySet,
+    SessionId, ToolCall, ToolExecutionReport, ToolExecutionRequest, ToolHarnessPort, ToolOutcome,
+    ToolRunId,
+};
+use aios_runtime::{KernelRuntime, RuntimeConfig, TickInput, TickKind};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+// ── In-memory event store ─────────────────────────────────────────────
+//
+// The runtime assigns sequences itself and only needs the store to
+// persist + echo (append), report the per-branch head, and replay
+// (read). `subscribe` is for external streaming consumers and is not on
+// the tick path, so it returns an empty stream.
+
+#[derive(Default)]
+struct MemEventStore {
+    events: Mutex<Vec<EventRecord>>,
+}
+
+#[async_trait]
+impl EventStorePort for MemEventStore {
+    async fn append(&self, event: EventRecord) -> KernelResult<EventRecord> {
+        self.events.lock().push(event.clone());
+        Ok(event)
+    }
+
+    async fn read(
+        &self,
+        session_id: SessionId,
+        branch_id: BranchId,
+        from_sequence: u64,
+        limit: usize,
+    ) -> KernelResult<Vec<EventRecord>> {
+        let events = self.events.lock();
+        Ok(events
+            .iter()
+            .filter(|e| {
+                e.session_id == session_id
+                    && e.branch_id == branch_id
+                    && e.sequence >= from_sequence
+            })
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    async fn head(&self, session_id: SessionId, branch_id: BranchId) -> KernelResult<u64> {
+        let events = self.events.lock();
+        Ok(events
+            .iter()
+            .filter(|e| e.session_id == session_id && e.branch_id == branch_id)
+            .map(|e| e.sequence)
+            .max()
+            .unwrap_or(0))
+    }
+
+    async fn subscribe(
+        &self,
+        _session_id: SessionId,
+        _branch_id: BranchId,
+        _after_sequence: u64,
+    ) -> KernelResult<EventRecordStream> {
+        Ok(Box::pin(futures_util::stream::empty()))
+    }
+}
+
+// ── Scripted model provider ───────────────────────────────────────────
+//
+// Records the `client_tools` of the most recent request (so the test
+// can assert they were threaded into `ModelCompletionRequest`) and, on
+// its first completion, optionally proposes a single tool call by name.
+
+#[derive(Default)]
+struct ScriptedProvider {
+    /// Tool name to propose on the first completion (`None` → just answer).
+    propose_tool: Option<String>,
+    /// `client_tools` seen on the most recent request.
+    seen_client_tools: Mutex<Vec<ClientToolDefinition>>,
+    /// Whether the first completion has already been served.
+    answered: AtomicBool,
+}
+
+impl ScriptedProvider {
+    fn proposing(tool_name: &str) -> Self {
+        Self {
+            propose_tool: Some(tool_name.to_owned()),
+            ..Default::default()
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProviderPort for ScriptedProvider {
+    async fn complete(&self, request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        *self.seen_client_tools.lock() = request.client_tools.clone();
+
+        // Propose the tool only on the first completion; subsequent
+        // ticks (if any) answer normally so loops terminate.
+        let first = !self.answered.swap(true, Ordering::SeqCst);
+        if first && let Some(tool_name) = self.propose_tool.clone() {
+            return Ok(ModelCompletion {
+                provider: "scripted".to_owned(),
+                model: "scripted-deterministic".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::ToolCall {
+                    call: ToolCall {
+                        call_id: "call-1".to_owned(),
+                        tool_name,
+                        input: serde_json::json!({ "q": "berlin" }),
+                        requested_capabilities: Vec::new(),
+                    },
+                }],
+                stop_reason: ModelStopReason::ToolCall,
+                usage: None,
+                final_answer: None,
+            });
+        }
+
+        Ok(ModelCompletion {
+            provider: "scripted".to_owned(),
+            model: "scripted-deterministic".to_owned(),
+            llm_call_record: None,
+            directives: vec![ModelDirective::Message {
+                role: "assistant".to_owned(),
+                content: "done".to_owned(),
+            }],
+            stop_reason: ModelStopReason::Completed,
+            usage: None,
+            final_answer: Some("done".to_owned()),
+        })
+    }
+}
+
+// ── Recording tool harness ────────────────────────────────────────────
+//
+// Flips `executed` the moment `execute` is called, so a test can assert
+// the harness was (or was NOT) consulted. Returns a trivial success so
+// registry-tool paths still complete.
+
+#[derive(Default)]
+struct RecordingHarness {
+    executed: AtomicBool,
+}
+
+#[async_trait]
+impl ToolHarnessPort for RecordingHarness {
+    async fn execute(&self, request: ToolExecutionRequest) -> KernelResult<ToolExecutionReport> {
+        self.executed.store(true, Ordering::SeqCst);
+        Ok(ToolExecutionReport {
+            tool_run_id: ToolRunId::default(),
+            call_id: request.call.call_id.clone(),
+            tool_name: request.call.tool_name.clone(),
+            exit_status: 0,
+            duration_ms: 0,
+            outcome: ToolOutcome::Success {
+                output: serde_json::json!({ "ok": true }),
+            },
+        })
+    }
+}
+
+// ── Recording policy gate ─────────────────────────────────────────────
+//
+// Flips `evaluated` when `evaluate` is called. Allows every capability
+// so governed registry-tool paths proceed; the flag lets a test assert
+// that client-tool calls never reach the gate.
+
+#[derive(Default)]
+struct RecordingPolicy {
+    evaluated: AtomicBool,
+}
+
+#[async_trait]
+impl PolicyGatePort for RecordingPolicy {
+    async fn evaluate(
+        &self,
+        _session_id: SessionId,
+        requested: Vec<Capability>,
+    ) -> KernelResult<PolicyGateDecision> {
+        self.evaluated.store(true, Ordering::SeqCst);
+        Ok(PolicyGateDecision {
+            allowed: requested,
+            requires_approval: Vec::new(),
+            denied: Vec::new(),
+        })
+    }
+}
+
+// ── No-op approval port ───────────────────────────────────────────────
+
+#[derive(Default)]
+struct NoopApprovals;
+
+#[async_trait]
+impl ApprovalPort for NoopApprovals {
+    async fn enqueue(&self, request: ApprovalRequest) -> KernelResult<ApprovalTicket> {
+        Ok(ApprovalTicket {
+            approval_id: ApprovalId::default(),
+            session_id: request.session_id,
+            call_id: request.call_id,
+            tool_name: request.tool_name,
+            capability: request.capability,
+            reason: request.reason,
+            created_at: chrono::Utc::now(),
+        })
+    }
+
+    async fn list_pending(&self, _session_id: SessionId) -> KernelResult<Vec<ApprovalTicket>> {
+        Ok(Vec::new())
+    }
+
+    async fn resolve(
+        &self,
+        approval_id: ApprovalId,
+        approved: bool,
+        actor: String,
+    ) -> KernelResult<ApprovalResolution> {
+        Ok(ApprovalResolution {
+            approval_id,
+            approved,
+            actor,
+            resolved_at: chrono::Utc::now(),
+        })
+    }
+}
+
+// ── Harness wiring ────────────────────────────────────────────────────
+
+/// The mock ports a test wants to inspect after driving a tick.
+struct Ports {
+    provider: Arc<ScriptedProvider>,
+    harness: Arc<RecordingHarness>,
+    policy: Arc<RecordingPolicy>,
+}
+
+fn build_runtime(
+    provider: ScriptedProvider,
+    registry_tool_names: Vec<&str>,
+) -> (KernelRuntime, Ports) {
+    let root = std::env::temp_dir().join(format!(
+        "aios-runtime-client-tools-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let event_store: Arc<dyn EventStorePort> = Arc::new(MemEventStore::default());
+
+    let provider = Arc::new(provider);
+    let harness = Arc::new(RecordingHarness::default());
+    let policy = Arc::new(RecordingPolicy::default());
+
+    let runtime = KernelRuntime::new(
+        RuntimeConfig::new(root),
+        event_store,
+        provider.clone() as Arc<dyn ModelProviderPort>,
+        harness.clone() as Arc<dyn ToolHarnessPort>,
+        Arc::new(NoopApprovals) as Arc<dyn ApprovalPort>,
+        policy.clone() as Arc<dyn PolicyGatePort>,
+    )
+    .with_registry_tool_names(registry_tool_names);
+
+    (
+        runtime,
+        Ports {
+            provider,
+            harness,
+            policy,
+        },
+    )
+}
+
+fn client_tool(name: &str) -> ClientToolDefinition {
+    ClientToolDefinition {
+        name: name.to_owned(),
+        description: format!("client tool {name}"),
+        parameters: serde_json::json!({ "type": "object" }),
+    }
+}
+
+async fn tick_with_client_tools(
+    runtime: &KernelRuntime,
+    session: &SessionId,
+    client_tools: Vec<ClientToolDefinition>,
+) -> aios_runtime::TickOutput {
+    runtime
+        .tick_on_branch(
+            session,
+            &BranchId::main(),
+            TickInput {
+                objective: "look up the weather".to_owned(),
+                proposed_tool: None,
+                system_prompt: None,
+                allowed_tools: None,
+                client_tools,
+                kind: TickKind::Direct,
+            },
+        )
+        .await
+        .expect("tick succeeds")
+}
+
+async fn new_session(runtime: &KernelRuntime) -> SessionId {
+    let manifest = runtime
+        .create_session("test-owner", PolicySet::default(), ModelRouting::default())
+        .await
+        .expect("create session");
+    manifest.session_id
+}
+
+fn count_kinds(events: &[EventRecord]) -> HashMap<&'static str, usize> {
+    let mut counts = HashMap::new();
+    for record in events {
+        let name = match &record.kind {
+            EventKind::ToolCallRequested { .. } => "ToolCallRequested",
+            EventKind::ToolCallStarted { .. } => "ToolCallStarted",
+            EventKind::ToolCallCompleted { .. } => "ToolCallCompleted",
+            EventKind::ToolCallFailed { .. } => "ToolCallFailed",
+            EventKind::RunFinished { .. } => "RunFinished",
+            EventKind::RunErrored { .. } => "RunErrored",
+            _ => continue,
+        };
+        *counts.entry(name).or_insert(0) += 1;
+    }
+    counts
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tick_threads_client_tools_into_model_request() {
+    // A tick carrying `client_tools` must surface them on the
+    // `ModelCompletionRequest` the provider receives.
+    let (runtime, ports) = build_runtime(ScriptedProvider::default(), Vec::new());
+    let session = new_session(&runtime).await;
+
+    let tools = vec![client_tool("get_weather"), client_tool("get_time")];
+    let _ = tick_with_client_tools(&runtime, &session, tools.clone()).await;
+
+    let seen = ports.provider.seen_client_tools.lock().clone();
+    assert_eq!(
+        seen, tools,
+        "provider request should carry the client tools"
+    );
+}
+
+#[tokio::test]
+async fn client_tool_call_is_handed_back_not_executed() {
+    // The model proposes a client-declared tool. The kernel must:
+    //  - emit ToolCallRequested { category: "client" },
+    //  - NOT run the harness for it,
+    //  - NOT evaluate policy for it,
+    //  - end the turn in a mode that breaks the Execute-continue loop
+    //    and is not Recover, while still emitting RunFinished.
+    let (runtime, ports) = build_runtime(ScriptedProvider::proposing("get_weather"), Vec::new());
+    let session = new_session(&runtime).await;
+
+    let output = tick_with_client_tools(&runtime, &session, vec![client_tool("get_weather")]).await;
+
+    // Mode breaks the dispatch loop (≠ Execute) and is not an error (≠ Recover).
+    assert_ne!(
+        output.mode,
+        OperatingMode::Execute,
+        "client-tool turn must not stay in Execute (loop would not break)"
+    );
+    assert_ne!(
+        output.mode,
+        OperatingMode::Recover,
+        "client-tool handoff is not an error"
+    );
+
+    // The harness and policy gate are never consulted for a client tool.
+    assert!(
+        !ports.harness.executed.load(Ordering::SeqCst),
+        "harness must NOT execute a client tool"
+    );
+    assert!(
+        !ports.policy.evaluated.load(Ordering::SeqCst),
+        "policy gate must NOT be evaluated for a client tool"
+    );
+
+    // The journal carries the client handoff and a clean finish, and no
+    // execution events (Started/Completed/Failed).
+    let events = runtime
+        .read_events(&session, 0, 1024)
+        .await
+        .expect("read events");
+    let counts = count_kinds(&events);
+    assert_eq!(
+        counts.get("ToolCallRequested").copied().unwrap_or(0),
+        1,
+        "exactly one ToolCallRequested (the client handoff)"
+    );
+    assert_eq!(
+        counts.get("ToolCallStarted").copied().unwrap_or(0),
+        0,
+        "no ToolCallStarted — client tools are not executed"
+    );
+    assert_eq!(
+        counts.get("ToolCallCompleted").copied().unwrap_or(0),
+        0,
+        "no ToolCallCompleted — client tools are not executed"
+    );
+    assert_eq!(
+        counts.get("RunFinished").copied().unwrap_or(0),
+        1,
+        "RunFinished still emits after the client handoff"
+    );
+    assert_eq!(
+        counts.get("RunErrored").copied().unwrap_or(0),
+        0,
+        "client handoff is not an error"
+    );
+
+    // The single ToolCallRequested is tagged category "client".
+    let requested = events
+        .iter()
+        .find_map(|r| match &r.kind {
+            EventKind::ToolCallRequested {
+                tool_name,
+                category,
+                ..
+            } => Some((tool_name.clone(), category.clone())),
+            _ => None,
+        })
+        .expect("a ToolCallRequested event");
+    assert_eq!(requested.0, "get_weather");
+    assert_eq!(requested.1.as_deref(), Some("client"));
+}
+
+#[tokio::test]
+async fn registry_tool_wins_name_collision() {
+    // A client declares a tool whose name is also a kernel registry
+    // tool. The registry wins: the proposed call is treated as a
+    // governed registry tool (policy + harness run) and is NOT handed
+    // back to the client as a category-"client" handoff.
+    let (runtime, ports) = build_runtime(
+        ScriptedProvider::proposing("get_weather"),
+        vec!["get_weather"],
+    );
+    let session = new_session(&runtime).await;
+
+    let _ = tick_with_client_tools(&runtime, &session, vec![client_tool("get_weather")]).await;
+
+    // Registry path: the harness executes and policy is evaluated.
+    assert!(
+        ports.harness.executed.load(Ordering::SeqCst),
+        "registry tool must execute through the harness on a collision"
+    );
+    assert!(
+        ports.policy.evaluated.load(Ordering::SeqCst),
+        "registry tool must be policy-evaluated on a collision"
+    );
+
+    // The ToolCallRequested for a registry tool is NOT category "client".
+    let events = runtime
+        .read_events(&session, 0, 1024)
+        .await
+        .expect("read events");
+    let category = events.iter().find_map(|r| match &r.kind {
+        EventKind::ToolCallRequested { category, .. } => Some(category.clone()),
+        _ => None,
+    });
+    assert_ne!(
+        category.flatten().as_deref(),
+        Some("client"),
+        "a registry tool must not be tagged as a client handoff"
+    );
+}

--- a/crates/aios/aios-runtime/tests/client_tools.rs
+++ b/crates/aios/aios-runtime/tests/client_tools.rs
@@ -108,6 +108,9 @@ impl EventStorePort for MemEventStore {
 struct ScriptedProvider {
     /// Tool name to propose on the first completion (`None` → just answer).
     propose_tool: Option<String>,
+    /// Registry tool to ALSO propose first (with a capability) — drives
+    /// the mixed registry+client completion path.
+    propose_registry_tool: Option<String>,
     /// `client_tools` seen on the most recent request.
     seen_client_tools: Mutex<Vec<ClientToolDefinition>>,
     /// Whether the first completion has already been served.
@@ -118,6 +121,16 @@ impl ScriptedProvider {
     fn proposing(tool_name: &str) -> Self {
         Self {
             propose_tool: Some(tool_name.to_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// First completion proposes a capability-bearing registry tool AND
+    /// a client tool, in that order (mirrors a mixed model turn).
+    fn proposing_pair(registry_tool: &str, client_tool: &str) -> Self {
+        Self {
+            propose_tool: Some(client_tool.to_owned()),
+            propose_registry_tool: Some(registry_tool.to_owned()),
             ..Default::default()
         }
     }
@@ -132,18 +145,30 @@ impl ModelProviderPort for ScriptedProvider {
         // ticks (if any) answer normally so loops terminate.
         let first = !self.answered.swap(true, Ordering::SeqCst);
         if first && let Some(tool_name) = self.propose_tool.clone() {
+            let mut directives = Vec::new();
+            if let Some(registry_tool) = self.propose_registry_tool.clone() {
+                directives.push(ModelDirective::ToolCall {
+                    call: ToolCall {
+                        call_id: "call-0".to_owned(),
+                        tool_name: registry_tool,
+                        input: serde_json::json!({ "path": "artifacts/x" }),
+                        requested_capabilities: vec![Capability::fs_write("/session/artifacts/**")],
+                    },
+                });
+            }
+            directives.push(ModelDirective::ToolCall {
+                call: ToolCall {
+                    call_id: "call-1".to_owned(),
+                    tool_name,
+                    input: serde_json::json!({ "q": "berlin" }),
+                    requested_capabilities: Vec::new(),
+                },
+            });
             return Ok(ModelCompletion {
                 provider: "scripted".to_owned(),
                 model: "scripted-deterministic".to_owned(),
                 llm_call_record: None,
-                directives: vec![ModelDirective::ToolCall {
-                    call: ToolCall {
-                        call_id: "call-1".to_owned(),
-                        tool_name,
-                        input: serde_json::json!({ "q": "berlin" }),
-                        requested_capabilities: Vec::new(),
-                    },
-                }],
+                directives,
                 stop_reason: ModelStopReason::ToolCall,
                 usage: None,
                 final_answer: None,
@@ -202,6 +227,9 @@ impl ToolHarnessPort for RecordingHarness {
 #[derive(Default)]
 struct RecordingPolicy {
     evaluated: AtomicBool,
+    /// When set, every requested capability requires approval — drives
+    /// the AskHuman path for governed registry tools.
+    require_approval: bool,
 }
 
 #[async_trait]
@@ -212,6 +240,13 @@ impl PolicyGatePort for RecordingPolicy {
         requested: Vec<Capability>,
     ) -> KernelResult<PolicyGateDecision> {
         self.evaluated.store(true, Ordering::SeqCst);
+        if self.require_approval {
+            return Ok(PolicyGateDecision {
+                allowed: Vec::new(),
+                requires_approval: requested,
+                denied: Vec::new(),
+            });
+        }
         Ok(PolicyGateDecision {
             allowed: requested,
             requires_approval: Vec::new(),
@@ -271,6 +306,14 @@ fn build_runtime(
     provider: ScriptedProvider,
     registry_tool_names: Vec<&str>,
 ) -> (KernelRuntime, Ports) {
+    build_runtime_with_policy(provider, registry_tool_names, RecordingPolicy::default())
+}
+
+fn build_runtime_with_policy(
+    provider: ScriptedProvider,
+    registry_tool_names: Vec<&str>,
+    policy: RecordingPolicy,
+) -> (KernelRuntime, Ports) {
     let root = std::env::temp_dir().join(format!(
         "aios-runtime-client-tools-{}",
         uuid::Uuid::new_v4()
@@ -279,7 +322,7 @@ fn build_runtime(
 
     let provider = Arc::new(provider);
     let harness = Arc::new(RecordingHarness::default());
-    let policy = Arc::new(RecordingPolicy::default());
+    let policy = Arc::new(policy);
 
     let runtime = KernelRuntime::new(
         RuntimeConfig::new(root),
@@ -496,5 +539,31 @@ async fn registry_tool_wins_name_collision() {
         category.flatten().as_deref(),
         Some("client"),
         "a registry tool must not be tagged as a client handoff"
+    );
+}
+
+#[tokio::test]
+async fn mixed_completion_preserves_ask_human_over_client_handoff() {
+    // A mixed first completion: a governed registry tool whose
+    // capability requires approval, THEN a client tool. The client-tool
+    // handoff forces `Sleep` for plain turns — but it must NOT clobber
+    // `AskHuman`, or the host loses the only pending-approval signal
+    // and the approval stalls silently on the next dispatch.
+    let (runtime, _ports) = build_runtime_with_policy(
+        ScriptedProvider::proposing_pair("fs.write", "get_weather"),
+        vec!["fs.write"],
+        RecordingPolicy {
+            require_approval: true,
+            ..Default::default()
+        },
+    );
+    let session = new_session(&runtime).await;
+
+    let output = tick_with_client_tools(&runtime, &session, vec![client_tool("get_weather")]).await;
+
+    assert_eq!(
+        output.mode,
+        OperatingMode::AskHuman,
+        "pending approval must win over the client-tool Sleep forcing"
     );
 }

--- a/crates/arcan/arcan-aios-adapters/src/provider.rs
+++ b/crates/arcan/arcan-aios-adapters/src/provider.rs
@@ -352,13 +352,20 @@ impl ModelProviderPort for ArcanProviderAdapter {
         // the registry tools. Registry tools win on a name collision
         // (collisions are pruned upstream too, but dedup here keeps the
         // provider request well-formed even if a stray duplicate arrives).
+        // The collision check runs against the FULL registry (`self.tools`),
+        // not the allowed_tools-filtered list: a client def named after a
+        // whitelisted-OUT registry tool must not surface, because the
+        // kernel's registry-wins routing would execute the registry tool
+        // the whitelist excluded (with client-shaped arguments).
         // These are surfaced only — the kernel never executes them; when
         // the model proposes one, the tick hands the call back to the
         // client (see `aios_runtime` client-tool handoff). `parameters`
         // passes through verbatim as the tool's input schema.
         if !request.client_tools.is_empty() {
             for client_tool in &request.client_tools {
-                if tools.iter().any(|t| t.name == client_tool.name) {
+                if self.tools.iter().any(|t| t.name == client_tool.name)
+                    || tools.iter().any(|t| t.name == client_tool.name)
+                {
                     continue;
                 }
                 tools.push(arcan_core::protocol::ToolDefinition {

--- a/crates/arcan/arcan-aios-adapters/src/provider.rs
+++ b/crates/arcan/arcan-aios-adapters/src/provider.rs
@@ -346,7 +346,34 @@ impl ModelProviderPort for ArcanProviderAdapter {
         }
 
         // Apply tool filtering from active skill's allowed_tools whitelist.
-        let tools = self.filter_tools(request.allowed_tools.as_deref());
+        let mut tools = self.filter_tools(request.allowed_tools.as_deref());
+
+        // Append client-declared tools so the model sees them alongside
+        // the registry tools. Registry tools win on a name collision
+        // (collisions are pruned upstream too, but dedup here keeps the
+        // provider request well-formed even if a stray duplicate arrives).
+        // These are surfaced only — the kernel never executes them; when
+        // the model proposes one, the tick hands the call back to the
+        // client (see `aios_runtime` client-tool handoff). `parameters`
+        // passes through verbatim as the tool's input schema.
+        if !request.client_tools.is_empty() {
+            for client_tool in &request.client_tools {
+                if tools.iter().any(|t| t.name == client_tool.name) {
+                    continue;
+                }
+                tools.push(arcan_core::protocol::ToolDefinition {
+                    name: client_tool.name.clone(),
+                    description: client_tool.description.clone(),
+                    input_schema: client_tool.parameters.clone(),
+                    title: None,
+                    output_schema: None,
+                    annotations: None,
+                    category: Some("client".to_owned()),
+                    tags: Vec::new(),
+                    timeout_secs: None,
+                });
+            }
+        }
 
         let provider_request = ProviderRequest {
             run_id: request.run_id.as_str().to_owned(),
@@ -715,6 +742,7 @@ mod tests {
                 system_prompt: None,
                 allowed_tools: Some(vec!["read_file".to_owned()]),
                 conversation_history: Vec::new(),
+                client_tools: Vec::new(),
             })
             .await
             .unwrap();

--- a/crates/arcan/arcan-ergon/src/provider.rs
+++ b/crates/arcan/arcan-ergon/src/provider.rs
@@ -247,6 +247,9 @@ fn build_completion_request(
             Some(req.tools.iter().map(|t| t.name.clone()).collect())
         },
         conversation_history: history,
+        // ergon workflows do not carry client-declared tools (no chat
+        // client trust domain in the workflow body) — always empty.
+        client_tools: Vec::new(),
     }
 }
 

--- a/crates/arcan/arcan-ergon/tests/anthropic_workflow.rs
+++ b/crates/arcan/arcan-ergon/tests/anthropic_workflow.rs
@@ -305,6 +305,7 @@ async fn run_validation(provider_port: Arc<dyn ModelProviderPort>, model: String
         proposed_tool: None,
         system_prompt: None,
         allowed_tools: None,
+        client_tools: Vec::new(),
         kind: TickKind::Workflow {
             name: "test.summarize".to_owned(),
             input: workflow_input,

--- a/crates/arcan/arcan-ergon/tests/workflow_tick_e2e.rs
+++ b/crates/arcan/arcan-ergon/tests/workflow_tick_e2e.rs
@@ -159,6 +159,7 @@ async fn workflow_tick_runs_end_to_end() {
         proposed_tool: None,
         system_prompt: None,
         allowed_tools: None,
+        client_tools: Vec::new(),
         kind: TickKind::Workflow {
             name: "test.greeter".to_owned(),
             input: workflow_input,
@@ -208,6 +209,7 @@ async fn workflow_tick_emits_output_event() {
                 proposed_tool: None,
                 system_prompt: None,
                 allowed_tools: None,
+                client_tools: Vec::new(),
                 kind: TickKind::Workflow {
                     name: "test.greeter".to_owned(),
                     input: serde_json::json!({"name": "ergon"}),
@@ -273,6 +275,7 @@ async fn direct_tick_still_works_after_dispatcher_registration() {
         proposed_tool: None,
         system_prompt: None,
         allowed_tools: None,
+        client_tools: Vec::new(),
         kind: TickKind::Direct,
     };
 
@@ -314,6 +317,7 @@ async fn unknown_workflow_routes_to_run_errored_and_recover_mode() {
                 proposed_tool: None,
                 system_prompt: None,
                 allowed_tools: None,
+                client_tools: Vec::new(),
                 kind: TickKind::Workflow {
                     name: "no.such.workflow".to_owned(),
                     input: serde_json::Value::Null,
@@ -541,6 +545,7 @@ mod fully_wired {
                     proposed_tool: None,
                     system_prompt: None,
                     allowed_tools: None,
+                    client_tools: Vec::new(),
                     kind: TickKind::Workflow {
                         name: "test.inferring".to_owned(),
                         input: serde_json::json!({"name": "wired"}),

--- a/crates/arcan/arcan/src/chronos_wiring.rs
+++ b/crates/arcan/arcan/src/chronos_wiring.rs
@@ -70,6 +70,7 @@ impl KernelDispatcher for ArcandKernelDispatcher {
             proposed_tool: None,
             system_prompt: None,
             allowed_tools: None,
+            client_tools: Vec::new(),
             kind: TickKind::Direct,
         };
 

--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -878,6 +878,13 @@ fn run_serve(
     // Shared handle: starts empty, filled after runtime creation.
     let streaming_sender: StreamingSenderHandle = Arc::new(std::sync::Mutex::new(None));
     let tool_definitions = registry.definitions();
+    // Names of the kernel's governed (registry) tools — captured before
+    // `tool_definitions` is moved into the adapter. Wired into the
+    // KernelRuntime below so the client-tool handoff path enforces
+    // registry-wins on name collisions (a client tool sharing a registry
+    // name is NOT handed back to the client; the registry tool runs).
+    let registry_tool_names: Vec<String> =
+        tool_definitions.iter().map(|t| t.name.clone()).collect();
     let adapter = ArcanProviderAdapter::from_handle(
         provider_handle.clone(),
         tool_definitions,
@@ -951,7 +958,8 @@ fn run_serve(
         approvals,
         policy_gate,
         turn_middlewares,
-    );
+    )
+    .with_registry_tool_names(registry_tool_names);
 
     // Register the ergon-workflow tick dispatcher (BRO-1001). No
     // workflows are registered by default — adopting daemons override

--- a/crates/arcan/arcand/src/canonical.rs
+++ b/crates/arcan/arcand/src/canonical.rs
@@ -1822,6 +1822,7 @@ async fn run_session(
                 proposed_tool,
                 system_prompt: system_prompt.clone(),
                 allowed_tools: combined_allowed_tools.clone(),
+                client_tools: Vec::new(),
                 kind: aios_runtime::TickKind::Direct,
             },
         )
@@ -1848,6 +1849,7 @@ async fn run_session(
                             proposed_tool: None,
                             system_prompt: system_prompt.clone(),
                             allowed_tools: combined_allowed_tools.clone(),
+                            client_tools: Vec::new(),
                             kind: aios_runtime::TickKind::Direct,
                         },
                     )

--- a/crates/arcan/arcand/src/consciousness.rs
+++ b/crates/arcan/arcand/src/consciousness.rs
@@ -717,6 +717,7 @@ impl SessionConsciousness {
                     proposed_tool: run_context.proposed_tool,
                     system_prompt: run_context.system_prompt.clone(),
                     allowed_tools: run_context.allowed_tools.clone(),
+                    client_tools: Vec::new(),
                     kind: aios_runtime::TickKind::Direct,
                 },
             )
@@ -788,6 +789,7 @@ impl SessionConsciousness {
                                 proposed_tool: None,
                                 system_prompt: run_context.system_prompt.clone(),
                                 allowed_tools: run_context.allowed_tools.clone(),
+                                client_tools: Vec::new(),
                                 kind: aios_runtime::TickKind::Direct,
                             },
                         )

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -27,7 +27,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use aios_protocol::{
-    BranchId, EventKind, EventRecord, ModelRouting, OperatingMode, PolicySet, SessionId,
+    BranchId, ClientToolDefinition, EventKind, EventRecord, ModelRouting, OperatingMode, PolicySet,
+    SessionId,
 };
 use aios_runtime::{KernelRuntime, TickInput, TickKind};
 use arcan_substrate_proto::arcan::v1::{
@@ -150,21 +151,43 @@ impl AgentSubstrate for SubstrateService {
         let content = body.content;
         // Client tool definitions arrive as JSON bytes on
         // `tool_definitions` (additive field — lifed forwards the chat
-        // surface's tools). The kernel's tick path executes tools from
-        // its own governed registry; merging client-declared tools into
-        // the per-session tool surface is a follow-up (the HTTP-backed
-        // `ArcanCall` impls in arcan-proxy honour them today). Log so
-        // operators can see when a client declared tools that the
-        // kernel path does not yet surface to the model.
-        if !body.tool_definitions.is_empty() {
-            tracing::debug!(
+        // surface's tools, each entry one JSON object in the OpenAI
+        // function shape `{"name","description","parameters"}`). Parse
+        // them at this trust boundary: a malformed entry is warned and
+        // skipped, never aborting an otherwise-valid turn. The parsed
+        // set is surfaced to the model on every tick of this dispatch;
+        // the kernel enforces registry-wins on name collisions and, when
+        // the model proposes a client tool, hands the call back to the
+        // caller as TOOL_CALL_PENDING (category "client") instead of
+        // executing it through the harness.
+        let client_tools: Vec<ClientToolDefinition> = if body.tool_definitions.is_empty() {
+            Vec::new()
+        } else {
+            let total = body.tool_definitions.len();
+            let parsed: Vec<ClientToolDefinition> = body
+                .tool_definitions
+                .iter()
+                .filter_map(|bytes| match ClientToolDefinition::from_wire_bytes(bytes) {
+                    Ok(def) => Some(def),
+                    Err(err) => {
+                        tracing::warn!(
+                            sid = %sid_proto.value,
+                            error = %err,
+                            "dispatch_message: skipping malformed client tool definition"
+                        );
+                        None
+                    }
+                })
+                .collect();
+            tracing::info!(
                 sid = %sid_proto.value,
-                tool_count = body.tool_definitions.len(),
-                "dispatch_message: client tool definitions received; kernel \
-                 tick uses the registry-driven tool set (client-tool merge \
-                 is a follow-up)"
+                accepted = parsed.len(),
+                skipped = total - parsed.len(),
+                "dispatch_message: client tool definitions parsed; surfacing to model \
+                 (registry tools win on collision; client tools are client-executed)"
             );
-        }
+            parsed
+        };
 
         let (tx, rx) = mpsc::channel::<Result<AgentEvent, Status>>(DISPATCH_CHANNEL_CAPACITY);
 
@@ -243,6 +266,11 @@ impl AgentSubstrate for SubstrateService {
                     proposed_tool: None,
                     system_prompt: None,
                     allowed_tools: None,
+                    // Surfaced on every tick of this dispatch so the model
+                    // keeps seeing the client tools across the multi-tick
+                    // loop (e.g. a registry tool runs, then the model
+                    // proposes a client tool on the follow-up call).
+                    client_tools: client_tools.clone(),
                     kind: TickKind::Direct,
                 };
                 match runtime

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -49,6 +49,26 @@ const MAX_AGENT_ITERATIONS: u32 = 10;
 // terminal frames; 64 is sufficient headroom for the slowest reader.
 const DISPATCH_CHANNEL_CAPACITY: usize = 64;
 
+// Trust-boundary caps for client-supplied tool definitions. These are
+// UNTRUSTED remote input (the chat surface forwards whatever a client
+// declares) and are re-serialized into the provider request on every
+// tick of a dispatch — without caps a remote user can inflate every
+// model call (cost/context amplification) or smuggle a name the
+// provider rejects (turning every tick into a wire ERROR). Limits are
+// deliberately generous: real chat surfaces ship ~20 tools with ~1-4KB
+// schemas. OpenAI's function-name charset is `[a-zA-Z0-9_-]{1,64}`.
+const MAX_CLIENT_TOOL_DEFS: usize = 64;
+const MAX_CLIENT_TOOL_DEF_BYTES: usize = 16 * 1024;
+
+/// Provider-portable tool-name check (`[a-zA-Z0-9_-]{1,64}`).
+fn valid_client_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// arcand's `arcan.v1.AgentSubstrate` impl. Holds a shared
 /// `KernelRuntime` handle so every RPC reuses the same in-memory
 /// session store, journal, and tick engine that the HTTP plane is
@@ -164,18 +184,46 @@ impl AgentSubstrate for SubstrateService {
             Vec::new()
         } else {
             let total = body.tool_definitions.len();
+            if total > MAX_CLIENT_TOOL_DEFS {
+                tracing::warn!(
+                    sid = %sid_proto.value,
+                    total,
+                    cap = MAX_CLIENT_TOOL_DEFS,
+                    "dispatch_message: client tool definitions exceed cap; truncating"
+                );
+            }
             let parsed: Vec<ClientToolDefinition> = body
                 .tool_definitions
                 .iter()
-                .filter_map(|bytes| match ClientToolDefinition::from_wire_bytes(bytes) {
-                    Ok(def) => Some(def),
-                    Err(err) => {
+                .take(MAX_CLIENT_TOOL_DEFS)
+                .filter_map(|bytes| {
+                    if bytes.len() > MAX_CLIENT_TOOL_DEF_BYTES {
                         tracing::warn!(
                             sid = %sid_proto.value,
-                            error = %err,
-                            "dispatch_message: skipping malformed client tool definition"
+                            bytes = bytes.len(),
+                            cap = MAX_CLIENT_TOOL_DEF_BYTES,
+                            "dispatch_message: skipping oversized client tool definition"
                         );
-                        None
+                        return None;
+                    }
+                    match ClientToolDefinition::from_wire_bytes(bytes) {
+                        Ok(def) if !valid_client_tool_name(&def.name) => {
+                            tracing::warn!(
+                                sid = %sid_proto.value,
+                                name = %def.name,
+                                "dispatch_message: skipping client tool with provider-unsafe name"
+                            );
+                            None
+                        }
+                        Ok(def) => Some(def),
+                        Err(err) => {
+                            tracing::warn!(
+                                sid = %sid_proto.value,
+                                error = %err,
+                                "dispatch_message: skipping malformed client tool definition"
+                            );
+                            None
+                        }
                     }
                 })
                 .collect();

--- a/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
+++ b/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
@@ -408,3 +408,187 @@ async fn destroy_agent_is_idempotent_ok() {
         .expect("destroy_agent ok unknown");
     env.shutdown().await;
 }
+
+/// Provider that proposes a CLIENT tool (one declared via
+/// `tool_definitions`, absent from the kernel registry) on its first
+/// completion. A second completion would answer normally — but the
+/// client-tool handoff must END the dispatch after the first call, so
+/// the test asserts the counter never reaches 2.
+#[derive(Debug, Default)]
+struct ClientToolProvider {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl ModelProviderPort for ClientToolProvider {
+    async fn complete(&self, request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        // The merge contract: the provider-visible request must carry
+        // the client tool defs the dispatch received on the wire.
+        assert!(
+            request.client_tools.iter().any(|t| t.name == "get_weather"),
+            "client tool defs must reach the provider request"
+        );
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Ok(ModelCompletion {
+                provider: "test".to_owned(),
+                model: "test-model".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::ToolCall {
+                    call: ToolCall {
+                        call_id: "call-client-1".to_owned(),
+                        tool_name: "get_weather".to_owned(),
+                        input: serde_json::json!({ "city": "Medellín" }),
+                        requested_capabilities: vec![],
+                    },
+                }],
+                stop_reason: ModelStopReason::ToolCall,
+                usage: None,
+                final_answer: None,
+            })
+        } else {
+            Ok(ModelCompletion {
+                provider: "test".to_owned(),
+                model: "test-model".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::Message {
+                    role: "assistant".to_owned(),
+                    content: "should never be asked".to_owned(),
+                }],
+                stop_reason: ModelStopReason::Completed,
+                usage: None,
+                final_answer: Some("unexpected".to_owned()),
+            })
+        }
+    }
+}
+
+#[tokio::test]
+async fn dispatch_message_hands_off_client_tool_calls() {
+    // The #1697-completion contract on the kernel path: client tool
+    // defs ride DispatchMessageReq.tool_definitions → the model sees
+    // them → a proposal of a client tool surfaces as TOOL_CALL_PENDING
+    // with category "client" and the turn ENDS (FINISH) without kernel
+    // execution — the chat surface executes the tool and continues via
+    // replayed history on its next dispatch.
+    let tempdir = TempDir::new().expect("tempdir");
+    let socket = tempdir.path().join("arcand.sock");
+    let root = tempdir.path().join("kernel-root");
+
+    let event_store_backend = Arc::new(FileEventStore::new(root.join("kernel")));
+    let journal = Arc::new(EventJournal::new(
+        event_store_backend,
+        EventStreamHub::new(1024),
+    ));
+    let event_store: Arc<dyn EventStorePort> = journal;
+    let policy_engine = Arc::new(SessionPolicyEngine::new(PolicySet::default()));
+    let policy_gate: Arc<dyn PolicyGatePort> = policy_engine.clone();
+    let approvals: Arc<dyn ApprovalPort> = Arc::new(ApprovalQueue::default());
+    let registry = Arc::new(ToolRegistry::with_core_tools());
+    let sandbox = Arc::new(LocalSandboxRunner::new(vec!["echo".to_owned()]));
+    let dispatcher = Arc::new(ToolDispatcher::new(registry, policy_engine, sandbox));
+    let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
+    let provider_calls = Arc::new(AtomicU32::new(0));
+    let provider = ClientToolProvider {
+        calls: Arc::clone(&provider_calls),
+    };
+    let runtime = Arc::new(KernelRuntime::new(
+        RuntimeConfig::new(root),
+        event_store,
+        Arc::new(provider),
+        tool_harness,
+        approvals,
+        policy_gate,
+    ));
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let service = SubstrateService::new(Arc::clone(&runtime));
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind UDS");
+    let incoming = tokio_stream::wrappers::UnixListenerStream::new(listener);
+    let server_handle = tokio::spawn(async move {
+        let _ = tonic::transport::Server::builder()
+            .add_service(AgentSubstrateServer::new(service))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let proxy = ArcanProxy::connect(socket.clone())
+        .await
+        .expect("dial substrate UDS");
+    let sid = "client-tool-handoff";
+    let _ = proxy.create_agent(sid).await.expect("create_agent");
+
+    let tools = vec![serde_json::json!({
+        "name": "get_weather",
+        "description": "Get the weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        }
+    })];
+    let mut stream = proxy
+        .dispatch_message(sid, "what's the weather in Medellín?", None, &tools)
+        .await
+        .expect("dispatch_message");
+
+    let mut pending: Option<serde_json::Value> = None;
+    let mut saw_tool_result = false;
+    let mut terminal_seen = false;
+    let mut count = 0;
+    while let Some(evt) = stream.next().await {
+        let evt = evt.expect("substrate event ok");
+        count += 1;
+        let payload = evt.record.as_ref().map(|r| {
+            serde_json::from_slice::<serde_json::Value>(&r.payload).expect("record payload JSON")
+        });
+        if evt.kind == AgentEventKind::ToolCallPending as i32 {
+            pending = payload.clone();
+        }
+        if evt.kind == AgentEventKind::ToolResult as i32 {
+            saw_tool_result = true;
+        }
+        if evt.kind == AgentEventKind::Finish as i32 || evt.kind == AgentEventKind::Error as i32 {
+            terminal_seen = true;
+            assert_eq!(
+                evt.kind,
+                AgentEventKind::Finish as i32,
+                "client-tool handoff must FINISH cleanly, not ERROR"
+            );
+            break;
+        }
+        if count > 64 {
+            break;
+        }
+    }
+    drop(stream);
+
+    assert!(terminal_seen, "stream should reach a terminal frame");
+    let pending = pending.expect("TOOL_CALL_PENDING frame should arrive at the proxy");
+    assert_eq!(pending["call_id"], "call-client-1");
+    assert_eq!(pending["tool_name"], "get_weather");
+    assert_eq!(
+        pending["category"], "client",
+        "handoff frames must be marked category=client: {pending}"
+    );
+    assert_eq!(pending["arguments"]["city"], "Medellín");
+    assert!(
+        !saw_tool_result,
+        "client tools are client-executed — the kernel must not emit TOOL_RESULT"
+    );
+    assert_eq!(
+        provider_calls.load(Ordering::SeqCst),
+        1,
+        "the handoff ends the turn — no follow-up provider call"
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_handle).await;
+}

--- a/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
+++ b/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
@@ -485,20 +485,33 @@ async fn dispatch_message_hands_off_client_tool_calls() {
     let approvals: Arc<dyn ApprovalPort> = Arc::new(ApprovalQueue::default());
     let registry = Arc::new(ToolRegistry::with_core_tools());
     let sandbox = Arc::new(LocalSandboxRunner::new(vec!["echo".to_owned()]));
-    let dispatcher = Arc::new(ToolDispatcher::new(registry, policy_engine, sandbox));
+    let dispatcher = Arc::new(ToolDispatcher::new(
+        Arc::clone(&registry),
+        policy_engine,
+        sandbox,
+    ));
     let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
     let provider_calls = Arc::new(AtomicU32::new(0));
     let provider = ClientToolProvider {
         calls: Arc::clone(&provider_calls),
     };
-    let runtime = Arc::new(KernelRuntime::new(
-        RuntimeConfig::new(root),
-        event_store,
-        Arc::new(provider),
-        tool_harness,
-        approvals,
-        policy_gate,
-    ));
+    // Mirror `arcan serve`: declare the registry's tool names so the
+    // kernel can enforce registry-wins on client-tool collisions (the
+    // foot-gun the empty default would hide — see
+    // `KernelRuntime::with_registry_tool_names`).
+    let registry_tool_names: Vec<String> =
+        registry.definitions().map(|def| def.name.clone()).collect();
+    let runtime = Arc::new(
+        KernelRuntime::new(
+            RuntimeConfig::new(root),
+            event_store,
+            Arc::new(provider),
+            tool_harness,
+            approvals,
+            policy_gate,
+        )
+        .with_registry_tool_names(registry_tool_names),
+    );
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let service = SubstrateService::new(Arc::clone(&runtime));

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1638,9 +1638,12 @@ collisions; a model proposal of a client tool emits
 `ToolCallRequested(category="client")` → wire `TOOL_CALL_PENDING` and
 ends the turn cleanly (no kernel policy/harness involvement — the chat
 surface executes the tool and continues via replayed history).
-Covered by aios-protocol parse tests, aios-runtime tick tests, and a
-topology-B e2e (defs → provider request → TOOL_CALL_PENDING(category
-=client) → FINISH, no TOOL_RESULT, exactly one provider call).
+Covered by aios-protocol parse tests (7, incl. strict field-type
+rejection), aios-runtime tick tests (4, incl. mixed-completion
+AskHuman preservation), and a topology-B e2e (defs → provider request
+→ TOOL_CALL_PENDING(category=client) → FINISH, no TOOL_RESULT, exactly
+one provider call) — net +12 tests on the arc. Gap closed:
+"kernel dispatch drops client tool_definitions" (BRO-1463).
 
 ## Health Summary
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1626,6 +1626,22 @@ the runbook §6.1 known-limitations log):**
 the runbook → Phase 1 SHIPPED; then queue Phase 2 (J-Sub-H/I/J)
 gated on Spec E E-Sub-F conformance completion.
 
+**2026-06-11 — kernel dispatch path surfaces client tool definitions
+(BRO-1463, completes the #1697 arc).** Stage-5's real-arcand activation
+had regressed chat client tools: the gateway (mock) path attached
+`tool_definitions` since #1697, but arcand's kernel/UDS dispatch
+received and dropped them (the documented substrate.rs follow-up).
+Now: `ClientToolDefinition` (aios-protocol, strict wire parse —
+malformed entries warn+skip) rides `TickInput.client_tools` into the
+provider request on every tick of a dispatch; registry tools win name
+collisions; a model proposal of a client tool emits
+`ToolCallRequested(category="client")` → wire `TOOL_CALL_PENDING` and
+ends the turn cleanly (no kernel policy/harness involvement — the chat
+surface executes the tool and continues via replayed history).
+Covered by aios-protocol parse tests, aios-runtime tick tests, and a
+topology-B e2e (defs → provider request → TOOL_CALL_PENDING(category
+=client) → FINISH, no TOOL_RESULT, exactly one provider call).
+
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |


### PR DESCRIPTION
## Summary

**Stage-5's real-arcand activation regressed chat client tools.** Since #1697, the gateway (mock-substrate) path attached the chat surface's `tool_definitions` to the provider call — but arcand's kernel/UDS dispatch path received and **dropped** them (the documented follow-up at `substrate.rs:151-167`). When #1695 flipped production to the real substrate, the chat UI's tools silently stopped reaching the model (confirmed by live dogfood: the model enumerated only arcan's 14 registry tools). This PR completes the #1697 arc on the path production actually runs.

## Behavior

- `ClientToolDefinition` (new in `aios-protocol`): strict wire parse of the OpenAI function shape `{"name","description","parameters"}`; malformed entries **warn + skip**, never aborting an otherwise-valid dispatch.
- `dispatch_message` parses defs once and surfaces them via `TickInput.client_tools` on **every tick** of the dispatch (multi-tick loops keep seeing them).
- The provider adapter appends client tools to the provider-visible tools array (`parameters` passed through verbatim).
- **Registry wins name collisions** (kernel-governed shadows client; warned).
- A model proposal of a client tool emits `ToolCallRequested(category="client")` → wire `TOOL_CALL_PENDING` — **no policy gate, no harness execution** (the tool runs in the chat surface's trust domain). The turn then **ends cleanly** (FINISH, mode breaks the Execute-continue loop without Recover): the client executes the tool and continues via replayed history on its next dispatch (the chat client already creates a session per message and replays prior turns).
- Mixed completions: registry tools execute exactly as before; the handoff rule applies after all calls are processed.

## Tests

- `aios-protocol`: 6 parse/serde unit tests (invalid JSON, non-object, missing name, defaults, full shape, roundtrip).
- `aios-runtime` `tests/client_tools.rs`: 3 tick tests — defs reach `ModelCompletionRequest`; client-tool proposal → `ToolCallRequested(category="client")` with no harness/policy involvement and a non-Execute, non-Recover final mode; registry-collision resolution.
- `arcand` topology-B e2e (`dispatch_message_hands_off_client_tool_calls`): defs ride `ArcanProxy → UDS → dispatch_message`; asserts TOOL_CALL_PENDING payload (`tool_name`, `category:"client"`, arguments), clean FINISH, **no TOOL_RESULT**, and **exactly one provider call**.

## Gates

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p aios-protocol -p aios-runtime -p arcand -p arcan-aios-adapters -p arcan-ergon -p aios-kernel -- -D warnings`
- [x] `cargo test` green on all touched crates (198 in the heavier three)
- [x] `cargo check --workspace`
- [ ] CI green (Test (Linux) on the #1700-hardened lane)
- [ ] Post-merge live receipt: chat.broomva.tech model lists client tools; triggering one yields a TOOL_CALL event in the stream

Closes BRO-1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for client-supplied tool definitions in model completion requests
  * Client tool proposals bypass kernel processing and are returned directly to callers
  * Name collision resolution with kernel registry tools taking precedence

* **Tests**
  * Added comprehensive test coverage for client tool integration and handoff behavior

* **Documentation**
  * Updated project status documenting client tool support and integration flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->