### PR TITLE
docs(handoff): BRO-1490 closed — write_file→lago receipt green (next: tool-surface UX)

### DIFF
--- a/crates/praxis/praxis-core/src/fs_port.rs
+++ b/crates/praxis/praxis-core/src/fs_port.rs
@@ -36,7 +36,9 @@ pub trait FsPort: Send + Sync {
     /// Resolve an existing path within the workspace.
     fn resolve(&self, path: &Path) -> PraxisResult<PathBuf>;
 
-    /// Resolve a path for writing (file may not exist yet).
+    /// Resolve a path for writing (neither the file nor its parent
+    /// directories need exist yet; the nearest existing ancestor is
+    /// boundary-checked).
     fn resolve_for_write(&self, path: &Path) -> PraxisResult<PathBuf>;
 
     /// Read a file as UTF-8 text.

--- a/crates/praxis/praxis-core/src/local_fs.rs
+++ b/crates/praxis/praxis-core/src/local_fs.rs
@@ -50,17 +50,14 @@ impl FsPort for LocalFs {
     }
 
     fn write(&self, path: &Path, content: &[u8]) -> PraxisResult<()> {
-        // Compute the target path within the workspace.
-        let joined = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            self.policy.workspace_root().join(path)
-        };
-        // Create parent directories first (resolve_for_write needs the parent to exist).
-        if let Some(parent) = joined.parent() {
+        // Resolve (and boundary-check) BEFORE creating anything on disk —
+        // resolve_for_write tolerates missing parents, so creating them
+        // first would only manufacture directories for a path that may
+        // then be rejected as outside the workspace.
+        let resolved = self.policy.resolve_for_write(path)?;
+        if let Some(parent) = resolved.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let resolved = self.policy.resolve_for_write(path)?;
         Ok(std::fs::write(resolved, content)?)
     }
 
@@ -131,6 +128,42 @@ mod tests {
         fs.write(&path, b"nested").unwrap();
         assert!(path.exists());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "nested");
+    }
+
+    #[test]
+    fn resolve_for_write_then_write_into_missing_relative_dir() {
+        // The exact WriteFileTool flow that hit BRO-1490 in prod: pre-flight
+        // resolve_for_write on a workspace-relative path whose parent does
+        // not exist yet, then write to the resolved path.
+        let (tmp, fs) = make_fs();
+
+        let resolved = fs
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .expect("resolve_for_write must tolerate a missing parent dir");
+        fs.write(&resolved, b"BRO-1490").unwrap();
+
+        let on_disk = tmp.path().join("artifacts/receipt.txt");
+        assert!(on_disk.exists());
+        assert_eq!(std::fs::read_to_string(on_disk).unwrap(), "BRO-1490");
+    }
+
+    #[test]
+    fn write_outside_workspace_creates_nothing() {
+        // The boundary check must run BEFORE any directory creation: a
+        // rejected write must not leave stray directories behind.
+        let (_tmp, fs) = make_fs();
+        let outside = std::env::temp_dir().join("praxis-localfs-escape-check/sub/file.txt");
+
+        let err = fs.write(&outside, b"nope").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::PraxisError::PathOutsideWorkspace { .. }
+        ));
+        assert!(
+            !std::env::temp_dir()
+                .join("praxis-localfs-escape-check")
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/praxis/praxis-core/src/workspace.rs
+++ b/crates/praxis/praxis-core/src/workspace.rs
@@ -42,22 +42,52 @@ impl FsPolicy {
         Ok(canonical)
     }
 
-    /// Resolve a path for writing. The parent must exist and be within workspace,
-    /// but the file itself may not exist yet.
+    /// Resolve a path for writing. Neither the file nor its parent
+    /// directories need exist yet (BRO-1490: `write_file artifacts/x.txt`
+    /// into a fresh workspace must resolve, not ENOENT): the nearest
+    /// EXISTING ancestor is canonicalized and boundary-checked, then the
+    /// not-yet-existing components are re-appended. Those must be plain
+    /// segments — a `..` (or stray `.`) past the verified prefix cannot be
+    /// canonicalized (nothing to stat) and could escape the workspace once
+    /// the directories are created, so it is rejected.
     pub fn resolve_for_write(&self, candidate: &Path) -> PraxisResult<PathBuf> {
         let joined = if candidate.is_absolute() {
             candidate.to_path_buf()
         } else {
             self.workspace_root.join(candidate)
         };
-        let parent = joined
-            .parent()
-            .ok_or_else(|| PraxisError::PathOutsideWorkspace {
-                path: joined.display().to_string(),
-            })?;
-        let canonical_parent = parent.canonicalize()?;
-        self.ensure_within_root(&canonical_parent)?;
-        Ok(canonical_parent.join(joined.file_name().unwrap()))
+        let outside = || PraxisError::PathOutsideWorkspace {
+            path: joined.display().to_string(),
+        };
+        // `file_name()` is None for paths ending in `..` — reject those
+        // outright rather than guessing what the caller meant to write.
+        let file_name = joined.file_name().ok_or_else(outside)?.to_os_string();
+
+        // Walk up to the nearest existing ancestor, collecting the
+        // not-yet-existing directory components in between.
+        let mut missing: Vec<std::ffi::OsString> = Vec::new();
+        let mut ancestor = joined.parent().ok_or_else(outside)?;
+        while !ancestor.exists() {
+            // None ⇒ the ancestor ends in `..` (traversal through a
+            // non-existing directory) — nothing trustworthy to anchor on.
+            missing.push(ancestor.file_name().ok_or_else(outside)?.to_os_string());
+            ancestor = ancestor.parent().ok_or_else(outside)?;
+        }
+
+        // Canonicalize the existing prefix and enforce the boundary THERE —
+        // before any caller creates the missing directories under it.
+        let canonical = ancestor.canonicalize()?;
+        self.ensure_within_root(&canonical)?;
+
+        let mut resolved = canonical;
+        for component in missing.iter().rev() {
+            if component == ".." || component == "." {
+                return Err(outside());
+            }
+            resolved.push(component);
+        }
+        resolved.push(&file_name);
+        Ok(resolved)
     }
 
     /// Validate that a canonical path is within the workspace root.
@@ -197,5 +227,104 @@ mod tests {
         let policy = FsPolicy::new(dir.path());
         let rel = policy.relative(&file_path).unwrap();
         assert_eq!(rel, PathBuf::from("sub/test.txt"));
+    }
+
+    // ── resolve_for_write with missing parents (BRO-1490) ───────────────
+
+    #[test]
+    fn resolve_for_write_accepts_missing_parent() {
+        // The prod regression: `write_file artifacts/receipt.txt` into a
+        // fresh workspace whose `artifacts/` does not exist yet.
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("artifacts/receipt.txt"));
+        // Resolution must not create anything — that's the writer's job.
+        assert!(!dir.path().join("artifacts").exists());
+    }
+
+    #[test]
+    fn resolve_for_write_accepts_nested_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("a/b/c/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("a/b/c/receipt.txt"));
+    }
+
+    #[test]
+    fn resolve_for_write_existing_parent_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("artifacts")).unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("artifacts/receipt.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("artifacts/receipt.txt"));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_traversal_through_missing_dir() {
+        // `ghost/` does not exist, so the `..` segments after it cannot be
+        // canonicalized — allowing them could escape the workspace once the
+        // directories are created.
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let err = policy
+            .resolve_for_write(Path::new("ghost/../../escape.txt"))
+            .unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_absolute_outside_with_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        // Nearest existing ancestor is the system temp dir — outside the
+        // workspace — so the boundary check must reject it.
+        let outside = std::env::temp_dir().join("praxis-resolve-for-write-nope/sub/file.txt");
+        let err = policy.resolve_for_write(&outside).unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_rejects_trailing_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let err = policy
+            .resolve_for_write(Path::new("artifacts/.."))
+            .unwrap_err();
+        assert!(matches!(err, PraxisError::PathOutsideWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolve_for_write_traversal_within_existing_dirs_still_works() {
+        // `..` through EXISTING directories canonicalizes safely — the
+        // missing-suffix restriction must not break this.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        let policy = FsPolicy::new(dir.path());
+
+        let resolved = policy
+            .resolve_for_write(Path::new("sub/../newdir/file.txt"))
+            .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(resolved, root.join("newdir/file.txt"));
     }
 }

--- a/crates/praxis/praxis-tools/src/fs.rs
+++ b/crates/praxis/praxis-tools/src/fs.rs
@@ -622,6 +622,32 @@ mod tests {
     }
 
     #[test]
+    fn write_file_into_missing_subdirectory() {
+        // BRO-1490 prod regression: the model writes
+        // `artifacts/receipt.txt` into a fresh workspace. The tool's
+        // pre-flight resolve_for_write used to ENOENT on the missing
+        // `artifacts/` parent before LocalFs::write could create it
+        // ("io error: No such file or directory" → mode=Recover).
+        let dir = TempDir::new().unwrap();
+        let fs = make_fs(&dir);
+        let tool = WriteFileTool::new(fs);
+        let ctx = make_ctx();
+
+        let call = make_call(
+            "write_file",
+            json!({"path": "artifacts/receipt.txt", "content": "BRO-1490 receipt"}),
+        );
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert_eq!(result.output["success"], true);
+
+        let on_disk = dir.path().join("artifacts/receipt.txt");
+        assert_eq!(
+            std::fs::read_to_string(on_disk).unwrap(),
+            "BRO-1490 receipt"
+        );
+    }
+
+    #[test]
     fn list_dir_shows_entries() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("a.txt"), "").unwrap();

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1914,10 +1914,14 @@ Current suite validates:
 ### Canonical Tool Execution Engine
 
 - Standalone tool execution and sandbox engine extracted from `arcan-harness`.
-- 4 crates: `praxis-core` (21 tests), `praxis-tools` (24 tests), `praxis-skills` (11 tests), `praxis-mcp` (34 tests).
-- **90 tests total** across all crates.
+- Crates: `praxis-core` (30 tests), `praxis-tools` (34 tests), `praxis-skills` (16 tests), `praxis-mcp-bridge` + `life-praxis` (34 tests).
+- **114 tests total** across all crates.
 - Depends only on `aios-protocol` — no dependency on Arcan, Lago, or Autonomic.
 - Implements canonical `Tool` trait from `aios-protocol::tool`.
+- `FsPolicy::resolve_for_write` resolves paths whose parent directories do
+  not exist yet (nearest-existing-ancestor boundary check; `..`/`.` rejected
+  in the not-yet-existing suffix) — BRO-1490 part 2, #1744. `LocalFs::write`
+  boundary-checks **before** creating parent directories.
 
 ### Components
 

--- a/docs/handoffs/2026-06-12-agent-tools-end-to-end.md
+++ b/docs/handoffs/2026-06-12-agent-tools-end-to-end.md
@@ -1,0 +1,120 @@
+# Agent tools end-to-end — BRO-1490 closed, fresh-session pickup
+
+**TL;DR.** The file-tool write path is **validated end-to-end in prod**:
+chat `write_file` → policy gate → resolve → disk → lago tracking → clean
+tick (receipt 2026-06-12 13:50Z, session `krzw3zpmzm2nfqyqjjfcp2hfge`,
+`file written bytes=27`, tick `mode=Verify`, zero failures). BRO-1490
+turned out to be TWO stacked bugs — the root-owned workspace (#1742) and
+a `resolve_for_write` missing-parent ENOENT (#1744) — both merged and
+live @ `880fd08b`. **FIRST ACTION: BRO-1466/1465 (tool-surface + denial
+wrap-up)** — read the scoping comments on the issues first; a naive
+`tools_allowed_by_policy` wiring would REGRESS the receipt path.
+
+## State of the world (P15 snapshot 2026-06-12 ~09:00 -05)
+
+- **life** (this repo) — `main` @ `880fd08b`. Workspace `riyadh`, branch
+  `agent-tools-end-to-end` (reset onto main between the two PRs; holds
+  only uncommitted docs at handoff time). BRO-1490 **Done** in Linear.
+- **Railway prod (Life project, lifegw-stack)** — deploy `ccb3ec37` @
+  `880fd08b` SUCCESS, healthz OK. Boot receipt:
+  `workspace=/var/life-state/arcan/workspace` (writable, probe green) ·
+  remote lago journal + remote blobs · `substrates=arcan=real lago=real
+  haima=mock anima=mock` · 9 authored agents.
+- **broomva.tech (Vercel, separate repo)** — UNCHANGED and now provably
+  misleading: during the green receipt the UI rendered its own no-tools
+  completion (*"I can't run write_file here…"*) while the substrate
+  executed the tool. BRO-1471 commented with the evidence.
+- **No open PRs, no unresolved review threads.** Local daemons: none.
+
+## What this arc delivered (don't redo it)
+
+| PR | Merge | What it gave |
+|----|-------|--------------|
+| #1742 | `1c279909` | `arcan serve --workspace <DIR>` (env `ARCAN_WORKSPACE_DIR` — `ARCAN_WORKSPACE` was taken by hooks); boot-time writability probe (WARN + remedy); entrypoint §3b creates + chowns `${ARCAN_DATA_DIR}/workspace` (volume-backed) and passes `--workspace`; README updated (incl. stale BRO-1478 note fixed). |
+| #1744 | `880fd08b` | **The actual ENOENT fix**: `FsPolicy::resolve_for_write` now walks to the nearest EXISTING ancestor, boundary-checks there, re-appends missing components (rejects `..`/`.` in the not-yet-existing suffix). `LocalFs::write` resolves BEFORE `create_dir_all` (old order manufactured dirs for unchecked paths). 10 new tests incl. the exact prod regression (`write_file artifacts/receipt.txt` in an empty workspace). |
+
+Receipt: `.context/dogfood-receipt-2026-06-12.md` (riyadh workspace).
+Supersedes: `2026-06-11-agent-tools-end-to-end.md`.
+
+### Why two bugs looked like one
+
+The 02:44Z re-receipt after #1742 failed with the IDENTICAL
+`io error: No such file or directory` — the tool's pre-flight
+`resolve_for_write` canonicalized a parent that must exist
+(`artifacts/` doesn't, in a fresh workspace), failing BEFORE
+`LocalFs::write`'s `create_dir_all`. Tests never caught it because every
+write-tool test writes at the workspace root. The bare `io error:` (no
+`Failed to write file:` prefix) pinned the failing call. Lesson recorded:
+error-prefix forensics beat assumption; the handoff's single-cause
+diagnosis cost one deploy cycle.
+
+## First action — BRO-1466 + BRO-1465 (tool-surface + denial UX)
+
+Read the issue comments FIRST (both have code-verified scoping from this
+arc, 2026-06-11/12):
+
+- **BRO-1466 (tool surface)** — `substrate.rs:394` hardcodes
+  `allowed_tools: None`; `canonical.rs:1462` already derives it.
+  **TRAP**: `tools_allowed_by_policy` counts only BROAD grants
+  (`fs:write:*`), but dispatch sessions get path-scoped
+  `PolicySet::default()` (`fs:write:/session/artifacts/**`, `exec:git`) —
+  wiring it as-is would HIDE write_file and regress the receipt. Fix
+  shape: any-grant-based visibility (gate still enforces scope at
+  execution), then thread at `substrate.rs:394`. Bigger second half:
+  dispatch has NO tier differentiation (every lifed-routed session gets
+  the default policy; tier threading gw→lifed→CreateAgentReq→policy).
+- **BRO-1465 (denial dead-air)** — `aios-runtime/lib.rs:1091-1117`:
+  denial ⇒ `mode=Recover` ⇒ both dispatch loops break with no wrap-up
+  call. Fix shape: ONE wrap-up iteration on Recover (flag-guarded,
+  Recover→Recover breaks), both `substrate.rs` and `canonical.rs`.
+  **Verify first**: does the context compiler render `ToolCallFailed`
+  into provider messages? (If not, the wrap-up call sees nothing.)
+  Related fresh evidence: gpt-5-mini re-called write_file 4× across
+  continuation ticks even on SUCCESS — tool-result legibility in
+  reconstructed history may be weak for the dispatch path generally.
+
+## Pickup state (≤5 open threads)
+
+- [ ] **BRO-1466 / BRO-1465** — first action above. Highest-leverage
+  chat UX; both scoped on the issues.
+- [ ] **BRO-1471 (cross-repo, broomva.tech)** — now urgent-ish: the UI
+  actively contradicts the runtime (renders its own no-tools completion
+  while the substrate executes tools). Flip the client wire (#1697 +
+  #1714 server-side ready) + render TOOL_CALL/TOOL_RESULT frames.
+- [ ] **BRO-1491** — per-session workspace isolation (kernel already
+  threads `manifest.workspace_root` per request; adapter drops it;
+  full design notes + acceptance criteria on the issue). Note the
+  kernel session log now shows per-session
+  `workspace_root=/var/life-state/arcan/sessions/<sid>` — the dirs
+  exist and are writable; only the praxis FsPort rebind is missing.
+- [ ] **Branching client UX** — `branch` wire-ready (#1733); fresh chat
+  could expose a branch selector / fork button.
+- [ ] Backlog (no action): BRO-1480 (blob MIME durability policy),
+  BRO-1481 (same-second same-size edits), Stage 7 (haima/anima real),
+  Topology-A HTTP branch param (`canonical.rs` still `BranchId::main()`).
+
+## Operational notes for the next dogfood
+
+- Browser drivers (claude-in-chrome MCP, Interceptor) lose their native
+  host when Chrome idles overnight. Wake them WITHOUT restarting Chrome:
+  `osascript -e 'tell application "Google Chrome" to open location
+  "<url>"'` — the tab event wakes the MV3 service workers; then
+  `interceptor tabs` works.
+- Receipt greps (lifegw is the one service; lagod logs only boot lines):
+  `railway logs --service lifegw | grep -E "write_file|file written|FileWrite|NOT tracked|Recover|tick finalized"`.
+  Positive signals: `file written bytes=N` + `life.tool.status="ok"` +
+  tick mode ≠ Recover. Silent-failure checks: `NOT tracked` (blob),
+  `failed to append event` (journal) — both must be zero.
+- `dev_signer_enabled = false` in prod lifegw.toml — there is no
+  API-direct token path; the receipt REQUIRES the authed browser.
+
+## Related context
+
+- Receipt: `.context/dogfood-receipt-2026-06-12.md` (riyadh)
+- Prior arc: `docs/handoffs/2026-06-11-agent-tools-end-to-end.md`
+  (superseded), `2026-06-11-lago-fs-substrate-and-branching.md` (Stage 5)
+- Linear: BRO-1490 (Done) · BRO-1491 (new) · BRO-1465/1466/1471
+  (scoping comments) · BRO-1479/1480/1481
+- Key code: `capability_map.rs` (tool surface), `substrate.rs:394`
+  (dispatch allowed_tools), `aios-runtime/lib.rs:1091` (denial path),
+  `praxis-core/src/workspace.rs` (resolve_for_write)


### PR DESCRIPTION
## What

- **New handoff** `docs/handoffs/2026-06-12-agent-tools-end-to-end.md` — supersedes the 2026-06-11 one. Contains: the green receipt chain (session `krzw3zpmzm2nfqyqjjfcp2hfge`, `file written bytes=27`, tick `mode=Verify`), the two-stacked-bugs post-mortem (#1742 workspace + #1744 resolve_for_write), the scoped first action (BRO-1466/1465 — including the `tools_allowed_by_policy` broad-vs-scoped-grant trap that would regress the receipt if wired naively), browser-driver wake procedure, and the receipt grep cookbook.
- **STATUS.md** — praxis test counts refreshed (114 total: praxis-core 30, praxis-tools 34, praxis-skills 16, mcp-bridge+life-praxis 34; crate rename praxis-mcp → praxis-mcp-bridge reflected) + the new `resolve_for_write` contract documented.

## Receipt (prod, 2026-06-12 13:50Z, deploy `ccb3ec37` @ `880fd08b`)

```
session created  workspace_root=/var/life-state/arcan/sessions/krzw3zpmzm2nfqyqjjfcp2hfge
tick objective_len=103  finish_reasons="tool_calls"
praxis.fs{operation="write" path=artifacts/receipt.txt}: file written bytes=27  life.tool.status="ok"
tool execution completed write_file exit_status=0 mode=Execute file_mutations=1
tick finalized mode=Verify     ← NOT Recover
```

Zero `tool execution failed` / `capabilities denied` / `NOT tracked` / `failed to append event`.

BRO-1490 → Done in Linear (receipt comment). Follow-ups filed: BRO-1491 (per-session isolation, design notes), comments on BRO-1465/1466/1471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)