### PR TITLE
feat(nous): BRO-1311 dual-classifier surface — premise-staleness alongside control-divergence

### DIFF
--- a/crates/nous/CLAUDE.md
+++ b/crates/nous/CLAUDE.md
@@ -11,7 +11,7 @@ Hybrid deployment: embedded inline heuristics (< 2ms, Arcan middleware hooks) + 
 
 ## Crates
 
-- `nous-core` — Types, traits, errors (zero I/O). `NousEvaluator` trait, `EvalScore`, `EvalResult`, `EvalLayer` taxonomy
+- `nous-core` — Types, traits, errors (zero I/O). `NousEvaluator` trait, `EvalScore`, `EvalResult`, `EvalLayer` taxonomy. Dual-classifier surface (`premise` module): `watch_premise_validity(session)` premise-staleness detector (output/plant/no-op divergence, deterministic, no LLM in hot path), `FailureClass` (epistemic/control/both/neither) → `DiagnosisRoute`, and `reconcile` discrepancy taxonomy (`PremiseStale` third class + `ShadowCompetence` inverse/promote-candidate)
 - `nous-heuristics` — Inline evaluators: token efficiency, budget adherence, tool correctness, argument validity, safety compliance, step efficiency
 - `nous-middleware` — `NousMiddleware: impl arcan_core::Middleware` — wires evaluators into agent loop
 - `nous-judge` — Async LLM-as-judge: plan quality, plan adherence, task completion

--- a/crates/nous/nous-core/src/events.rs
+++ b/crates/nous/nous-core/src/events.rs
@@ -7,6 +7,9 @@ use aios_protocol::event::EventKind;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use crate::premise::{
+    Diagnosis, DiagnosisRoute, FailureClass, PremiseStalenessSignal, StalenessSignalKind,
+};
 use crate::score::{EvalScore, ScoreLabel};
 use crate::taxonomy::EvalLayer;
 
@@ -49,6 +52,18 @@ pub enum NousEvent {
         trial_id: Option<String>,
         outcome: serde_json::Value,
     },
+    /// A premise-staleness detector fired, tagged with its dual-classifier
+    /// diagnosis and route. This is the second Nous observation lens alongside
+    /// control-divergence (see [`crate::premise`]).
+    PremiseStalenessAlarm {
+        session_id: String,
+        kind: StalenessSignalKind,
+        magnitude: f64,
+        class: FailureClass,
+        route: DiagnosisRoute,
+        run_id: Option<String>,
+        explanation: Option<String>,
+    },
 }
 
 /// Summary of a score for event serialization.
@@ -82,6 +97,23 @@ impl NousEvent {
             session_id: score.session_id.clone(),
             run_id: score.run_id.clone(),
             explanation: score.explanation.clone(),
+        }
+    }
+
+    /// Create a premise-staleness alarm event from a fired signal and its
+    /// dual-classifier diagnosis.
+    pub fn from_premise_signal(signal: &PremiseStalenessSignal, diagnosis: &Diagnosis) -> Self {
+        Self::PremiseStalenessAlarm {
+            session_id: signal.session_id.clone(),
+            kind: signal.kind,
+            magnitude: signal.magnitude,
+            class: diagnosis.class,
+            route: diagnosis.route,
+            run_id: None,
+            explanation: signal
+                .detail
+                .clone()
+                .or_else(|| diagnosis.rationale.clone()),
         }
     }
 
@@ -150,6 +182,26 @@ impl NousEvent {
                     "session_id": session_id,
                     "trial_id": trial_id,
                     "outcome": outcome,
+                }),
+            ),
+            Self::PremiseStalenessAlarm {
+                session_id,
+                kind,
+                magnitude,
+                class,
+                route,
+                run_id,
+                explanation,
+            } => (
+                "eval.PremiseStalenessAlarm",
+                json!({
+                    "session_id": session_id,
+                    "kind": kind,
+                    "magnitude": magnitude,
+                    "class": class,
+                    "route": route,
+                    "run_id": run_id,
+                    "explanation": explanation,
                 }),
             ),
         };
@@ -238,6 +290,33 @@ impl NousEvent {
                     session_id,
                     trial_id,
                     outcome,
+                })
+            }
+            "eval.PremiseStalenessAlarm" => {
+                let session_id = data.get("session_id")?.as_str()?.to_owned();
+                let kind: StalenessSignalKind =
+                    serde_json::from_value(data.get("kind")?.clone()).ok()?;
+                let magnitude = data.get("magnitude")?.as_f64()?;
+                let class: FailureClass =
+                    serde_json::from_value(data.get("class")?.clone()).ok()?;
+                let route: DiagnosisRoute =
+                    serde_json::from_value(data.get("route")?.clone()).ok()?;
+                let run_id = data
+                    .get("run_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                let explanation = data
+                    .get("explanation")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                Some(Self::PremiseStalenessAlarm {
+                    session_id,
+                    kind,
+                    magnitude,
+                    class,
+                    route,
+                    run_id,
+                    explanation,
                 })
             }
             _ => None,
@@ -403,6 +482,59 @@ mod tests {
             }
         } else {
             panic!("expected Custom variant");
+        }
+    }
+
+    #[test]
+    fn premise_staleness_alarm_roundtrip() {
+        use crate::premise::{DiagnosisRoute, FailureClass, StalenessSignalKind};
+
+        let event = NousEvent::PremiseStalenessAlarm {
+            session_id: "sess-1".into(),
+            kind: StalenessSignalKind::OutputDivergence,
+            magnitude: 0.62,
+            class: FailureClass::Epistemic,
+            route: DiagnosisRoute::PremiseUpdate,
+            run_id: Some("run-7".into()),
+            explanation: Some("cosine distance 0.62 > k".into()),
+        };
+        let kind = event.into_event_kind();
+        if let EventKind::Custom { event_type, data } = kind {
+            assert_eq!(event_type, "eval.PremiseStalenessAlarm");
+            assert_eq!(data["class"], "epistemic");
+            assert_eq!(data["route"], "premise_update");
+            assert_eq!(data["kind"], "output_divergence");
+            let parsed = NousEvent::from_custom(&event_type, &data).unwrap();
+            match parsed {
+                NousEvent::PremiseStalenessAlarm {
+                    class, route, kind, ..
+                } => {
+                    assert_eq!(class, FailureClass::Epistemic);
+                    assert_eq!(route, DiagnosisRoute::PremiseUpdate);
+                    assert_eq!(kind, StalenessSignalKind::OutputDivergence);
+                }
+                _ => panic!("expected PremiseStalenessAlarm variant"),
+            }
+        } else {
+            panic!("expected Custom variant");
+        }
+    }
+
+    #[test]
+    fn premise_alarm_from_signal_and_diagnosis() {
+        use crate::premise::watch_premise_validity;
+
+        let mut w = watch_premise_validity("sess-1");
+        let signal = w.observe_plant(1.0, 0.0).expect("plant divergence fires");
+        let diagnosis = signal.diagnose(false);
+        let event = NousEvent::from_premise_signal(&signal, &diagnosis);
+        assert!(NousEvent::is_eval_event("eval.PremiseStalenessAlarm"));
+        match event {
+            NousEvent::PremiseStalenessAlarm { class, route, .. } => {
+                assert_eq!(class, crate::premise::FailureClass::Epistemic);
+                assert_eq!(route, crate::premise::DiagnosisRoute::PremiseUpdate);
+            }
+            _ => panic!("expected PremiseStalenessAlarm"),
         }
     }
 

--- a/crates/nous/nous-core/src/lib.rs
+++ b/crates/nous/nous-core/src/lib.rs
@@ -7,6 +7,8 @@ pub mod egri;
 pub mod error;
 pub mod evaluator;
 pub mod events;
+pub mod premise;
+pub mod reconcile;
 pub mod registry;
 pub mod score;
 pub mod taxonomy;
@@ -15,6 +17,12 @@ pub mod taxonomy;
 pub use error::{NousError, NousResult};
 pub use evaluator::{EvalContext, EvalHook, NousEvaluator};
 pub use events::{EVAL_EVENT_PREFIX, NousEvent};
+pub use premise::{
+    Diagnosis, DiagnosisRoute, FailureClass, LEXICAL_DIM, PremiseStalenessSignal,
+    PremiseValidityWatcher, PremiseWatchConfig, StalenessSignalKind, lexical_features,
+    watch_premise_validity,
+};
+pub use reconcile::{DiscrepancyClass, ReconcileDiscrepancy};
 pub use registry::EvaluatorRegistry;
 pub use score::{EvalResult, EvalScore, ScoreLabel};
 pub use taxonomy::{EvalLayer, EvalTiming};

--- a/crates/nous/nous-core/src/premise.rs
+++ b/crates/nous/nous-core/src/premise.rs
@@ -210,6 +210,12 @@ pub enum StalenessSignalKind {
     /// A predicted plant reading diverged from the observed one.
     PlantDivergence,
     /// Consecutive no-op actions accumulated past the reverse-burden threshold.
+    ///
+    /// Pinned to `noop_accumulation` so the serde wire form matches
+    /// [`label()`](Self::label); the default `snake_case` derive would split the
+    /// "NoOp" acronym into `no_op_accumulation`, desyncing the JSON `kind` field
+    /// from the label used in logs and rationale text.
+    #[serde(rename = "noop_accumulation")]
     NoOpAccumulation,
 }
 
@@ -240,7 +246,8 @@ pub struct PremiseStalenessSignal {
     /// Signal strength: cosine distance, normalized plant gap, or no-op run
     /// length (as `f64`), depending on `kind`.
     pub magnitude: f64,
-    /// The watcher's observation index at which the signal fired.
+    /// The watcher's monotonic observation sequence — counting every
+    /// `observe_*` call (output, plant, and action) — at which the signal fired.
     pub observation: u64,
     /// Optional detail string.
     pub detail: Option<String>,
@@ -302,6 +309,10 @@ pub struct PremiseValidityWatcher {
     config: PremiseWatchConfig,
     window: VecDeque<Vec<f64>>,
     observations: u64,
+    /// Monotonic index over *every* `observe_*` call, used to stamp signals so
+    /// plant/no-op signals get a call-sequential index rather than the
+    /// output-only `observations` count.
+    sequence: u64,
     consecutive_noops: usize,
 }
 
@@ -313,6 +324,7 @@ impl PremiseValidityWatcher {
             config,
             window: VecDeque::new(),
             observations: 0,
+            sequence: 0,
             consecutive_noops: 0,
         }
     }
@@ -325,6 +337,12 @@ impl PremiseValidityWatcher {
     /// Total number of output observations fed so far.
     pub fn observations(&self) -> u64 {
         self.observations
+    }
+
+    /// Monotonic count of all observations (output, plant, and action) fed so
+    /// far — the index that stamps each emitted signal's `observation` field.
+    pub fn sequence(&self) -> u64 {
+        self.sequence
     }
 
     /// Current consecutive no-op run length.
@@ -341,6 +359,7 @@ impl PremiseValidityWatcher {
     /// fired, so the baseline adapts.
     pub fn observe_output(&mut self, features: &[f64]) -> Option<PremiseStalenessSignal> {
         self.observations += 1;
+        self.sequence += 1;
         let signal = if self.config.window > 0 && self.window.len() >= self.config.window {
             let mean = window_mean(&self.window);
             let distance = cosine_distance(features, &mean);
@@ -348,7 +367,7 @@ impl PremiseValidityWatcher {
                 session_id: self.session_id.clone(),
                 kind: StalenessSignalKind::OutputDivergence,
                 magnitude: distance,
-                observation: self.observations,
+                observation: self.sequence,
                 detail: Some(format!(
                     "cosine distance {:.3} > k={:.3} over {}-back window",
                     distance, self.config.distance_threshold, self.config.window
@@ -383,13 +402,14 @@ impl PremiseValidityWatcher {
         predicted: f64,
         observed: f64,
     ) -> Option<PremiseStalenessSignal> {
+        self.sequence += 1;
         let scale = predicted.abs().max(observed.abs()).max(f64::EPSILON);
         let normalized = (predicted - observed).abs() / scale;
         (normalized > self.config.plant_divergence_threshold).then(|| PremiseStalenessSignal {
             session_id: self.session_id.clone(),
             kind: StalenessSignalKind::PlantDivergence,
             magnitude: normalized.min(1.0),
-            observation: self.observations,
+            observation: self.sequence,
             detail: Some(format!(
                 "predicted {predicted:.3} vs observed {observed:.3}, normalized gap {normalized:.3}"
             )),
@@ -402,6 +422,7 @@ impl PremiseValidityWatcher {
     /// `config.noop_threshold` the burden reverses and each further no-op fires
     /// a signal whose magnitude is the run length.
     pub fn observe_action(&mut self, made_progress: bool) -> Option<PremiseStalenessSignal> {
+        self.sequence += 1;
         if made_progress {
             self.consecutive_noops = 0;
             return None;
@@ -412,7 +433,7 @@ impl PremiseValidityWatcher {
                 session_id: self.session_id.clone(),
                 kind: StalenessSignalKind::NoOpAccumulation,
                 magnitude: self.consecutive_noops as f64,
-                observation: self.observations,
+                observation: self.sequence,
                 detail: Some(format!(
                     "{} consecutive no-ops >= threshold {}",
                     self.consecutive_noops, self.config.noop_threshold
@@ -741,6 +762,50 @@ mod tests {
         for _ in 0..10 {
             assert!(w.observe_output(&[1.0, 0.0]).is_none());
         }
+    }
+
+    #[test]
+    fn staleness_kind_serde_matches_label() {
+        // Regression (CodeRabbit): the serde wire form must equal `label()` for
+        // every variant — in particular NoOpAccumulation, which the default
+        // snake_case derive would render as `no_op_accumulation`.
+        for kind in [
+            StalenessSignalKind::OutputDivergence,
+            StalenessSignalKind::PlantDivergence,
+            StalenessSignalKind::NoOpAccumulation,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(json, format!("\"{}\"", kind.label()));
+            let back: StalenessSignalKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, kind);
+        }
+        assert_eq!(
+            serde_json::to_string(&StalenessSignalKind::NoOpAccumulation).unwrap(),
+            "\"noop_accumulation\""
+        );
+    }
+
+    #[test]
+    fn observation_index_is_sequential_across_detectors() {
+        // Regression (CodeRabbit): plant/no-op signals must carry a call-
+        // sequential index, not the stale output-only count.
+        let cfg = PremiseWatchConfig {
+            noop_threshold: 1,
+            ..Default::default()
+        };
+        let mut w = PremiseValidityWatcher::new("s", cfg);
+        // 1: action no-op fires (threshold 1) → observation == sequence == 1.
+        let s1 = w.observe_action(false).expect("fires at threshold 1");
+        assert_eq!(s1.observation, 1);
+        // 2: plant divergence fires → observation == 2 (not 0/output-count).
+        let s2 = w.observe_plant(1.0, 0.0).expect("plant fires");
+        assert_eq!(s2.observation, 2);
+        // 3: another no-op → observation == 3.
+        let s3 = w.observe_action(false).expect("fires again");
+        assert_eq!(s3.observation, 3);
+        // sequence counts all three; output count stayed 0.
+        assert_eq!(w.sequence(), 3);
+        assert_eq!(w.observations(), 0);
     }
 
     #[test]

--- a/crates/nous/nous-core/src/premise.rs
+++ b/crates/nous/nous-core/src/premise.rs
@@ -1,0 +1,753 @@
+//! Premise-staleness classifier — the second Nous observation lens.
+//!
+//! Nous historically shipped a single classifier: **control-divergence**
+//! ("did execution match the plan?", realized by `nous-judge::PlanAdherence`).
+//! That lens answers *is the loop wrong?* It cannot answer the orthogonal
+//! question *was the plan still valid given the current world?* — and without
+//! that question, every premise failure is misread as a loop failure, energy is
+//! spent re-engineering the loop, the premise stays stale, and the cycle
+//! compounds. See `research/entities/pattern/shadow-competence.md` (9/9).
+//!
+//! This module adds the missing lens: **premise-staleness**. It is a stateful,
+//! session-scoped, deterministic detector — *no LLM in the hot path* — plus the
+//! dual-classifier schema that routes a diagnosis to the layer that can fix it.
+//!
+//! # The dual-classifier schema
+//!
+//! Every diagnosis is tagged along two independent axes and routed accordingly:
+//!
+//! | [`FailureClass`] | Meaning | Route ([`DiagnosisRoute`]) |
+//! |------------------|---------|----------------------------|
+//! | [`Epistemic`](FailureClass::Epistemic) | the premise was/became wrong for the task | premise update |
+//! | [`Control`](FailureClass::Control) | execution diverged from a still-valid plan | monitoring tweak |
+//! | [`Both`](FailureClass::Both) | premise stale *and* execution diverged | architectural rework |
+//! | [`Neither`](FailureClass::Neither) | false alarm | false-alarm corpus |
+//!
+//! A note on terminology: the source framing labels "a premise that *drifted*" a
+//! *control* failure because the monitoring loop should have caught the drift.
+//! We collapse "wrong from the start" and "drifted" onto the **epistemic** axis,
+//! because the *remedy* for both is the same — **update the premise**. The
+//! control axis is reserved for the pre-existing control-divergence lens
+//! (execution vs. plan). This keeps routing 1:1 with the layer that acts on it.
+//!
+//! # The detector
+//!
+//! [`PremiseValidityWatcher`] accumulates three orthogonal staleness signals
+//! over the life of a session:
+//!
+//! 1. **Output divergence** — cosine distance from a new output's feature vector
+//!    to the mean of the rolling `N`-back window. ami_ai_'s concrete proposal:
+//!    *"this output looks structurally different from the last five iterations."*
+//! 2. **Plant divergence** — normalized gap between a predicted and an observed
+//!    plant reading. The world moved out from under the plan.
+//! 3. **No-op accumulation** — reverse-burden signal: consecutive actions that
+//!    made no progress. Normally the burden is on the watcher to prove staleness;
+//!    once no-ops pile up past a threshold, the burden reverses — the premise is
+//!    presumed stale until progress resumes.
+//!
+//! The watcher is **embedding-agnostic**: it consumes feature vectors, so a real
+//! embedding model can be substituted freely. For a zero-dependency default it
+//! ships [`lexical_features`], a deterministic hashed-token bag that needs no
+//! model and no I/O — resolving the "embedding model choice" open question by
+//! not forcing one.
+
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+
+/// One of the two orthogonal failure axes, or their combination / absence.
+///
+/// Produced by [`Diagnosis::classify`] from a premise-staleness signal (the
+/// epistemic axis) and a control-divergence signal (the control axis).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    /// The premise was wrong, or drifted out of validity. Fix the premise.
+    Epistemic,
+    /// Execution diverged from a still-valid plan. Fix the monitoring loop.
+    Control,
+    /// Premise stale *and* execution diverged. Rework the architecture.
+    Both,
+    /// Neither axis fired — a false alarm worth recording for calibration.
+    Neither,
+}
+
+impl FailureClass {
+    /// Build a class from the two independent axis signals.
+    pub fn from_signals(epistemic: bool, control: bool) -> Self {
+        match (epistemic, control) {
+            (true, false) => Self::Epistemic,
+            (false, true) => Self::Control,
+            (true, true) => Self::Both,
+            (false, false) => Self::Neither,
+        }
+    }
+
+    /// The layer that can act on this class of failure.
+    pub fn route(&self) -> DiagnosisRoute {
+        match self {
+            Self::Epistemic => DiagnosisRoute::PremiseUpdate,
+            Self::Control => DiagnosisRoute::MonitoringTweak,
+            Self::Both => DiagnosisRoute::ArchitecturalRework,
+            Self::Neither => DiagnosisRoute::FalseAlarmCorpus,
+        }
+    }
+
+    /// Stable snake_case label for events and logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Epistemic => "epistemic",
+            Self::Control => "control",
+            Self::Both => "both",
+            Self::Neither => "neither",
+        }
+    }
+}
+
+impl std::fmt::Display for FailureClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Where a diagnosis should be routed — one destination per [`FailureClass`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosisRoute {
+    /// Epistemic failure → revise the stale/wrong premise.
+    PremiseUpdate,
+    /// Control failure → adjust the monitoring loop / control law.
+    MonitoringTweak,
+    /// Both → deeper architectural rework spanning premise and loop.
+    ArchitecturalRework,
+    /// Neither → append to the false-alarm corpus for threshold calibration.
+    FalseAlarmCorpus,
+}
+
+impl DiagnosisRoute {
+    /// Stable snake_case label for events and logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::PremiseUpdate => "premise_update",
+            Self::MonitoringTweak => "monitoring_tweak",
+            Self::ArchitecturalRework => "architectural_rework",
+            Self::FalseAlarmCorpus => "false_alarm_corpus",
+        }
+    }
+}
+
+impl std::fmt::Display for DiagnosisRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// A tagged diagnosis: a failure class, its derived route, and a rationale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Diagnosis {
+    /// Session the diagnosis belongs to.
+    pub session_id: String,
+    /// Which failure axis (or combination) fired.
+    pub class: FailureClass,
+    /// Where the diagnosis routes — always `class.route()`.
+    pub route: DiagnosisRoute,
+    /// Confidence in `[0.0, 1.0]`.
+    pub confidence: f64,
+    /// Optional human-readable rationale.
+    pub rationale: Option<String>,
+}
+
+impl Diagnosis {
+    /// Build a diagnosis from an explicit class; the route is derived.
+    pub fn new(session_id: impl Into<String>, class: FailureClass, confidence: f64) -> Self {
+        Self {
+            session_id: session_id.into(),
+            class,
+            route: class.route(),
+            confidence: confidence.clamp(0.0, 1.0),
+            rationale: None,
+        }
+    }
+
+    /// Classify from the two independent axis signals.
+    ///
+    /// `premise_stale` is the epistemic axis (this module's detector);
+    /// `control_diverged` is the control axis (the existing control-divergence
+    /// classifier, e.g. `nous-judge::PlanAdherence` scoring low).
+    pub fn classify(
+        session_id: impl Into<String>,
+        premise_stale: bool,
+        control_diverged: bool,
+        confidence: f64,
+    ) -> Self {
+        Self::new(
+            session_id,
+            FailureClass::from_signals(premise_stale, control_diverged),
+            confidence,
+        )
+    }
+
+    /// Attach a rationale.
+    pub fn with_rationale(mut self, rationale: impl Into<String>) -> Self {
+        self.rationale = Some(rationale.into());
+        self
+    }
+
+    /// Whether this diagnosis is a false alarm (`Neither`).
+    pub fn is_false_alarm(&self) -> bool {
+        self.class == FailureClass::Neither
+    }
+}
+
+/// Which of the three orthogonal staleness detectors produced a signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StalenessSignalKind {
+    /// A new output diverged structurally from the rolling window.
+    OutputDivergence,
+    /// A predicted plant reading diverged from the observed one.
+    PlantDivergence,
+    /// Consecutive no-op actions accumulated past the reverse-burden threshold.
+    NoOpAccumulation,
+}
+
+impl StalenessSignalKind {
+    /// Stable snake_case label for events and logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::OutputDivergence => "output_divergence",
+            Self::PlantDivergence => "plant_divergence",
+            Self::NoOpAccumulation => "noop_accumulation",
+        }
+    }
+}
+
+impl std::fmt::Display for StalenessSignalKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// A fired premise-staleness alarm. Feeds the epistemic axis of [`Diagnosis`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PremiseStalenessSignal {
+    /// Session the signal belongs to.
+    pub session_id: String,
+    /// Which detector fired.
+    pub kind: StalenessSignalKind,
+    /// Signal strength: cosine distance, normalized plant gap, or no-op run
+    /// length (as `f64`), depending on `kind`.
+    pub magnitude: f64,
+    /// The watcher's observation index at which the signal fired.
+    pub observation: u64,
+    /// Optional detail string.
+    pub detail: Option<String>,
+}
+
+impl PremiseStalenessSignal {
+    /// Build a [`Diagnosis`] treating this signal as the epistemic axis,
+    /// combined with an externally-supplied control-divergence flag.
+    pub fn diagnose(&self, control_diverged: bool) -> Diagnosis {
+        Diagnosis::classify(
+            self.session_id.clone(),
+            true,
+            control_diverged,
+            self.magnitude.clamp(0.0, 1.0),
+        )
+        .with_rationale(format!(
+            "premise-staleness [{}] magnitude {:.3} at observation {}",
+            self.kind, self.magnitude, self.observation
+        ))
+    }
+}
+
+/// Tuning knobs for [`PremiseValidityWatcher`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PremiseWatchConfig {
+    /// Rolling `N`-back window size for output-divergence detection.
+    pub window: usize,
+    /// Cosine-distance threshold `k`; a new output beyond it fires.
+    pub distance_threshold: f64,
+    /// Consecutive no-ops before the reverse burden trips.
+    pub noop_threshold: usize,
+    /// Normalized plant-gap threshold for plant-divergence detection.
+    pub plant_divergence_threshold: f64,
+}
+
+impl Default for PremiseWatchConfig {
+    fn default() -> Self {
+        // window=5 mirrors ami_ai_'s "last five iterations"; the thresholds are
+        // conservative starting points pending empirical calibration (the
+        // false-alarm corpus, `DiagnosisRoute::FalseAlarmCorpus`, is the data
+        // source for that calibration).
+        Self {
+            window: 5,
+            distance_threshold: 0.35,
+            noop_threshold: 3,
+            plant_divergence_threshold: 0.5,
+        }
+    }
+}
+
+/// Session-scoped, deterministic premise-staleness detector.
+///
+/// Construct via [`watch_premise_validity`] (defaults) or
+/// [`PremiseValidityWatcher::new`] (explicit config). Feed it observations;
+/// each `observe_*` call returns `Some(signal)` when its detector trips.
+#[derive(Debug, Clone)]
+pub struct PremiseValidityWatcher {
+    session_id: String,
+    config: PremiseWatchConfig,
+    window: VecDeque<Vec<f64>>,
+    observations: u64,
+    consecutive_noops: usize,
+}
+
+impl PremiseValidityWatcher {
+    /// Create a watcher with an explicit config.
+    pub fn new(session_id: impl Into<String>, config: PremiseWatchConfig) -> Self {
+        Self {
+            session_id: session_id.into(),
+            config,
+            window: VecDeque::new(),
+            observations: 0,
+            consecutive_noops: 0,
+        }
+    }
+
+    /// The session this watcher observes.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Total number of output observations fed so far.
+    pub fn observations(&self) -> u64 {
+        self.observations
+    }
+
+    /// Current consecutive no-op run length.
+    pub fn consecutive_noops(&self) -> usize {
+        self.consecutive_noops
+    }
+
+    /// Observe a new output as a feature vector.
+    ///
+    /// Once the rolling window holds a full baseline (`config.window` prior
+    /// vectors), the cosine distance from `features` to the window mean is
+    /// compared against `config.distance_threshold`. `features` is always
+    /// appended to the window (evicting the oldest) regardless of whether it
+    /// fired, so the baseline adapts.
+    pub fn observe_output(&mut self, features: &[f64]) -> Option<PremiseStalenessSignal> {
+        self.observations += 1;
+        let signal = if self.config.window > 0 && self.window.len() >= self.config.window {
+            let mean = window_mean(&self.window);
+            let distance = cosine_distance(features, &mean);
+            (distance > self.config.distance_threshold).then(|| PremiseStalenessSignal {
+                session_id: self.session_id.clone(),
+                kind: StalenessSignalKind::OutputDivergence,
+                magnitude: distance,
+                observation: self.observations,
+                detail: Some(format!(
+                    "cosine distance {:.3} > k={:.3} over {}-back window",
+                    distance, self.config.distance_threshold, self.config.window
+                )),
+            })
+        } else {
+            None
+        };
+
+        self.window.push_back(features.to_vec());
+        while self.window.len() > self.config.window {
+            self.window.pop_front();
+        }
+        signal
+    }
+
+    /// Observe a new output as raw text, vectorized via [`lexical_features`].
+    ///
+    /// Convenience wrapper for the zero-dependency default embedding.
+    pub fn observe_output_text(&mut self, text: &str) -> Option<PremiseStalenessSignal> {
+        let features = lexical_features(text);
+        self.observe_output(&features)
+    }
+
+    /// Observe a predicted-vs-observed plant reading.
+    ///
+    /// The gap is normalized by the larger magnitude of the two readings, so the
+    /// threshold is scale-free. Returns a signal when the normalized gap exceeds
+    /// `config.plant_divergence_threshold`.
+    pub fn observe_plant(
+        &mut self,
+        predicted: f64,
+        observed: f64,
+    ) -> Option<PremiseStalenessSignal> {
+        let scale = predicted.abs().max(observed.abs()).max(f64::EPSILON);
+        let normalized = (predicted - observed).abs() / scale;
+        (normalized > self.config.plant_divergence_threshold).then(|| PremiseStalenessSignal {
+            session_id: self.session_id.clone(),
+            kind: StalenessSignalKind::PlantDivergence,
+            magnitude: normalized.min(1.0),
+            observation: self.observations,
+            detail: Some(format!(
+                "predicted {predicted:.3} vs observed {observed:.3}, normalized gap {normalized:.3}"
+            )),
+        })
+    }
+
+    /// Observe whether an action made progress (reverse-burden no-op counter).
+    ///
+    /// Progress resets the counter. A no-op increments it; once the run reaches
+    /// `config.noop_threshold` the burden reverses and each further no-op fires
+    /// a signal whose magnitude is the run length.
+    pub fn observe_action(&mut self, made_progress: bool) -> Option<PremiseStalenessSignal> {
+        if made_progress {
+            self.consecutive_noops = 0;
+            return None;
+        }
+        self.consecutive_noops += 1;
+        if self.config.noop_threshold > 0 && self.consecutive_noops >= self.config.noop_threshold {
+            Some(PremiseStalenessSignal {
+                session_id: self.session_id.clone(),
+                kind: StalenessSignalKind::NoOpAccumulation,
+                magnitude: self.consecutive_noops as f64,
+                observation: self.observations,
+                detail: Some(format!(
+                    "{} consecutive no-ops >= threshold {}",
+                    self.consecutive_noops, self.config.noop_threshold
+                )),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Start watching a session's premise validity with default tuning.
+///
+/// This is the `nous::watch_premise_validity(session)` entry point named in the
+/// design: a session-scoped, stateful, deterministic premise-staleness detector.
+pub fn watch_premise_validity(session_id: impl Into<String>) -> PremiseValidityWatcher {
+    PremiseValidityWatcher::new(session_id, PremiseWatchConfig::default())
+}
+
+/// Dimensionality of the [`lexical_features`] vector.
+pub const LEXICAL_DIM: usize = 64;
+
+/// Deterministic, dependency-free lexical feature vector for a text output.
+///
+/// Tokens (maximal alphanumeric runs, lowercased) are hashed into a fixed
+/// [`LEXICAL_DIM`]-bucket bag-of-words count vector using `DefaultHasher` (fixed
+/// SipHash keys → stable across runs and machines). This is a cheap stand-in for
+/// a real sentence embedding: it captures *structural* shifts in an output's
+/// token distribution — exactly the "looks different from the last five
+/// iterations" signal — with no model and no I/O. Swap in a real embedding by
+/// calling [`PremiseValidityWatcher::observe_output`] with your own vector.
+pub fn lexical_features(text: &str) -> Vec<f64> {
+    let mut v = vec![0.0f64; LEXICAL_DIM];
+    for token in text
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+    {
+        let lower = token.to_ascii_lowercase();
+        let mut hasher = DefaultHasher::new();
+        lower.hash(&mut hasher);
+        let bucket = (hasher.finish() as usize) % LEXICAL_DIM;
+        v[bucket] += 1.0;
+    }
+    v
+}
+
+/// Element-wise mean of a window of feature vectors (zero-padded to the widest).
+fn window_mean(window: &VecDeque<Vec<f64>>) -> Vec<f64> {
+    let dim = window.iter().map(Vec::len).max().unwrap_or(0);
+    let mut mean = vec![0.0f64; dim];
+    if window.is_empty() {
+        return mean;
+    }
+    for vec in window {
+        for (i, &x) in vec.iter().enumerate() {
+            mean[i] += x;
+        }
+    }
+    let n = window.len() as f64;
+    for m in &mut mean {
+        *m /= n;
+    }
+    mean
+}
+
+/// Cosine distance `1 - cos_sim` between two vectors (zero-padded to the widest).
+///
+/// A zero-norm vector on either side yields distance `1.0` (maximal), since
+/// similarity is undefined. Range is `[0.0, 2.0]`; for non-negative feature
+/// vectors it stays within `[0.0, 1.0]`.
+fn cosine_distance(a: &[f64], b: &[f64]) -> f64 {
+    let dim = a.len().max(b.len());
+    let mut dot = 0.0;
+    let mut norm_a = 0.0;
+    let mut norm_b = 0.0;
+    for i in 0..dim {
+        let x = a.get(i).copied().unwrap_or(0.0);
+        let y = b.get(i).copied().unwrap_or(0.0);
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    if norm_a <= f64::EPSILON || norm_b <= f64::EPSILON {
+        return 1.0;
+    }
+    let sim = dot / (norm_a.sqrt() * norm_b.sqrt());
+    1.0 - sim
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_class_from_signals() {
+        assert_eq!(
+            FailureClass::from_signals(true, false),
+            FailureClass::Epistemic
+        );
+        assert_eq!(
+            FailureClass::from_signals(false, true),
+            FailureClass::Control
+        );
+        assert_eq!(FailureClass::from_signals(true, true), FailureClass::Both);
+        assert_eq!(
+            FailureClass::from_signals(false, false),
+            FailureClass::Neither
+        );
+    }
+
+    #[test]
+    fn failure_class_routes_one_to_one() {
+        assert_eq!(
+            FailureClass::Epistemic.route(),
+            DiagnosisRoute::PremiseUpdate
+        );
+        assert_eq!(
+            FailureClass::Control.route(),
+            DiagnosisRoute::MonitoringTweak
+        );
+        assert_eq!(
+            FailureClass::Both.route(),
+            DiagnosisRoute::ArchitecturalRework
+        );
+        assert_eq!(
+            FailureClass::Neither.route(),
+            DiagnosisRoute::FalseAlarmCorpus
+        );
+    }
+
+    #[test]
+    fn failure_class_serde_roundtrip() {
+        for class in [
+            FailureClass::Epistemic,
+            FailureClass::Control,
+            FailureClass::Both,
+            FailureClass::Neither,
+        ] {
+            let json = serde_json::to_string(&class).unwrap();
+            let back: FailureClass = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, class);
+        }
+        assert_eq!(
+            serde_json::to_string(&FailureClass::Epistemic).unwrap(),
+            "\"epistemic\""
+        );
+    }
+
+    #[test]
+    fn diagnosis_derives_route_and_clamps_confidence() {
+        let d = Diagnosis::new("s", FailureClass::Both, 1.7);
+        assert_eq!(d.route, DiagnosisRoute::ArchitecturalRework);
+        assert!((d.confidence - 1.0).abs() < f64::EPSILON);
+
+        let d = Diagnosis::new("s", FailureClass::Neither, -0.5);
+        assert!((d.confidence).abs() < f64::EPSILON);
+        assert!(d.is_false_alarm());
+    }
+
+    #[test]
+    fn diagnosis_classify_maps_axes() {
+        assert_eq!(
+            Diagnosis::classify("s", true, false, 0.9).class,
+            FailureClass::Epistemic
+        );
+        assert_eq!(
+            Diagnosis::classify("s", false, true, 0.9).class,
+            FailureClass::Control
+        );
+        assert_eq!(
+            Diagnosis::classify("s", true, true, 0.9).class,
+            FailureClass::Both
+        );
+        let neither = Diagnosis::classify("s", false, false, 0.9);
+        assert_eq!(neither.class, FailureClass::Neither);
+        assert_eq!(neither.route, DiagnosisRoute::FalseAlarmCorpus);
+    }
+
+    #[test]
+    fn cosine_distance_identical_is_zero() {
+        let a = vec![1.0, 2.0, 3.0];
+        assert!(cosine_distance(&a, &a).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cosine_distance_orthogonal_is_one() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        assert!((cosine_distance(&a, &b) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cosine_distance_zero_norm_is_max() {
+        let a = vec![0.0, 0.0];
+        let b = vec![1.0, 1.0];
+        assert!((cosine_distance(&a, &b) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cosine_distance_handles_unequal_lengths() {
+        let a = vec![1.0, 1.0];
+        let b = vec![1.0, 1.0, 0.0, 0.0];
+        assert!(cosine_distance(&a, &b).abs() < 1e-9);
+    }
+
+    #[test]
+    fn window_warmup_returns_none() {
+        let mut w = PremiseValidityWatcher::new("s", PremiseWatchConfig::default());
+        // window=5 default; first 5 observations are warm-up.
+        for _ in 0..5 {
+            assert!(w.observe_output(&[1.0, 0.0, 0.0]).is_none());
+        }
+        assert_eq!(w.observations(), 5);
+    }
+
+    #[test]
+    fn output_divergence_fires_on_structural_shift() {
+        let cfg = PremiseWatchConfig {
+            window: 3,
+            distance_threshold: 0.3,
+            ..Default::default()
+        };
+        let mut w = PremiseValidityWatcher::new("s", cfg);
+        // Establish a stable baseline pointing along axis 0.
+        for _ in 0..3 {
+            assert!(w.observe_output(&[1.0, 0.0, 0.0]).is_none());
+        }
+        // A consistent output does not fire.
+        assert!(w.observe_output(&[1.0, 0.0, 0.0]).is_none());
+        // A structurally different output (orthogonal) fires.
+        let sig = w.observe_output(&[0.0, 1.0, 0.0]).expect("should fire");
+        assert_eq!(sig.kind, StalenessSignalKind::OutputDivergence);
+        assert!(sig.magnitude > 0.3);
+        assert_eq!(sig.session_id, "s");
+    }
+
+    #[test]
+    fn output_divergence_via_text() {
+        let cfg = PremiseWatchConfig {
+            window: 3,
+            distance_threshold: 0.5,
+            ..Default::default()
+        };
+        let mut w = PremiseValidityWatcher::new("s", cfg);
+        for _ in 0..3 {
+            assert!(
+                w.observe_output_text("reading the config file and applying the plan")
+                    .is_none()
+            );
+        }
+        // Same topic — should stay quiet.
+        assert!(
+            w.observe_output_text("reading the config file and applying the plan step")
+                .is_none()
+        );
+        // Totally different vocabulary — should fire.
+        let sig = w.observe_output_text("quantum entanglement violin sonata pancake");
+        assert!(sig.is_some());
+        assert_eq!(sig.unwrap().kind, StalenessSignalKind::OutputDivergence);
+    }
+
+    #[test]
+    fn plant_divergence_normalizes() {
+        let mut w = watch_premise_validity("s");
+        // Small gap relative to magnitude — no fire.
+        assert!(w.observe_plant(100.0, 105.0).is_none());
+        // Large relative gap — fires.
+        let sig = w.observe_plant(100.0, 20.0).expect("should fire");
+        assert_eq!(sig.kind, StalenessSignalKind::PlantDivergence);
+        assert!(sig.magnitude > 0.5);
+        assert!(sig.magnitude <= 1.0);
+    }
+
+    #[test]
+    fn noop_accumulation_reverse_burden() {
+        let cfg = PremiseWatchConfig {
+            noop_threshold: 3,
+            ..Default::default()
+        };
+        let mut w = PremiseValidityWatcher::new("s", cfg);
+        assert!(w.observe_action(false).is_none()); // 1
+        assert!(w.observe_action(false).is_none()); // 2
+        let sig = w.observe_action(false).expect("should fire at 3"); // 3
+        assert_eq!(sig.kind, StalenessSignalKind::NoOpAccumulation);
+        assert!((sig.magnitude - 3.0).abs() < f64::EPSILON);
+        // Progress resets the counter.
+        assert!(w.observe_action(true).is_none());
+        assert_eq!(w.consecutive_noops(), 0);
+        assert!(w.observe_action(false).is_none()); // 1 again
+    }
+
+    #[test]
+    fn signal_diagnoses_epistemic_or_both() {
+        let mut w = watch_premise_validity("s");
+        let sig = w.observe_plant(1.0, 0.0).expect("should fire");
+        // Premise stale, control ok → epistemic → premise update.
+        let d = sig.diagnose(false);
+        assert_eq!(d.class, FailureClass::Epistemic);
+        assert_eq!(d.route, DiagnosisRoute::PremiseUpdate);
+        // Premise stale AND control diverged → both → architectural rework.
+        let d = sig.diagnose(true);
+        assert_eq!(d.class, FailureClass::Both);
+        assert_eq!(d.route, DiagnosisRoute::ArchitecturalRework);
+        assert!(d.rationale.is_some());
+    }
+
+    #[test]
+    fn lexical_features_is_deterministic() {
+        let a = lexical_features("the quick brown fox");
+        let b = lexical_features("the quick brown fox");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), LEXICAL_DIM);
+        // Non-empty text produces a non-zero vector.
+        assert!(a.iter().any(|&x| x > 0.0));
+        // Empty / punctuation-only text produces a zero vector.
+        assert!(lexical_features("   ... !!! ").iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn zero_window_disables_output_divergence() {
+        let cfg = PremiseWatchConfig {
+            window: 0,
+            ..Default::default()
+        };
+        let mut w = PremiseValidityWatcher::new("s", cfg);
+        for _ in 0..10 {
+            assert!(w.observe_output(&[1.0, 0.0]).is_none());
+        }
+    }
+
+    #[test]
+    fn watcher_is_clone_and_session_scoped() {
+        let w = watch_premise_validity("sess-42");
+        assert_eq!(w.session_id(), "sess-42");
+        let w2 = w.clone();
+        assert_eq!(w2.session_id(), "sess-42");
+    }
+}

--- a/crates/nous/nous-core/src/reconcile.rs
+++ b/crates/nous/nous-core/src/reconcile.rs
@@ -1,0 +1,204 @@
+//! Reconcile discrepancy taxonomy — Nous's contribution to `bstack reconcile`.
+//!
+//! Reconcile (BRO-1039) cross-references narrative claims against external
+//! evidence. It historically catches two forward discrepancies:
+//!
+//! - [`ClaimedNotDone`](DiscrepancyClass::ClaimedNotDone) — the narrative claims
+//!   an action; no external evidence backs it (deflection).
+//! - [`ReportedNoAction`](DiscrepancyClass::ReportedNoAction) — report-mass
+//!   without corresponding action-mass.
+//!
+//! The premise-staleness work adds two more classes, both driven by the
+//! dual-classifier surface in [`crate::premise`]:
+//!
+//! - [`PremiseStale`](DiscrepancyClass::PremiseStale) — the **third** class
+//!   (ticket item 4): the plan is internally valid but its premise drifted, so
+//!   narrative and evidence agree with each other yet both diverge from the
+//!   *current world*. Routes to a premise update, not a monitoring tweak.
+//! - [`ShadowCompetence`](DiscrepancyClass::ShadowCompetence) — the **inverse**
+//!   class (ticket item 5): *done-but-not-claimed*. A Vigil span shows an action
+//!   the bridge log never planned — a successful adaptation the architecture
+//!   never authorized. This is the dual of `ClaimedNotDone` and is flagged as a
+//!   **promote candidate**, not a failure. See
+//!   `research/entities/pattern/shadow-competence.md`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::premise::FailureClass;
+
+/// A class of discrepancy surfaced by reconcile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscrepancyClass {
+    /// Narrative claims an action; no external evidence backs it.
+    ClaimedNotDone,
+    /// Report-mass without corresponding action-mass.
+    ReportedNoAction,
+    /// Plan valid, but its premise drifted out from under it (third class).
+    PremiseStale,
+    /// Evidence of an action with no matching plan — done-but-not-claimed.
+    ShadowCompetence,
+}
+
+impl DiscrepancyClass {
+    /// Stable snake_case label for events and logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::ClaimedNotDone => "claimed_not_done",
+            Self::ReportedNoAction => "reported_no_action",
+            Self::PremiseStale => "premise_stale",
+            Self::ShadowCompetence => "shadow_competence",
+        }
+    }
+
+    /// Whether this discrepancy is a promotion candidate rather than a failure.
+    ///
+    /// Only shadow competence qualifies: it is a *successful* adaptation the
+    /// architecture did not authorize, worth crystallizing into official
+    /// structure (subject to the architecture's judgment — detection is not
+    /// endorsement).
+    pub fn is_promote_candidate(&self) -> bool {
+        matches!(self, Self::ShadowCompetence)
+    }
+
+    /// The dual-classifier failure axis this discrepancy maps to, if any.
+    ///
+    /// `PremiseStale` maps to [`FailureClass::Epistemic`] (fix the premise).
+    /// The narrative-vs-evidence classes and shadow competence are reconcile's
+    /// own concerns and do not route through the failure classifier.
+    pub fn failure_class(&self) -> Option<FailureClass> {
+        match self {
+            Self::PremiseStale => Some(FailureClass::Epistemic),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DiscrepancyClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// A single reconcile finding: a class, its session, and an optional detail.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReconcileDiscrepancy {
+    /// Session the discrepancy belongs to.
+    pub session_id: String,
+    /// Which class of discrepancy.
+    pub class: DiscrepancyClass,
+    /// Optional human-readable detail.
+    pub detail: Option<String>,
+}
+
+impl ReconcileDiscrepancy {
+    /// Construct a discrepancy of the given class.
+    pub fn new(session_id: impl Into<String>, class: DiscrepancyClass) -> Self {
+        Self {
+            session_id: session_id.into(),
+            class,
+            detail: None,
+        }
+    }
+
+    /// Attach a detail string.
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    /// Detect a shadow-competence trail: action evidence without a plan.
+    ///
+    /// The done-but-not-claimed detector (ticket item 5): a Vigil span shows an
+    /// action (`has_action_span`) but the bridge log has no plan
+    /// (`has_plan_record`). When those hold, the action is a shadow trail and a
+    /// promote candidate; otherwise there is nothing to flag.
+    pub fn from_shadow_trail(
+        session_id: impl Into<String>,
+        has_action_span: bool,
+        has_plan_record: bool,
+    ) -> Option<Self> {
+        (has_action_span && !has_plan_record).then(|| {
+            Self::new(session_id, DiscrepancyClass::ShadowCompetence).with_detail(
+                "action span present with no matching plan record (done-but-not-claimed)",
+            )
+        })
+    }
+
+    /// Whether this finding should be routed as a promote candidate.
+    pub fn is_promote_candidate(&self) -> bool {
+        self.class.is_promote_candidate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_stable() {
+        assert_eq!(DiscrepancyClass::ClaimedNotDone.label(), "claimed_not_done");
+        assert_eq!(
+            DiscrepancyClass::ReportedNoAction.label(),
+            "reported_no_action"
+        );
+        assert_eq!(DiscrepancyClass::PremiseStale.label(), "premise_stale");
+        assert_eq!(
+            DiscrepancyClass::ShadowCompetence.label(),
+            "shadow_competence"
+        );
+    }
+
+    #[test]
+    fn only_shadow_competence_is_promote_candidate() {
+        assert!(!DiscrepancyClass::ClaimedNotDone.is_promote_candidate());
+        assert!(!DiscrepancyClass::ReportedNoAction.is_promote_candidate());
+        assert!(!DiscrepancyClass::PremiseStale.is_promote_candidate());
+        assert!(DiscrepancyClass::ShadowCompetence.is_promote_candidate());
+    }
+
+    #[test]
+    fn premise_stale_maps_to_epistemic() {
+        assert_eq!(
+            DiscrepancyClass::PremiseStale.failure_class(),
+            Some(FailureClass::Epistemic)
+        );
+        assert!(DiscrepancyClass::ClaimedNotDone.failure_class().is_none());
+        assert!(DiscrepancyClass::ShadowCompetence.failure_class().is_none());
+    }
+
+    #[test]
+    fn shadow_trail_detects_action_without_plan() {
+        // Action span, no plan → shadow trail (promote candidate).
+        let d = ReconcileDiscrepancy::from_shadow_trail("s", true, false)
+            .expect("should detect shadow trail");
+        assert_eq!(d.class, DiscrepancyClass::ShadowCompetence);
+        assert!(d.is_promote_candidate());
+        assert!(d.detail.is_some());
+
+        // Action span with a plan → authorized, nothing to flag.
+        assert!(ReconcileDiscrepancy::from_shadow_trail("s", true, true).is_none());
+        // Plan but no action → not this detector's concern (forward case).
+        assert!(ReconcileDiscrepancy::from_shadow_trail("s", false, true).is_none());
+        // Neither → nothing.
+        assert!(ReconcileDiscrepancy::from_shadow_trail("s", false, false).is_none());
+    }
+
+    #[test]
+    fn discrepancy_serde_roundtrip() {
+        let d = ReconcileDiscrepancy::new("sess-1", DiscrepancyClass::PremiseStale)
+            .with_detail("premise drifted");
+        let json = serde_json::to_string(&d).unwrap();
+        let back: ReconcileDiscrepancy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, d);
+        assert_eq!(back.class, DiscrepancyClass::PremiseStale);
+    }
+
+    #[test]
+    fn discrepancy_class_serde_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&DiscrepancyClass::ShadowCompetence).unwrap(),
+            "\"shadow_competence\""
+        );
+    }
+}


### PR DESCRIPTION
## BRO-1311 — Nous: dual-classifier surface

**Origin:** ami_ai_ (k=5,731) on the SparkLabScout loop-fidelity post (2026-05-10) — the *epistemic vs control failure* framing ("reasoned correctly from a wrong premise" ≠ "reasoned correctly from a premise that drifted") and *shadow competence* (skills agents develop outside the official architecture, invisible to the system that built them). Design spec: `research/entities/pattern/shadow-competence.md` (9/9).

### The gap this closes
Nous had **one** classifier — control-divergence (*does execution match the plan?*, `nous-judge::PlanAdherence`). With only that lens, every premise failure reads as a loop failure → energy is spent re-engineering the loop → the premise stays stale → the cycle compounds. This PR adds the **second** lens: premise-staleness (*was the plan still valid given the current world?*).

### What's implemented (all in `nous-core`, zero-I/O + dependency-free — invariant preserved)

**`premise` module**
- **`watch_premise_validity(session)` → `PremiseValidityWatcher`** — session-scoped, stateful, deterministic; *no LLM in the hot path*. Three orthogonal detectors:
  - **output divergence** — cosine distance from a new output's feature vector to the rolling `N`-back window mean > `k` (ami_ai_'s "looks structurally different from the last five iterations");
  - **plant divergence** — scale-free predicted-vs-observed gap;
  - **no-op accumulation** — reverse-burden: consecutive no-progress actions past a threshold flip the presumption to *premise stale*.
- **Embedding-agnostic** — consumes feature vectors, so a real embedding model drops in freely. Ships `lexical_features`, a deterministic hashed-token bag (no model, no I/O) as the default → resolves the *embedding-model choice* open question by not forcing one.
- **Dual-classifier schema** — `FailureClass` (`epistemic | control | both | neither`) → `DiagnosisRoute` (`premise_update | monitoring_tweak | architectural_rework | false_alarm_corpus`), 1:1 with the layer that fixes it. `Diagnosis::classify` fuses the premise-staleness (epistemic) axis with the existing control-divergence (control) axis. Terminology note in the module docs reconciles "drifted premise" onto the epistemic axis (the *remedy* is a premise update either way).

**`reconcile` module (BRO-1039 integration)**
- **`PremiseStale`** — the **third** discrepancy class: plan internally valid but its premise drifted; maps to `FailureClass::Epistemic`.
- **`ShadowCompetence`** — the **inverse** class (done-but-not-claimed): `from_shadow_trail(session, has_action_span, has_plan_record)` flags an action span with no matching plan record as a **promote candidate** (not a failure) — detection ≠ endorsement.

**`events`**
- `NousEvent::PremiseStalenessAlarm` variant + `from_premise_signal(&signal, &diagnosis)`, wiring premise signals into the canonical `eval.*` `EventKind::Custom` taxonomy (round-trips through `into_event_kind`/`from_custom`).

### Routing (ticket item 3)
`epistemic → premise update` · `control → monitoring tweak` · `both → architectural rework` · `neither → false-alarm corpus`.

### Validation (P11 — GREEN, run in-turn)
- `cargo fmt -p nous-core --check` — clean
- `cargo clippy -p nous-core --all-targets -- -D warnings` — clean
- `cargo test -p nous-core` — **67 passed** (26 new across `premise`, `reconcile`, `events`)
- `cargo test -p nous-heuristics -p nous-judge -p nous-lago -p nous-middleware -p life-nous` — compile + green (additive public API, no signature changes)

### Scope notes
- Keeps `nous-core`'s "depends only on `aios-protocol`" invariant — the watcher is a session-lifetime stateful API, deliberately *not* forced into the stateless per-hook `NousEvaluator` trait.
- Composes with BRO-1041 / BRO-1039 / BRO-1037 and the loop-tightness ticket. Downstream wiring (autonomic fold, reconcile consumer, Vigil span attribute) consumes these types; those integrations land in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added premise-staleness monitoring for output drift, plant divergence, and repeated no-progress actions.
  * Added diagnosis and routing for premise-related and execution-related failures.
  * Added structured reconciliation discrepancy categories, including stale premises and shadow competence.
  * Added event reporting and serialization for premise-staleness alarms.
  * Added deterministic text-based feature extraction for monitoring observations.

* **Tests**
  * Added coverage for detection, diagnosis, reconciliation classification, event roundtrips, and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->