### PR TITLE
ci(railway): watchPatterns cover proto/** + apps/** on substrate services (BRO-1467)

### DIFF
--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -1,0 +1,47 @@
+# Railway config-as-code — substrate services
+
+Each Life substrate service on Railway (project `Life`, environment
+`production`) builds the whole Cargo workspace from a Docker build context
+rooted at the repo root. The build inputs are therefore **shared** across
+every substrate binary, not just that binary's own crate subtree.
+
+## Why these files exist (BRO-1467)
+
+The substrate services previously watched **crate subtrees only** in their
+Railway dashboard `watchPatterns`. That missed two build-input roots that the
+active Dockerfiles (`docker/*.Dockerfile`) copy into the build context:
+
+- `proto/**` — read by the `*-substrate-proto`, `aios-proto`, and
+  `life-*-proto` build scripts (`build.rs`) relative to the repo root.
+- `apps/**` — workspace members that must be present for `cargo` to resolve
+  the workspace manifest.
+
+A change under `proto/` or `apps/` recompiles the binary but did **not** trigger
+a Railway rebuild, so production drifted from source. See the arcan Dockerfile's
+own comment block for the canonical statement of these inputs.
+
+These [config-as-code](https://docs.railway.com/config-as-code) files pin
+`watchPatterns` to the **full set of Docker build inputs**, so the trigger set
+can never silently drift from the build context again. `watchPatterns` is the
+only field declared — every other build/deploy setting continues to combine
+from the Railway dashboard.
+
+| File | Service | Extra input |
+| --- | --- | --- |
+| `arcan.railway.json` | `arcan` | `agents/**` (blessed authored agents copied into the runtime image) |
+| `lagod.railway.json` | `lagod` | — |
+| `haimad.railway.json` | `haimad` | — |
+| `autonomicd.railway.json` | `autonomicd` | — |
+
+The declared pattern set is a **superset** of the previous "crate subtrees
+only" configuration, so it can only *widen* the rebuild trigger set — the worst
+case is an over-rebuild, never a missed one.
+
+## Wiring
+
+Each service's Railway **Config-as-code file path** is set to its file above
+(e.g. `deploy/railway/arcan.railway.json`), and the equivalent `watchPatterns`
+were applied directly to the live service settings so the fix takes effect
+before this config lands on the deployed branch. Once on the deployed branch,
+the file is authoritative (config-as-code always overrides the dashboard for
+the fields it declares).

--- a/deploy/railway/arcan.railway.json
+++ b/deploy/railway/arcan.railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "watchPatterns": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "crates/**",
+      "apps/**",
+      "proto/**",
+      "agents/**"
+    ]
+  }
+}

--- a/deploy/railway/autonomicd.railway.json
+++ b/deploy/railway/autonomicd.railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "watchPatterns": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "crates/**",
+      "apps/**",
+      "proto/**"
+    ]
+  }
+}

--- a/deploy/railway/haimad.railway.json
+++ b/deploy/railway/haimad.railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "watchPatterns": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "crates/**",
+      "apps/**",
+      "proto/**"
+    ]
+  }
+}

--- a/deploy/railway/lagod.railway.json
+++ b/deploy/railway/lagod.railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "watchPatterns": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "crates/**",
+      "apps/**",
+      "proto/**"
+    ]
+  }
+}


### PR DESCRIPTION
## BRO-1467 — Railway watchPatterns missing `proto/**` + `apps/**` on substrate services

### Problem
The `arcan` / `lagod` / `haimad` / `autonomicd` Railway services (project **Life**, env **production**) watched **crate subtrees only** in their `watchPatterns`. Yet the active Dockerfiles (`docker/*.Dockerfile`) build the whole Cargo workspace from a repo-root context and COPY:

- `Cargo.toml`, `Cargo.lock`
- `crates/`
- `apps/` — workspace members required for `cargo` to resolve the workspace manifest
- `proto/` — read by the `*-substrate-proto` / `aios-proto` / `life-*-proto` `build.rs` scripts
- `agents/` — arcan only (blessed authored agents copied into the runtime image)

So a change under `proto/` or `apps/` recompiles the binary but did **not** trigger a Railway rebuild → production could drift from source. The arcan Dockerfile's own comment block documents these inputs.

### Change (config-only)
1. **Config-as-code** — new `deploy/railway/<service>.railway.json` files pin `build.watchPatterns` to the full Docker build-input set. `watchPatterns` is the **only** field declared, so every other build/deploy setting continues to combine from the Railway dashboard ([config-as-code semantics](https://docs.railway.com/config-as-code)).
2. **Live application** — the same `watchPatterns` were applied directly to the four production services via the Railway API, and each service's *Config-as-code file path* was pointed at its committed file, so the fix takes effect immediately and becomes authoritative once this lands on the deployed branch.
3. `deploy/railway/README.md` documents the rationale + wiring.

| Service | watchPatterns |
| --- | --- |
| arcan | `Cargo.toml`, `Cargo.lock`, `crates/**`, `apps/**`, `proto/**`, `agents/**` |
| lagod / haimad / autonomicd | `Cargo.toml`, `Cargo.lock`, `crates/**`, `apps/**`, `proto/**` |

### Risk
The new set is a **superset** of "crate subtrees only", so it can only *widen* the rebuild trigger set — worst case is an over-rebuild, never a missed one. `Cargo.toml`/`Cargo.lock` are added because they are literal build-context inputs (a `cargo update` that touches only `Cargo.lock` should rebuild); `agents/**` is added for arcan because its Dockerfile copies `agents/` into the runtime image.

### Validation
- All four `*.railway.json` files validated as JSON.
- All 8 Railway API mutations (4× `watchPatterns`, 4× config-file path) returned success.
- **Observability limits** (per DoD): the Railway MCP config summary does not surface `watchPatterns`/config-file values, and the end-to-end trigger ("a `proto/`-only push rebuilds the substrate") only manifests on a real future push to the deployed branch — not cleanly observable in-turn. Falling back to config review, as the ticket authorizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)