### PR TITLE
fix(arcan): give the agent file-tool workspace a writable root (BRO-1490)

### DIFF
--- a/crates/arcan/arcan/src/main.rs
+++ b/crates/arcan/arcan/src/main.rs
@@ -148,6 +148,16 @@ struct Cli {
     /// set this so lifed's arcan-proxy can dial in. BRO-1016.
     #[arg(long, global = true, env = "ARCAN_UDS_SOCKET", value_name = "PATH")]
     uds_socket: Option<PathBuf>,
+
+    /// Workspace root for agent file tools (read_file, write_file, bash, …).
+    /// Created if missing; must be writable by the arcan process. Defaults
+    /// to the process CWD — deployments whose CWD is a read-only install
+    /// dir (e.g. a root-owned image WORKDIR) MUST set this to a writable
+    /// path or every file-tool write fails before reaching lago. BRO-1490.
+    /// (Env is ARCAN_WORKSPACE_DIR, not ARCAN_WORKSPACE — the latter is
+    /// already the per-run hook variable set by arcan-core hooks.)
+    #[arg(long, global = true, env = "ARCAN_WORKSPACE_DIR", value_name = "DIR")]
+    workspace: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -454,6 +464,27 @@ fn resolve_data_dir(data_dir: &PathBuf) -> anyhow::Result<PathBuf> {
     Ok(workspace_root.join(data_dir))
 }
 
+/// Resolve the agent file-tool workspace root (BRO-1490).
+///
+/// An explicit `--workspace` / `ARCAN_WORKSPACE_DIR` is created if missing
+/// and canonicalized (FsPolicy compares canonical paths, and the boot log
+/// should show the real location). Without one, fall back to the process
+/// CWD — correct for `arcan serve` run from a project checkout, wrong for
+/// images whose WORKDIR is a root-owned install dir.
+fn resolve_workspace_root(explicit: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    match explicit {
+        Some(dir) => {
+            std::fs::create_dir_all(&dir).map_err(|error| {
+                anyhow::anyhow!("cannot create workspace dir {}: {error}", dir.display())
+            })?;
+            dir.canonicalize().map_err(|error| {
+                anyhow::anyhow!("cannot canonicalize workspace {}: {error}", dir.display())
+            })
+        }
+        None => Ok(std::env::current_dir()?),
+    }
+}
+
 fn read_last_session_hint(data_dir: &Path) -> Option<String> {
     let path = data_dir.join("last_session");
     let raw = std::fs::read_to_string(path).ok()?;
@@ -623,6 +654,7 @@ fn build_provider(resolved: &ResolvedConfig) -> anyhow::Result<Arc<dyn Provider>
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_serve(
     data_dir: &Path,
     resolved: &ResolvedConfig,
@@ -630,6 +662,7 @@ fn run_serve(
     prosopon_port: Option<std::net::SocketAddr>,
     agents_dir: Option<PathBuf>,
     uds_socket: Option<PathBuf>,
+    workspace: Option<PathBuf>,
     tokio_runtime: &tokio::runtime::Runtime,
     chronos_enabled: bool,
     chronos_http_bind: Option<std::net::SocketAddr>,
@@ -639,7 +672,25 @@ fn run_serve(
     //   - async reqwest Client + tonic Channel work (they find `Handle::current()`)
     //   - reqwest::blocking::Client also works (no nested runtime panic)
     //   - `tokio::spawn()` works (tasks are queued, run when block_on starts)
-    let workspace_root = std::env::current_dir()?;
+    let workspace_root = resolve_workspace_root(workspace)?;
+
+    // BRO-1490 defence-in-depth: a non-writable workspace surfaces at
+    // runtime as an opaque per-tool io error ("No such file or directory")
+    // deep inside a chat turn. Probe once at boot and say exactly what is
+    // wrong while the operator is still watching the boot log. Warn-only:
+    // a read-only workspace still serves read_file/grep/glob.
+    let probe = workspace_root.join(format!(".arcan-write-probe-{}", std::process::id()));
+    match std::fs::write(&probe, b"probe") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+        }
+        Err(error) => tracing::warn!(
+            workspace = %workspace_root.display(),
+            %error,
+            "agent workspace is NOT writable — file tools (write_file, edit_file, bash) \
+             will fail; set --workspace / ARCAN_WORKSPACE_DIR to a writable directory"
+        ),
+    }
 
     // --- Lago persistence ---
     //
@@ -1763,6 +1814,7 @@ fn main() -> anyhow::Result<()> {
                 cli.prosopon_port,
                 cli.agents_dir,
                 cli.uds_socket,
+                cli.workspace,
                 &tokio_runtime,
                 chronos,
                 chronos_http_bind,
@@ -2136,5 +2188,39 @@ mod tests {
         let selected = resolve_session(&dir, None, None).await;
         assert_eq!(selected, "default");
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn workspace_root_defaults_to_cwd() {
+        let resolved = resolve_workspace_root(None).expect("resolve");
+        assert_eq!(resolved, std::env::current_dir().expect("cwd"));
+    }
+
+    #[test]
+    fn workspace_root_creates_missing_explicit_dir() {
+        let base = unique_temp_dir("arcan-workspace-create");
+        let target = base.join("nested/agent-workspace");
+        assert!(!target.exists());
+
+        let resolved = resolve_workspace_root(Some(target.clone())).expect("resolve");
+
+        assert!(target.is_dir(), "explicit workspace dir must be created");
+        // Canonicalized result points at the same directory (macOS tempdirs
+        // canonicalize through /private, so compare canonical forms).
+        assert_eq!(resolved, target.canonicalize().expect("canonicalize"));
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn workspace_root_canonicalizes_existing_dir() {
+        let base = unique_temp_dir("arcan-workspace-existing");
+        // Route through `..` so the input is non-canonical.
+        let indirect = base.join("sub/..");
+        std::fs::create_dir_all(base.join("sub")).expect("mkdir");
+
+        let resolved = resolve_workspace_root(Some(indirect)).expect("resolve");
+
+        assert_eq!(resolved, base.canonicalize().expect("canonicalize"));
+        let _ = std::fs::remove_dir_all(base);
     }
 }

--- a/deploy/railway/lifegw-stack/README.md
+++ b/deploy/railway/lifegw-stack/README.md
@@ -62,9 +62,18 @@ journal to lagod over HTTP: `entrypoint.sh` sets `LAGO_URL=http://127.0.0.1:8077
 embedded RedbJournal — file-write events, tool calls, and messages for every
 public session land in the durable, volume-backed lago store and survive
 redeploys. Boot log: `Starting arcan (remote Lago journal)`. Set
-`ARCAN_LAGO_URL=embedded` to fall back to the local RedbJournal. (Blob
-*content* still writes to arcan's local cache until the remote blob backend
-lands — BRO-1478.)
+`ARCAN_LAGO_URL=embedded` to fall back to the local RedbJournal. Blob
+*content* follows the journal's locality (BRO-1478): with `LAGO_URL` set,
+arcan stores file content through lagod's blob store too — boot log:
+`arcan blob content: remote lago blob store`.
+
+**Agent file-tool workspace (BRO-1490).** `entrypoint.sh` creates a
+writable, volume-backed workspace at `${ARCAN_DATA_DIR}/workspace`
+(override: `ARCAN_WORKSPACE_DIR`) and passes it via `arcan serve
+--workspace`. Without it, arcan's file tools anchor at the process CWD —
+the root-owned image `WORKDIR /opt/life` — and every `write_file` /
+`edit_file` / `bash` write fails before it can reach the lago manifest.
+arcan probes the workspace at boot and logs a WARN if it is not writable.
 
 > **Why real arcan + lago but mock haima/anima?** Stage 5/6 ship the two
 > substrates the core chat path exercises — the agent loop (arcan) and its

--- a/deploy/railway/lifegw-stack/entrypoint.sh
+++ b/deploy/railway/lifegw-stack/entrypoint.sh
@@ -226,7 +226,19 @@ if [[ "${ARCAN_ENABLED}" == "1" ]]; then
 ARCAN_DATA_DIR="${ARCAN_DATA_DIR:-${LIFE_STATE_DIR}/arcan}"
 mkdir -p "${ARCAN_DATA_DIR}"
 chown -R life:life-runtime "${ARCAN_DATA_DIR}"
-echo "[entrypoint] starting arcan substrate (uds=${LIFE_RUNTIME_DIR}/arcan.sock data=${ARCAN_DATA_DIR})"
+# BRO-1490: the agent's file-tool workspace. Without an explicit
+# --workspace, arcan falls back to its CWD — the image WORKDIR
+# /opt/life, which is created by root and shipped read-only to the
+# `life` runtime user, so every write_file/edit_file/bash write fails
+# ENOENT/EACCES before it can reach the lago manifest. Give the agent
+# a writable workspace under the volume-backed data dir instead
+# (survives redeploys when a Railway volume is mounted). Overridable
+# via ARCAN_WORKSPACE_DIR; chown explicitly because an override may
+# point outside ARCAN_DATA_DIR's recursive chown above.
+ARCAN_WORKSPACE_DIR="${ARCAN_WORKSPACE_DIR:-${ARCAN_DATA_DIR}/workspace}"
+mkdir -p "${ARCAN_WORKSPACE_DIR}"
+chown life:life-runtime "${ARCAN_WORKSPACE_DIR}"
+echo "[entrypoint] starting arcan substrate (uds=${LIFE_RUNTIME_DIR}/arcan.sock data=${ARCAN_DATA_DIR} workspace=${ARCAN_WORKSPACE_DIR})"
 # `env -u`: the Tier-2 token-minting key is lifegw's secret. arcan
 # executes tool calls (incl. shell) for remote chat users — that key
 # must never be readable from the agent process environment.
@@ -273,6 +285,7 @@ runuser --preserve-environment -u life -g life-runtime -- \
     --uds-socket "${LIFE_RUNTIME_DIR}/arcan.sock" \
     --data-dir "${ARCAN_DATA_DIR}" \
     --agents-dir /opt/life/agents \
+    --workspace "${ARCAN_WORKSPACE_DIR}" \
   &
 ARCAN_PID=$!
 


### PR DESCRIPTION
## Problem

The live dogfood that validated #1730 (`write_file` now **passes the policy gate**) surfaced the next blocker one layer down (BRO-1490, GH #1740): the praxis tools' workspace root is `std::env::current_dir()` — in the lifegw-stack image that is `WORKDIR /opt/life`, created by root and never chowned to the `life` runtime user. Every public file-tool write fails:

```
WARN aios_runtime: tool execution failed (write_file):
     io error: No such file or directory (os error 2)
tick finalized mode=Recover
```

— after passing policy, before reaching the lago tracker. No blob PUT, no FileWrite, dead-air turn.

## Fix (deploy-fast path per handoff)

- **`arcan serve --workspace <DIR>`** (env `ARCAN_WORKSPACE_DIR`): explicit workspace root for agent file tools; created if missing, canonicalized; falls back to CWD when unset (existing behavior, zero impact on dev/Topology-A). Env name avoids colliding with the existing `ARCAN_WORKSPACE` per-run hook variable (`arcan-core/src/hooks.rs`).
- **Boot-time writability probe**: a non-writable workspace now WARNs at boot with the exact remedy, instead of surfacing as an opaque per-tool io error mid-chat (this is the diagnostic that would have caught BRO-1490 on deploy day).
- **`entrypoint.sh` §3b**: create + `chown life:life-runtime` `${ARCAN_DATA_DIR}/workspace` (volume-backed, survives redeploys) and pass `--workspace`. Boot line now prints the workspace.
- **lifegw-stack README**: document the workspace knob; fix the stale BRO-1478 parenthetical (remote blobs shipped in #1725).

`docker/arcan.Dockerfile` (standalone image) is unaffected — it already runs as user `arcan` with a writable `WORKDIR /home/arcan`.

## Tests

- 3 new unit tests for `resolve_workspace_root` (default-to-CWD, create-missing, canonicalize).
- `cargo fmt` + `cargo clippy -p arcan --all-targets` + `cargo test -p arcan` green (14 integration + 136 bin tests).
- `bash -n` + shellcheck on entrypoint.sh (only pre-existing info-level notes).

## Receipt plan (after merge + Railway deploy)

chat.broomva.tech: *"use write_file to create artifacts/receipt.txt"* → expect **no** `tool execution failed`, a `FileWrite` event + remote blob PUT in lago, tick finalized clean (not `mode=Recover`).

## Not in scope (designed follow-up)

Per-session workspace isolation: the kernel already creates `{data_dir}/sessions/<id>/` per session and threads `manifest.workspace_root` in **every** `ToolExecutionRequest` — but `ArcanHarnessAdapter::execute` drops it and the praxis `FsPort` is construction-time-fixed. Threading it through needs FsTracker re-keying (manifest paths must be session-unique), exec-path reconciler scoping, and sandbox cwd threading. Tracked as the second half of BRO-1490.

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--workspace` CLI option (env: `ARCAN_WORKSPACE_DIR`) to configure agent tool workspace directory, with boot-time writability validation.

* **Documentation**
  * Updated deployment documentation to clarify workspace requirements and storage configuration for file operations.

* **Chores**
  * Updated deployment scripts to automatically provision and configure workspace directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->