### PR TITLE
chore(gitignore): ignore .claude/arc-status.json* (BRO-1833 P1 — VPS partition)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,13 @@ Thumbs.db
 
 # Claude Code worktrees
 .claude/worktrees/
+# ticket-dispatch arc↔governor IPC (BRO-1833) — runtime status a dispatched arc
+# writes at each pause; the governor reads it from the worktree. This repo is
+# the VPS Life-governor's $WORKDIR, so its arc worktrees are governed here.
+# Never a deliverable — the glob covers the file and any .tmp/temp variant so a
+# blanket `git add -A` in an arc worktree can never stage it. Mirrors the
+# workspace root .gitignore.
+.claude/arc-status.json*
 
 # Python
 .venv/


### PR DESCRIPTION
Companion to workspace [PR #195](https://github.com/broomva/workspace/pull/195) — BRO-1833 Phase P1 (resumable governed arcs).

## Why
The ticket-dispatch **VPS Life-governor** runs with `$WORKDIR=core/life`, so the git worktrees it creates for dispatched arcs are linked worktrees of **this** repo — governed by **this** `.gitignore`. Phase P1 has arcs write a runtime status file at `<WT>/.claude/arc-status.json` (governor↔arc IPC, never a deliverable). Without a matching ignore here, a VPS arc's `git add -A` would stage that file into its PR.

## Change
One line: `.claude/arc-status.json*` (glob covers the file + any `.tmp`/mktemp temp variant). Mirrors the workspace root `.gitignore`.

## Provenance
Found by the P20 cross-model adversarial review of PR #195 as blocking finding **B1** (host-asymmetric gitignore): the workspace-only ignore left the invariant "an arc's `git add .` can never stage it" **false on the VPS partition**. Verified: `git check-ignore` now covers `.json`, `.json.tmp`, `.json.tmp.<rand>`, `.json.new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)