### PR TITLE
ci: Merge Gate aggregate + enable P6 auto-merge for feature/bro-* (BRO-1833)

### DIFF
--- a/.control/policy.yaml
+++ b/.control/policy.yaml
@@ -71,7 +71,7 @@ ci_heal:
 # Closes the MERGE_READY → merged gap. Default-disabled; opt-in branch class.
 
 auto_merge:
-  enabled: false
+  enabled: true
   require_no_requested_changes: true
   require_branch_up_to_date: true
   merge_method: squash
@@ -116,6 +116,15 @@ auto_merge:
     #   action: auto
     # - branch_pattern: "research/*"
     #   action: auto
+    # Agent-worked ticket-dispatch arcs (BRO-1833 P6): the arc that works a Life
+    # ticket merges its OWN PR via the p9 lifecycle (watch -> merge-ready ->
+    # auto-merge) after CI-green + a fresh-context P20 (>=7/10). The governor never
+    # merges (invariant 4). Server-side backstop: broomva/life main requires the
+    # `Merge Gate` check (merge-gate.yml) — so CI-green is enforced repo-side, not
+    # only by the arc's p9 flow. Governance/injection paths above still
+    # hard-require-human via the matcher pre-pass.
+    - branch_pattern: "feature/bro-*"
+      action: auto
   default_action: notify
 
 # === Indirect-prompt-injection defense — PreToolUse write gate (2026-05-15) ===

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,80 @@
+# Merge Gate — the single required check for autonomous + human merges (BRO-1833 P6).
+#
+# WHY: the CI workflow (ci.yml) is path-filtered at the workflow level
+# (paths-ignore: docs/**, research/**, **/*.md), so a docs-only PR skips the
+# entire suite. Requiring the individual CI jobs would leave those checks in a
+# permanent "Expected" state on docs-only PRs and block them forever (GitHub's
+# skipped-but-required footgun). This job instead runs on EVERY PR (no filter)
+# and passes iff every OTHER check-run on the PR head has concluded without a
+# hard failure — so it is always reported, tolerant of skipped/path-filtered
+# checks, and is the one thing the branch ruleset requires.
+#
+# It is the server-side backstop behind the ticket-dispatch loop's autonomous
+# `p9 auto-merge`: an arc can only merge its own PR once this gate is green,
+# which means the full CI suite (Format/Lint/MSRV/Security/dep-rules/tests) that
+# actually ran on the code change passed. Native `gh api` only — no third-party
+# actions on the merge-critical path (supply-chain hygiene).
+name: merge-gate
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: merge-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+
+jobs:
+  gate:
+    name: Merge Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Require all other checks green (or skipped)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Conclusions that BLOCK a merge (a check that actually failed).
+          # success / skipped / neutral do NOT block.
+          BLOCKING='failure|cancelled|timed_out|action_required|startup_failure|stale'
+          for i in $(seq 1 80); do   # up to ~40 min (Rust CI + macOS runners are slow)
+            # All check-runs on this head SHA except this gate itself.
+            runs=$(gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
+                     --jq '.check_runs[] | select(.name != "Merge Gate") | [.name, .status, (.conclusion // "")] | @tsv' \
+                   || echo "")
+            # Legacy commit statuses (belt-and-suspenders; most checks are check-runs).
+            st_state=$(gh api "repos/$REPO/commits/$SHA/status" --jq '.state' 2>/dev/null || echo "unknown")
+
+            failed=$(printf '%s\n' "$runs" | awk -F'\t' -v b="$BLOCKING" 'NF>=3 && $3 ~ ("^(" b ")$"){print $1}')
+            if [ -n "$failed" ] || [ "$st_state" = "failure" ] || [ "$st_state" = "error" ]; then
+              echo "::error::Merge Gate FAILED — blocking checks:"
+              [ -n "$failed" ] && printf '  - %s\n' $failed
+              [ "$st_state" = "failure" ] || [ "$st_state" = "error" ] && echo "  - (legacy commit status: $st_state)"
+              exit 1
+            fi
+
+            n=$(printf '%s\n' "$runs" | grep -c . || true)
+            incomplete=$(printf '%s\n' "$runs" | awk -F'\t' 'NF>=2 && $2 != "completed"{c++} END{print c+0}')
+
+            if [ "$n" -gt 0 ] && [ "$incomplete" -eq 0 ] && { [ "$st_state" = "success" ] || [ "$st_state" = "pending" ]; }; then
+              echo "Merge Gate PASS — $n check(s) completed, none failed (commit status: $st_state)."
+              exit 0
+            fi
+            # No other checks after a short grace = path-filtered/docs-only PR (CI never ran) → nothing to gate.
+            if [ "$n" -eq 0 ] && [ "$i" -ge 5 ]; then
+              echo "Merge Gate PASS — no other checks on this PR after grace (CI path-filtered / docs-only)."
+              exit 0
+            fi
+            echo "waiting: $n check(s), $incomplete still running, commit status=$st_state (poll $i/80)…"
+            sleep 30
+          done
+          echo "::error::Merge Gate timed out waiting for checks to conclude."
+          exit 1


### PR DESCRIPTION
## What
The server-side backstop for the ticket-dispatch loop's **autonomous merge-close** (BRO-1833 P6).

1. **`.github/workflows/merge-gate.yml`** — a single **Merge Gate** check that runs on every PR (no path filter) and passes iff every *other* check-run on the PR head concluded without a hard failure. `ci.yml` is path-filtered at the workflow level, so requiring individual jobs would block docs-only PRs forever (skipped-but-required footgun). This aggregate is always reported, tolerant of skipped checks, and will be the one required check. Native `gh api` only (no third-party actions on the merge path).
2. **`.control/policy.yaml`** — `auto_merge.enabled: true` + `feature/bro-*: auto`. The dispatched arc merges its own green PR via the p9 lifecycle (`watch → merge-ready → auto-merge`) after a fresh-context P20 (≥7/10); the governor never merges (invariant 4).

## Validating on itself
This PR **runs the Merge Gate on its own head** — it should appear and pass once the (skipped, docs+ci-adjacent) checks settle. That's the first live proof the gate reports correctly.

## Next (out of band)
A ruleset on `main` requiring `Merge Gate` + a PR, then future `feature/bro-*` arc PRs auto-merge with a real server-side net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic merging for eligible feature branches.
  * Added a merge gate that monitors pull request checks and prevents merging when checks fail, are cancelled, or time out.
  * Supports pull requests where checks are skipped, such as documentation-only changes.

* **Bug Fixes**
  * Improved merge reliability by waiting for required checks to complete before allowing merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->