### PR TITLE
fix(praxis): resolve_for_write tolerates missing parent dirs (BRO-1490)

### DIFF
--- a/crates/praxis/praxis-core/src/fs_port.rs
+++ b/crates/praxis/praxis-core/src/fs_port.rs
@@ -36,7 +36,9 @@ pub trait FsPort: Send + Sync {
     /// Resolve an existing path within the workspace.
     fn resolve(&self, path: &Path) -> PraxisResult<PathBuf>;
 
-    /// Resolve a path for writing (file may not exist yet).
+    /// Resolve a path for writing (neither the file nor its parent
+    /// directories need exist yet; the nearest existing ancestor is
+    /// boundary-checked).
     fn resolve_for_write(&self, path: &Path) -> PraxisResult<PathBuf>;
 
     /// Read a file as UTF-8 text.

--- a/crates/praxis/praxis-core/src/local_fs.rs
+++ b/crates/praxis/praxis-core/src/local_fs.rs
@@ -50,17 +50,14 @@ impl FsPort for LocalFs {
     }
 
     fn write(&self, path: &Path, content: &[u8]) -> PraxisResult<()> {
-        // Compute the target path within the workspace.
-        let joined = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            self.policy.workspace_root().join(path)
-        };
-        // Create parent directories first (resolve_for_write needs the parent to exist).
-        if let Some(parent) = joined.parent() {
+        // Resolve (and boundary-check) BEFORE creating anything on disk —
+        // resolve_for_write tolerates missing parents, so creating them
+        // first would only manufacture directories for a path that may
+        // then be rejected as outside the workspace.
+        let resolved = self.policy.resolve_for_write(path)?;
+        if let Some(parent) = resolved.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let resolved = self.policy.resolve_for_write(path)?;
         Ok(std::fs::write(resolved, content)?)
     }
 
@@ -131,6 +128,42 @@ mod tests {
         fs.write(&path, b"nested").unwrap();
         assert!(path.exists());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "nested");
+    }
+
+    #[test]
+    fn resolve_for_write_then_write_into_missing_relative_dir() {
+        // The exact WriteFileTool flow that hit BRO-1490 in prod: pre-flight
+        // resolve_for_write on a workspace-relative path whose parent does
+        // not exist yet, then write to the resolved path.
+        let (tmp, fs) = make_fs();
+
+        let resolved = fs
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .expect("resolve_for_write must tolerate a missing parent dir");
+        fs.write(&resolved, b"BRO-1490").unwrap();
+
+        let on_disk = tmp.path().join("artifacts/receipt.txt");
+        assert!(on_disk.exists());
+        assert_eq!(std::fs::read_to_string(on_disk).unwrap(), "BRO-1490");
+    }
+
+    #[test]
+    fn write_outside_workspace_creates_nothing() {
+        // The boundary check must run BEFORE any directory creation: a
+        // rejected write must not leave stray directories behind.
+        let (_tmp, fs) = make_fs();
+        let outside = std::env::temp_dir().join("praxis-localfs-escape-check/sub/file.txt");
+
+        let err = fs.write(&outside, b"nope").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::PraxisError::PathOutsideWorkspace { .. }
+        ));
+        assert!(
+            !std::env::temp_dir()
+                .join("praxis-localfs-escape-check")
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/praxis/praxis-core/src/workspace.rs
+++ b/crates/praxis/praxis-core/src/workspace.rs
@@ -42,22 +42,52 @@ impl FsPolicy {
         Ok(canonical)
     }
 
-    /// Resolve a path for writing. The parent must exist and be within workspace,
-    /// but the file itself may not exist yet.
+    /// Resolve a path for writing. Neither the file nor its parent
+    /// directories need exist yet (BRO-1490: `write_file artifacts/x.txt`
+    /// into a fresh workspace must resolve, not ENOENT): the nearest
+    /// EXISTING ancestor is canonicalized and boundary-checked, then the
+    /// not-yet-existing components are re-appended. Those must be plain
+    /// segments — a `..` (or stray `.`) past the verified prefix cannot be
+    /// canonicalized (nothing to stat) and could escape the workspace once
+    /// the directories are created, so it is rejected.
     pub fn resolve_for_write(&self, candidate: &Path) -> PraxisResult<PathBuf> {
         let joined = if candidate.is_absolute() {
             candidate.to_path_buf()
         } else {
             self.workspace_root.join(candidate)
         };
-        let parent = joined
-            .parent()
-            .ok_or_else(|| PraxisError::PathOutsideWorkspace {
-                path: joined.display().to_string(),
-            })?;
-        let canonical_parent = parent.canonicalize()?;
-        self.ensure_within_root(&canonical_parent)?;
-        Ok(canonical_parent.join(joined.file_name().unwrap()))
+        let outside = || PraxisError::PathOutsideWorkspace {
+            path: joined.display().to_string(),
+        };
+        // `file_name()` is None for paths ending in `..` — reject those
+        // outright rather than guessing what the caller meant to write.
+        let file_name = joined.file_name().ok_or_else(outside)?.to_os_string();
+
+        // Walk up to the nearest existing ancestor, collecting the
+        // not-yet-existing directory components in between.
+        let mut missing: Vec<std::ffi::OsString> = Vec::new();
+        let mut ancestor = joined.parent().ok_or_else(outside)?;
+        while !ancestor.exists() {
+            // None ⇒ the ancestor ends in `..` (traversal through a
+            // non-existing directory) — nothing trustworthy to anchor on.
+            missing.push(ancestor.file_name().ok_or_else(outside)?.to_os_string());
+            ancestor = ancestor.parent().ok_or_else(outside)?;
+        }
+
+        // Canonicalize the existing prefix and enforce the boundary THERE —
+        // before any caller creates the missing directories under it.
+        let canonical = ancestor.canonicalize()?;
+        self.ensure_within_root(&canonical)?;
+
+        let mut resolved = canonical;
+        for component in missing.iter().rev() {
+            if component == ".." || component == "." {
+                return Err(outside());
+            }
+            resolved.push(component);
+        }
+        resolved.push(&file_name);
+        Ok(resolved)
     }
 
     /// Validate that a canonical path is within the workspace root.
@@ -197,5 +227,104 @@ mod tests {
         let policy = FsPolicy::new(dir.path());
         let rel = policy.relative(&file_path).unwrap();
         assert_eq!(rel, PathBuf::from("sub/test.txt"));
+    }
+
+    // ── resolve_for_write with missing parents (BRO-1490) ───────────────
+
+    #[test]
+    fn resolve_for_write_accepts_missing_parent() {
+        // The prod regression: `write_file artifacts/receipt.txt` into a
+        // fresh workspace whose `artifacts/` does not exist yet.
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("artifacts/receipt.txt"));
+        // Resolution must not create anything — that's the writer's job.
+        assert!(!dir.path().join("artifacts").exists());
+    }
+
+    #[test]
+    fn resolve_for_write_accepts_nested_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("a/b/c/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("a/b/c/receipt.txt"));
+    }
+
+    #[test]
+    fn resolve_for_write_existing_parent_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("artifacts")).unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("artifacts/receipt.txt"));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_traversal_through_missing_dir() {
+        // `ghost/` does not exist, so the `..` segments after it cannot be
+        // canonicalized — allowing them could escape the workspace once the
+        // directories are created.
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let err = policy
+            .resolve_for_write(Path::new("ghost/../../escape.txt"))
+            .unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_absolute_outside_with_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        // Nearest existing ancestor is the system temp dir — outside the
+        // workspace — so the boundary check must reject it.
+        let outside = std::env::temp_dir().join("praxis-resolve-for-write-nope/sub/file.txt");
+        let err = policy.resolve_for_write(&outside).unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_trailing_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let err = policy
+            .resolve_for_write(Path::new("artifacts/.."))
+            .unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_traversal_within_existing_dirs_still_works() {
+        // `..` through EXISTING directories canonicalizes safely — the
+        // missing-suffix restriction must not break this.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("sub/../newdir/file.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("newdir/file.txt"));
     }
 }

--- a/crates/praxis/praxis-tools/src/fs.rs
+++ b/crates/praxis/praxis-tools/src/fs.rs
@@ -622,6 +622,32 @@ mod tests {
     }
 
     #[test]
+    fn write_file_into_missing_subdirectory() {
+        // BRO-1490 prod regression: the model writes
+        // `artifacts/receipt.txt` into a fresh workspace. The tool's
+        // pre-flight resolve_for_write used to ENOENT on the missing
+        // `artifacts/` parent before LocalFs::write could create it
+        // ("io error: No such file or directory" → mode=Recover).
+        let dir = TempDir::new().unwrap();
+        let fs = make_fs(&dir);
+        let tool = WriteFileTool::new(fs);
+        let ctx = make_ctx();
+
+        let call = make_call(
+            "write_file",
+            json!({"path": "artifacts/receipt.txt", "content": "BRO-1490 receipt"}),
+        );
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert_eq!(result.output["success"], true);
+
+        let on_disk = dir.path().join("artifacts/receipt.txt");
+        assert_eq!(
+            std::fs::read_to_string(on_disk).unwrap(),
+            "BRO-1490 receipt"
+        );
+    }
+
+    #[test]
     fn list_dir_shows_entries() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("a.txt"), "").unwrap();


### PR DESCRIPTION
## The re-receipt that found it

After #1742 deployed (writable workspace confirmed: boot log `workspace=/var/life-state/arcan/workspace`, writability probe green), the live chat receipt **still failed with the identical error**:

```
WARN aios_runtime: tool execution failed (write_file):
     io error: No such file or directory (os error 2)   → tick finalized mode=Recover
```

session `evacfsw4bazqduistcygkpqc5e`, 2026-06-12T02:44Z — message *"use your write_file tool to create artifacts/receipt.txt …"*.

## Root cause (the REAL ENOENT)

`WriteFileTool::execute` pre-flights `FsPort::resolve_for_write` (praxis-tools `fs.rs:164`, error surfaced verbatim — the log's bare `io error:` with no `Failed to write file:` prefix pins the failing call). `FsPolicy::resolve_for_write` canonicalized the immediate parent — which **requires the parent to exist**. Writing `artifacts/receipt.txt` into a fresh workspace has no `artifacts/` yet → the pre-flight ENOENTs before `LocalFs::write`'s `create_dir_all` can ever run.

The unit tests never caught it because every write-tool test targets the workspace **root** (parent always exists). `LocalFs::write` called directly also masked it by creating dirs *before* resolving — which is itself a bug (see below).

## Fix

- **`FsPolicy::resolve_for_write`**: walk up to the nearest **existing** ancestor, canonicalize + boundary-check there, then re-append the missing components. Missing components must be plain segments — a `..` (or `.`) past the verified prefix cannot be canonicalized (nothing to stat) and could escape the workspace once the dirs are created → `PathOutsideWorkspace`. Behavior with an existing parent is byte-identical to before.
- **`LocalFs::write`**: resolve **before** `create_dir_all`. The old order created parent dirs for the *unchecked* joined path — a write outside the workspace was correctly rejected, but its directories were still manufactured on disk as a side effect. New test proves a rejected write creates nothing.
- `LagoTrackedFs` delegates `resolve_for_write` to `LocalFs`, so arcan's tracked write path inherits the fix with no change.

## Tests

- 7 new `FsPolicy` tests: missing parent (the prod shape), nested missing parents, traversal-through-missing rejected, absolute-outside-with-missing-parents rejected, trailing `..` rejected, `..` through existing dirs still canonicalizes, resolve creates no dirs.
- 2 new `LocalFs` tests (tool-flow pre-flight + no-stray-dirs-on-reject), 1 `WriteFileTool` regression test (exact prod call: `artifacts/receipt.txt` in an empty workspace).
- Suites green: praxis-core 30, praxis-tools 34, arcan-lago 175, arcan `praxis_integration` 14. Clippy `-D warnings` clean.

## Receipt plan (after merge + deploy)

Same two-line receipt; this time `resolve_for_write` resolves, `LocalFs::write` creates `artifacts/` inside the (now writable, #1742) workspace, the tracked write reaches the lago manifest → expect a `FileWrite` event + remote blob PUT + clean tick.

Part 2 of BRO-1490 (part 1 = #1742; per-session isolation = BRO-1491).

🤖 Generated with [Claude Code](https://claude.com/claude-code)