### PR TITLE
fix(ci): green main — clippy drift + RUSTSEC advisory bumps + documented ignores (BRO-1832)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,6 +9,7 @@
 # RUSTSEC-2026-0104 — rustls-webpki reachable panic on crafted CRLs; we don't parse untrusted CRLs. Patched in >=0.103.13 (follow-up dep bump).
 # RUSTSEC-2026-0098 — rustls-webpki name-constraint URI-name acceptance; transitive via aws-smithy-http-client → hyper-rustls 0.24 → rustls 0.21 → rustls-webpki 0.101. We don't use Name Constraints in our PKI surface (Tier-1 verifier uses ES256 against a known issuer); rolls off when aws-sdk-kms upgrades its TLS chain.
 # RUSTSEC-2026-0099 — rustls-webpki wildcard name-constraint acceptance; same provenance as RUSTSEC-2026-0098. Same mitigation reasoning.
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195 — quick-xml quadratic-attr / unbounded-namespace DoS. Deep-transitive (quick-xml 0.37 ← object_store ← datafusion 45 ← lance ← lago-lance ← arcan); patched only in >=0.41.0, a semver-breaking jump requiring the whole lance/datafusion/object_store stack to upgrade (tracked separately). Reachable only when parsing UNTRUSTED XML via NsReader/attributes-with-checks; life uses quick-xml solely through object_store against trusted cloud-storage endpoints, so the DoS surface does not apply. Rolls off when the lance/datafusion upgrade lands.
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071",
@@ -20,4 +21,6 @@ ignore = [
     "RUSTSEC-2026-0104",
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -2667,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3766,9 +3766,9 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -4106,11 +4106,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4120,11 +4118,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6947,9 +6947,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -8690,15 +8690,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
@@ -8835,6 +8836,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/crates/autonomic/autonomic-controller/src/projection.rs
+++ b/crates/autonomic/autonomic-controller/src/projection.rs
@@ -55,11 +55,7 @@ pub fn fold(
         }
 
         // ── Tool lifecycle ──
-        EventKind::ToolCallCompleted {
-            status,
-            duration_ms: _,
-            ..
-        } => {
+        EventKind::ToolCallCompleted { status, .. } => {
             if *status == SpanStatus::Ok {
                 state.operational.total_successes += 1;
                 state.operational.error_streak = 0;

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,8 @@ ignore = [
     "RUSTSEC-2017-0008",  # serial unmaintained — transitive dep, no impact on agent runtime
     "RUSTSEC-2026-0104",  # rustls-webpki reachable panic on empty BIT STRING in CRL onlySomeReasons — we don't parse untrusted CRLs; patched in >=0.103.13 (follow-up dep bump)
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — transitive via tabled_derive→tabled (CLI table rendering only); migrating off tabled tracked as a follow-up dep change
+    "RUSTSEC-2026-0194",  # quick-xml quadratic-attr DoS — deep-transitive (object_store→datafusion 45→lance→lago-lance→arcan); patched only >=0.41.0 (semver-breaking, needs the lance/datafusion stack upgrade). Reachable only on UNTRUSTED XML via NsReader; life uses quick-xml via object_store against trusted cloud storage. Rolls off with the lance/datafusion upgrade.
+    "RUSTSEC-2026-0195",  # quick-xml unbounded-namespace-alloc DoS — same provenance + mitigation as RUSTSEC-2026-0194.
     # RUSTSEC-2026-0002 (lru IterMut unsoundness) removed 2026-06-10: the
     # advisory no longer matches any crate in the graph (cargo-deny
     # "no crate matched advisory criteria").


### PR DESCRIPTION
## Why
`broomva/life` `main` is red-CI, which blocks **every** Life PR from going green — including the VPS Life-governor's dispatches (it only reconciles on a *merged* PR). Surfaced by life#1771 (BRO-1491), whose three red checks are all pre-existing repo-health, none from that arc's code.

## Fix (three failures, all pre-existing)
1. **Lint/clippy** — remove a redundant `duration_ms: _` in `autonomic-controller/src/projection.rs`; rust-1.97 clippy `unneeded_wildcard_pattern` flags it since the trailing `..` already covers the field. (Validated locally: `cargo clippy -p autonomic-controller -- -D warnings` green.)
2. **Advisories fixed by patch-compatible bumps** (`cargo update -p`, same semver range, no API break):
   - `anyhow` 1.0.102→1.0.103 — RUSTSEC-2026-0190 (unsound `downcast_mut`)
   - `crossbeam-epoch` 0.9.18→0.9.20 — RUSTSEC-2026-0204 (invalid ptr deref)
   - `memmap2` 0.9.10→0.9.11 — RUSTSEC-2026-0186 (unsound advise/flush)
   - `quinn-proto` 0.11.14→0.11.16 — RUSTSEC-2026-0185 (memory-exhaustion DoS)
   - `fastrand` 2.4.0→2.4.1 — off the yanked version
3. **quick-xml RUSTSEC-2026-0194 / -0195** (quadratic-attr + unbounded-namespace DoS) — **documented ignore** in `.cargo/audit.toml` + `deny.toml`. It's a deep-transitive dep (`quick-xml 0.37 ← object_store ← datafusion 45 ← lance ← lago-lance ← arcan`), patched only in `>=0.41.0` — a semver-breaking jump that requires upgrading the whole lance/datafusion/object_store stack (tracked separately). The DoS is reachable only when parsing **untrusted** XML via `NsReader`/attributes-with-checks; life uses quick-xml solely through `object_store` against **trusted** cloud-storage endpoints, so the attack surface doesn't apply. Rolls off with the lance/datafusion upgrade.

## Dep-chain (P14)
Upstream: `.cargo/audit.toml`, `deny.toml`, `Cargo.lock`, `autonomic-controller`. Downstream: **all** Life PRs (life#1771 first) + the VPS Life-governor's ability to land merges (BRO-1744). No `Cargo.toml` API changes; bumps are lockfile-only patch bumps.

## Validation
`autonomic-controller` clippy green locally; the workspace build + tests + full `cargo audit`/`cargo deny` run on CI (rust-1.97, authoritative).

Linear: BRO-1832 · unblocks BRO-1491 / BRO-1744