### PR TITLE
fix(security): zeroize transient seed copies in identity_loader + life-cli read_seed (BRO-1468)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "walkdir",
+ "zeroize",
 ]
 
 [[package]]
@@ -6308,6 +6309,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/arcan/arcan/Cargo.toml
+++ b/crates/arcan/arcan/Cargo.toml
@@ -56,6 +56,10 @@ ergon-nous-adapter.workspace = true
 # Custody identity loading for soul attestation (`--anima-identity-dir`):
 # reconstructs the `life init` InProcessAnima from `.life/identity/`.
 anima-identity = { path = "../../anima/anima-identity", version = "0.3.0" }
+# Zeroize transient seed copies read off disk before they hit the heap/stack
+# and linger (BRO-1468). `MasterSeed` already zeroizes on drop; this covers
+# the intermediate buffers in `identity_loader`.
+zeroize.workspace = true
 arcan-harness = { path = "../arcan-harness", version = "0.3.0" }
 praxis-core.workspace = true
 praxis-tools.workspace = true

--- a/crates/arcan/arcan/src/identity_loader.rs
+++ b/crates/arcan/arcan/src/identity_loader.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use anima_identity::custody::AnimaCustody;
 use anima_identity::{InProcessAnima, MasterSeed};
 use anyhow::{Context, bail};
+use zeroize::Zeroizing;
 
 /// Read-side projection of `.life/identity/soul.json`.
 ///
@@ -99,23 +100,30 @@ pub fn load_custody_from_disk(
     }
 
     let seed_path = identity_dir.join(&doc.custody.seed_file);
-    let seed_bytes = std::fs::read(&seed_path).with_context(|| {
+    // Raw master-seed material. Hold every transient copy in `Zeroizing` so the
+    // bytes are wiped on drop instead of lingering on the heap/stack after
+    // `MasterSeed` (which zeroizes itself) has consumed them (BRO-1468).
+    let seed_bytes = Zeroizing::new(std::fs::read(&seed_path).with_context(|| {
         format!(
             "{} claims in_process custody but the seed at {} is unreadable — restore it from \
              backup, or remove soul.json and re-run `life init` (this regenerates the DID)",
             soul_path.display(),
             seed_path.display()
         )
-    })?;
-    let seed_arr: [u8; 32] = seed_bytes.try_into().map_err(|v: Vec<u8>| {
-        anyhow::anyhow!(
+    })?);
+    if seed_bytes.len() != 32 {
+        bail!(
             "{} is corrupt: {} bytes (expected 32)",
             seed_path.display(),
-            v.len()
-        )
-    })?;
+            seed_bytes.len()
+        );
+    }
+    // Copy from the heap Vec into a fixed array (leaves `seed_bytes` intact so
+    // its own zeroize-on-drop still fires); both buffers are zeroized on drop.
+    let mut seed_arr = Zeroizing::new([0u8; 32]);
+    seed_arr.copy_from_slice(seed_bytes.as_slice());
 
-    let custody = InProcessAnima::from_seed_arc(MasterSeed::from_bytes(seed_arr))
+    let custody = InProcessAnima::from_seed_arc(MasterSeed::from_bytes(*seed_arr))
         .context("failed to derive identity from master seed")?;
 
     // Sanity: the soul document pins the auth pubkey + DID at init
@@ -346,5 +354,37 @@ mod tests {
 
         let err = load_err(&identity_dir);
         assert!(format!("{err:#}").contains("out of sync"), "got: {err:#}");
+    }
+
+    /// BRO-1468: the loader reads raw master-seed bytes off disk into
+    /// transient buffers before `MasterSeed` consumes them. Those buffers
+    /// are held in `Zeroizing`, so the seed is wiped on drop instead of
+    /// lingering on the heap/stack. This mirrors the loader's exact
+    /// construction (`Zeroizing<Vec<u8>>` from the file → copy into
+    /// `Zeroizing<[u8; 32]>`) and asserts the Drop path (`Zeroize::zeroize`,
+    /// which `Zeroizing::drop` calls) zeroes the fixed-array copy — the
+    /// buffer that is handed onward to `MasterSeed::from_bytes`.
+    #[test]
+    fn transient_seed_buffers_are_zeroized_on_drop() {
+        use zeroize::Zeroize;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = write_identity(tmp.path(), SEED);
+        let seed_path = identity_dir.join("seed.local.bin");
+
+        let seed_bytes = Zeroizing::new(std::fs::read(&seed_path).unwrap());
+        assert_eq!(seed_bytes.as_slice(), &SEED, "seed reads back intact");
+
+        let mut seed_arr = Zeroizing::new([0u8; 32]);
+        seed_arr.copy_from_slice(seed_bytes.as_slice());
+        assert_eq!(*seed_arr, SEED, "fixed-array copy intact before drop");
+
+        // `Zeroizing::drop` delegates to exactly this call; invoking it
+        // directly lets us observe the wipe without reading freed memory.
+        seed_arr.zeroize();
+        assert_eq!(
+            *seed_arr, [0u8; 32],
+            "transient array seed copy must be zeroized by the Drop path"
+        );
     }
 }

--- a/crates/cli/life-cli/Cargo.toml
+++ b/crates/cli/life-cli/Cargo.toml
@@ -54,6 +54,11 @@ life-paths = { path = "../../life-paths", version = "0.3.0" }
 anima-identity = { path = "../../anima/anima-identity" }
 anima-core = { path = "../../anima/anima-core" }
 
+# Zeroize the transient seed copies `read_seed` pulls off disk (BRO-1468) so
+# raw master-seed bytes don't linger on the heap/stack after use. `MasterSeed`
+# already zeroizes on drop; this covers the buffers around it.
+zeroize.workspace = true
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/crates/cli/life-cli/src/init.rs
+++ b/crates/cli/life-cli/src/init.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 use anima_core::soul::{AgentSoul, SoulBuilder};
 use anima_identity::{InProcessAnima, MasterSeed};
 use anyhow::{Context, Result};
+use zeroize::Zeroizing;
 
 // ── ANSI helpers ──────────────────────────────────────────────────────────
 
@@ -291,20 +292,29 @@ fn write_seed(identity_dir: &Path, seed_bytes: &[u8; 32]) -> Result<()> {
 /// Read the master seed from `.life/identity/seed.local.bin`, if present.
 /// Returns `Ok(None)` if the file doesn't exist; `Err` if it exists but is
 /// malformed (wrong length).
-fn read_seed(identity_dir: &Path) -> Result<Option<[u8; 32]>> {
+///
+/// The result is wrapped in `Zeroizing` so the raw master-seed bytes are
+/// wiped on drop rather than lingering on the heap/stack (BRO-1468). The
+/// intermediate `Vec<u8>` read off disk is likewise zeroized on drop.
+fn read_seed(identity_dir: &Path) -> Result<Option<Zeroizing<[u8; 32]>>> {
     let path = identity_dir.join("seed.local.bin");
     if !path.exists() {
         return Ok(None);
     }
-    let bytes =
-        std::fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
-    let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
-        anyhow::anyhow!(
+    let bytes = Zeroizing::new(
+        std::fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?,
+    );
+    if bytes.len() != 32 {
+        return Err(anyhow::anyhow!(
             "{} has wrong length: {} bytes (expected 32)",
             path.display(),
-            v.len()
-        )
-    })?;
+            bytes.len()
+        ));
+    }
+    // Copy from the heap Vec into a fixed array (leaves `bytes` intact so its
+    // own zeroize-on-drop still fires); both buffers are zeroized on drop.
+    let mut arr = Zeroizing::new([0u8; 32]);
+    arr.copy_from_slice(bytes.as_slice());
     Ok(Some(arr))
 }
 
@@ -387,19 +397,21 @@ pub fn bootstrap_anima_identity(life_dir: &Path) -> Result<(IdentitySummary, boo
     }
 
     // ── Reuse a leftover seed if the operator ran reset half-way through ─
+    // `seed_bytes` is `Zeroizing<[u8; 32]>` throughout so the transient
+    // master-seed copy is wiped on drop (BRO-1468).
     let seed_bytes = match read_seed(&identity_dir)? {
         Some(bytes) => bytes,
         None => {
             let seed = MasterSeed::generate();
-            let bytes = *seed.as_bytes();
-            // Seed handed to InProcessAnima below; bytes is a copy held here
-            // for at-rest persistence before the seed gets zeroized on drop.
+            // Copy held here for at-rest persistence; the in-memory copy is
+            // zeroized on drop (the `MasterSeed` itself zeroizes separately).
+            let bytes = Zeroizing::new(*seed.as_bytes());
             write_seed(&identity_dir, &bytes)?;
             bytes
         }
     };
 
-    let seed = MasterSeed::from_bytes(seed_bytes);
+    let seed = MasterSeed::from_bytes(*seed_bytes);
     let custody = InProcessAnima::from_seed_arc(seed)
         .context("failed to derive identity from master seed")?;
 
@@ -806,6 +818,37 @@ mod tests {
         assert!(
             err.contains("wrong length"),
             "error should describe the length problem; got: {err}"
+        );
+    }
+
+    /// BRO-1468: `read_seed` returns the master seed in a `Zeroizing` buffer
+    /// so the raw bytes are wiped on drop rather than lingering. Two things
+    /// are asserted: (1) the seed round-trips intact — a mis-scoped zeroize
+    /// that cleared a buffer still in use would break identity loading; and
+    /// (2) the Drop path (`Zeroize::zeroize`, which `Zeroizing::drop` calls)
+    /// zeroes the returned buffer.
+    #[test]
+    fn read_seed_returns_zeroizing_wiped_on_drop() {
+        use zeroize::Zeroize;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let identity_dir = tmp.path().join("identity");
+        std::fs::create_dir_all(&identity_dir).unwrap();
+
+        let expected = [0xABu8; 32];
+        write_seed(&identity_dir, &expected).unwrap();
+
+        let mut seed = read_seed(&identity_dir)
+            .unwrap()
+            .expect("seed present on disk");
+        assert_eq!(*seed, expected, "seed round-trips intact (not mis-cleared)");
+
+        // `Zeroizing::drop` delegates to exactly this call; invoking it
+        // directly lets us observe the wipe without reading freed memory.
+        seed.zeroize();
+        assert_eq!(
+            *seed, [0u8; 32],
+            "transient seed buffer must be zeroized by the Drop path"
         );
     }
 }


### PR DESCRIPTION
## BRO-1468 — Zeroize transient seed copies in `identity_loader` + life-cli `read_seed`

Review follow-up from #1694: transient copies of the raw 32-byte master
seed were freed **without** being zeroized in the `identity_loader` and
life-cli `read_seed` paths, so seed material could linger on the
heap/stack after use. `MasterSeed` already zeroizes on drop; this closes
the gap for the intermediate buffers around it.

### Change (additive, defensive — no behavior change)
- **`crates/arcan/arcan/src/identity_loader.rs`** — read the seed into a
  `Zeroizing<Vec<u8>>` and copy it into a `Zeroizing<[u8; 32]>` before
  `MasterSeed::from_bytes`. The previous `Vec::try_into::<[u8;32]>()`
  moved the bytes and dropped the heap `Vec` unzeroized; a manual
  length-check + `copy_from_slice` keeps `Zeroizing`'s drop-wipe on both
  buffers and preserves the exact `N bytes (expected 32)` error message.
- **`crates/cli/life-cli/src/init.rs`** — `read_seed` now returns
  `Zeroizing<[u8; 32]>` (was `[u8; 32]`) and wraps the transient
  `Vec<u8>`; `bootstrap_anima_identity` threads `Zeroizing` through so the
  reuse/generate copy is wiped on drop as well.
- Adds `zeroize.workspace = true` to both crates (already a workspace dep,
  used by `anima-identity`).

### Dogfood — integration + runtime validation (foreground, in-turn)
The DoD flags the sharp edge: a **mis-scoped** zeroize that clears a
buffer still in use would break identity loading. Both new tests assert
(1) the seed round-trips **intact** and (2) the transient buffer is
zeroized by the Drop path (`Zeroize::zeroize` — the call `Zeroizing::drop`
makes), observed without reading freed memory.

- `cargo test -p life-cli` → **16/16 green** (incl.
  `read_seed_returns_zeroizing_wiped_on_drop`)
- `cargo test -p arcan --bin arcan identity_loader` → **11/11 green**
  (incl. `transient_seed_buffers_are_zeroized_on_drop`, plus the existing
  `happy_path_loads_custody_with_pinned_did` /
  `corrupt_seed_wrong_length_errors` /
  `loaded_custody_drives_agent_attestation_adapter` still passing)
- `cargo clippy -p life-cli` clean; arcan-crate clippy deferred to CI
  (full arcan clippy is a ~9-min recompile; the arcan test build was
  warning-free)

Bounded, in-repo, no deploy. Security-touch (operates on seed material,
the reason it was escalated) but the change itself is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)