### PR TITLE
ci(control): wire the control-harness into CI + reconcile stale scripts (BRO-1858)

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,0 +1,77 @@
+# Control Harness — runs the control metalayer's OWN canonical gate (`make ci`) in CI.
+#
+# WHY (BRO-1858): the control metalayer DECLARES `make ci` (smoke → check → test,
+# via scripts/control/*.sh) as its gate, but that gate was only enforced by
+# BYPASSABLE local git hooks (pre-commit=smoke, pre-push=check) and never in CI.
+# A gate enforced only by local discipline is open-loop. This workflow makes the
+# canonical commands a REQUIRED, unbypassable CI check (closed-loop) and catches
+# drift between "what governance says the gate is" and "what actually passes".
+#
+# This deliberately overlaps ci.yml's Format/Lint/Test — that duplication is the
+# self-consistency tax: ci.yml runs the raw cargo jobs (hardened, MSRV, security,
+# dep-rules, macOS); this proves the CANONICAL `make` command surface itself is
+# green. ci.yml stays the source of coverage; this stays the source of governance
+# self-consistency. `scripts/control/*.sh` mirror ci.yml's commands exactly.
+name: Control Harness
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - "**/CHANGELOG.md"
+      - "docs/**"
+      - "research/**"
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - "**/CHANGELOG.md"
+      - "docs/**"
+      - "research/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_RETRY: "10"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  harness:
+    name: make ci (control harness)
+    runs-on: ubuntu-latest
+    # Same disk-exhaustion hardening as ci.yml's Test (Linux) lane: `make ci`
+    # runs `cargo test --workspace` over the 125-crate workspace.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free runner disk (unused preinstalled toolchains)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift || true
+          df -h /
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-harness
+      - name: make ci (smoke + check + test — the control metalayer's canonical gate)
+        run: make ci
+      - name: Disk headroom after harness
+        if: always()
+        run: df -h /

--- a/Makefile.harness
+++ b/Makefile.harness
@@ -1,17 +1,16 @@
-.PHONY: smoke test lint typecheck check ci
-
-smoke:
-	@./scripts/harness/smoke.sh
-
-test:
-	@./scripts/harness/test.sh
+# Harness-engineering convenience targets. The control metalayer (Makefile.control,
+# included LAST) OWNS the gate targets smoke/check/test/ci — this file must NOT
+# define them, or GNU make ACCUMULATES prerequisites across the duplicate `check:`
+# definitions (a recipe override does not drop prereqs), leaking scripts/harness/
+# lint.sh into `make check`/`make ci`. That divergence — a stricter clippy than
+# ci.yml (no `-A too_many_arguments`, plus `--all-targets --all-features`) — would
+# false-block PRs on a lint ci.yml explicitly allows. Exactly what BRO-1858 P20
+# caught. So this file keeps ONLY its unique standalone targets `lint`/`typecheck`
+# (documented in AGENTS.md), reconciled to mirror .github/workflows/ci.yml.
+.PHONY: lint typecheck
 
 lint:
 	@./scripts/harness/lint.sh
 
 typecheck:
 	@./scripts/harness/typecheck.sh
-
-check: lint typecheck
-
-ci: smoke check test

--- a/scripts/control/check.sh
+++ b/scripts/control/check.sh
@@ -15,20 +15,13 @@ if [ -n "${CONTROL_CHECK_CMD:-}" ]; then
   exit 0
 fi
 
-# Multi-workspace monorepo: all Life crates (format + lint)
-if command -v cargo >/dev/null 2>&1; then
-  ran=0
-  for ws in aiOS arcan lago autonomic praxis vigil spaces anima haima nous; do
-    if [ -f "$ws/Cargo.toml" ]; then
-      (cd "$ws" && cargo fmt --check && cargo clippy --workspace -- -D warnings)
-      ran=1
-    fi
-  done
-  [ "$ran" -eq 1 ] && exit 0
-fi
-
+# Single root virtual workspace (crates/<cluster>/<crate>) — BRO-1858.
+# Mirror .github/workflows/ci.yml's Format + Lint gates exactly so `make check`
+# (and the pre-push hook) validate the SAME surface as CI. The old per-subdir loop
+# was stale dead code (those dirs no longer carry Cargo.toml).
 if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
-  cargo clippy --all-targets --all-features -- -D warnings
+  cargo fmt --all -- --check
+  cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments
   exit 0
 fi
 

--- a/scripts/control/smoke.sh
+++ b/scripts/control/smoke.sh
@@ -9,20 +9,12 @@ if [ -n "${CONTROL_SMOKE_CMD:-}" ]; then
   exit 0
 fi
 
-# Multi-workspace monorepo: aiOS + Arcan + Lago + Autonomic + Spaces
-if command -v cargo >/dev/null 2>&1; then
-  ran=0
-  for ws in aiOS arcan lago autonomic praxis vigil spaces anima haima nous; do
-    if [ -f "$ws/Cargo.toml" ]; then
-      (cd "$ws" && cargo check --quiet)
-      ran=1
-    fi
-  done
-  [ "$ran" -eq 1 ] && exit 0
-fi
-
+# Single root virtual workspace (crates/<cluster>/<crate>) — BRO-1858.
+# The old per-subdir loop (aiOS/arcan/lago/…) is stale: those top-level dirs no
+# longer carry Cargo.toml, so `--workspace` at the root is the current model and
+# mirrors .github/workflows/ci.yml (aiOS is now a separate repo, not a member).
 if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
-  cargo check --quiet
+  cargo check --workspace --quiet
   exit 0
 fi
 

--- a/scripts/control/test.sh
+++ b/scripts/control/test.sh
@@ -15,20 +15,11 @@ if [ -n "${CONTROL_TEST_CMD:-}" ]; then
   exit 0
 fi
 
-# Multi-workspace monorepo: aiOS + Arcan + Lago + Autonomic + Spaces
-if command -v cargo >/dev/null 2>&1; then
-  ran=0
-  for ws in aiOS arcan lago autonomic praxis vigil spaces anima haima nous; do
-    if [ -f "$ws/Cargo.toml" ]; then
-      (cd "$ws" && cargo test --workspace --quiet)
-      ran=1
-    fi
-  done
-  [ "$ran" -eq 1 ] && exit 0
-fi
-
+# Single root virtual workspace (crates/<cluster>/<crate>) — BRO-1858.
+# `--workspace` at the root mirrors .github/workflows/ci.yml's Test (Linux) gate.
+# The old per-subdir loop was stale dead code (those dirs no longer carry Cargo.toml).
 if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
-  cargo test --quiet
+  cargo test --workspace --quiet
   exit 0
 fi
 

--- a/scripts/harness/lint.sh
+++ b/scripts/harness/lint.sh
@@ -9,22 +9,15 @@ if [ -n "${HARNESS_LINT_CMD:-}" ]; then
   exit 0
 fi
 
-# Multi-workspace monorepo: aiOS + Arcan + Lago + Spaces
-if command -v cargo >/dev/null 2>&1; then
-  cd "$root_dir"
-  ran=0
-  for ws in aiOS arcan lago spaces anima autonomic haima nous praxis vigil; do
-    if [ -f "$ws/Cargo.toml" ]; then
-      (cd "$ws" && cargo clippy --workspace -- -D warnings)
-      ran=1
-    fi
-  done
-  [ "$ran" -eq 1 ] && exit 0
-fi
-
+# Single root virtual workspace (crates/<cluster>/<crate>) — BRO-1858.
+# Mirror .github/workflows/ci.yml's Lint gate EXACTLY (incl. the
+# `-A too_many_arguments` allow) so `make lint` never false-blocks on a lint CI
+# permits. The old per-subdir loop was stale (those dirs no longer carry
+# Cargo.toml); the old `--all-targets --all-features` fallthrough was stricter
+# than ci.yml.
 if [ -f "$root_dir/Cargo.toml" ] && command -v cargo >/dev/null 2>&1; then
   cd "$root_dir"
-  cargo clippy --all-targets --all-features -- -D warnings
+  cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments
   exit 0
 fi
 

--- a/scripts/harness/typecheck.sh
+++ b/scripts/harness/typecheck.sh
@@ -9,22 +9,12 @@ if [ -n "${HARNESS_TYPECHECK_CMD:-}" ]; then
   exit 0
 fi
 
-# Multi-workspace monorepo: aiOS + Arcan + Lago + Spaces
-if command -v cargo >/dev/null 2>&1; then
-  cd "$root_dir"
-  ran=0
-  for ws in aiOS arcan lago spaces; do
-    if [ -f "$ws/Cargo.toml" ]; then
-      (cd "$ws" && cargo check --quiet)
-      ran=1
-    fi
-  done
-  [ "$ran" -eq 1 ] && exit 0
-fi
-
+# Single root virtual workspace (crates/<cluster>/<crate>) — BRO-1858.
+# `cargo check --workspace` mirrors ci.yml's build/MSRV surface; the old
+# per-subdir loop was stale dead code.
 if [ -f "$root_dir/Cargo.toml" ] && command -v cargo >/dev/null 2>&1; then
   cd "$root_dir"
-  cargo check --quiet
+  cargo check --workspace --quiet
   exit 0
 fi
 


### PR DESCRIPTION
## What (BRO-1858 — Q3 control-audit finding)

The control metalayer *declares* `make ci` (smoke→check→test) as its gate, but that gate was only enforced by **bypassable local git hooks** (pre-commit=smoke, pre-push=check) — never in CI. A gate enforced only by local discipline is open-loop; this makes the canonical commands a **required CI check** (closed-loop, `h⟂U`) — the same principle as BRO-1857.

- **`scripts/control/{smoke,check,test}.sh`** — drop the stale per-subdir loop (`aiOS arcan lago …` no longer carry Cargo.toml; core/life is now a single root virtual workspace `crates/<cluster>/<crate>`) and align the root commands **exactly** with `ci.yml`: `cargo check --workspace` / `cargo fmt --all --check` + `cargo clippy --workspace -- -D warnings -A clippy::too_many_arguments` / `cargo test --workspace`. Also fixes the local hooks, which previously fell through to a subtly-different root command (no `fmt`).
- **`.github/workflows/harness.yml`** — thin workflow running `make ci`, with the same disk-free + protoc + cache hardening as `ci.yml`'s Test lane.

**Not** a refactor of `ci.yml` (that would regress its hardening/MSRV/security/dep-rules/macOS coverage). This overlaps `ci.yml`'s Format/Lint/Test deliberately — the self-consistency tax: `ci.yml` stays the coverage source, this proves the canonical `make` surface is green.

Closes 2 of the 3 `make control-audit` findings (harness.yml exists + invokes `make ci`). The 3rd (architecture-audit stale-aiOS) is a distinct concern → BRO-1859.

**Validation:** this PR's own `harness.yml` run executes `make ci` end-to-end — if the aligned scripts diverge from the green `ci.yml`, it fails here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI & Quality**
  * Added an automated control workflow for pull requests, pushes to the main branch, and manual runs.
  * Standardized formatting, linting, type checking, smoke checks, and tests across the Rust workspace.
  * Improved CI reliability with dependency caching, runner cleanup, and concurrency controls.
  * Updated development checks to use the repository’s unified workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->