### PR TITLE
feat(life-runtime): branch through the dispatch path with auto-fork (BRO-1479)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,8 @@ aiOS (kernel contract — types, traits, event taxonomy)
 
 **Known gaps** (blocks Phase 0 stabilization):
 
-- Branching not exposed (Lago supports it, Arcan defaults to "main")
+- Branching exposed on the dispatch path with auto-fork (BRO-1479);
+  Topology-A HTTP route + merge wire-params + client UI still pending
 - No OS-level sandbox isolation (soft sandbox only)
 - Network isolation declared but not enforced
 - Mount trait defined but unimplemented

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,11 +417,17 @@ longer drops TOKEN text on the real-arcand path (PR #1686, merge
 
 ### Branching policy (production)
 
-Lago supports branching (per `lago branch`); arcand currently
-hardcodes `BranchId::main()` at `crates/arcan/arcand/src/canonical.rs:1265`.
-Exposing branch as a route param is a small follow-up that unlocks
-parallel exploration workflows. Listed as "Phase 0 stabilization gap"
-above and in `MEMORY.md`.
+Branching is exposed through the production dispatch path (BRO-1479):
+`SendMessageReq.branch` threads lifegw ws → lifed → arcan-proxy →
+arcand substrate, which **auto-forks an unknown branch from `main` at
+the current head** via the kernel's `create_branch` (real fork
+semantics — parent, fork_sequence, head tracking; `BranchCreated` is
+the fork's first event). Empty/absent ⇒ `main` (fully backward
+compatible). Branch names are validated `[a-zA-Z0-9_-]{1,64}` at BOTH
+trust boundaries (lifegw edge closes the WS; arcand returns
+INVALID_ARGUMENT). Still deferred: the Topology-A HTTP path
+(`canonical.rs` still keys `BranchId::main()`), merge/fork-point
+params on the wire, and client UI for branch selection.
 
 ## Shared Conventions
 

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -210,17 +210,33 @@ impl AgentSubstrate for SubstrateService {
         // An existing branch is reused as-is; a merged (read-only) branch
         // fails inside the tick with the kernel's own clear error.
         if branch != BranchId::main() {
+            let branch_exists = |branches: Vec<aios_protocol::BranchInfo>| {
+                branches.iter().any(|info| info.branch_id == branch)
+            };
             let known = runtime
                 .list_branches(&session_id)
                 .await
-                .map_err(|e| Status::internal(format!("list_branches: {e}")))?
-                .iter()
-                .any(|info| info.branch_id == branch);
-            if !known {
-                runtime
+                .map(branch_exists)
+                .map_err(|e| Status::internal(format!("list_branches: {e}")))?;
+            if !known
+                && let Err(create_err) = runtime
                     .create_branch(&session_id, branch.clone(), None, None)
                     .await
-                    .map_err(|e| Status::internal(format!("create_branch: {e}")))?;
+            {
+                // Idempotent under concurrency: two dispatches naming the
+                // same new branch can both observe "unknown" and race the
+                // fork — the loser's create fails ("branch already
+                // exists") although the branch is now perfectly usable.
+                // Re-check existence instead of string-matching the error;
+                // only a still-missing branch is a real failure.
+                let now_known = runtime
+                    .list_branches(&session_id)
+                    .await
+                    .map(branch_exists)
+                    .unwrap_or(false);
+                if !now_known {
+                    return Err(Status::internal(format!("create_branch: {create_err}")));
+                }
             }
         }
 

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -69,6 +69,20 @@ fn valid_client_tool_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
+/// Branch-name check (`[a-zA-Z0-9_-]{1,64}`). The dispatch branch is
+/// UNTRUSTED remote input that keys directly into redb compound keys
+/// (session + branch + seq) and lago-fs manifest keys, so it is
+/// validated at this trust boundary and rejected — never sanitized
+/// silently. The charset matches the provider-portable tool-name rule
+/// for consistency; `main` and other simple identifiers pass.
+fn valid_branch_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// arcand's `arcan.v1.AgentSubstrate` impl. Holds a shared
 /// `KernelRuntime` handle so every RPC reuses the same in-memory
 /// session store, journal, and tick engine that the HTTP plane is
@@ -167,7 +181,49 @@ impl AgentSubstrate for SubstrateService {
             )));
         }
 
+        // Resolve the target branch at this trust boundary (BRO-1479).
+        // Empty ⇒ "main" (backward-compatible: pre-BRO-1479 callers
+        // never set the field, so the dispatch keys onto main exactly
+        // as before). A non-empty value is validated before it is
+        // allowed to key into redb compound keys + lago-fs manifests —
+        // an invalid name is rejected, never sanitized silently.
+        let branch = if body.branch.is_empty() {
+            BranchId::main()
+        } else if valid_branch_name(&body.branch) {
+            BranchId::from_string(&body.branch)
+        } else {
+            return Err(Status::invalid_argument(format!(
+                "invalid branch name {branch:?}: must match [a-zA-Z0-9_-]{{1,64}}",
+                branch = body.branch
+            )));
+        };
+
         let runtime = Arc::clone(&self.runtime);
+
+        // Auto-fork semantics (BRO-1479): the kernel requires a branch to
+        // EXIST before any tick can sequence events onto it
+        // (`next_sequence` bails "branch not found"). Sessions are born
+        // with only `main`, so a dispatch naming an unknown branch forks
+        // it from main at the CURRENT head — the natural "this dispatch
+        // explores a fork of the session" semantic, and it keeps the wire
+        // ergonomic (no separate create-branch RPC for the common case).
+        // An existing branch is reused as-is; a merged (read-only) branch
+        // fails inside the tick with the kernel's own clear error.
+        if branch != BranchId::main() {
+            let known = runtime
+                .list_branches(&session_id)
+                .await
+                .map_err(|e| Status::internal(format!("list_branches: {e}")))?
+                .iter()
+                .any(|info| info.branch_id == branch);
+            if !known {
+                runtime
+                    .create_branch(&session_id, branch.clone(), None, None)
+                    .await
+                    .map_err(|e| Status::internal(format!("create_branch: {e}")))?;
+            }
+        }
+
         let content = body.content;
         // Client tool definitions arrive as JSON bytes on
         // `tool_definitions` (additive field — lifed forwards the chat
@@ -242,9 +298,12 @@ impl AgentSubstrate for SubstrateService {
         // Subscribe to the broadcast stream BEFORE issuing the first
         // tick — events emitted during the tick get captured. Note:
         // `subscribe_events` returns a single subscriber that sees
-        // every session's events; we filter by `session_id` in the
-        // pump task so cross-session traffic doesn't leak into this
-        // stream.
+        // every session's events; we filter by `session_id` AND
+        // `branch_id` in the pump task so neither cross-session traffic
+        // nor a concurrent dispatch on a SIBLING branch of the same
+        // session leaks into this stream (BRO-1479: `EventRecord`
+        // carries `branch_id`, so cross-branch frames are filtered
+        // rather than interleaved).
         let mut events_rx = runtime.subscribe_events();
 
         tokio::spawn(async move {
@@ -257,13 +316,16 @@ impl AgentSubstrate for SubstrateService {
             // task drains the event broadcast and forwards filtered
             // events to the streaming client.
             let session_for_pump = session_id.clone();
+            let branch_for_pump = branch.clone();
             let tx_pump = tx.clone();
             let terminal_for_pump = Arc::clone(&terminal_sent);
             let pump_handle = tokio::spawn(async move {
                 loop {
                     match events_rx.recv().await {
                         Ok(record) => {
-                            if record.session_id != session_for_pump {
+                            if record.session_id != session_for_pump
+                                || record.branch_id != branch_for_pump
+                            {
                                 continue;
                             }
                             if let Some(evt) = translate_event(&record) {
@@ -322,7 +384,7 @@ impl AgentSubstrate for SubstrateService {
                     kind: TickKind::Direct,
                 };
                 match runtime
-                    .tick_on_branch(&session_id, &BranchId::main(), tick_input)
+                    .tick_on_branch(&session_id, &branch, tick_input)
                     .await
                 {
                     Ok(output) => {

--- a/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
+++ b/crates/arcan/arcand/tests/topology_b_e2e_arcan.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use aios_events::{EventJournal, EventStreamHub, FileEventStore};
 use aios_policy::{ApprovalQueue, SessionPolicyEngine};
 use aios_protocol::{
-    ApprovalPort, Capability, EventStorePort, KernelResult, ModelCompletion,
+    ApprovalPort, BranchId, Capability, EventStorePort, KernelResult, ModelCompletion,
     ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort,
     PolicySet, SessionId, ToolCall, ToolHarnessPort,
 };
@@ -203,7 +203,7 @@ async fn dispatch_message_streams_real_substrate_events() {
     // it. This Topology B e2e test exercises the gRPC path so the
     // override is irrelevant — pass `None`.
     let mut stream = proxy
-        .dispatch_message(sid, "Hello, substrate!", None, &[])
+        .dispatch_message(sid, "Hello, substrate!", None, "", &[])
         .await
         .expect("dispatch_message");
 
@@ -338,7 +338,7 @@ async fn dispatch_message_streams_tool_lifecycle_events() {
     let sid = "phase2-tool-lifecycle";
     let _ = proxy.create_agent(sid).await.expect("create_agent");
     let mut stream = proxy
-        .dispatch_message(sid, "write the e2e artifact", None, &[])
+        .dispatch_message(sid, "write the e2e artifact", None, "", &[])
         .await
         .expect("dispatch_message");
 
@@ -548,7 +548,7 @@ async fn dispatch_message_hands_off_client_tool_calls() {
         }
     })];
     let mut stream = proxy
-        .dispatch_message(sid, "what's the weather in Medellín?", None, &tools)
+        .dispatch_message(sid, "what's the weather in Medellín?", None, "", &tools)
         .await
         .expect("dispatch_message");
 
@@ -604,4 +604,196 @@ async fn dispatch_message_hands_off_client_tool_calls() {
 
     let _ = shutdown_tx.send(());
     let _ = tokio::time::timeout(Duration::from_secs(5), server_handle).await;
+}
+
+#[tokio::test]
+async fn dispatch_message_on_branch_lands_under_that_branch() {
+    // BRO-1479: a dispatch with a non-empty `branch` auto-forks the
+    // branch from main at the current head (sessions are born with only
+    // `main`; the kernel's `next_sequence` requires the branch to exist)
+    // and keys every tick onto it. Assert the events land under `exp-1`
+    // AND that main's event stream is unchanged by the dispatch, proving
+    // the branch threads end-to-end through the substrate wire (not a
+    // hardcoded `BranchId::main()`).
+    let env = SubstrateUnderTest::start().await;
+    let proxy = ArcanProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    let sid = "bro-1479-branch";
+    let _ = proxy.create_agent(sid).await.expect("create_agent");
+
+    // Snapshot main BEFORE the branch dispatch: session creation seeds
+    // events on main, and the fork must not add to them.
+    let session_id = SessionId::from_string(sid);
+    let main_before = env
+        .runtime
+        .read_events_on_branch(&session_id, &BranchId::main(), 0, 1000)
+        .await
+        .expect("read main before")
+        .len();
+
+    let mut stream = proxy
+        .dispatch_message(sid, "Hello, exp branch!", None, "exp-1", &[])
+        .await
+        .expect("dispatch_message on branch");
+
+    let mut terminal_seen = false;
+    let mut count = 0;
+    while let Some(evt) = stream.next().await {
+        let evt = evt.expect("substrate event ok");
+        count += 1;
+        if evt.kind == AgentEventKind::Finish as i32 || evt.kind == AgentEventKind::Error as i32 {
+            terminal_seen = true;
+            break;
+        }
+        if count > 32 {
+            break;
+        }
+    }
+    drop(stream);
+    assert!(terminal_seen, "dispatch on branch should reach a terminal");
+
+    let exp_branch = BranchId::from_string("exp-1");
+    let on_branch = env
+        .runtime
+        .read_events_on_branch(&session_id, &exp_branch, 0, 1000)
+        .await
+        .expect("read exp-1 events");
+    assert!(
+        !on_branch.is_empty(),
+        "dispatch on exp-1 should have journaled events under that branch"
+    );
+    assert!(
+        on_branch.iter().all(|e| e.branch_id == exp_branch),
+        "every journaled event should carry the exp-1 branch id"
+    );
+    // The auto-fork is itself journaled ON the new branch — its first
+    // event is the BranchCreated marker carrying the fork point.
+    assert!(
+        matches!(
+            on_branch.first().map(|e| &e.kind),
+            Some(aios_protocol::EventKind::BranchCreated { .. })
+        ),
+        "the forked branch's first event should be BranchCreated"
+    );
+
+    // The sibling main branch must be unchanged — the dispatch forked
+    // off it without writing to it.
+    let main_after = env
+        .runtime
+        .read_events_on_branch(&session_id, &BranchId::main(), 0, 1000)
+        .await
+        .expect("read main events");
+    assert_eq!(
+        main_after.len(),
+        main_before,
+        "dispatching on exp-1 must not add events to main"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn dispatch_message_default_branch_lands_on_main() {
+    // BRO-1479 backward-compat: an empty branch behaves exactly as
+    // before — events land on main. This mirrors the pre-existing
+    // `dispatch_message_streams_real_substrate_events` contract, now
+    // pinned against the branch field so the default can never regress.
+    let env = SubstrateUnderTest::start().await;
+    let proxy = ArcanProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    let sid = "bro-1479-default-main";
+    let _ = proxy.create_agent(sid).await.expect("create_agent");
+
+    let mut stream = proxy
+        .dispatch_message(sid, "Hello, default branch!", None, "", &[])
+        .await
+        .expect("dispatch_message default branch");
+
+    let mut terminal_seen = false;
+    let mut count = 0;
+    while let Some(evt) = stream.next().await {
+        let evt = evt.expect("substrate event ok");
+        count += 1;
+        if evt.kind == AgentEventKind::Finish as i32 || evt.kind == AgentEventKind::Error as i32 {
+            terminal_seen = true;
+            break;
+        }
+        if count > 32 {
+            break;
+        }
+    }
+    drop(stream);
+    assert!(terminal_seen, "default dispatch should reach a terminal");
+
+    let session_id = SessionId::from_string(sid);
+    let on_main = env
+        .runtime
+        .read_events_on_branch(&session_id, &BranchId::main(), 0, 1000)
+        .await
+        .expect("read main events");
+    assert!(
+        !on_main.is_empty(),
+        "an empty branch must journal events on main"
+    );
+    assert!(
+        on_main.iter().all(|e| e.branch_id == BranchId::main()),
+        "every journaled event should carry the main branch id"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+async fn dispatch_message_invalid_branch_name_is_rejected() {
+    // BRO-1479: the branch is UNTRUSTED remote input that keys directly
+    // into redb compound keys + lago-fs manifests. An invalid name is
+    // rejected with INVALID_ARGUMENT at the substrate trust boundary,
+    // never sanitized silently.
+    let env = SubstrateUnderTest::start().await;
+    let proxy = ArcanProxy::connect(env.socket.clone())
+        .await
+        .expect("dial substrate UDS");
+
+    let sid = "bro-1479-invalid-branch";
+    let _ = proxy.create_agent(sid).await.expect("create_agent");
+
+    // Session creation itself journals events on main — snapshot the
+    // count so the assertion below isolates what the REJECTED dispatch
+    // added (which must be nothing).
+    let session_id = SessionId::from_string(sid);
+    let main_before = env
+        .runtime
+        .read_events_on_branch(&session_id, &BranchId::main(), 0, 1000)
+        .await
+        .expect("read main before")
+        .len();
+
+    // A slash is outside `[a-zA-Z0-9_-]` — must be rejected before any
+    // tick runs.
+    let err = proxy
+        .dispatch_message(sid, "should be rejected", None, "../etc/passwd", &[])
+        .await
+        .err()
+        .expect("invalid branch name must error");
+    // The proxy maps the gRPC Status into its own error type; the
+    // important contract is that the dispatch did NOT succeed and
+    // journaled nothing beyond the pre-existing session events.
+    let _ = err;
+
+    let main_after = env
+        .runtime
+        .read_events_on_branch(&session_id, &BranchId::main(), 0, 1000)
+        .await
+        .expect("read main events");
+    assert_eq!(
+        main_after.len(),
+        main_before,
+        "a rejected dispatch must not journal anything: {main_after:?}"
+    );
+
+    env.shutdown().await;
 }

--- a/crates/life-runtime/arcan-proxy/src/anthropic.rs
+++ b/crates/life-runtime/arcan-proxy/src/anthropic.rs
@@ -230,6 +230,12 @@ impl ArcanCall for AnthropicArcan {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        // BRO-1479: branching is a substrate (event-journal) concept;
+        // the raw Anthropic Messages API wire has no notion of it, so
+        // this HTTP-backed impl accepts the field and ignores it. Branch
+        // forking takes effect only on the substrate-gRPC `ArcanProxy`
+        // path (real arcand).
+        _branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>>
     {

--- a/crates/life-runtime/arcan-proxy/src/client.rs
+++ b/crates/life-runtime/arcan-proxy/src/client.rs
@@ -192,11 +192,22 @@ impl ArcanProxy {
     /// payload_json wire pattern) so the chat surface's tools reach the
     /// substrate. Entries that fail to serialize are skipped — a
     /// malformed definition must not poison the whole dispatch.
+    ///
+    /// BRO-1479: `branch` is forwarded verbatim onto
+    /// `DispatchMessageReq.branch`. Empty ⇒ the substrate dispatches on
+    /// `main` (backward-compatible). A non-empty value forks the
+    /// session's event stream + filesystem manifest on that branch; the
+    /// arcand substrate validates the name (`[a-zA-Z0-9_-]{1,64}`) at
+    /// its trust boundary and rejects an invalid name with
+    /// `INVALID_ARGUMENT`. This proxy passes the bytes through unaltered
+    /// — validation is the substrate's responsibility (defence in depth:
+    /// the public lifegw edge also pre-validates).
     pub async fn dispatch_message(
         &self,
         sid: &str,
         content: &str,
         _model: Option<&str>,
+        branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<
         Pin<
@@ -217,6 +228,7 @@ impl ArcanProxy {
             }),
             content: content.to_owned(),
             tool_definitions: serialize_tool_definitions(tools),
+            branch: branch.to_owned(),
         });
         self.attach_token(&mut req);
         let upstream = match client.dispatch_message(req).await {
@@ -287,6 +299,14 @@ fn record_outcome(guard: Option<PoolGuard>, success_or_permanent: bool) {
 /// `ArcanProxy` forwards them as `DispatchMessageReq.tool_definitions`
 /// bytes; HTTP-backed impls inject them into the outbound provider
 /// request body (`tools` array).
+///
+/// BRO-1479: `branch` selects the target branch for this dispatch's
+/// ticks. Empty ⇒ `main` (backward-compatible — pre-BRO-1479 callers
+/// never set it). The substrate-gRPC `ArcanProxy` forwards it onto
+/// `DispatchMessageReq.branch`, where arcand validates + keys it into
+/// the event journal and filesystem manifest. HTTP-backed impls
+/// (`VercelAiGatewayArcan`, `AnthropicArcan`) have no branch concept on
+/// the raw provider wire and ignore it; mocks accept and ignore it.
 #[async_trait]
 pub trait ArcanCall: Send + Sync {
     async fn create_agent(&self, sid: &str) -> ArcanProxyResult<String>;
@@ -296,6 +316,7 @@ pub trait ArcanCall: Send + Sync {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<
         Pin<
@@ -320,6 +341,7 @@ impl ArcanCall for ArcanProxy {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<
         Pin<
@@ -329,7 +351,7 @@ impl ArcanCall for ArcanProxy {
             >,
         >,
     > {
-        ArcanProxy::dispatch_message(self, sid, content, model, tools).await
+        ArcanProxy::dispatch_message(self, sid, content, model, branch, tools).await
     }
 }
 
@@ -396,6 +418,7 @@ impl<C: ArcanCall> ArcanCall for Pooled<C> {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<
         Pin<
@@ -409,7 +432,7 @@ impl<C: ArcanCall> ArcanCall for Pooled<C> {
         let guard = self.pool.acquire().await.map_err(ArcanProxyError::from)?;
         match self
             .inner
-            .dispatch_message(sid, content, model, tools)
+            .dispatch_message(sid, content, model, branch, tools)
             .await
         {
             Ok(stream) => Ok(Box::pin(PoolGuardedStream::new(stream, Some(guard)))),
@@ -538,6 +561,7 @@ mod tests {
                 _sid: &str,
                 _content: &str,
                 _model: Option<&str>,
+                _branch: &str,
                 _tools: &[serde_json::Value],
             ) -> ArcanProxyResult<
                 Pin<
@@ -588,6 +612,7 @@ mod tests {
                 _sid: &str,
                 _content: &str,
                 _model: Option<&str>,
+                _branch: &str,
                 _tools: &[serde_json::Value],
             ) -> ArcanProxyResult<
                 Pin<
@@ -659,6 +684,7 @@ mod tests {
             }),
             content: "hello".to_string(),
             tool_definitions: serialize_tool_definitions(&tools),
+            branch: String::new(),
         };
         let bytes = req.encode_to_vec();
         let decoded = arcan_pb::DispatchMessageReq::decode(bytes.as_slice()).expect("decode");
@@ -667,6 +693,40 @@ mod tests {
         let tool: serde_json::Value =
             serde_json::from_slice(&decoded.tool_definitions[0]).expect("JSON");
         assert_eq!(tool["name"], "get_weather");
+    }
+
+    /// Wire-shape guard: `DispatchMessageReq.branch` survives a prost
+    /// encode/decode round trip unchanged (additive field 4 on the
+    /// substrate dispatch request, BRO-1479). An empty branch round-trips
+    /// to empty — the substrate reads that as `main`, preserving
+    /// pre-BRO-1479 wire compatibility.
+    #[test]
+    fn dispatch_message_req_proto_roundtrip_preserves_branch() {
+        use prost::Message;
+        // Non-empty branch survives the hop.
+        let req = arcan_pb::DispatchMessageReq {
+            sid: Some(aios_v1::SessionId {
+                value: "sid-1".to_string(),
+            }),
+            content: "hello".to_string(),
+            tool_definitions: Vec::new(),
+            branch: "exp-1".to_string(),
+        };
+        let bytes = req.encode_to_vec();
+        let decoded = arcan_pb::DispatchMessageReq::decode(bytes.as_slice()).expect("decode");
+        assert_eq!(decoded.branch, "exp-1");
+
+        // Empty branch round-trips to empty (⇒ main at the substrate).
+        let req_default = arcan_pb::DispatchMessageReq {
+            sid: None,
+            content: String::new(),
+            tool_definitions: Vec::new(),
+            branch: String::new(),
+        };
+        let decoded_default =
+            arcan_pb::DispatchMessageReq::decode(req_default.encode_to_vec().as_slice())
+                .expect("decode default");
+        assert!(decoded_default.branch.is_empty());
     }
 
     #[tokio::test]

--- a/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
+++ b/crates/life-runtime/arcan-proxy/src/vercel_ai_gateway.rs
@@ -274,6 +274,12 @@ impl ArcanCall for VercelAiGatewayArcan {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        // BRO-1479: branching is a substrate (event-journal) concept;
+        // the raw OpenAI-compatible gateway wire has no notion of it, so
+        // this HTTP-backed impl accepts the field and ignores it. Branch
+        // forking takes effect only on the substrate-gRPC `ArcanProxy`
+        // path (real arcand).
+        _branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<AgentEvent, tonic::Status>> + Send>>>
     {
@@ -1092,7 +1098,7 @@ mod tests {
             "parameters": {"type": "object", "properties": {}},
         })];
         let stream = arc
-            .dispatch_message("sess_x", "hi", None, &tools)
+            .dispatch_message("sess_x", "hi", None, "", &tools)
             .await
             .expect("tools reach body");
         let mut s = Box::pin(stream);
@@ -1269,7 +1275,7 @@ mod tests {
 
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
         let stream = arc
-            .dispatch_message("sess_x", "hello?", None, &[])
+            .dispatch_message("sess_x", "hello?", None, "", &[])
             .await
             .expect("dispatch");
         let mut tokens = Vec::new();
@@ -1319,7 +1325,7 @@ mod tests {
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
         // Override should win over `cfg.model = "test-model"`.
         let stream = arc
-            .dispatch_message("sess_x", "hi", Some("openai/gpt-4o-mini"), &[])
+            .dispatch_message("sess_x", "hi", Some("openai/gpt-4o-mini"), "", &[])
             .await
             .expect("override reaches body");
         let mut s = Box::pin(stream);
@@ -1352,7 +1358,7 @@ mod tests {
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
         // No override → cfg.model is "test-model" (from `cfg(...)` helper).
         let stream = arc
-            .dispatch_message("sess_x", "hi", None, &[])
+            .dispatch_message("sess_x", "hi", None, "", &[])
             .await
             .expect("env fallback reaches body");
         let mut s = Box::pin(stream);
@@ -1370,7 +1376,7 @@ mod tests {
             .await;
 
         let arc = VercelAiGatewayArcan::new(cfg(server.uri())).expect("build");
-        match arc.dispatch_message("sess_x", "hi", None, &[]).await {
+        match arc.dispatch_message("sess_x", "hi", None, "", &[]).await {
             Ok(_) => panic!("must surface 401"),
             Err(ArcanProxyError::Transport(m)) => {
                 assert!(m.contains("401"), "msg: {m}");

--- a/crates/life-runtime/lifed/src/dev_mocks.rs
+++ b/crates/life-runtime/lifed/src/dev_mocks.rs
@@ -47,6 +47,13 @@ pub struct MockArcan {
     /// substrate-call boundary.
     #[allow(clippy::type_complexity)]
     pub dispatch_tools: Arc<Mutex<Vec<(String, Vec<serde_json::Value>)>>>,
+    /// BRO-1479: captures the target `branch` passed to
+    /// `dispatch_message`. Tests assert this to prove the branch
+    /// selector travels from `Agent.SendMessage` (`SendMessageReq.branch`)
+    /// through lifed's fanout pump to the substrate-call boundary
+    /// (empty ⇒ main).
+    #[allow(clippy::type_complexity)]
+    pub dispatch_branches: Arc<Mutex<Vec<(String, String)>>>,
     /// When set, the next `create_agent` returns an error (then resets).
     pub fail_next: Arc<AtomicBool>,
     /// Sub-phase D: sustained failure mode for chaos tests.
@@ -132,14 +139,15 @@ impl ArcanCall for MockArcan {
         sid: &str,
         content: &str,
         model: Option<&str>,
+        branch: &str,
         tools: &[serde_json::Value],
     ) -> ArcanProxyResult<Pin<Box<dyn Stream<Item = Result<pb::AgentEvent, tonic::Status>> + Send>>>
     {
         // BRO-1206: mock records the dispatch (sid, content) — model
-        // override is captured separately on `dispatch_models`, and
-        // client tool definitions on `dispatch_tools`, so tests can
-        // assert plumbing without changing existing `dispatch_calls`
-        // semantics.
+        // override is captured separately on `dispatch_models`, client
+        // tool definitions on `dispatch_tools`, and the BRO-1479 branch
+        // selector on `dispatch_branches`, so tests can assert plumbing
+        // without changing existing `dispatch_calls` semantics.
         self.dispatch_calls
             .lock()
             .push((sid.to_string(), content.to_string()));
@@ -149,6 +157,9 @@ impl ArcanCall for MockArcan {
         self.dispatch_tools
             .lock()
             .push((sid.to_string(), tools.to_vec()));
+        self.dispatch_branches
+            .lock()
+            .push((sid.to_string(), branch.to_string()));
         if let Some(s) = self.force_fail_status() {
             return Err(ArcanProxyError::Substrate(s));
         }

--- a/crates/life-runtime/lifed/src/services/agent.rs
+++ b/crates/life-runtime/lifed/src/services/agent.rs
@@ -161,12 +161,21 @@ impl Drop for PumpGuard {
 /// the model provider (`ArcanCall::dispatch_message` → OpenAI/Anthropic
 /// `tools` array, or `DispatchMessageReq.tool_definitions` on the
 /// substrate wire).
+///
+/// BRO-1479: `branch` carries the target branch decoded from
+/// `SendMessageReq.branch`. Empty ⇒ `main` (backward-compatible —
+/// pre-BRO-1479 clients never set it). lifed forwards it verbatim to
+/// `ArcanCall::dispatch_message`, which threads it onto the substrate's
+/// `DispatchMessageReq.branch`. The arcand substrate validates the name
+/// and forks the session's event stream + filesystem manifest from main
+/// on that branch (the public lifegw edge pre-validates too).
 fn spawn_or_attach_fanout_pump(
     fanout: &Arc<FanoutRegistry>,
     arcan: Arc<dyn ArcanCall>,
     sid: String,
     content: String,
     model: Option<String>,
+    branch: String,
     tools: Vec<serde_json::Value>,
 ) {
     let Some(pump_guard) = PumpGuard::try_claim(Arc::clone(fanout), sid.clone()) else {
@@ -184,7 +193,7 @@ fn spawn_or_attach_fanout_pump(
         // slot — Spec C₂ §6.4 invariant preserved.
         let _pump_guard = pump_guard;
         match arcan
-            .dispatch_message(&sid, &content, model.as_deref(), &tools)
+            .dispatch_message(&sid, &content, model.as_deref(), &branch, &tools)
             .await
         {
             Ok(mut up) => {
@@ -519,6 +528,13 @@ impl pb::agent_server::Agent for AgentService {
                 }
             })
             .collect();
+        // BRO-1479: the target branch (`SendMessageReq.branch`) travels
+        // verbatim to the substrate-call boundary alongside the tool
+        // definitions. Empty ⇒ main. lifed does not validate it here —
+        // the arcand substrate validates at its trust boundary and the
+        // public lifegw edge pre-validates (defence in depth); lifed is
+        // an internal forwarder, mirroring the `tool_definitions` posture.
+        let branch = body.branch;
         // Sub-phase E: pool bracketing is inside the arcan-proxy `Pooled`
         // adapter; the pump only manages the one-pump-per-session slot
         // via `PumpGuard` (RAII).
@@ -528,6 +544,7 @@ impl pb::agent_server::Agent for AgentService {
             sid_value,
             body.content,
             model,
+            branch,
             tools,
         );
         Ok(Response::new(Box::pin(stream)))
@@ -690,6 +707,7 @@ mod fanout_pump_error_tests {
             "sid-test".to_string(),
             "hi".to_string(),
             None,
+            String::new(),
             Vec::new(),
         );
 

--- a/crates/life-runtime/lifed/tests/e2e_smoke.rs
+++ b/crates/life-runtime/lifed/tests/e2e_smoke.rs
@@ -90,6 +90,7 @@ async fn smoke_test_full_daemon_lifecycle() {
             content: "smoke message".to_string(),
             attachment_blob_ref: vec![],
             tool_definitions: vec![],
+            branch: String::new(),
         });
         req.metadata_mut().insert(
             "authorization",
@@ -147,6 +148,7 @@ async fn smoke_test_full_daemon_lifecycle() {
             content: "stream_session driver".to_string(),
             attachment_blob_ref: vec![],
             tool_definitions: vec![],
+            branch: String::new(),
         });
         send_req.metadata_mut().insert(
             "authorization",

--- a/crates/life-runtime/lifed/tests/integration_send_message.rs
+++ b/crates/life-runtime/lifed/tests/integration_send_message.rs
@@ -25,6 +25,7 @@ async fn send_message_streams_at_least_one_event() {
         content: "Hello, lifed".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     req.metadata_mut().insert(
         "authorization",
@@ -85,6 +86,7 @@ async fn stream_session_returns_canned_events() {
         content: "drive".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     send_req.metadata_mut().insert(
         "authorization",
@@ -128,6 +130,7 @@ async fn send_message_passes_per_session_model_override_to_arcan() {
         content: "hi".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     req.metadata_mut().insert(
         "authorization",
@@ -172,6 +175,10 @@ async fn send_message_passes_per_session_model_override_to_arcan() {
 ///    substrate-call boundary.
 /// 3. `MockArcan` records `(sid, tools)` on `dispatch_tools`, proving
 ///    the wire path is closed. Malformed entries are skipped.
+///
+/// BRO-1479: the same request carries a non-empty `branch`; the mock
+/// records it on `dispatch_branches`, pinning that the branch selector
+/// rides the identical pump → `dispatch_message` path as the tools.
 #[tokio::test]
 async fn send_message_passes_tool_definitions_to_arcan() {
     let env = TestEnv::start_with_mocks().await;
@@ -196,6 +203,8 @@ async fn send_message_passes_tool_definitions_to_arcan() {
             // Malformed entry — must be skipped, not fail the dispatch.
             b"not-json".to_vec(),
         ],
+        // BRO-1479: a non-empty branch rides the same pump path.
+        branch: "experiment-1".to_string(),
     });
     req.metadata_mut().insert(
         "authorization",
@@ -227,6 +236,19 @@ async fn send_message_passes_tool_definitions_to_arcan() {
          to dispatch_message; malformed entries are dropped"
     );
 
+    // BRO-1479: the branch selector rides the identical path.
+    let branches = env.mocks.arcan.dispatch_branches.lock().clone();
+    assert!(
+        !branches.is_empty(),
+        "expected the dispatch to record its branch selector"
+    );
+    assert_eq!(branches[0].0, sid.value);
+    assert_eq!(
+        branches[0].1, "experiment-1",
+        "SendMessageReq.branch should travel from SendMessage through the \
+         pump to dispatch_message verbatim (empty ⇒ main)"
+    );
+
     env.shutdown().await;
 }
 
@@ -247,6 +269,7 @@ async fn send_message_passes_none_when_no_model_override() {
         content: "hi".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     req.metadata_mut().insert(
         "authorization",
@@ -291,6 +314,7 @@ async fn empty_model_field_normalises_to_none() {
         content: "hi".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     req.metadata_mut().insert(
         "authorization",
@@ -363,6 +387,7 @@ async fn multi_tab_fanout_emits_to_all_attached_streams() {
         content: "fanout driver".to_string(),
         attachment_blob_ref: vec![],
         tool_definitions: vec![],
+        branch: String::new(),
     });
     send_req.metadata_mut().insert(
         "authorization",

--- a/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
+++ b/crates/life-runtime/lifegw/examples/local_smoke_anthropic.rs
@@ -253,7 +253,7 @@ impl Agent for AnthropicProxyAgentService {
         // from its routing-cache entry.
         let stream = self
             .arcan
-            .dispatch_message(&sid, &content, None, &[])
+            .dispatch_message(&sid, &content, None, "", &[])
             .await
             .map_err(|e| tonic::Status::internal(format!("AnthropicArcan dispatch failed: {e}")))?;
         Ok(tonic::Response::new(stream))

--- a/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
+++ b/crates/life-runtime/lifegw/src/services/anthropic_messages.rs
@@ -840,6 +840,9 @@ async fn send_message(
         content: content.to_string(),
         attachment_blob_ref: Vec::new(),
         tool_definitions: Vec::new(),
+        // BRO-1479: the Anthropic Messages compat surface has no branch
+        // concept on its public contract — dispatch always lands on main.
+        branch: String::new(),
     });
     attach_tier2(&mut req, tier2)?;
 

--- a/crates/life-runtime/lifegw/src/services/ws.rs
+++ b/crates/life-runtime/lifegw/src/services/ws.rs
@@ -134,6 +134,10 @@ pub enum CloseReason {
     /// reserved 4001 = rate-limit slot. Operators can correlate by
     /// the `policy_violation:token_expired` reason string.
     PolicyViolation,
+    /// `1008` — policy violation: invalid branch selector on
+    /// `send_message` (BRO-1479). Distinct from token expiry so client
+    /// protocol errors are not misclassified as auth problems.
+    InvalidBranch,
     /// `1011` — internal server error. Used for unexpected upstream
     /// failures AND heartbeat timeouts (Spec C₃ §6.4 + §6.5):
     /// Sub-phase D (D5) closes idle connections that don't pong
@@ -159,6 +163,7 @@ impl CloseReason {
             CloseReason::Normal => 1000,
             CloseReason::GoingAway => 1001,
             CloseReason::PolicyViolation => 1008,
+            CloseReason::InvalidBranch => 1008,
             CloseReason::InternalError => 1011,
             CloseReason::RateLimit => 4001,
             CloseReason::SlowConsumer => 4002,
@@ -173,6 +178,7 @@ impl CloseReason {
             CloseReason::Normal => "normal",
             CloseReason::GoingAway => "going_away",
             CloseReason::PolicyViolation => "policy_violation:token_expired",
+            CloseReason::InvalidBranch => "policy_violation:invalid_branch",
             CloseReason::InternalError => "internal_error",
             CloseReason::RateLimit => "rate_limit:per_user",
             CloseReason::SlowConsumer => "backpressure:slow_consumer",
@@ -1256,7 +1262,7 @@ async fn handle_inbound_frame(
                     branch = %name,
                     "ws: invalid branch name on send_message — closing"
                 );
-                return Some(CloseReason::PolicyViolation);
+                return Some(CloseReason::InvalidBranch);
             }
             // Sub-phase D (D9): hand off to the dispatcher. If the
             // bounded channel is full (>=64 queued commands), apply
@@ -1833,6 +1839,11 @@ mod tests {
         assert_eq!(CloseReason::Normal.code(), 1000);
         assert_eq!(CloseReason::GoingAway.code(), 1001);
         assert_eq!(CloseReason::PolicyViolation.code(), 1008);
+        assert_eq!(CloseReason::InvalidBranch.code(), 1008);
+        assert_eq!(
+            CloseReason::InvalidBranch.reason(),
+            "policy_violation:invalid_branch"
+        );
         assert_eq!(CloseReason::InternalError.code(), 1011);
         assert_eq!(CloseReason::RateLimit.code(), 4001);
         assert_eq!(CloseReason::SlowConsumer.code(), 4002);

--- a/crates/life-runtime/lifegw/src/services/ws.rs
+++ b/crates/life-runtime/lifegw/src/services/ws.rs
@@ -249,6 +249,15 @@ pub enum InboundFrame {
         /// like every other inbound field.
         #[serde(default)]
         tools: Option<Vec<serde_json::Value>>,
+        /// BRO-1479: target branch for this dispatch. Absent / empty ⇒
+        /// `main` (backward-compatible — pre-BRO-1479 clients never send
+        /// it). This is UNTRUSTED public input that keys into redb
+        /// compound keys + lago-fs manifests downstream, so the edge
+        /// validates `[a-zA-Z0-9_-]{1,64}` in `handle_inbound_frame` and
+        /// rejects the frame (never sanitizes) before forwarding it to
+        /// lifed as `SendMessageReq.branch`.
+        #[serde(default)]
+        branch: Option<String>,
     },
     /// Approve a pending dispatch.
     ApproveDispatch { dispatch_id: String },
@@ -1078,6 +1087,10 @@ enum DispatcherCommand {
         /// Client tool definitions, JSON-serialized into
         /// `SendMessageReq.tool_definitions` at request-build time.
         tools: Vec<serde_json::Value>,
+        /// BRO-1479: target branch, already validated at the edge in
+        /// `handle_inbound_frame`. Empty ⇒ main. Forwarded verbatim onto
+        /// `SendMessageReq.branch` at request-build time.
+        branch: String,
     },
 }
 
@@ -1108,6 +1121,7 @@ async fn run_send_message_dispatcher(
                 content,
                 attachment_blob_ref,
                 tools,
+                branch,
             } => {
                 let mut req = tonic::Request::new(pb::SendMessageReq {
                     sid: Some(aios_pb::SessionId { value: sid.clone() }),
@@ -1122,6 +1136,9 @@ async fn run_send_message_dispatcher(
                         .iter()
                         .filter_map(|t| serde_json::to_vec(t).ok())
                         .collect(),
+                    // BRO-1479: already edge-validated at frame parse;
+                    // empty ⇒ the substrate dispatches on main.
+                    branch,
                 });
                 if let Some(b) = bearer.as_deref()
                     && let Ok(mv) =
@@ -1189,6 +1206,18 @@ async fn run_send_message_dispatcher(
     }
 }
 
+/// Branch-name check (`[a-zA-Z0-9_-]{1,64}`), mirroring the arcand
+/// substrate's rule — the same value is re-validated there (defense in
+/// depth), but the public edge rejects it first so garbage never rides
+/// the internal wire.
+fn valid_branch_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// Handle an inbound frame. Returns `Some(reason)` to close the WS
 /// with the given reason, `None` to continue.
 ///
@@ -1210,7 +1239,25 @@ async fn handle_inbound_frame(
             content,
             attachment_blob_ref,
             tools,
+            branch,
         } => {
+            // BRO-1479: edge-validate the branch BEFORE it crosses into
+            // lifed/arcand — it is untrusted public input that keys into
+            // redb compound keys + lago-fs manifests downstream. An
+            // invalid name is a protocol violation: close (the WS error
+            // surface, matching every other malformed-frame posture)
+            // rather than sanitize silently. The substrate re-validates
+            // at its own boundary (defense in depth).
+            if let Some(name) = branch.as_deref()
+                && !name.is_empty()
+                && !valid_branch_name(name)
+            {
+                tracing::warn!(
+                    branch = %name,
+                    "ws: invalid branch name on send_message — closing"
+                );
+                return Some(CloseReason::PolicyViolation);
+            }
             // Sub-phase D (D9): hand off to the dispatcher. If the
             // bounded channel is full (>=64 queued commands), apply
             // backpressure: when the dispatcher is processing a
@@ -1226,6 +1273,7 @@ async fn handle_inbound_frame(
                     content,
                     attachment_blob_ref,
                     tools: tools.unwrap_or_default(),
+                    branch: branch.unwrap_or_default(),
                 })
                 .await
                 .is_err()
@@ -1948,6 +1996,32 @@ mod tests {
     }
 
     #[test]
+    fn inbound_frame_decodes_send_message_with_branch() {
+        // BRO-1479: an explicit branch rides the frame; the edge
+        // validator accepts the charset and the dispatcher forwards it.
+        let raw = r#"{"kind":"send_message","content":"Hi","branch":"exp-1"}"#;
+        let m = Message::Text(raw.into());
+        let parsed = decode_inbound(&m).expect("decode");
+        match parsed {
+            InboundFrame::SendMessage { branch, .. } => {
+                assert_eq!(branch.as_deref(), Some("exp-1"));
+            }
+            other => panic!("expected SendMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_name_validation_rules() {
+        assert!(valid_branch_name("main"));
+        assert!(valid_branch_name("exp-1"));
+        assert!(valid_branch_name("a_B-2"));
+        assert!(!valid_branch_name(""));
+        assert!(!valid_branch_name("../etc/passwd"));
+        assert!(!valid_branch_name("has space"));
+        assert!(!valid_branch_name(&"x".repeat(65)));
+    }
+
+    #[test]
     fn inbound_frame_decodes_send_message() {
         let raw = r#"{"kind":"send_message","content":"Hello"}"#;
         let m = Message::Text(raw.into());
@@ -1957,10 +2031,12 @@ mod tests {
                 content,
                 attachment_blob_ref,
                 tools,
+                branch,
             } => {
                 assert_eq!(content, "Hello");
                 assert!(attachment_blob_ref.is_none());
                 assert!(tools.is_none(), "no tools field → None");
+                assert!(branch.is_none(), "no branch field → None (main)");
             }
             other => panic!("expected SendMessage, got {other:?}"),
         }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1688,6 +1688,21 @@ panic "Cannot start a runtime from within a runtime"); a round-trip
 test drives it from inside a multi-thread runtime to pin that. Closes
 the "blobs stay local even in remote-journal mode" FS-substrate gap.
 
+**2026-06-11 — branching exposed through the dispatch path
+(BRO-1479).** `branch` rides additive proto fields
+(`life.v1.SendMessageReq` + `arcan.v1.DispatchMessageReq`) through
+lifegw ws → lifed → arcan-proxy → arcand. The substrate **auto-forks an
+unknown branch from main at the current head** using the kernel's
+existing `create_branch` (parent + fork_sequence + head tracking;
+`BranchCreated` is the new branch's first event) — dispatching to
+`exp-1` forks the session's event stream without touching main, the
+e2e pins both directions plus invalid-name rejection. Validation
+`[a-zA-Z0-9_-]{1,64}` at the public edge (WS close) AND the substrate
+(INVALID_ARGUMENT); the dispatch event pump filters by session+branch
+so sibling-branch dispatches cannot interleave. Empty/absent ⇒ main
+(every pre-existing test unchanged). Deferred: Topology-A HTTP path,
+merge/fork-point wire params, client UI.
+
 ## Health Summary
 
 | Area | aiOS | Arcan | Lago | Autonomic | Praxis | Vigil | Spaces |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1701,7 +1701,11 @@ e2e pins both directions plus invalid-name rejection. Validation
 (INVALID_ARGUMENT); the dispatch event pump filters by session+branch
 so sibling-branch dispatches cannot interleave. Empty/absent ⇒ main
 (every pre-existing test unchanged). Deferred: Topology-A HTTP path,
-merge/fork-point wire params, client UI.
+merge/fork-point wire params, client UI. Test delta: arcand topology-B
+e2e 5→8 (+branch fork / default-main / invalid-name), lifegw ws
++3 (frame decode, validator, close-code), lifed integration extended —
+598 green across the four touched crates. Gap closed: "Branching not
+exposed" (root CLAUDE.md known-gaps + §Branching policy updated).
 
 ## Health Summary
 

--- a/proto/arcan/v1/substrate.proto
+++ b/proto/arcan/v1/substrate.proto
@@ -59,6 +59,17 @@ message DispatchMessageReq {
   // tool set. Additive field — pre-existing clients/servers stay
   // wire-compatible.
   repeated bytes tool_definitions = 3;
+  // Target branch for this dispatch's ticks. Empty ⇒ "main"
+  // (backward-compatible: pre-BRO-1479 clients never set this, so the
+  // substrate dispatches on main exactly as before). A non-empty value
+  // keys every tick of this dispatch onto that branch — its event
+  // stream and filesystem manifest fork from main. arcand validates the
+  // name (`[a-zA-Z0-9_-]{1,64}`) at this trust boundary because it is
+  // UNTRUSTED remote input that flows directly into redb compound keys
+  // (session + branch + seq) and lago-fs manifest keys; an invalid name
+  // is rejected with INVALID_ARGUMENT, never silently sanitized.
+  // Additive field — pre-existing clients/servers stay wire-compatible.
+  string branch = 4;
 }
 
 // Mirrors life.v1.AgentEvent shape but lives in the substrate-plane

--- a/proto/life/v1/agent.proto
+++ b/proto/life/v1/agent.proto
@@ -93,6 +93,15 @@ message SendMessageReq {
   // tools" — backends fall back to their own tool registry (if any).
   // Additive field — pre-existing clients/servers stay wire-compatible.
   repeated bytes tool_definitions = 4;
+  // Target branch for this dispatch. Empty ⇒ "main" (backward-
+  // compatible: pre-BRO-1479 clients never set this). lifegw validates
+  // the name (`[a-zA-Z0-9_-]{1,64}`) at the public edge and lifed
+  // forwards it to `ArcanCall::dispatch_message`, which threads it onto
+  // the substrate's `arcan.v1.DispatchMessageReq.branch`. A non-empty
+  // value forks the session's event stream + filesystem manifest from
+  // main on that branch. Additive field — pre-existing clients/servers
+  // stay wire-compatible.
+  string branch = 5;
 }
 
 message AgentEvent {


### PR DESCRIPTION
## Summary

Closes the long-standing Phase-0 gap: **lago branching is now exposed through the production dispatch path**. A chat dispatch can name a `branch`, and the session's event stream + filesystem manifest fork — `main` stays untouched.

The interesting part: the kernel already had a full branch lifecycle (`create_branch` with parent / `fork_sequence` / head tracking, `merge_branch`, read-only-after-merge) and `next_sequence` correctly refuses unknown branches — the naive "just key ticks onto the name" approach journals **nothing** (found by e2e + traced to the `branch not found` bail). So the substrate implements the right semantic: **a dispatch naming an unknown branch auto-forks it from `main` at the current head**, with `BranchCreated` as the new branch's first event. Real fork, not a dangling stream.

## Dep chain

| Layer | Change |
|---|---|
| proto | additive `branch` on `life.v1.SendMessageReq` + `arcan.v1.DispatchMessageReq` |
| lifegw ws | optional `branch` on the SendMessage frame; **edge validation** `[a-zA-Z0-9_-]{1,64}` (invalid ⇒ PolicyViolation close, never sanitized); threaded via DispatcherCommand |
| lifed | `SendMessageReq.branch` → `ArcanCall::dispatch_message` (mirrors the #1697 tool_definitions path); mocks updated |
| arcan-proxy | `dispatch_message(.., branch, ..)` → `DispatchMessageReq.branch`; HTTP-backed impls ignore (no branch concept on the raw provider wire) |
| arcand substrate | re-validation (INVALID_ARGUMENT), **auto-fork-from-main-at-head** via kernel `create_branch`, ticks keyed on the branch, event pump filters by session+branch (sibling-branch dispatches can't interleave) |

## Backward compat

Empty/absent branch ⇒ `main`, byte-for-byte today's behavior — pinned by a dedicated default-branch e2e; every pre-existing test passes unchanged.

## Test plan

- [x] arcand e2e (8): `exp-1` dispatch lands every event under `exp-1` with `BranchCreated` first and main's stream unchanged; empty branch ⇒ main; `../etc/passwd` ⇒ rejected with nothing journaled
- [x] lifegw: frame-with-branch decode + validator rules; lifed: integration threading tests
- [x] 598 tests across arcand/arcan-proxy/lifed/lifegw; clippy `--all-targets -D warnings`; `cargo check --workspace --all-targets`

## Deferred (documented in CLAUDE.md §Branching policy)

Topology-A HTTP path (`canonical.rs`), merge/fork-point wire params, chat-client branch UI.

Closes BRO-1479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch parameter to message dispatch: specify target branch when sending messages.
  * Automatic branch creation from current head when dispatching to a non-existent branch.
  * Branch-scoped event filtering ensures clean event streams per branch without cross-branch leakage.
  * Branch name validation enforced at trust boundaries; invalid names rejected with errors.
  * Empty/missing branch defaults to `main` for backward compatibility.

* **Documentation**
  * Updated branching behavior and limitations in status documentation.

* **Tests**
  * Added comprehensive branch routing and validation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->