### PR TITLE
feat(lifegw-stack): arcan journals to in-container lagod (Stage 6b)

### DIFF
--- a/deploy/railway/lifegw-stack/Dockerfile
+++ b/deploy/railway/lifegw-stack/Dockerfile
@@ -87,11 +87,14 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Runtime layout — every UDS lifegw + lifed + arcan + lagod touches
-# lives under /run/life/. /var/lib/arcan holds arcan's journal + blob
-# storage. lagod's journal + blobs live under the mounted volume at
-# ${LIFE_STATE_DIR}/lago (entrypoint.sh creates it) so events survive
-# redeploys — the dir is NOT pre-created here because LIFE_STATE_DIR is
-# a runtime mount point.
+# lives under /run/life/. Both daemons' durable state lives under the
+# mounted volume so it survives redeploys (entrypoint.sh creates the
+# subdirs; NOT pre-created here because LIFE_STATE_DIR is a runtime
+# mount point): lagod at ${LIFE_STATE_DIR}/lago (journal + blobs),
+# arcan at ${LIFE_STATE_DIR}/arcan (session workspaces + local blob
+# cache — Stage 6b moved arcan's event JOURNAL to lagod over HTTP, so
+# the RedbJournal there is unused unless ARCAN_LAGO_URL=embedded). The
+# legacy /var/lib/arcan default is kept as a writable fallback.
 RUN groupadd --system life-runtime \
  && useradd  --system --gid life-runtime --home-dir /var/lib/life --create-home life \
  && mkdir -p /run/life /etc/lifegw/tls /etc/lifegw /etc/lifed /var/lib/arcan \

--- a/deploy/railway/lifegw-stack/README.md
+++ b/deploy/railway/lifegw-stack/README.md
@@ -48,12 +48,23 @@ broomva.tech (Vercel)
 | `lagod` | REAL lago substrate — `lago.v1.LagoSubstrate` (event journal + blobs) | `/run/life/lago.sock` (UDS) + `:50051` gRPC / `:8077` HTTP (internal) |
 
 `lifed` boots with `LIFED_ALLOW_MOCK_FALLBACK=1` and per-substrate real/mock
-selection: it dials each substrate's UDS once at boot. `arcan.sock` and
-`lago.sock` are bound by `entrypoint.sh` **before** lifed starts, so lifed
-selects the **real** arcan + lago substrates; `haima.sock` / `anima.sock`
-are absent, so haima/anima degrade to in-process mocks (gated by the
-fallback flag). Boot log prints the selection:
-`substrates: arcan=real lago=real haima=mock anima=mock`.
+selection: it dials each substrate's UDS once at boot. `lago.sock` and
+`arcan.sock` are bound by `entrypoint.sh` **before** lifed starts (lagod §3
+first, then arcan §3b), so lifed selects the **real** arcan + lago
+substrates; `haima.sock` / `anima.sock` are absent, so haima/anima degrade
+to in-process mocks (gated by the fallback flag). Boot log prints the
+selection: `substrates: arcan=real lago=real haima=mock anima=mock`.
+
+**Stage 6b — arcan's event journal IS lago.** Beyond lifed routing reads
+through lagod's UDS, the arcan agent loop itself now writes its event
+journal to lagod over HTTP: `entrypoint.sh` sets `LAGO_URL=http://127.0.0.1:8077`
+(lagod's lago-api plane), so arcan boots `RemoteLagoJournal` instead of an
+embedded RedbJournal — file-write events, tool calls, and messages for every
+public session land in the durable, volume-backed lago store and survive
+redeploys. Boot log: `Starting arcan (remote Lago journal)`. Set
+`ARCAN_LAGO_URL=embedded` to fall back to the local RedbJournal. (Blob
+*content* still writes to arcan's local cache until the remote blob backend
+lands — BRO-1478.)
 
 > **Why real arcan + lago but mock haima/anima?** Stage 5/6 ship the two
 > substrates the core chat path exercises — the agent loop (arcan) and its

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -103,89 +103,13 @@ fi
 LIFEGW_TIER2_SIGNING_KEY_PEM="$(cat "${TIER2_PEM_PATH}")"
 export LIFEGW_TIER2_SIGNING_KEY_PEM
 
-# ── 3. Start arcan (real arcan substrate) ───────────────────────────────────
-# Stage 5 (June 2026): lifed's bootstrap samples substrate UDS presence
-# ONCE at boot (per-substrate selection — see lifed::bootstrap). arcan
-# must therefore bind /run/life/arcan.sock and be ACCEPTING connections
-# BEFORE lifed starts, or lifed honestly falls back to MockArcan for
-# the container's lifetime. lago/haima/anima remain mocked via
-# LIFED_ALLOW_MOCK_FALLBACK=true until their daemons ship.
-#
-# The flag is `--uds-socket` (env ARCAN_UDS_SOCKET) — binds the
-# substrate-plane gRPC server (arcan.v1.AgentSubstrate, BRO-1016)
-# alongside arcan's HTTP :3000 server (container-internal only).
-# Provider preflight: arcan's build_provider runs BEFORE the UDS server
-# binds (main.rs), so a fresh container without provider credentials
-# would exit at boot and crash-loop the whole gateway. Degrade honestly
-# instead: skip arcan so lifed selects MockArcan, and say exactly which
-# env unlocks the real substrate.
-ARCAN_ENABLED=1
-if [[ -z "${ARCAN_PROVIDER:-}" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  ARCAN_ENABLED=0
-  echo "[entrypoint] WARN: skipping arcan substrate — no provider env." >&2
-  echo "[entrypoint]   set ANTHROPIC_API_KEY (default provider) or ARCAN_PROVIDER=openai + OPENAI_BASE_URL/OPENAI_API_KEY" >&2
-  echo "[entrypoint]   lifed will select MockArcan for this container lifetime." >&2
-fi
-
-if [[ "${ARCAN_ENABLED}" == "1" ]]; then
-ARCAN_DATA_DIR="${ARCAN_DATA_DIR:-/var/lib/arcan}"
-mkdir -p "${ARCAN_DATA_DIR}"
-chown -R life:life-runtime "${ARCAN_DATA_DIR}"
-echo "[entrypoint] starting arcan substrate (uds=${LIFE_RUNTIME_DIR}/arcan.sock data=${ARCAN_DATA_DIR})"
-# `env -u`: the Tier-2 token-minting key is lifegw's secret. arcan
-# executes tool calls (incl. shell) for remote chat users — that key
-# must never be readable from the agent process environment.
-# Base-URL scoping: lifed's vercel_ai_gateway client wants
-# OPENAI_BASE_URL **with** /v1; arcan-provider appends /v1 itself
-# (openai.rs: format!("{base}/v1/chat/completions")). Same container,
-# same var — so arcan gets a stripped copy, overridable via
-# ARCAN_OPENAI_BASE_URL. The `:-` default matters under `set -u`: an
-# ANTHROPIC_API_KEY-only config (the README smoke example) leaves
-# OPENAI_BASE_URL unset, and a bare ${OPENAI_BASE_URL%/v1} would abort
-# the whole entrypoint with 'unbound variable' here in §3 — before
-# lagod or lifed ever start.
-OPENAI_BASE_URL_RAW="${OPENAI_BASE_URL:-}"
-ARCAN_BASE_URL_EFFECTIVE="${ARCAN_OPENAI_BASE_URL:-${OPENAI_BASE_URL_RAW%/v1}}"
-runuser --preserve-environment -u life -g life-runtime -- \
-  env -u LIFEGW_TIER2_SIGNING_KEY_PEM \
-      OPENAI_BASE_URL="${ARCAN_BASE_URL_EFFECTIVE}" \
-  /usr/local/bin/arcan serve \
-    --uds-socket "${LIFE_RUNTIME_DIR}/arcan.sock" \
-    --data-dir "${ARCAN_DATA_DIR}" \
-    --agents-dir /opt/life/agents \
-  &
-ARCAN_PID=$!
-
-# Same probe discipline as the lifed probe below (BRO-1193): `nc -zU`
-# proves the listen backlog is up, not merely that bind() created the
-# socket file. A half-bound socket here would make lifed dial a dead
-# arcan at boot and fail the whole stack.
-echo "[entrypoint] waiting for arcan UDS at ${LIFE_RUNTIME_DIR}/arcan.sock"
-for i in $(seq 1 60); do
-  if [[ -S "${LIFE_RUNTIME_DIR}/arcan.sock" ]] \
-     && nc -zU "${LIFE_RUNTIME_DIR}/arcan.sock" 2>/dev/null; then
-    echo "[entrypoint] arcan UDS accepting connections (after ${i} half-seconds)"
-    break
-  fi
-  if ! kill -0 "${ARCAN_PID}" 2>/dev/null; then
-    echo "[entrypoint] FATAL: arcan exited before binding UDS" >&2
-    wait "${ARCAN_PID}" || true
-    exit 1
-  fi
-  sleep 0.5
-done
-if ! nc -zU "${LIFE_RUNTIME_DIR}/arcan.sock" 2>/dev/null; then
-  echo "[entrypoint] FATAL: arcan did not accept UDS connections within 30s" >&2
-  exit 1
-fi
-fi # ARCAN_ENABLED
-
-# ── 3b. Start lagod (real lago substrate) ───────────────────────────────────
+# ── 3. Start lagod (durable lago substrate — journal + blobs) ────────────────
 # Stage 6 (June 2026): lifed's bootstrap samples substrate UDS presence
 # ONCE at boot (per-substrate selection — see lifed::bootstrap). lagod
 # must therefore bind /run/life/lago.sock and be ACCEPTING connections
 # BEFORE lifed starts, or lifed honestly falls back to MockLago for the
-# container's lifetime. Same ordering rationale as the arcan block above.
+# container's lifetime. lagod starts FIRST so arcan (§3b) can journal
+# to its HTTP plane and lifed can dial its UDS.
 #
 # NO env gate — unlike arcan, lagod needs no provider credentials and
 # never preflights an LLM. It is the durable event journal + blob store,
@@ -255,6 +179,126 @@ if ! nc -zU "${LIFE_RUNTIME_DIR}/lago.sock" 2>/dev/null; then
   echo "[entrypoint] FATAL: lagod did not accept UDS connections within 30s" >&2
   exit 1
 fi
+
+# Stage 6b: arcan (§3b) journals to lagod's HTTP plane (lago-api),
+# not the UDS — so prove the HTTP listener accepts connections too
+# before arcan starts. Same /dev/tcp discipline as the lifegw probe.
+echo "[entrypoint] waiting for lagod HTTP plane on 127.0.0.1:${LAGO_HTTP_PORT}"
+for i in $(seq 1 60); do
+  if (echo > /dev/tcp/127.0.0.1/${LAGO_HTTP_PORT}) 2>/dev/null; then
+    echo "[entrypoint] lagod HTTP plane accepting connections (after ${i} half-seconds)"
+    break
+  fi
+  if ! kill -0 "${LAGOD_PID}" 2>/dev/null; then
+    echo "[entrypoint] FATAL: lagod exited before binding HTTP plane" >&2
+    wait "${LAGOD_PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+
+# ── 3b. Start arcan (real arcan substrate, journaling to lagod) ─────────────
+# Stage 5 (June 2026): lifed's bootstrap samples substrate UDS presence
+# ONCE at boot (per-substrate selection — see lifed::bootstrap). arcan
+# must therefore bind /run/life/arcan.sock and be ACCEPTING connections
+# BEFORE lifed starts, or lifed honestly falls back to MockArcan for
+# the container's lifetime. lagod is already up (§3 above); arcan
+# journals to it. haima/anima remain mocked via
+# LIFED_ALLOW_MOCK_FALLBACK=true until their daemons ship.
+#
+# The flag is `--uds-socket` (env ARCAN_UDS_SOCKET) — binds the
+# substrate-plane gRPC server (arcan.v1.AgentSubstrate, BRO-1016)
+# alongside arcan's HTTP :3000 server (container-internal only).
+# Provider preflight: arcan's build_provider runs BEFORE the UDS server
+# binds (main.rs), so a fresh container without provider credentials
+# would exit at boot and crash-loop the whole gateway. Degrade honestly
+# instead: skip arcan so lifed selects MockArcan, and say exactly which
+# env unlocks the real substrate.
+ARCAN_ENABLED=1
+if [[ -z "${ARCAN_PROVIDER:-}" && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  ARCAN_ENABLED=0
+  echo "[entrypoint] WARN: skipping arcan substrate — no provider env." >&2
+  echo "[entrypoint]   set ANTHROPIC_API_KEY (default provider) or ARCAN_PROVIDER=openai + OPENAI_BASE_URL/OPENAI_API_KEY" >&2
+  echo "[entrypoint]   lifed will select MockArcan for this container lifetime." >&2
+fi
+
+if [[ "${ARCAN_ENABLED}" == "1" ]]; then
+ARCAN_DATA_DIR="${ARCAN_DATA_DIR:-${LIFE_STATE_DIR}/arcan}"
+mkdir -p "${ARCAN_DATA_DIR}"
+chown -R life:life-runtime "${ARCAN_DATA_DIR}"
+echo "[entrypoint] starting arcan substrate (uds=${LIFE_RUNTIME_DIR}/arcan.sock data=${ARCAN_DATA_DIR})"
+# `env -u`: the Tier-2 token-minting key is lifegw's secret. arcan
+# executes tool calls (incl. shell) for remote chat users — that key
+# must never be readable from the agent process environment.
+# Stage 6b: arcan journals through the in-container lagod (durable
+# across redeploys) instead of an embedded RedbJournal on the
+# ephemeral data dir. main.rs selects on LAGO_URL presence:
+# set → RemoteLagoJournal (POST {base}/v1/sessions/{id}/events);
+# absent → local RedbJournal. lagod's HTTP plane (lago-api) listens
+# on 127.0.0.1:${LAGO_HTTP_PORT} and runs auth-disabled + no-policy
+# in-container, so the loopback events route accepts unauthenticated
+# appends. Escape hatch: ARCAN_LAGO_URL="embedded" keeps the local
+# RedbJournal; any other value overrides the loopback default.
+case "${ARCAN_LAGO_URL:-}" in
+  embedded) ARCAN_LAGO_URL_EFFECTIVE="" ;;
+  "")       ARCAN_LAGO_URL_EFFECTIVE="http://127.0.0.1:${LAGO_HTTP_PORT}" ;;
+  *)        ARCAN_LAGO_URL_EFFECTIVE="${ARCAN_LAGO_URL}" ;;
+esac
+# Conditional env: main.rs treats an EMPTY LAGO_URL as Ok("") and
+# would build a remote journal against an empty base — so omit the
+# var entirely in embedded mode rather than passing it empty.
+ARCAN_LAGO_ENV=()
+if [[ -n "${ARCAN_LAGO_URL_EFFECTIVE}" ]]; then
+  echo "[entrypoint] arcan journal: remote lago at ${ARCAN_LAGO_URL_EFFECTIVE}"
+  ARCAN_LAGO_ENV+=("LAGO_URL=${ARCAN_LAGO_URL_EFFECTIVE}")
+else
+  echo "[entrypoint] arcan journal: embedded RedbJournal (ARCAN_LAGO_URL=embedded)"
+fi
+# Base-URL scoping: lifed's vercel_ai_gateway client wants
+# OPENAI_BASE_URL **with** /v1; arcan-provider appends /v1 itself
+# (openai.rs: format!("{base}/v1/chat/completions")). Same container,
+# same var — so arcan gets a stripped copy, overridable via
+# ARCAN_OPENAI_BASE_URL. The `:-` default matters under `set -u`: an
+# ANTHROPIC_API_KEY-only config (the README smoke example) leaves
+# OPENAI_BASE_URL unset, and a bare ${OPENAI_BASE_URL%/v1} would abort
+# the whole entrypoint with 'unbound variable' here in §3 — before
+# lagod or lifed ever start.
+OPENAI_BASE_URL_RAW="${OPENAI_BASE_URL:-}"
+ARCAN_BASE_URL_EFFECTIVE="${ARCAN_OPENAI_BASE_URL:-${OPENAI_BASE_URL_RAW%/v1}}"
+runuser --preserve-environment -u life -g life-runtime -- \
+  env -u LIFEGW_TIER2_SIGNING_KEY_PEM \
+      OPENAI_BASE_URL="${ARCAN_BASE_URL_EFFECTIVE}" \
+      "${ARCAN_LAGO_ENV[@]}" \
+  /usr/local/bin/arcan serve \
+    --uds-socket "${LIFE_RUNTIME_DIR}/arcan.sock" \
+    --data-dir "${ARCAN_DATA_DIR}" \
+    --agents-dir /opt/life/agents \
+  &
+ARCAN_PID=$!
+
+# Same probe discipline as the lifed probe below (BRO-1193): `nc -zU`
+# proves the listen backlog is up, not merely that bind() created the
+# socket file. A half-bound socket here would make lifed dial a dead
+# arcan at boot and fail the whole stack.
+echo "[entrypoint] waiting for arcan UDS at ${LIFE_RUNTIME_DIR}/arcan.sock"
+for i in $(seq 1 60); do
+  if [[ -S "${LIFE_RUNTIME_DIR}/arcan.sock" ]] \
+     && nc -zU "${LIFE_RUNTIME_DIR}/arcan.sock" 2>/dev/null; then
+    echo "[entrypoint] arcan UDS accepting connections (after ${i} half-seconds)"
+    break
+  fi
+  if ! kill -0 "${ARCAN_PID}" 2>/dev/null; then
+    echo "[entrypoint] FATAL: arcan exited before binding UDS" >&2
+    wait "${ARCAN_PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! nc -zU "${LIFE_RUNTIME_DIR}/arcan.sock" 2>/dev/null; then
+  echo "[entrypoint] FATAL: arcan did not accept UDS connections within 30s" >&2
+  exit 1
+fi
+fi # ARCAN_ENABLED
 
 # ── 4. Start lifed ──────────────────────────────────────────────────────────
 # Stage 6: lifed's per-substrate bootstrap sees /run/life/arcan.sock AND

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1658,6 +1658,21 @@ AskHuman preservation), and a topology-B e2e (defs → provider request
 one provider call) — net +12 tests on the arc. Gap closed:
 "kernel dispatch drops client tool_definitions" (BRO-1463).
 
+**2026-06-11 — Stage 6b: arcan's event journal IS lago (BRO-1476).**
+The lifegw-stack agent loop previously journaled to an *embedded*
+RedbJournal on ephemeral disk while the durable volume-backed lagod
+(Stage 6) sat in the same container — two lago instances side by side.
+`entrypoint.sh` now starts lagod FIRST (§3, + an HTTP-plane readiness
+probe), then arcan (§3b) with `LAGO_URL=http://127.0.0.1:8077` pointed
+at lagod's lago-api plane, so arcan boots `RemoteLagoJournal`: every
+public session's FileWrite/ToolCall/message events land in the durable
+lago store and survive redeploys (`ARCAN_LAGO_URL=embedded` escapes to
+the local journal). arcan's data dir also moved to the volume
+(`${LIFE_STATE_DIR}/arcan`). Remaining FS-substrate gaps tracked:
+blob *content* still local until a remote blob backend (BRO-1478);
+exec-path (shell) writes still bypass the manifest until a post-exec
+diff (BRO-1477); branching still pinned to `main` (BRO-1479).
+
 ## Health Summary
 ## Health Summary
 


### PR DESCRIPTION
## Summary

Completes the gap surfaced after Stage 6: **the lifegw-stack ran two lago instances side by side.** lifed routed reads through the durable volume-backed lagod, but the *arcan agent loop itself* journaled to an embedded RedbJournal on the ephemeral data dir — so every public session's FileWrite / ToolCall / message events were lost on each redeploy. Stage 6b makes lago the real event-journal substrate for the agent loop.

## Changes (deploy-only — `deploy/railway/lifegw-stack/`)

- **entrypoint reordered lagod-first** (§3), then arcan (§3b). lagod's lago-api HTTP plane must be up before arcan dials it; added a `/dev/tcp` readiness probe on `127.0.0.1:${LAGO_HTTP_PORT}` (arcan uses the HTTP plane; lifed uses the UDS — both now gated).
- **arcan starts with `LAGO_URL=http://127.0.0.1:8077`** → `main.rs` selects `RemoteLagoJournal` (`POST {base}/v1/sessions/{id}/events`). The in-container lagod runs auth-disabled + no-policy and the events route is not JWT-gated, so the loopback append is accepted. Verified against `RemoteLagoJournal` (no auth header) + `lago-api/src/router.rs` (only `/v1/memory/*` is auth-gated).
- **Escape hatch:** `ARCAN_LAGO_URL=embedded` keeps the local RedbJournal; any other value overrides the loopback default. The `LAGO_URL` env is *omitted* (not passed empty) in embedded mode — `main.rs` treats `Ok("")` as a remote base, which would build a broken journal.
- **arcan data dir → `${LIFE_STATE_DIR}/arcan`** (the volume) so session workspaces + the local blob cache also survive redeploys.

## Why this is safe

`RemoteLagoJournal`'s client is lazy (`OnceCell`) — arcan does no journal I/O at boot, so even the lazy path wouldn't race lagod. But the principled ordering (substrate before consumer) is now enforced by the readiness probe regardless. Empty-array env expansion under `set -euo pipefail` was simulated across all three branches (unset → loopback, embedded → omit, custom → passthrough).

## Test plan

- [x] `bash -n deploy/railway/lifegw-stack/entrypoint.sh`
- [x] Simulated the `ARCAN_LAGO_ENV` array logic under `set -euo pipefail` (all 3 branches correct, empty-array safe)
- [x] Verified loopback append path: `RemoteLagoJournal` POSTs unauthenticated to `/v1/sessions/{id}/events`; lago-api gates only `/v1/memory/*`; in-container lagod boots auth-disabled + no-policy
- [ ] **Receipt (post-merge):** prod lifegw-stack boot log shows `Starting arcan (remote Lago journal)` and a successful append after a chat turn

## Follow-ups (the rest of the FS-substrate arc, already ticketed + in flight)

- BRO-1478 — remote blob backend (content still writes to arcan's local cache)
- BRO-1477 — exec-path manifest sync (shell writes still bypass the tracker)
- BRO-1479 — expose lago branching through dispatch

Closes BRO-1476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)