### PR TITLE
feat(kernel): tool transcript in history + Recover wrap-up + any-grant tool surface (BRO-1465, BRO-1466)

### DIFF
--- a/crates/aios/aios-runtime/src/lib.rs
+++ b/crates/aios/aios-runtime/src/lib.rs
@@ -609,6 +609,18 @@ impl KernelRuntime {
             .collect()
     }
 
+    /// The [`PolicySet`] a session was created with, deserialized from its
+    /// manifest. `None` when the session is unknown or its stored policy
+    /// JSON no longer matches the current `PolicySet` shape — callers must
+    /// treat `None` as "no policy-derived restriction available", never as
+    /// "allow everything was granted" (BRO-1466: drives tool VISIBILITY
+    /// only; the policy gate keeps enforcing at execution time either way).
+    pub fn session_policy(&self, session_id: &SessionId) -> Option<PolicySet> {
+        let sessions = self.sessions.lock();
+        let state = sessions.get(session_id.as_str())?;
+        serde_json::from_value(state.manifest.policy.clone()).ok()
+    }
+
     pub fn root_path(&self) -> &Path {
         &self.config.root
     }
@@ -1634,11 +1646,16 @@ impl KernelRuntime {
 
     /// Build conversation history from the session's event journal.
     ///
-    /// Reads prior events and extracts user objectives (from `DeliberationProposed`)
-    /// and assistant responses (from `Message` with role=assistant, or aggregated
-    /// `TextDelta` events). Returns a list of `ConversationTurn` entries in
-    /// chronological order, capped at the most recent 50 turns to avoid
-    /// context overflow.
+    /// Reads prior events and extracts user objectives (from `DeliberationProposed`),
+    /// assistant responses (from `Message` with role=assistant, or aggregated
+    /// `TextDelta` events), and the **tool transcript** (`ToolCallRequested` /
+    /// `ToolCallCompleted` / `ToolCallFailed`, rendered as bracketed lines inside
+    /// the assistant turn). Without the transcript the model has no evidence its
+    /// tools ever ran: observed live (BRO-1465 receipt, 2026-06-12) as gpt-5-mini
+    /// re-calling a SUCCESSFUL `write_file` on every continuation tick, and as
+    /// denial dead-air (a wrap-up call could not see `ToolCallFailed`).
+    /// Returns a list of `ConversationTurn` entries in chronological order,
+    /// capped at the most recent 50 turns to avoid context overflow.
     async fn build_conversation_history(
         &self,
         session_id: &SessionId,
@@ -1681,6 +1698,59 @@ impl KernelRuntime {
                 }
                 EventKind::TextDelta { delta, .. } => {
                     current_assistant_text.push_str(delta);
+                }
+                EventKind::ToolCallRequested {
+                    tool_name,
+                    arguments,
+                    category,
+                    ..
+                } => {
+                    // Client-category calls are handed back to the chat client;
+                    // their results return as ordinary conversation turns on the
+                    // next dispatch, so rendering them here would duplicate them.
+                    if category.as_deref() != Some("client") {
+                        append_tool_line(
+                            &mut current_assistant_text,
+                            &format!(
+                                "[tool_call {tool_name}({})]",
+                                truncate_for_history(
+                                    &arguments.to_string(),
+                                    TOOL_ARGS_HISTORY_BUDGET
+                                )
+                            ),
+                        );
+                    }
+                }
+                EventKind::ToolCallCompleted {
+                    tool_name,
+                    result,
+                    status,
+                    ..
+                } => {
+                    let status_label = match status {
+                        SpanStatus::Ok => "ok",
+                        SpanStatus::Error => "error",
+                        SpanStatus::Timeout => "timeout",
+                        SpanStatus::Cancelled => "cancelled",
+                    };
+                    append_tool_line(
+                        &mut current_assistant_text,
+                        &format!(
+                            "[tool_result {tool_name} {status_label}: {}]",
+                            truncate_for_history(&result.to_string(), TOOL_RESULT_HISTORY_BUDGET)
+                        ),
+                    );
+                }
+                EventKind::ToolCallFailed {
+                    tool_name, error, ..
+                } => {
+                    append_tool_line(
+                        &mut current_assistant_text,
+                        &format!(
+                            "[tool_result {tool_name} failed: {}]",
+                            truncate_for_history(error, TOOL_RESULT_HISTORY_BUDGET)
+                        ),
+                    );
                 }
                 EventKind::RunFinished { final_answer, .. } => {
                     // If we have a final answer and no accumulated text, use it.
@@ -2440,6 +2510,35 @@ impl KernelRuntime {
 fn sha256_json<T: Serialize>(value: &T) -> Result<String> {
     let payload = serde_json::to_vec(value)?;
     Ok(sha256_bytes(&payload))
+}
+
+/// Character budget for tool-call ARGUMENTS rendered into conversation
+/// history (`build_conversation_history`). Arguments can carry whole file
+/// bodies (`write_file.content`) — the model only needs enough to recognize
+/// what it already did.
+const TOOL_ARGS_HISTORY_BUDGET: usize = 600;
+
+/// Character budget for tool RESULTS rendered into conversation history.
+/// Results can be large (`read_file` returns hashline content for the whole
+/// file); the transcript exists so the model knows the call happened and how
+/// it ended, not to replay full payloads.
+const TOOL_RESULT_HISTORY_BUDGET: usize = 1200;
+
+/// Append a bracketed tool-transcript line to the in-progress assistant turn.
+fn append_tool_line(buffer: &mut String, line: &str) {
+    if !buffer.is_empty() {
+        buffer.push('\n');
+    }
+    buffer.push_str(line);
+}
+
+/// Truncate to `max_chars` characters (UTF-8 boundary safe), marking elision.
+fn truncate_for_history(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_owned();
+    }
+    let cut: String = text.chars().take(max_chars).collect();
+    format!("{cut}… (truncated)")
 }
 
 /// Write the current OTel trace context (trace_id, span_id) into an EventRecord.

--- a/crates/aios/aios-runtime/tests/tool_history.rs
+++ b/crates/aios/aios-runtime/tests/tool_history.rs
@@ -1,0 +1,431 @@
+//! Tool-transcript rendering in conversation history (BRO-1465).
+//!
+//! `build_conversation_history` must render registry tool activity —
+//! `ToolCallRequested` / `ToolCallCompleted` / `ToolCallFailed` — into the
+//! assistant turns of the reconstructed history. Without it the model has
+//! no evidence its tools ever ran, observed live (2026-06-12 receipt) as:
+//!
+//! * gpt-5-mini re-calling a SUCCESSFUL `write_file` on every continuation
+//!   tick (it could not see the result), and
+//! * denial dead-air — a post-`Recover` wrap-up call had nothing to
+//!   verbalize because `ToolCallFailed` never reached the prompt.
+//!
+//! Contract under test:
+//! 1. After a successful registry tool call, the NEXT tick's
+//!    `ModelCompletionRequest.conversation_history` contains
+//!    `[tool_call <name>(<args>)]` and `[tool_result <name> ok: …]`.
+//! 2. Oversized results are truncated with an elision marker.
+//! 3. After a policy denial, the next tick's history contains
+//!    `[tool_result <name> failed: capabilities denied…]`.
+//! 4. Client-category tool calls are NOT transcribed (their results return
+//!    as ordinary conversation turns on the next dispatch).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use aios_protocol::{
+    ApprovalId, ApprovalPort, ApprovalRequest, ApprovalResolution, ApprovalTicket, BranchId,
+    Capability, ClientToolDefinition, EventRecord, EventRecordStream, EventStorePort, KernelResult,
+    ModelCompletion, ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelRouting,
+    ModelStopReason, PolicyGateDecision, PolicyGatePort, PolicySet, SessionId, ToolCall,
+    ToolExecutionReport, ToolExecutionRequest, ToolHarnessPort, ToolOutcome, ToolRunId,
+};
+use aios_runtime::{KernelRuntime, RuntimeConfig, TickInput, TickKind};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+// ── In-memory event store ─────────────────────────────────────────────
+
+#[derive(Default)]
+struct MemEventStore {
+    events: Mutex<Vec<EventRecord>>,
+}
+
+#[async_trait]
+impl EventStorePort for MemEventStore {
+    async fn append(&self, event: EventRecord) -> KernelResult<EventRecord> {
+        self.events.lock().push(event.clone());
+        Ok(event)
+    }
+
+    async fn read(
+        &self,
+        session_id: SessionId,
+        branch_id: BranchId,
+        from_sequence: u64,
+        limit: usize,
+    ) -> KernelResult<Vec<EventRecord>> {
+        let events = self.events.lock();
+        Ok(events
+            .iter()
+            .filter(|e| {
+                e.session_id == session_id
+                    && e.branch_id == branch_id
+                    && e.sequence >= from_sequence
+            })
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    async fn head(&self, session_id: SessionId, branch_id: BranchId) -> KernelResult<u64> {
+        let events = self.events.lock();
+        Ok(events
+            .iter()
+            .filter(|e| e.session_id == session_id && e.branch_id == branch_id)
+            .map(|e| e.sequence)
+            .max()
+            .unwrap_or(0))
+    }
+
+    async fn subscribe(
+        &self,
+        _session_id: SessionId,
+        _branch_id: BranchId,
+        _after_sequence: u64,
+    ) -> KernelResult<EventRecordStream> {
+        Ok(Box::pin(futures_util::stream::empty()))
+    }
+}
+
+// ── History-recording provider ────────────────────────────────────────
+//
+// Records `conversation_history` of every request. The first completion
+// proposes one tool call (registry or client per the test); subsequent
+// completions answer plainly so loops terminate.
+
+struct HistoryProvider {
+    propose_tool: Option<ToolCall>,
+    histories: Mutex<Vec<Vec<aios_protocol::ConversationTurn>>>,
+    answered: AtomicBool,
+}
+
+impl HistoryProvider {
+    fn proposing(call: ToolCall) -> Self {
+        Self {
+            propose_tool: Some(call),
+            histories: Mutex::new(Vec::new()),
+            answered: AtomicBool::new(false),
+        }
+    }
+
+    /// All assistant-turn content seen by request `index`, joined.
+    fn assistant_text_at(&self, index: usize) -> String {
+        self.histories.lock()[index]
+            .iter()
+            .filter(|t| t.role == "assistant")
+            .map(|t| t.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn request_count(&self) -> usize {
+        self.histories.lock().len()
+    }
+}
+
+#[async_trait]
+impl ModelProviderPort for HistoryProvider {
+    async fn complete(&self, request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        self.histories
+            .lock()
+            .push(request.conversation_history.clone());
+
+        let first = !self.answered.swap(true, Ordering::SeqCst);
+        if first && let Some(call) = self.propose_tool.clone() {
+            return Ok(ModelCompletion {
+                provider: "scripted".to_owned(),
+                model: "scripted-deterministic".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::ToolCall { call }],
+                stop_reason: ModelStopReason::ToolCall,
+                usage: None,
+                final_answer: None,
+            });
+        }
+
+        Ok(ModelCompletion {
+            provider: "scripted".to_owned(),
+            model: "scripted-deterministic".to_owned(),
+            llm_call_record: None,
+            directives: vec![ModelDirective::Message {
+                role: "assistant".to_owned(),
+                content: "done".to_owned(),
+            }],
+            stop_reason: ModelStopReason::Completed,
+            usage: None,
+            final_answer: Some("done".to_owned()),
+        })
+    }
+}
+
+// ── Harness with configurable result size ─────────────────────────────
+
+struct SizedResultHarness {
+    result_payload: serde_json::Value,
+}
+
+#[async_trait]
+impl ToolHarnessPort for SizedResultHarness {
+    async fn execute(&self, request: ToolExecutionRequest) -> KernelResult<ToolExecutionReport> {
+        Ok(ToolExecutionReport {
+            tool_run_id: ToolRunId::default(),
+            call_id: request.call.call_id.clone(),
+            tool_name: request.call.tool_name.clone(),
+            exit_status: 0,
+            duration_ms: 0,
+            outcome: ToolOutcome::Success {
+                output: self.result_payload.clone(),
+            },
+        })
+    }
+}
+
+// ── Policy gate: allow-all or deny-all ────────────────────────────────
+
+struct StaticGate {
+    deny_all: bool,
+}
+
+#[async_trait]
+impl PolicyGatePort for StaticGate {
+    async fn evaluate(
+        &self,
+        _session_id: SessionId,
+        requested: Vec<Capability>,
+    ) -> KernelResult<PolicyGateDecision> {
+        if self.deny_all {
+            return Ok(PolicyGateDecision {
+                allowed: Vec::new(),
+                requires_approval: Vec::new(),
+                denied: requested,
+            });
+        }
+        Ok(PolicyGateDecision {
+            allowed: requested,
+            requires_approval: Vec::new(),
+            denied: Vec::new(),
+        })
+    }
+}
+
+// ── No-op approvals ───────────────────────────────────────────────────
+
+#[derive(Default)]
+struct NoopApprovals;
+
+#[async_trait]
+impl ApprovalPort for NoopApprovals {
+    async fn enqueue(&self, request: ApprovalRequest) -> KernelResult<ApprovalTicket> {
+        Ok(ApprovalTicket {
+            approval_id: ApprovalId::default(),
+            session_id: request.session_id,
+            call_id: request.call_id,
+            tool_name: request.tool_name,
+            capability: request.capability,
+            reason: request.reason,
+            created_at: chrono::Utc::now(),
+        })
+    }
+
+    async fn list_pending(&self, _session_id: SessionId) -> KernelResult<Vec<ApprovalTicket>> {
+        Ok(Vec::new())
+    }
+
+    async fn resolve(
+        &self,
+        approval_id: ApprovalId,
+        approved: bool,
+        actor: String,
+    ) -> KernelResult<ApprovalResolution> {
+        Ok(ApprovalResolution {
+            approval_id,
+            approved,
+            actor,
+            resolved_at: chrono::Utc::now(),
+        })
+    }
+}
+
+// ── Wiring ────────────────────────────────────────────────────────────
+
+fn registry_call(tool_name: &str) -> ToolCall {
+    ToolCall {
+        call_id: "call-0".to_owned(),
+        tool_name: tool_name.to_owned(),
+        input: serde_json::json!({ "path": "artifacts/receipt.txt", "content": "hi" }),
+        requested_capabilities: vec![Capability::fs_write("/session/artifacts/**")],
+    }
+}
+
+fn build_runtime(
+    provider: HistoryProvider,
+    harness_result: serde_json::Value,
+    deny_all: bool,
+) -> (KernelRuntime, Arc<HistoryProvider>) {
+    let root = std::env::temp_dir().join(format!(
+        "aios-runtime-tool-history-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let provider = Arc::new(provider);
+
+    let runtime = KernelRuntime::new(
+        RuntimeConfig::new(root),
+        Arc::new(MemEventStore::default()) as Arc<dyn EventStorePort>,
+        provider.clone() as Arc<dyn ModelProviderPort>,
+        Arc::new(SizedResultHarness {
+            result_payload: harness_result,
+        }) as Arc<dyn ToolHarnessPort>,
+        Arc::new(NoopApprovals) as Arc<dyn ApprovalPort>,
+        Arc::new(StaticGate { deny_all }) as Arc<dyn PolicyGatePort>,
+    )
+    .with_registry_tool_names(vec!["write_file"]);
+
+    (runtime, provider)
+}
+
+async fn tick(
+    runtime: &KernelRuntime,
+    session: &SessionId,
+    objective: &str,
+    client_tools: Vec<ClientToolDefinition>,
+) {
+    runtime
+        .tick_on_branch(
+            session,
+            &BranchId::main(),
+            TickInput {
+                objective: objective.to_owned(),
+                proposed_tool: None,
+                system_prompt: None,
+                allowed_tools: None,
+                client_tools,
+                kind: TickKind::Direct,
+            },
+        )
+        .await
+        .expect("tick");
+}
+
+async fn new_session(runtime: &KernelRuntime) -> SessionId {
+    let session = SessionId::default();
+    runtime
+        .create_session_with_id(
+            session.clone(),
+            "tool-history-test",
+            PolicySet::default(),
+            ModelRouting::default(),
+        )
+        .await
+        .expect("create session");
+    session
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn successful_tool_call_renders_transcript_in_next_tick_history() {
+    let (runtime, provider) = build_runtime(
+        HistoryProvider::proposing(registry_call("write_file")),
+        serde_json::json!({ "success": true, "path": "artifacts/receipt.txt" }),
+        false,
+    );
+    let session = new_session(&runtime).await;
+
+    tick(&runtime, &session, "create the receipt file", Vec::new()).await;
+    tick(&runtime, &session, "", Vec::new()).await;
+
+    assert_eq!(provider.request_count(), 2);
+    let history_text = provider.assistant_text_at(1);
+    assert!(
+        history_text.contains("[tool_call write_file("),
+        "second request must show the tool call; got: {history_text}"
+    );
+    assert!(
+        history_text.contains("[tool_result write_file ok:"),
+        "second request must show the tool result; got: {history_text}"
+    );
+    assert!(
+        history_text.contains("artifacts/receipt.txt"),
+        "result payload (path) must be visible for dedup awareness; got: {history_text}"
+    );
+}
+
+#[tokio::test]
+async fn oversized_tool_result_is_truncated_in_history() {
+    let big = "x".repeat(5000);
+    let (runtime, provider) = build_runtime(
+        HistoryProvider::proposing(registry_call("write_file")),
+        serde_json::json!({ "success": true, "blob": big }),
+        false,
+    );
+    let session = new_session(&runtime).await;
+
+    tick(&runtime, &session, "create it", Vec::new()).await;
+    tick(&runtime, &session, "", Vec::new()).await;
+
+    let history_text = provider.assistant_text_at(1);
+    assert!(
+        history_text.contains("(truncated)"),
+        "oversized result must carry the elision marker; got len {}",
+        history_text.len()
+    );
+    // Budget is 1200 chars for the result body — the rendered turn must be
+    // bounded well below the raw 5000-char payload.
+    assert!(
+        history_text.len() < 3000,
+        "rendered history must be bounded; got len {}",
+        history_text.len()
+    );
+}
+
+#[tokio::test]
+async fn denied_tool_call_renders_failure_in_next_tick_history() {
+    let (runtime, provider) = build_runtime(
+        HistoryProvider::proposing(registry_call("write_file")),
+        serde_json::json!({ "unused": true }),
+        true, // deny_all
+    );
+    let session = new_session(&runtime).await;
+
+    tick(&runtime, &session, "create the receipt file", Vec::new()).await;
+    tick(&runtime, &session, "", Vec::new()).await;
+
+    let history_text = provider.assistant_text_at(1);
+    assert!(
+        history_text.contains("[tool_result write_file failed: capabilities denied"),
+        "wrap-up call must see the denial; got: {history_text}"
+    );
+}
+
+#[tokio::test]
+async fn client_tool_calls_are_not_transcribed() {
+    // Propose a CLIENT tool (not in the registry; declared via TickInput).
+    let client_call = ToolCall {
+        call_id: "call-c".to_owned(),
+        tool_name: "web_search".to_owned(),
+        input: serde_json::json!({ "q": "berlin" }),
+        requested_capabilities: Vec::new(),
+    };
+    let (runtime, provider) = build_runtime(
+        HistoryProvider::proposing(client_call),
+        serde_json::json!({ "unused": true }),
+        false,
+    );
+    let session = new_session(&runtime).await;
+
+    let client_tools = vec![ClientToolDefinition {
+        name: "web_search".to_owned(),
+        description: "client web search".to_owned(),
+        parameters: serde_json::json!({ "type": "object" }),
+    }];
+    tick(&runtime, &session, "search berlin", client_tools.clone()).await;
+    tick(&runtime, &session, "", client_tools).await;
+
+    let history_text = provider.assistant_text_at(1);
+    assert!(
+        !history_text.contains("[tool_call web_search"),
+        "client-category calls must not be transcribed (their results return \
+         as conversation turns on the next dispatch); got: {history_text}"
+    );
+}

--- a/crates/arcan/arcan-aios-adapters/src/capability_map.rs
+++ b/crates/arcan/arcan-aios-adapters/src/capability_map.rs
@@ -176,14 +176,26 @@ pub fn tools_allowed_by_policy(
         return None;
     }
 
-    // Determine which high-privilege capability categories are broadly granted.
-    let exec_allowed = broadly_allows_category(allow, "exec:cmd:");
-    let fs_write_allowed = broadly_allows_category(allow, "fs:write:");
-
-    // If both are broadly allowed there is no useful filtering to apply.
-    if exec_allowed && fs_write_allowed {
+    // If both high-privilege categories are BROADLY granted there is no
+    // useful filtering to apply.
+    if broadly_allows_category(allow, "exec:cmd:") && broadly_allows_category(allow, "fs:write:") {
         return None;
     }
+
+    // Visibility is ANY-grant based (BRO-1466): a path-scoped grant like
+    // `fs:write:/session/artifacts/**` (the default policy) or a shell
+    // whitelist entry like `exec:cmd:cat` (the free tier) means the tool IS
+    // usable — the policy gate still enforces the path/binary scope at
+    // execution time. The previous broad-grant-only rule hid `write_file`
+    // from sessions whose policy explicitly permits artifact writes (live
+    // receipt 2026-06-12, BRO-1490) and hid `bash` from free-tier sessions
+    // whose whitelist allows `cat`/`ls`/`grep`/…. Gated-but-not-allowed
+    // capabilities (e.g. free's `fs:write:**` in `gate_capabilities`)
+    // deliberately do NOT count: until the dispatch path renders the
+    // approval flow, a tool that silently parks the turn in AskHuman is
+    // worse chat UX than a hidden one.
+    let exec_allowed = allows_category(allow, "exec:cmd:");
+    let fs_write_allowed = allows_category(allow, "fs:write:");
 
     // Safe tools — always visible regardless of tier (require only fs:read or
     // no capability at all).
@@ -255,6 +267,19 @@ fn requires_privilege(tool_name: &str) -> bool {
             | "read_env"
             | "get_credential"
     )
+}
+
+/// Returns `true` if ANY pattern in `allow` grants something inside
+/// `category` — broad (`exec:cmd:*`), scoped (`fs:write:/session/…/**`), or
+/// single (`exec:cmd:git`). The full wildcard counts for every category.
+///
+/// This drives tool VISIBILITY only; the policy gate still enforces the
+/// exact path/binary scope at execution time (BRO-1466).
+fn allows_category(allow: &[Capability], category: &str) -> bool {
+    allow.iter().any(|cap| {
+        let s = cap.as_str();
+        s == "*" || s.starts_with(category)
+    })
 }
 
 /// Returns `true` if `allow` contains a wildcard pattern that broadly covers
@@ -498,10 +523,18 @@ mod tests {
     }
 
     #[test]
-    fn free_policy_blocks_bash_and_write_tools() {
+    fn free_policy_exposes_whitelisted_bash_hides_write_tools() {
+        // free() grants a shell whitelist (exec:cmd:cat/ls/grep/…) — bash
+        // must be VISIBLE (the gate enforces the whitelist per binary at
+        // execution time). fs:write:** is only GATED (approval), not
+        // allowed, so write tools stay hidden until the dispatch path
+        // renders the approval flow (BRO-1466).
         let policy = PolicySet::free();
         let allowed = tools_allowed_by_policy(&policy, None).expect("should restrict");
-        assert!(!allowed.contains(&"bash".to_owned()));
+        assert!(
+            allowed.contains(&"bash".to_owned()),
+            "bash visible — the free tier explicitly whitelists shell commands"
+        );
         assert!(!allowed.contains(&"write_file".to_owned()));
         assert!(!allowed.contains(&"edit_file".to_owned()));
         // read tools still visible
@@ -524,19 +557,53 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_blocks_bash_restricts_writes() {
-        // default() allows exec:git (not exec:cmd:*) and fs:write:/session/artifacts/**
-        // (not broadly fs:write:*) — so bash and write tools should be hidden.
+    fn default_policy_exposes_scoped_write_and_exec_tools() {
+        // default() allows exec:cmd:git and fs:write:/session/artifacts/** —
+        // SCOPED grants. The tools must be VISIBLE (the gate enforces the
+        // git-only / artifacts-only scope at execution time); hiding them
+        // regressed the chat write receipt (BRO-1490/BRO-1466, 2026-06-12).
+        // The catalog is still restricted (Some, not None): nothing grants
+        // net or secrets, so those tool families stay hidden.
         let policy = PolicySet::default();
         let allowed = tools_allowed_by_policy(&policy, None).expect("should restrict");
         assert!(
-            !allowed.contains(&"bash".to_owned()),
-            "bash hidden (only exec:git allowed)"
+            allowed.contains(&"bash".to_owned()),
+            "bash visible — exec:cmd:git is a usable grant"
         );
         assert!(
-            !allowed.contains(&"write_file".to_owned()),
-            "write_file hidden (only /session/artifacts/** allowed)"
+            allowed.contains(&"write_file".to_owned()),
+            "write_file visible — /session/artifacts/** is a usable grant"
         );
+        assert!(
+            allowed.contains(&"edit_file".to_owned()),
+            "edit_file rides the same fs:write grant"
+        );
+        assert!(
+            !allowed.contains(&"web_search".to_owned()),
+            "no net grant — net tools stay hidden"
+        );
+        assert!(
+            !allowed.contains(&"get_secret".to_owned()),
+            "no secrets grant — secrets tools stay hidden"
+        );
+    }
+
+    #[test]
+    fn allows_category_matches_scoped_single_and_broad_grants() {
+        let scoped = vec![Capability::new("fs:write:/session/artifacts/**")];
+        assert!(allows_category(&scoped, "fs:write:"));
+        assert!(!allows_category(&scoped, "exec:cmd:"));
+
+        let single = vec![Capability::new("exec:cmd:git")];
+        assert!(allows_category(&single, "exec:cmd:"));
+        assert!(!allows_category(&single, "fs:write:"));
+
+        let broad = vec![Capability::new("exec:cmd:*")];
+        assert!(allows_category(&broad, "exec:cmd:"));
+
+        let wildcard = vec![Capability::new("*")];
+        assert!(allows_category(&wildcard, "fs:write:"));
+        assert!(allows_category(&wildcard, "exec:cmd:"));
     }
 
     #[test]

--- a/crates/arcan/arcand/src/canonical.rs
+++ b/crates/arcan/arcand/src/canonical.rs
@@ -1831,33 +1831,42 @@ async fn run_session(
 
     // Continue ticking if the agent executed tools and needs to call the LLM
     // again with tool results (mode=Execute means tools ran, needs continuation).
+    // BRO-1465: a Recover tick (tool denial / execution failure) also gets ONE
+    // continuation — the failure is rendered into conversation history (the
+    // kernel's tool transcript), so the wrap-up call verbalizes what happened
+    // instead of ending the turn as dead air. The flag caps Recover→Recover
+    // chains at a single wrap-up.
+    let mut recover_wrapup_used = false;
     for iteration in 1..MAX_AGENT_ITERATIONS {
-        match &tick_result {
-            Ok(tick) if tick.mode == OperatingMode::Execute => {
-                tracing::info!(
-                    iteration,
-                    mode = ?tick.mode,
-                    "Agent loop: continuing after tool execution"
-                );
-                tick_result = state
-                    .runtime
-                    .tick_on_branch(
-                        &session_id,
-                        &branch,
-                        TickInput {
-                            objective: String::new(), // continuation — no new objective
-                            proposed_tool: None,
-                            system_prompt: system_prompt.clone(),
-                            allowed_tools: combined_allowed_tools.clone(),
-                            client_tools: Vec::new(),
-                            kind: aios_runtime::TickKind::Direct,
-                        },
-                    )
-                    .instrument(agent_span.clone())
-                    .await;
+        let continue_reason = match &tick_result {
+            Ok(tick) if tick.mode == OperatingMode::Execute => "tool execution",
+            Ok(tick) if tick.mode == OperatingMode::Recover && !recover_wrapup_used => {
+                recover_wrapup_used = true;
+                "recover wrap-up (BRO-1465)"
             }
-            _ => break, // Done, error, or non-Execute mode
-        }
+            _ => break, // Done, error, or non-continuable mode
+        };
+        tracing::info!(
+            iteration,
+            reason = continue_reason,
+            "Agent loop: continuing"
+        );
+        tick_result = state
+            .runtime
+            .tick_on_branch(
+                &session_id,
+                &branch,
+                TickInput {
+                    objective: String::new(), // continuation — no new objective
+                    proposed_tool: None,
+                    system_prompt: system_prompt.clone(),
+                    allowed_tools: combined_allowed_tools.clone(),
+                    client_tools: Vec::new(),
+                    kind: aios_runtime::TickKind::Direct,
+                },
+            )
+            .instrument(agent_span.clone())
+            .await;
     }
 
     // Always unmark after tick completes (success or error) to avoid leaking the

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -200,6 +200,16 @@ impl AgentSubstrate for SubstrateService {
 
         let runtime = Arc::clone(&self.runtime);
 
+        // BRO-1466: derive the tier tool surface from the session's policy
+        // so the model only sees tools it can actually use. Visibility is a
+        // pre-filter (any-grant based — see `tools_allowed_by_policy`); the
+        // policy gate remains the authoritative enforcement at execution
+        // time. `None` (unknown session policy, or a fully-permissive one)
+        // ⇒ the full catalog, exactly as before this wiring.
+        let allowed_tools = runtime
+            .session_policy(&session_id)
+            .and_then(|policy| arcan_aios_adapters::tools_allowed_by_policy(&policy, None));
+
         // Auto-fork semantics (BRO-1479): the kernel requires a branch to
         // EXIST before any tick can sequence events onto it
         // (`next_sequence` bails "branch not found"). Sessions are born
@@ -381,6 +391,14 @@ impl AgentSubstrate for SubstrateService {
             // tool results and can respond (mirrors
             // `canonical.rs::run_session`).
             let mut errored = false;
+            // BRO-1465: a tick that finalizes `Recover` (tool denial or
+            // execution failure) used to END the dispatch here — the model
+            // never got a call after the failure event, so the user saw
+            // dead air. Grant ONE wrap-up iteration per dispatch: the
+            // failure is rendered into conversation history (the kernel's
+            // tool transcript), so the follow-up call can verbalize what
+            // happened. The flag caps Recover→Recover chains at one.
+            let mut recover_wrapup_used = false;
             for iteration in 0..MAX_AGENT_ITERATIONS {
                 let objective = if iteration == 0 {
                     content.clone()
@@ -391,7 +409,10 @@ impl AgentSubstrate for SubstrateService {
                     objective,
                     proposed_tool: None,
                     system_prompt: None,
-                    allowed_tools: None,
+                    // Tier tool surface derived from the session policy
+                    // (BRO-1466) — pre-filter only; the gate still
+                    // enforces scope at execution time.
+                    allowed_tools: allowed_tools.clone(),
                     // Surfaced on every tick of this dispatch so the model
                     // keeps seeing the client tools across the multi-tick
                     // loop (e.g. a registry tool runs, then the model
@@ -406,9 +427,15 @@ impl AgentSubstrate for SubstrateService {
                     Ok(output) => {
                         // Continue the loop only when the model executed
                         // tools and needs another call to see their
-                        // results — same predicate as the HTTP path.
-                        if !matches!(output.mode, OperatingMode::Execute) {
-                            break;
+                        // results (same predicate as the HTTP path) — or
+                        // ONCE after a Recover, so the failure gets a
+                        // verbal wrap-up instead of dead air (BRO-1465).
+                        match output.mode {
+                            OperatingMode::Execute => {}
+                            OperatingMode::Recover if !recover_wrapup_used => {
+                                recover_wrapup_used = true;
+                            }
+                            _ => break,
                         }
                     }
                     Err(e) => {

--- a/crates/arcan/arcand/tests/canonical_api.rs
+++ b/crates/arcan/arcand/tests/canonical_api.rs
@@ -1,14 +1,14 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aios_events::{EventJournal, EventStreamHub, FileEventStore};
 use aios_policy::{ApprovalQueue, SessionPolicyEngine};
 use aios_protocol::{
-    AgentId, AgentIdentityProvider, ApprovalPort, EventStorePort, KernelResult, ModelCompletion,
-    ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort,
-    PolicySet, SoulProfile, ToolHarnessPort,
+    AgentId, AgentIdentityProvider, ApprovalPort, Capability, EventStorePort, KernelResult,
+    ModelCompletion, ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelStopReason,
+    PolicyGatePort, PolicySet, SoulProfile, ToolCall, ToolHarnessPort,
 };
 use aios_runtime::{KernelRuntime, RuntimeConfig};
 use aios_sandbox::LocalSandboxRunner;
@@ -282,6 +282,129 @@ async fn canonical_session_api_round_trip() {
         .unwrap_or_default();
     assert!(branch_ids.iter().any(|branch| branch == "main"));
     assert!(branch_ids.iter().any(|branch| branch == "feature-api"));
+
+    server.abort();
+}
+
+/// Proposes a policy-DENIED tool on the first completion, answers with text
+/// on every later completion — the wrap-up the model gives once it sees the
+/// `[tool_result … failed: capabilities denied…]` transcript line.
+#[derive(Debug, Default)]
+struct DeniedToolThenAnswerProvider {
+    answered: AtomicBool,
+}
+
+#[async_trait]
+impl ModelProviderPort for DeniedToolThenAnswerProvider {
+    async fn complete(&self, _request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        let first = !self.answered.swap(true, Ordering::SeqCst);
+        if first {
+            return Ok(ModelCompletion {
+                provider: "test".to_owned(),
+                model: "test-model".to_owned(),
+                llm_call_record: None,
+                directives: vec![ModelDirective::ToolCall {
+                    call: ToolCall {
+                        call_id: "call-denied".to_owned(),
+                        tool_name: "fetch_url".to_owned(),
+                        input: json!({ "url": "https://example.com" }),
+                        // Neither allowed nor gated by PolicySet::default()
+                        // → the gate denies immediately (BRO-216).
+                        requested_capabilities: vec![Capability::new("net:egress:example.com")],
+                    },
+                }],
+                stop_reason: ModelStopReason::ToolCall,
+                usage: None,
+                final_answer: None,
+            });
+        }
+        Ok(ModelCompletion {
+            provider: "test".to_owned(),
+            model: "test-model".to_owned(),
+            llm_call_record: None,
+            directives: vec![ModelDirective::Message {
+                role: "assistant".to_owned(),
+                content: "I could not fetch that URL — network egress is denied by policy."
+                    .to_owned(),
+            }],
+            stop_reason: ModelStopReason::Completed,
+            usage: None,
+            final_answer: Some("fetch denied by policy".to_owned()),
+        })
+    }
+}
+
+/// BRO-1465: a policy-denied tool call must NOT end the run as dead air.
+/// The agent loop grants ONE wrap-up tick after a `Recover` finalize; the
+/// wrap-up completion (which sees the failure in the conversation-history
+/// tool transcript) verbalizes what happened, so the run ends with
+/// assistant text and a non-Recover mode.
+#[tokio::test]
+async fn canonical_run_verbalizes_policy_denial_instead_of_dead_air() {
+    let runtime = build_runtime_with_provider(
+        unique_root("arcand-recover-wrapup"),
+        Arc::new(DeniedToolThenAnswerProvider::default()),
+    );
+    let router = create_canonical_router(runtime, test_provider_handle(), test_provider_factory());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://{addr}");
+
+    let session_response = client
+        .post(format!("{base}/sessions"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(session_response.status(), StatusCode::OK);
+    let session_payload: serde_json::Value = session_response.json().await.unwrap();
+    let session_id = session_payload["session_id"].as_str().expect("session_id");
+
+    let run_response = client
+        .post(format!("{base}/sessions/{session_id}/runs"))
+        .json(&json!({ "objective": "fetch https://example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(run_response.status(), StatusCode::OK);
+    let run_payload: serde_json::Value = run_response.json().await.unwrap();
+
+    // Pre-BRO-1465 this run finalized mode=Recover with zero assistant text.
+    let mode_repr = run_payload["mode"].to_string().to_lowercase();
+    assert!(
+        !mode_repr.contains("recover"),
+        "denied tool must get a wrap-up tick, not end in Recover; got mode {mode_repr}"
+    );
+
+    // The event stream must show the denial FOLLOWED by the verbal wrap-up.
+    let events_response = client
+        .get(format!("{base}/sessions/{session_id}/events"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(events_response.status(), StatusCode::OK);
+    let events_payload: serde_json::Value = events_response.json().await.unwrap();
+    let events = events_payload["events"].as_array().expect("events array");
+
+    let event_strings: Vec<String> = events.iter().map(|e| e.to_string()).collect();
+    let denial_index = event_strings
+        .iter()
+        .position(|e| e.contains("ToolCallFailed") || e.contains("tool_call_failed"))
+        .expect("denial event recorded");
+    let wrapup_index = event_strings
+        .iter()
+        .position(|e| e.contains("network egress is denied by policy"))
+        .expect("wrap-up assistant text recorded — dead air means BRO-1465 regressed");
+    assert!(
+        wrapup_index > denial_index,
+        "wrap-up text must come after the denial (denial at {denial_index}, wrap-up at {wrapup_index})"
+    );
 
     server.abort();
 }


### PR DESCRIPTION
Three coupled fixes for the dispatch-path chat UX, driven straight from the BRO-1490 green-receipt observations (2026-06-12, session `krzw3zpmzm2nfqyqjjfcp2hfge`).

## 1. Tool transcript in conversation history (aios-runtime)

`build_conversation_history` rendered ONLY user objectives + assistant text — **all tool events fell into `_ => {}`**. The model literally never saw that its tools ran. Observed live:
- gpt-5-mini re-called a **successful** `write_file` on 4 consecutive continuation ticks (no evidence of the result in its context), and
- denial dead-air was unfixable: a wrap-up call would have seen nothing.

Registry `ToolCallRequested`/`Completed`/`Failed` now render as bracketed lines inside the assistant turns (`[tool_call write_file({…})]`, `[tool_result write_file ok: {…}]`, `[tool_result … failed: capabilities denied…]`). Args capped at 600 chars, results at 1200 with elision markers. Client-category calls are excluded — their results return as ordinary conversation turns on the next dispatch (would double-render).

## 2. Recover wrap-up (arcand — BRO-1465)

Both agent loops (substrate `DispatchMessage` + canonical `run_session`) ended the turn the moment a tick finalized `Recover` — the model never got a call AFTER a denial/failure, so the user saw dead air (prod evidence: empty bubble + `tick finalized mode=Recover`). Each run now grants **one** wrap-up iteration (flag-guarded; Recover→Recover breaks, no loop risk). With (1), the wrap-up call actually sees the failure and verbalizes it.

## 3. Any-grant tool surface, wired into dispatch (arcan-aios-adapters — BRO-1466)

`substrate.rs` hardcoded `allowed_tools: None` (model advertises everything; canonical.rs already filtered). But the existing `tools_allowed_by_policy` counted only **broad** grants (`fs:write:*`) — wiring it in unchanged would have HIDDEN `write_file` from sessions whose policy explicitly allows `/session/artifacts/**` (the exact live receipt path) and `bash` from free-tier sessions with `exec:cmd:cat/ls/…` whitelists. Visibility is now **any-grant-based** (the policy gate still enforces path/binary scope at execution); gated-but-not-allowed capabilities (free's `fs:write:**`) deliberately stay hidden until the dispatch path renders the approval flow. New `KernelRuntime::session_policy` accessor; dispatch derives the surface from the session's policy.

## Tests

- 4 new aios-runtime integration tests (`tool_history.rs`): transcript on success, truncation bound, denial visibility (the literal wrap-up precondition), client-tool exclusion.
- 1 new arcand e2e (`canonical_api.rs`): drives a real denial through the router + real `SessionPolicyEngine` — asserts the run ends **non-Recover** with assistant text **after** `ToolCallFailed` (this exact assertion fails on pre-PR main).
- capability_map tests updated to the new contract (default policy exposes scoped write/exec tools, hides net/secrets; free exposes whitelisted bash) + `allows_category` coverage.
- 205 tests green across the three crates; clippy `-D warnings` clean.

## Receipt plan (after merge + deploy)

Same chat receipt as BRO-1490 — expect: **single** write_file call (no 4× repeat), a verbal assistant reply in the turn, and on a denied call (e.g. ask it to write outside artifacts/) a verbal explanation instead of dead air.

Closes #1705, closes #1706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)