### PR TITLE
fix(life-runtime): de-flake BRO-1861 group_gid — reentrant getgrnam_r kills the static-buffer race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,6 +6693,7 @@ dependencies = [
  "life-runtime-proto",
  "life-vigil",
  "lifed-conformance",
+ "nix 0.31.2",
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",

--- a/crates/life-kernel/soma/src/admin/peercred.rs
+++ b/crates/life-kernel/soma/src/admin/peercred.rs
@@ -2,9 +2,10 @@
 //!
 //! Mirrors the lifegw implementation at
 //! `crates/life-runtime/lifegw/src/admin/peercred.rs`. soma's admin
-//! plane reaches `unsafe` only for the SO_PEERCRED syscall + group
-//! lookup — `lib.rs` denies unsafe at the crate root, this module
-//! re-allows it locally.
+//! plane reaches `unsafe` only for the SO_PEERCRED syscall — `lib.rs`
+//! denies unsafe at the crate root, this module re-allows it locally.
+//! Group lookups go through the safe reentrant `nix::unistd::Group`
+//! wrapper (`getgrnam_r`), not raw `getgrnam`.
 
 #![allow(unsafe_code)]
 
@@ -87,19 +88,21 @@ mod imp {
 
 pub use imp::{PeerCred, peer_cred};
 
-/// Look up the GID of a named group via `getgrnam(3)`.
+/// Look up the GID of a named group via the **reentrant** `getgrnam_r(3)`
+/// (through [`nix::unistd::Group`]).
+///
+/// `getgrnam(3)` (the non-reentrant variant) returns a pointer into a
+/// process-shared static buffer, so a concurrent group or passwd lookup on
+/// another thread can clobber the record between the call and the `gr_gid`
+/// read — a data race that intermittently flaked the sibling
+/// `group_gid_root_resolves` test under `cargo test`'s parallel runner
+/// (BRO-1861) and is a latent hazard on the admin-auth path itself.
+/// `getgrnam_r` fills a caller-owned buffer, so it is thread-safe and no
+/// longer needs `unsafe`.
 pub fn group_gid(name: &str) -> std::io::Result<Option<u32>> {
-    use std::ffi::CString;
-    let cname = CString::new(name)
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "group name has nul"))?;
-    // SAFETY: getgrnam returns a raw pointer that points to
-    // thread-static memory; we copy out the gid before another call
-    // could clobber it.
-    let g = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if g.is_null() {
-        return Ok(None);
-    }
-    Ok(Some(unsafe { (*g).gr_gid }))
+    let group = nix::unistd::Group::from_name(name)
+        .map_err(|e| std::io::Error::other(format!("getgrnam_r({name}): {e}")))?;
+    Ok(group.map(|g| g.gid.as_raw()))
 }
 
 /// Sub-phase E parity: query supplementary groups for a uid.

--- a/crates/life-runtime/lifed/Cargo.toml
+++ b/crates/life-runtime/lifed/Cargo.toml
@@ -78,6 +78,9 @@ sha2 = "0.10"
 base32 = "0.5"
 # admin-plane peer-cred extraction (SO_PEERCRED on Linux, getuid fallback elsewhere)
 libc = "0.2"
+# reentrant getgrnam_r(3) via the safe wrapper — replaces the thread-unsafe
+# libc::getgrnam so parallel group lookups don't race the static buffer (BRO-1861)
+nix = { version = "0.31", default-features = false, features = ["user"] }
 
 # substrate proxy clients (real impls in sub-phase B; stubs in sub-phase A)
 arcan-proxy.workspace = true

--- a/crates/life-runtime/lifed/src/auth/peercred.rs
+++ b/crates/life-runtime/lifed/src/auth/peercred.rs
@@ -10,7 +10,9 @@
 //! This module is the only place the lifed crate reaches for `unsafe`.
 //! `lib.rs` denies unsafe at the crate root; we re-allow it here for the
 //! one syscall block that drives `getsockopt(SO_PEERCRED)`,
-//! `pidfd_open(2)`, `getgrnam(3)`, and `getuid(2)`.
+//! `pidfd_open(2)`, and `getuid(2)`. Group lookups go through the safe
+//! reentrant `nix::unistd::Group` wrapper (`getgrnam_r`), not raw
+//! `getgrnam`.
 
 #![allow(unsafe_code)]
 
@@ -102,17 +104,20 @@ pub use imp::{PeerCred, peer_cred, pidfd_open};
 
 /// Look up the GID of a named group. Used to gate admin-plane access by
 /// `cfg.admin_plane.unix_socket_group`.
+///
+/// Uses the **reentrant** `getgrnam_r(3)` (via [`nix::unistd::Group`])
+/// rather than `getgrnam(3)`. The non-reentrant `getgrnam` returns a pointer
+/// into a process-shared static buffer, so a concurrent group or passwd
+/// lookup on another thread can clobber the record between the call and the
+/// `gr_gid` read — a data race that intermittently flaked the sibling
+/// `group_gid_root_resolves` test under `cargo test`'s parallel runner
+/// (BRO-1861) and is a latent hazard on the admin-auth path itself.
+/// `getgrnam_r` fills a caller-owned buffer, so it is thread-safe and no
+/// longer needs `unsafe`.
 pub fn group_gid(name: &str) -> std::io::Result<Option<u32>> {
-    use std::ffi::CString;
-    let cname = CString::new(name)
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "group name has nul"))?;
-    // SAFETY: getgrnam returns a raw pointer that points to thread-static memory; we
-    // copy out the gid before another call could clobber it.
-    let g = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if g.is_null() {
-        return Ok(None);
-    }
-    Ok(Some(unsafe { (*g).gr_gid }))
+    let group = nix::unistd::Group::from_name(name)
+        .map_err(|e| std::io::Error::other(format!("getgrnam_r({name}): {e}")))?;
+    Ok(group.map(|g| g.gid.as_raw()))
 }
 
 /// Test whether `cred` belongs to a process whose primary group is `gid`.

--- a/crates/life-runtime/lifegw/src/admin/peercred.rs
+++ b/crates/life-runtime/lifegw/src/admin/peercred.rs
@@ -87,18 +87,21 @@ pub use imp::{PeerCred, peer_cred};
 
 /// Look up the GID of a named group. Used to gate admin-plane access
 /// by `cfg.admin_plane.unix_socket_group`.
+///
+/// Uses the **reentrant** `getgrnam_r(3)` (via [`nix::unistd::Group`])
+/// rather than `getgrnam(3)`. The non-reentrant `getgrnam` returns a
+/// pointer into a process-shared static buffer, so a concurrent group
+/// or passwd lookup on another thread can clobber the record between
+/// the call and the `gr_gid` read — a data race that intermittently
+/// flaked `group_gid_root_resolves` under `cargo test`'s parallel
+/// runner (a clobbered record yields a garbage GID; BRO-1861) and is a
+/// latent hazard on the admin-auth path itself. `getgrnam_r` fills a
+/// caller-owned buffer, so it is thread-safe and no longer needs
+/// `unsafe`.
 pub fn group_gid(name: &str) -> std::io::Result<Option<u32>> {
-    use std::ffi::CString;
-    let cname = CString::new(name)
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "group name has nul"))?;
-    // SAFETY: getgrnam returns a raw pointer that points to
-    // thread-static memory; we copy out the gid before another call
-    // could clobber it.
-    let g = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if g.is_null() {
-        return Ok(None);
-    }
-    Ok(Some(unsafe { (*g).gr_gid }))
+    let group = nix::unistd::Group::from_name(name)
+        .map_err(|e| std::io::Error::other(format!("getgrnam_r({name}): {e}")))?;
+    Ok(group.map(|g| g.gid.as_raw()))
 }
 
 /// Test whether `cred` belongs to a process whose primary group is


### PR DESCRIPTION
## BRO-1861 — Flaky env-dependent test: `lifegw admin::peercred::group_gid_root_resolves`

### Root cause (not an env-value difference — a data race)
`admin::peercred::group_gid` used the **non-reentrant** `getgrnam(3)`, which returns a pointer into a **process-shared static buffer**. `cargo test` runs a crate's tests in parallel threads of one process, and this module also runs concurrent group/passwd lookups (`group_gid_missing_returns_none`, `supplementary_gids_of_uid_*` → `getgrouplist`/`getpwuid_r`). A concurrent lookup can clobber the `getgrnam` record **between the call and the `gr_gid` read**, so `group_gid("root")` returns a garbage GID and `group_gid_root_resolves` panics at `assert!(g <= 100)` (peercred.rs:162).

Because it's timing-dependent it flakes on some runners while the **identical** `cargo test --workspace` on the **same commit** passes in the control-harness job — exactly the symptom the ticket reports (deterministic env differences would fail consistently; a race does not).

### Fix
Route group lookups through the **reentrant** `getgrnam_r(3)` via the safe `nix::unistd::Group::from_name` wrapper (caller-owned buffer, no shared static state). This eliminates the race in **both** the test *and* the live admin-auth path (`group_gid` gates admin-plane access by group), and drops the `unsafe` block from `group_gid`.

Rather than paper over the assertion, this fixes the actual thread-safety defect — a latent hazard in production SO_PEERCRED group gating, not just a test artifact.

### Scope — all three copies of the identical bug
The gate is `cargo test --workspace`, so a trustworthy gate means killing the flake everywhere it lives. The same non-reentrant `getgrnam` + same `group_gid_root_resolves` test appears in three crates:
- `crates/life-runtime/lifegw/src/admin/peercred.rs` (ticket target)
- `crates/life-runtime/lifed/src/auth/peercred.rs` (adds the already-in-tree `nix` dep — `["user"]`)
- `crates/life-kernel/soma/src/admin/peercred.rs` (already had `nix`)

### Validation (P11)
- `cargo build -p lifegw -p lifed`, `cargo test -p soma` — clean
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` — clean on all three
- All peercred unit tests pass (lifegw 5, lifed 3, soma 3)
- **Stress: 40 iterations × 16 threads** of the previously-flaky lifegw + soma peercred modules → **0 failures**
- `scripts/verify_dependencies_lifed.sh` → "all lifed dependency rules pass"

### Notes
- No public API change (`fn group_gid(name: &str) -> io::Result<Option<u32>>` unchanged); re-exports and callers unaffected.
- Minor semantic nicety: a group name containing an interior NUL now returns `Ok(None)` ("no such group") instead of `Err(InvalidInput)`; no caller or test relies on the old error path, and no real group name can contain NUL.

Provenance: surfaced while shipping BRO-1858 (control-harness CI). Related: BRO-1858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system group lookups used during peer credential authentication.
  * Group resolution is now safer and more reliable when multiple lookups occur concurrently.
  * Missing groups continue to be handled correctly, while lookup failures now provide clearer error reporting.
* **Documentation**
  * Updated technical documentation to accurately describe group lookup behavior and safety guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->