### PR TITLE
fix(kernel): dispatch loops continue on tool execution, not the Execute-mode proxy

### DIFF
--- a/crates/aios/aios-runtime/src/lib.rs
+++ b/crates/aios/aios-runtime/src/lib.rs
@@ -107,6 +107,12 @@ pub struct TickOutput {
     pub state: AgentStateVector,
     pub events_emitted: u64,
     pub last_sequence: u64,
+    /// Registry tool calls evaluated this tick (gated, denied, or executed).
+    /// Dispatch loops continue on this — NOT on `mode == Execute`, which is
+    /// also the homeostatic default for text-only ticks and caused 4-5
+    /// wasted continuation model calls per chat turn (observed in prod,
+    /// 2026-06-12 session vcz5i4zq…).
+    pub tool_calls_executed: u32,
 }
 
 #[derive(Clone)]
@@ -695,7 +701,7 @@ impl KernelRuntime {
 
         let mut emitted = 0_u64;
         let mut previous_mode = Some(ctx.mode);
-        let mut _tool_calls_this_tick = 0_u32;
+        let mut tool_calls_this_tick = 0_u32;
         let mut _file_mutations_this_tick = 0_u32;
         let mut mode = ctx.mode;
 
@@ -744,8 +750,9 @@ impl KernelRuntime {
                 .finalize_tick(session_id, branch_id, manifest, state, &mode)
                 .await?;
             ctx.mode = mode;
+            // Early return before the directive loop — no tools ran.
             return self
-                .current_tick_output(session_id, branch_id, mode, (*state).clone(), emitted)
+                .current_tick_output(session_id, branch_id, mode, (*state).clone(), emitted, 0)
                 .await;
         }
 
@@ -879,9 +886,11 @@ impl KernelRuntime {
                 .await?;
             ctx.mode = mode;
             let _ = previous_mode; // suppress unused warning on this branch
-            let _ = (&mut _tool_calls_this_tick, &mut _file_mutations_this_tick);
+            let _ = (&mut tool_calls_this_tick, &mut _file_mutations_this_tick);
+            // Workflow ticks run their own internal loop (ergon) — one tick
+            // IS the whole turn, so the dispatch loop must not continue.
             return self
-                .current_tick_output(session_id, branch_id, mode, (*state).clone(), emitted)
+                .current_tick_output(session_id, branch_id, mode, (*state).clone(), emitted, 0)
                 .await;
         }
 
@@ -1099,7 +1108,7 @@ impl KernelRuntime {
                                 .map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
                             // Track tool calls for per-tick Autonomic limits.
-                            _tool_calls_this_tick += 1;
+                            tool_calls_this_tick += 1;
                             if !policy.denied.is_empty() {
                                 mode = OperatingMode::Recover;
                                 state.error_streak += 1;
@@ -1217,7 +1226,7 @@ impl KernelRuntime {
                                         tool_run_id = %report.tool_run_id,
                                         exit_status = report.exit_status,
                                         mode = ?mode,
-                                        tool_calls = _tool_calls_this_tick,
+                                        tool_calls = tool_calls_this_tick,
                                         file_mutations = _file_mutations_this_tick,
                                         "tool execution completed"
                                     );
@@ -1357,8 +1366,15 @@ impl KernelRuntime {
             .await?;
         ctx.mode = mode;
         info!(mode = ?mode, emitted, "tick finalized");
-        self.current_tick_output(session_id, branch_id, mode, (*state).clone(), emitted)
-            .await
+        self.current_tick_output(
+            session_id,
+            branch_id,
+            mode,
+            (*state).clone(),
+            emitted,
+            tool_calls_this_tick,
+        )
+        .await
     }
 
     #[instrument(
@@ -2437,6 +2453,7 @@ impl KernelRuntime {
         mode: OperatingMode,
         state: AgentStateVector,
         events_emitted: u64,
+        tool_calls_executed: u32,
     ) -> Result<TickOutput> {
         Ok(TickOutput {
             session_id: session_id.clone(),
@@ -2444,6 +2461,7 @@ impl KernelRuntime {
             state,
             events_emitted,
             last_sequence: self.peek_last_sequence(session_id, branch_id)?,
+            tool_calls_executed,
         })
     }
 

--- a/crates/arcan/arcand/src/canonical.rs
+++ b/crates/arcan/arcand/src/canonical.rs
@@ -1829,8 +1829,11 @@ async fn run_session(
         .instrument(agent_span.clone())
         .await;
 
-    // Continue ticking if the agent executed tools and needs to call the LLM
-    // again with tool results (mode=Execute means tools ran, needs continuation).
+    // Continue ticking only when the tick actually evaluated registry tool
+    // calls — the model needs another call to see their results. `mode ==
+    // Execute` alone is NOT the signal: it is also the homeostatic default
+    // for text-only ticks, and looping on it burned 4-5 wasted model calls
+    // per chat turn (prod, 2026-06-12).
     // BRO-1465: a Recover tick (tool denial / execution failure) also gets ONE
     // continuation — the failure is rendered into conversation history (the
     // kernel's tool transcript), so the wrap-up call verbalizes what happened
@@ -1839,12 +1842,14 @@ async fn run_session(
     let mut recover_wrapup_used = false;
     for iteration in 1..MAX_AGENT_ITERATIONS {
         let continue_reason = match &tick_result {
-            Ok(tick) if tick.mode == OperatingMode::Execute => "tool execution",
+            Ok(tick) if tick.mode == OperatingMode::Execute && tick.tool_calls_executed > 0 => {
+                "tool execution"
+            }
             Ok(tick) if tick.mode == OperatingMode::Recover && !recover_wrapup_used => {
                 recover_wrapup_used = true;
                 "recover wrap-up (BRO-1465)"
             }
-            _ => break, // Done, error, or non-continuable mode
+            _ => break, // Done, error, text-only completion, or non-continuable mode
         };
         tracing::info!(
             iteration,

--- a/crates/arcan/arcand/src/substrate.rs
+++ b/crates/arcan/arcand/src/substrate.rs
@@ -425,13 +425,17 @@ impl AgentSubstrate for SubstrateService {
                     .await
                 {
                     Ok(output) => {
-                        // Continue the loop only when the model executed
-                        // tools and needs another call to see their
-                        // results (same predicate as the HTTP path) — or
-                        // ONCE after a Recover, so the failure gets a
-                        // verbal wrap-up instead of dead air (BRO-1465).
+                        // Continue the loop only when the tick actually
+                        // evaluated registry tool calls — the model needs
+                        // another call to see their results. `mode ==
+                        // Execute` alone is NOT the signal: it is also the
+                        // homeostatic default for text-only ticks, and
+                        // looping on it burned 4-5 wasted model calls per
+                        // chat turn (prod, 2026-06-12). A Recover tick
+                        // still gets ONE wrap-up call so failures are
+                        // verbalized instead of dead air (BRO-1465).
                         match output.mode {
-                            OperatingMode::Execute => {}
+                            OperatingMode::Execute if output.tool_calls_executed > 0 => {}
                             OperatingMode::Recover if !recover_wrapup_used => {
                                 recover_wrapup_used = true;
                             }

--- a/crates/arcan/arcand/tests/canonical_api.rs
+++ b/crates/arcan/arcand/tests/canonical_api.rs
@@ -286,6 +286,57 @@ async fn canonical_session_api_round_trip() {
     server.abort();
 }
 
+/// A text-only completion must end the turn after ONE model call. The agent
+/// loop used to continue on `mode == Execute` — which is also the
+/// homeostatic default for text-only ticks — burning 4-5 wasted
+/// continuation calls per chat turn (observed in prod, 2026-06-12, session
+/// vcz5i4zq…). The loop now continues only on `tool_calls_executed > 0`.
+#[tokio::test]
+async fn canonical_run_text_only_completion_ends_after_one_model_call() {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_runtime_with_provider(
+        unique_root("arcand-no-continuation-burn"),
+        Arc::new(CapturingProvider::new(requests.clone())),
+    );
+    let router = create_canonical_router(runtime, test_provider_handle(), test_provider_factory());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://{addr}");
+
+    let session_response = client
+        .post(format!("{base}/sessions"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(session_response.status(), StatusCode::OK);
+    let session_payload: serde_json::Value = session_response.json().await.unwrap();
+    let session_id = session_payload["session_id"].as_str().expect("session_id");
+
+    let run_response = client
+        .post(format!("{base}/sessions/{session_id}/runs"))
+        .json(&json!({ "objective": "say hello" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(run_response.status(), StatusCode::OK);
+
+    let call_count = requests.lock().unwrap().len();
+    assert_eq!(
+        call_count, 1,
+        "a text-only completion must not trigger continuation ticks; \
+         got {call_count} model calls"
+    );
+
+    server.abort();
+}
+
 /// Proposes a policy-DENIED tool on the first completion, answers with text
 /// on every later completion — the wrap-up the model gives once it sees the
 /// `[tool_result … failed: capabilities denied…]` transcript line.


### PR DESCRIPTION
## What the post-#1748 receipt showed

Prod session `vcz5i4zq…` (2026-06-12 16:04Z), message *"use your write_file tool to create artifacts/receipt.txt…"*:

- ✅ `write_file` executed **exactly once** (`file written bytes=16`, exit 0) — the transcript fix works, the 4×-repeat is gone.
- ❌ Then the loop burned **four more text-only model calls** (ticks at :59, :02, :06, :10 — every one `finish_reasons="stop"`, `mode=Execute`) before collapsing into Recover. ~6 gpt-5-mini round trips per chat turn, five of them waste.

Root cause: both dispatch loops continue on `mode == Execute` as a proxy for "tools ran" — but `estimate_mode` returns Execute as the homeostatic **default** for text-only ticks too. Pre-#1748 this was masked because tool-heavy turns raised `side_effect_pressure` into Verify; now that the model answers in text (it can finally see its tool results), the proxy loops freely.

## Fix

- `TickOutput.tool_calls_executed` — the tick body already counted registry tool evaluations in an underscore-unused variable (`_tool_calls_this_tick`); it's now wired through `current_tick_output`. AskHuman/Sleep early-return and the workflow tick body report 0 (ergon workflow ticks run their own internal loop — one tick IS the whole turn).
- Both loops (substrate `DispatchMessage` + canonical `run_session`) continue on Execute **only when `tool_calls_executed > 0`**. The BRO-1465 Recover wrap-up (one extra tick, flag-capped) is unchanged and re-verified.

## Tests

- New e2e: **a text-only completion ends the turn after exactly one model call** (CapturingProvider records requests; pre-fix this looped to MAX_AGENT_ITERATIONS).
- The denial wrap-up e2e from #1748 still passes under the stricter predicate.
- 113 tests green across aios-runtime + arcand; arcan `praxis_integration` 14 green; clippy `-D warnings` clean.

## Receipt plan

Same chat probe after deploy — expect: one `write_file` tick, **one** text continuation tick, turn ends clean (two model calls total, not six).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tool execution metrics tracking per tick
  * Session policies are now retrievable and accessible
  * Conversation history now includes bounded tool call transcripts

* **Bug Fixes**
  * Refined continuation logic to prevent unnecessary ticks when tools aren't executed
  * Improved policy denial handling in conversation flow

* **Tests**
  * Added comprehensive test scenarios for text-only completions and policy denials
<!-- end of auto-generated comment: release notes by coderabbit.ai -->